### PR TITLE
[test-util] Move core-tracing to peerDependencies

### DIFF
--- a/common/tools/dev-tool/src/commands/run/bundle.ts
+++ b/common/tools/dev-tool/src/commands/run/bundle.ts
@@ -100,6 +100,7 @@ export default leafCommand(commandInfo, async (options) => {
         ...nodeBuiltins,
         ...Object.keys(info.packageJson.dependencies),
         ...Object.keys(info.packageJson.devDependencies),
+        ...Object.keys(info.packageJson.peerDependencies ?? {}),
       ],
       preserveSymlinks: false,
       plugins: [nodeResolve(), sourcemaps()],

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -60,6 +60,7 @@ declare global {
     private: boolean;
 
     dependencies: Record<string, string>;
+    peerDependencies?: Record<string, string>;
     devDependencies: Record<string, string>;
 
     [METADATA_KEY]?: AzureSdkMetadata;

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -58,7 +58,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
-    "@azure/core-tracing": "^1.0.0",
     "@opentelemetry/api": "^1.8.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.4",
@@ -67,6 +66,9 @@
     "chai-exclude": "^2.1.0",
     "mocha": "^10.0.0",
     "tslib": "^2.2.0"
+  },
+  "peerDependencies": {
+    "@azure/core-tracing": "^1.0.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",


### PR DESCRIPTION
### Packages impacted by this PR

@azure-tools/test-utils

### Issues associated with this PR

Resolves #29736

### Describe the problem that is addressed by this PR

When @azure-tools/test-utils moves to `npm` it will no longer default to the on-disk version of core-tracing. This impacts our `supportsTracing` test helper as it no longer sets the instrumenter on the same version as the client package. Imagine this flow:

<img src="https://github.com/Azure/azure-sdk-for-js/assets/753570/12d52e8e-16c1-44b3-b57d-edd31a1e4627" width=70% height=70%>

In this case, test-util and app-configuration are not talking to the same "module global" instrumenter. 

This PR fixes this by removing core-tracing from test-utils, setting it as a peerDependency instead. All packages that test tracing also implement tracing, and as such are already depending on core-tracing.

This was verified locally, but I'll need to get it out to NPM before verification can complete

### Alternatives

See #29709 for a few alternatives:
1. Pass the instrumenter through
2. Use mocks

Both require updates to multiple packages and/or adding public API surface which is unnecessary. We can fallback to those options if we have to, but this is a promising alternative.

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
