### PR TITLE
Added beta4 interruptCallMediaOperation to playToAll.

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -167,7 +167,7 @@ export class CallMedia {
     cancelAllOperations(): Promise<void>;
     hold(targetParticipant: CommunicationIdentifier, options?: HoldOptions): Promise<void>;
     play(playSources: (FileSource | TextSource | SsmlSource)[], playTo: CommunicationIdentifier[], options?: PlayOptions): Promise<void>;
-    playToAll(playSources: (FileSource | TextSource | SsmlSource)[], options?: PlayOptions): Promise<void>;
+    playToAll(playSources: (FileSource | TextSource | SsmlSource)[], options?: PlayToAllOptions): Promise<void>;
     sendDtmfTones(tones: Tone[] | DtmfTone[], targetParticipant: CommunicationIdentifier, options?: SendDtmfTonesOptions): Promise<SendDtmfTonesResult>;
     startContinuousDtmfRecognition(targetParticipant: CommunicationIdentifier, options?: ContinuousDtmfRecognitionOptions): Promise<void>;
     // @deprecated
@@ -564,6 +564,11 @@ export interface PlaySource {
     // @deprecated (undocumented)
     playsourcacheid?: string;
     playSourceCacheId?: string;
+}
+
+// @public
+export interface PlayToAllOptions extends PlayOptions {
+    interruptCallMediaOperation?: boolean;
 }
 
 // @public

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -35,6 +35,7 @@ import {
 import { FileSource, TextSource, SsmlSource, DtmfTone } from "./models/models";
 import {
   PlayOptions,
+  PlayToAllOptions,
   CallMediaRecognizeDtmfOptions,
   CallMediaRecognizeChoiceOptions,
   ContinuousDtmfRecognitionOptions,
@@ -156,7 +157,7 @@ export class CallMedia {
    */
   public async playToAll(
     playSources: (FileSource | TextSource | SsmlSource)[],
-    options: PlayOptions = { loop: false },
+    options: PlayToAllOptions = { loop: false },
   ): Promise<void> {
     const playRequest: PlayRequest = {
       playSources: playSources.map((source) => this.createPlaySourceInternal(source)),
@@ -164,6 +165,10 @@ export class CallMedia {
       playOptions: {
         loop: false,
       },
+      interruptCallMediaOperation:
+        options.interruptCallMediaOperation !== undefined
+          ? options.interruptCallMediaOperation
+          : false,
       operationContext: options.operationContext,
       operationCallbackUri: options.operationCallbackUrl,
     };

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -219,6 +219,14 @@ export interface PlayOptions extends OperationOptions {
 }
 
 /**
+ * Options to playToAll audio.
+ */
+export interface PlayToAllOptions extends PlayOptions {
+  /** If set play can barge into other existing queued-up/currently-processing requests. */
+  interruptCallMediaOperation?: boolean;
+}
+
+/**
  * Options to get call connection properties.
  */
 export type GetCallConnectionPropertiesOptions = OperationOptions;

--- a/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
+++ b/sdk/communication/communication-call-automation/test/callMediaClient.spec.ts
@@ -37,6 +37,7 @@ import {
   StopTranscriptionOptions,
   HoldOptions,
   UnholdOptions,
+  PlayToAllOptions,
 } from "../src";
 
 // Current directory imports
@@ -179,6 +180,63 @@ describe("CallMedia Unit Tests", async function () {
     assert.equal(data.playSources[0].kind, "file");
     assert.equal(data.playSources[0].file.uri, playSource[0].url);
     assert.equal(request.method, "POST");
+  });
+
+  it("makes successful PlayToAll barge in request", async function () {
+    const mockHttpClient = generateHttpClient(202);
+
+    callMedia = createMediaClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+
+    const playSource: FileSource[] = [
+      {
+        url: MEDIA_URL_WAV,
+        kind: "fileSource",
+      },
+    ];
+
+    const options: PlayToAllOptions = {
+      interruptCallMediaOperation: true,
+      operationContext: "interruptMediaContext",
+    };
+
+    await callMedia.playToAll(playSource, options);
+    const request = spy.getCall(0).args[0];
+    const data = JSON.parse(request.body?.toString() || "");
+
+    assert.equal(data.playSources[0].kind, "file");
+    assert.equal(data.playSources[0].file.uri, playSource[0].url);
+    assert.equal(request.method, "POST");
+    assert.equal(data.operationContext, options.operationContext);
+    assert.equal(data.interruptCallMediaOperation, options.interruptCallMediaOperation);
+  });
+
+  it("makes successful PlayToAll barge in request with PlayOptions instead of PlayToAllOptions", async function () {
+    const mockHttpClient = generateHttpClient(202);
+
+    callMedia = createMediaClient(mockHttpClient);
+    const spy = sinon.spy(mockHttpClient, "sendRequest");
+
+    const playSource: FileSource[] = [
+      {
+        url: MEDIA_URL_WAV,
+        kind: "fileSource",
+      },
+    ];
+
+    const options: PlayOptions = {
+      operationContext: "interruptMediaContext",
+    };
+
+    await callMedia.playToAll(playSource, options);
+    const request = spy.getCall(0).args[0];
+    const data = JSON.parse(request.body?.toString() || "");
+
+    assert.equal(data.playSources[0].kind, "file");
+    assert.equal(data.playSources[0].file.uri, playSource[0].url);
+    assert.equal(request.method, "POST");
+    assert.equal(data.operationContext, options.operationContext);
+    assert.equal(data.interruptCallMediaOperation, false);
   });
 
   it("makes successful StartRecognizing DTMF request", async function () {


### PR DESCRIPTION

### Issues associated with this PR
[User Story 3576848](https://skype.visualstudio.com/SPOOL/_workitems/edit/3576848): [Beta4][CA SDK][JS] Update SDK with the interrupt call media flag for Play api

### Describe the problem that is addressed by this PR

1.Added beta4 interruptCallMediaOperation to playToAll.
2.Unit test.

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
