### PR TITLE
[Recorder] RemoveSanitizers API to 3.4.0 hotfix

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.4.0 (2024-05-08)
+
+### Features Added
+
+- Added support for the TestProxy/removeSanitizers API, to support the removing the central sanitizers by id at the test-proxy level.
+
 ## 3.3.0 (2024-05-07)
 
 ### Features Added

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/test-recorder",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "sdk-type": "utility",
   "description": "This library provides interfaces and helper methods to provide recording and playback capabilities for the tests in Azure JS/TS SDKs",
   "main": "dist/index.js",

--- a/sdk/test-utils/recorder/src/sanitizer.ts
+++ b/sdk/test-utils/recorder/src/sanitizer.ts
@@ -110,6 +110,36 @@ function makeBatchSanitizerBody(sanitizers: SanitizerOptions): SanitizerRequestB
 }
 
 /**
+ * Makes a /removeSanitizers request to the test proxy
+ * This API is meant to remove the central sanitizers that were added by the proxy-tool
+ * You'd need to pass the sanitizer ids that you want the test-proxy to remove for your recording
+ *
+ * Read more at https://github.com/Azure/azure-sdk-tools/pull/8142
+ */
+export async function removeSanitizers(
+  httpClient: HttpClient,
+  url: string,
+  recordingId: string | undefined,
+  removalList: string[],
+): Promise<void> {
+  const uri = `${url}${paths.admin}${paths.removeSanitizers}`;
+  const req = createRecordingRequest(uri, undefined, recordingId);
+  req.headers.set("Content-Type", "application/json");
+  req.body = JSON.stringify({
+    Sanitizers: removalList,
+  });
+  logger.info("[removeSanitizers] Removing sanitizers", removalList);
+  const rsp = await httpClient.sendRequest({
+    ...req,
+    allowInsecureConnection: true,
+  });
+  if (rsp.status !== 200) {
+    logger.error("[removeSanitizers] removeSanitizers request failed", rsp);
+    throw new RecorderError("removeSanitizers request failed.");
+  }
+}
+
+/**
  * Makes an /addSanitizers request to the test proxy
  */
 export async function addSanitizers(

--- a/sdk/test-utils/recorder/src/utils/fallbackSanitizers.ts
+++ b/sdk/test-utils/recorder/src/utils/fallbackSanitizers.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { HttpClient } from "@azure/core-rest-pipeline";
-import { addSanitizers } from "../sanitizer";
+import { addSanitizers, removeSanitizers } from "../sanitizer";
 import { BodyKeySanitizer, FindReplaceSanitizer, HeaderSanitizer } from "./utils";
 
 const JSON_BODY_KEYS_TO_REDACT = [
@@ -125,6 +125,11 @@ export async function fallbackSanitizers(
   ];
 
   const headersForRemoval: string[] = HEADER_KEYS_TO_REDACT;
+
+  //  https://github.com/Azure/azure-sdk-tools/pull/8142/
+  const removalList = ["AZSDK2003"];
+  await removeSanitizers(httpClient, url, recordingId, removalList);
+
   await addSanitizers(httpClient, url, recordingId, {
     bodyKeySanitizers,
     generalSanitizers,

--- a/sdk/test-utils/recorder/src/utils/paths.ts
+++ b/sdk/test-utils/recorder/src/utils/paths.ts
@@ -12,6 +12,7 @@ export const paths = {
   admin: "/admin",
   addSanitizer: "/addSanitizer",
   addSanitizers: "/addSanitizers",
+  removeSanitizers: "/removeSanitizers",
   info: "/info",
   available: "/available",
   active: "/active",


### PR DESCRIPTION
### Packages impacted by this PR
`@azure-tools/test-recorder@3.4.0`

### What?

- Added support for the TestProxy/removeSanitizers API, to support the removing the central sanitizers by id at the test-proxy level.

Cherrypicking from #29661 