### PR TITLE
[engsys] attempt to fix warnings in `js - core - ci` build

### DIFF
--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -48,12 +48,25 @@ steps:
     displayName: "Test libraries"
     condition: and(succeeded(),eq(variables['TestType'], 'browser'))
 
+  # copy first before uploading to avoid issue of file being accessed by multiple processes.
   - ${{ if eq(parameters.TestProxy, true) }}:
     - pwsh: |
         copy $(Build.SourcesDirectory)/test-proxy.log $(Build.ArtifactStagingDirectory)
       displayName: 'Dump Test Proxy logs'
       condition: succeededOrFailed()
-      
+
+  - ${{ if eq(parameters.TestProxy, true) }}:
+    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+      parameters:
+        ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.log'
+        ArtifactName: 'test proxy logs $(Agent.JobName)'
+        SbomEnabled: false
+
+  - ${{ if eq(parameters.TestProxy, true) }}:
+    - pwsh: |
+        del $(Build.ArtifactStagingDirectory)/test-proxy.log
+      displayName: 'Dump Test Proxy logs'
+
   # Unlink node_modules folders to significantly improve performance of subsequent tasks
   # which need to walk the directory tree (and are hardcoded to follow symlinks).
   # Retry for 30 seconds, since this command may fail with error "Another rush command is already
@@ -90,10 +103,3 @@ steps:
       testRunTitle: "$(OSName) - Browser - Unit Tests - [Node $(NodeTestVersion)]"
     condition: and(always(),eq(variables['TestType'], 'browser'))
     displayName: "Publish browser unit test results"
-
-  - ${{ if eq(parameters.TestProxy, true) }}:
-    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-      parameters:
-        ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.log'
-        ArtifactName: 'test proxy logs $(Agent.JobName)'
-        SbomEnabled: false


### PR DESCRIPTION
The SDL step seems to have been failing to upload artifact due to existing
artifact. Not sure how it is triggered by publishing test proxy log.  This PR
attempts to work around the issue by changing the order of steps and deleting
copied test proxy log file.