### PR TITLE
[Azure Monitor] Update codeowners for Monitor OpenTelemetry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1212,9 +1212,6 @@
 #/<NotInRepo>/          @SameergMS @dadunl @AzMonEssential @AzmonAlerts @AzmonActionG @AzmonLogA
 
 # ServiceLabel: %Monitor - ApplicationInsights %Service Attention
-#/<NotInRepo>/          @azmonapplicationinsights
-
-# ServiceLabel: %Monitor - Exporter %Service Attention
 #/<NotInRepo>/          @JacksonWeber @hectorhdzg @ramthi
 
 # ServiceLabel: %MySQL %Service Attention


### PR DESCRIPTION
Added correct aliases for Application Insights
Removed # ServiceLabel: %Monitor - Exporter %Service Attention, # PRLabel: %Monitor already exists for OTel and Exporter with correct owners