### PR TITLE
Remove usage of azure-sdk-docs-prod-sas

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -13,7 +13,7 @@ parameters:
 stages:
   - ${{if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
       - ${{ each artifact in parameters.Artifacts }}:
-          - stage: 
+          - stage:
             variables:
               - template: /eng/pipelines/templates/variables/globals.yml
             displayName: 'Release: ${{artifact.name}}'
@@ -171,7 +171,6 @@ stages:
                             - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
                               parameters:
                                 FolderForUpload: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                                BlobSASKey: $(azure-sdk-docs-prod-sas)
                                 BlobName: $(azure-sdk-docs-prod-blob-name)
                                 TargetLanguage: javascript
                                 ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
@@ -265,7 +264,7 @@ stages:
                       Registry: ${{parameters.Registry}}
                       PathToArtifacts: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
                       Tag: "dev"
-                    
+
       - job: PublishDocsToNightlyBranch
         condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),  ne(variables['Skip.PublishDocs'], 'true')))
         dependsOn: PublishPackages


### PR DESCRIPTION
The publish-blobs.yml uses AzurePowerShell now and no longer required the azure-sdk-docs-prod-sas. This is cleanup needs to be done in order to remove the SAS from the variable group and, ultimately, the keyvault.