### PR TITLE
Beta4 HoldOptions update operationCallbackUri to operationCallbackUrl

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -441,7 +441,7 @@ export interface HoldFailed extends Omit<RestHoldFailed, "callConnectionId" | "s
 
 // @public
 export interface HoldOptions extends OperationOptions {
-    operationCallbackUri?: string;
+    operationCallbackUrl?: string;
     operationContext?: string;
     playSource?: FileSource | TextSource | SsmlSource;
 }

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -453,7 +453,7 @@ export class CallMedia {
       operationContext:
         options.operationContext !== undefined ? options.operationContext : undefined,
       operationCallbackUri:
-        options.operationCallbackUri !== undefined ? options.operationCallbackUri : undefined,
+        options.operationCallbackUrl !== undefined ? options.operationCallbackUrl : undefined,
     };
     return this.callMedia.hold(this.callConnectionId, holdRequest);
   }

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -362,8 +362,8 @@ export interface HoldOptions extends OperationOptions {
   playSource?: FileSource | TextSource | SsmlSource;
   /** Operation Context. */
   operationContext?: string;
-  /** Set a callback URI that overrides the default callback URI set by CreateCall/AnswerCall for this operation. */
-  operationCallbackUri?: string;
+  /** Set a callback URL that overrides the default callback URL set by CreateCall/AnswerCall for this operation. */
+  operationCallbackUrl?: string;
 }
 
 /**

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -338,7 +338,7 @@ describe("CallMedia Unit Tests", async function () {
     const options: HoldOptions = {
       playSource: playSource,
       operationContext: "withPlaySource",
-      operationCallbackUri: "https://localhost",
+      operationCallbackUrl: "https://localhost",
     };
     await callMedia.hold(participantToHold, options);
     const request = spy.getCall(0).args[0];


### PR DESCRIPTION

### Issues associated with this PR

[User Story 3667737](https://skype.visualstudio.com/SPOOL/_workitems/edit/3667737): [Beta4][JS][SDK] Update the SDK according to Azure Board's comments.

### Describe the problem that is addressed by this PR
HoldOptions update operationCallbackUri to operationCallbackUrl


### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
