### PR TITLE
[Test] add environment variables that is needed by samples

### DIFF
--- a/sdk/cognitivelanguage/ai-language-conversations/tests.yml
+++ b/sdk/cognitivelanguage/ai-language-conversations/tests.yml
@@ -11,3 +11,10 @@ extends:
         LANGUAGE_CLU_DEPLOYMENT_NAME: $(clu-project-deployment)
         LANGUAGE_ORCHESTRATION_PROJECT_NAME: $(clu-workflow-project)
         LANGUAGE_ORCHESTRATION_DEPLOYMENT_NAME: $(clu-workflow-project-deployment)
+        # The following are for samples
+        AZURE_CONVERSATIONS_ENDPOINT: $(clu-uri)
+        AZURE_CONVERSATIONS_KEY: $(clu-key)
+        AZURE_CONVERSATIONS_PROJECT_NAME: $(clu-project)
+        AZURE_CONVERSATIONS_DEPLOYMENT_NAME: $(clu-project-deployment)
+        AZURE_CONVERSATIONS_WORKFLOW_PROJECT_NAME: $(clu-workflow-project)
+        AZURE_CONVERSATIONS_WORKFLOW_DEPLOYMENT_NAME: $(clu-workflow-project-deployment)


### PR DESCRIPTION
to fix samples run in live tests.  It would have been nicer if the same set of variables are used for both tests and samples. However the names in samples are better customer-facing and this PR is a simple and straightforward fix.