### PR TITLE
[notification-hubs] Adding FCMv1 to Notification Outcomes

### DIFF
--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.2.3 (2024-05-21)
 
 ### Bugs Fixed
 
-### Other Changes
+- Added outcome counts to the `NotificationOutcomeDetails` response for browser and FCMV1 notifications.
+  - [#29404](https://github.com/Azure/azure-sdk-for-js/issues/29777)
 
 ## 1.2.2 (2024-04-29)
 

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs-models.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs-models.api.md
@@ -802,6 +802,7 @@ export interface NotificationDetails {
     endTime?: Date;
     enqueueTime?: Date;
     fcmOutcomeCounts?: NotificationOutcome[];
+    fcmV1OutcomeCounts?: NotificationOutcome[];
     location?: string;
     notificationBody?: string;
     notificationId?: string;

--- a/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
+++ b/sdk/notificationhubs/notification-hubs/review/notification-hubs.api.md
@@ -803,6 +803,7 @@ export interface NotificationDetails {
     endTime?: Date;
     enqueueTime?: Date;
     fcmOutcomeCounts?: NotificationOutcome[];
+    fcmV1OutcomeCounts?: NotificationOutcome[];
     location?: string;
     notificationBody?: string;
     notificationId?: string;

--- a/sdk/notificationhubs/notification-hubs/src/models/notificationDetails.ts
+++ b/sdk/notificationhubs/notification-hubs/src/models/notificationDetails.ts
@@ -99,6 +99,11 @@ export interface NotificationDetails {
   fcmOutcomeCounts?: NotificationOutcome[];
 
   /**
+   * FCM V1 outcome counts per state.
+   */
+  fcmV1OutcomeCounts?: NotificationOutcome[];
+
+  /**
    * ADM outcome counts per state.
    */
   admOutcomeCounts?: NotificationOutcome[];

--- a/sdk/notificationhubs/notification-hubs/src/serializers/notificationDetailsSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/notificationDetailsSerializer.ts
@@ -34,9 +34,21 @@ export async function parseNotificationDetails(bodyText: string): Promise<Notifi
     baiduOutcomeCounts = parseOutcomeCounts(notificationDetails["BaiduOutcomeCounts"]["Outcome"]);
   }
 
+  let browserOutcomeCounts: NotificationOutcome[] | undefined;
+  if (isDefined(notificationDetails["BrowserOutcomeCounts"])) {
+    browserOutcomeCounts = parseOutcomeCounts(
+      notificationDetails["BrowserOutcomeCounts"]["Outcome"],
+    );
+  }
+
   let fcmOutcomeCounts: NotificationOutcome[] | undefined;
   if (isDefined(notificationDetails["GcmOutcomeCounts"])) {
     fcmOutcomeCounts = parseOutcomeCounts(notificationDetails["GcmOutcomeCounts"]["Outcome"]);
+  }
+
+  let fcmV1OutcomeCounts: NotificationOutcome[] | undefined;
+  if (isDefined(notificationDetails["FcmV1OutcomeCounts"])) {
+    fcmV1OutcomeCounts = parseOutcomeCounts(notificationDetails["FcmV1OutcomeCounts"]["Outcome"]);
   }
 
   let xiaomiOutcomeCounts: NotificationOutcome[] | undefined;
@@ -62,7 +74,9 @@ export async function parseNotificationDetails(bodyText: string): Promise<Notifi
     apnsOutcomeCounts,
     admOutcomeCounts,
     baiduOutcomeCounts,
+    browserOutcomeCounts,
     fcmOutcomeCounts,
+    fcmV1OutcomeCounts,
     xiaomiOutcomeCounts,
     wnsOutcomeCounts,
   };

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/notificationDetailsSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/notificationDetailsSerializer.spec.ts
@@ -4,7 +4,161 @@
 import { describe, it, assert } from "vitest";
 import { parseNotificationDetails } from "../../../src/serializers/notificationDetailsSerializer.js";
 
-const NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+const APNS_NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"aps":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>apple</TargetPlatforms>
+  <ApnsOutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </ApnsOutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const ADM_NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"message":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>adm</TargetPlatforms>
+  <AdmOutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </AdmOutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const BAIDU_NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"message":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>baidu</TargetPlatforms>
+  <BaiduOutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </BaiduOutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const BROWSER_NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"message":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>browser</TargetPlatforms>
+  <BrowserOutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </BrowserOutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const FIREBASE_NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"message":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>gcm</TargetPlatforms>
+  <GcmOutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </GcmOutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const FIREBASE_V1__NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"message":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>fcm</TargetPlatforms>
+  <FcmV1OutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </FcmV1OutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const XIAOMI__NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <NotificationId>{Your message id}</NotificationId>
+  <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
+  <State>Completed</State>
+  <EnqueueTime>2015-11-02T21:19:43Z</EnqueueTime>
+  <StartTime>2015-11-02T21:19:43.9926996Z</StartTime>
+  <EndTime>2015-11-02T21:19:43.9926996Z</EndTime>
+  <NotificationBody>{"message":{"alert":"hello"}}</NotificationBody>
+  <TargetPlatforms>xiaomi</TargetPlatforms>
+  <XiaomiOutcomeCounts>
+    <Outcome>
+      <Name>Success</Name>
+      <Count>3</Count>
+    </Outcome>
+    <Outcome>
+      <Name>WrongToken</Name>
+      <Count>1</Count>
+    </Outcome>
+  </XiaomiOutcomeCounts>
+  <PnsErrorDetailsUri>{Blob uri}</PnsErrorDetailsUri>
+</NotificationDetails>`;
+
+const WNS_NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
   <NotificationId>{Your message id}</NotificationId>
   <Location>sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04</Location>
   <State>Completed</State>
@@ -27,8 +181,162 @@ const NOTIFICATION_DETAILS = `<NotificationDetails xmlns="http://schemas.microso
 </NotificationDetails>`;
 
 describe("parseNotificationDetails", () => {
-  it("should parse notification details", async () => {
-    const parsedXML = await parseNotificationDetails(NOTIFICATION_DETAILS);
+  it("should parse ADM notification details", async () => {
+    const parsedXML = await parseNotificationDetails(ADM_NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.admOutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "adm");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"message":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.apnsOutcomeCounts);
+    assert.isUndefined(parsedXML.baiduOutcomeCounts);
+    assert.isUndefined(parsedXML.browserOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse APNs notification details", async () => {
+    const parsedXML = await parseNotificationDetails(APNS_NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.apnsOutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "apple");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"aps":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.admOutcomeCounts);
+    assert.isUndefined(parsedXML.baiduOutcomeCounts);
+    assert.isUndefined(parsedXML.browserOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse Baidu notification details", async () => {
+    const parsedXML = await parseNotificationDetails(BAIDU_NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.baiduOutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "baidu");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"message":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.apnsOutcomeCounts);
+    assert.isUndefined(parsedXML.admOutcomeCounts);
+    assert.isUndefined(parsedXML.browserOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse Browser notification details", async () => {
+    const parsedXML = await parseNotificationDetails(BROWSER_NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.browserOutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "browser");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"message":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.apnsOutcomeCounts);
+    assert.isUndefined(parsedXML.admOutcomeCounts);
+    assert.isUndefined(parsedXML.baiduOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse Firebase notification details", async () => {
+    const parsedXML = await parseNotificationDetails(FIREBASE_NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.fcmOutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "gcm");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"message":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.apnsOutcomeCounts);
+    assert.isUndefined(parsedXML.admOutcomeCounts);
+    assert.isUndefined(parsedXML.baiduOutcomeCounts);
+    assert.isUndefined(parsedXML.browserOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse Firebase V1 notification details", async () => {
+    const parsedXML = await parseNotificationDetails(FIREBASE_V1__NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.fcmV1OutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "fcm");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"message":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.apnsOutcomeCounts);
+    assert.isUndefined(parsedXML.admOutcomeCounts);
+    assert.isUndefined(parsedXML.baiduOutcomeCounts);
+    assert.isUndefined(parsedXML.browserOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse Xiaomi notification details", async () => {
+    const parsedXML = await parseNotificationDetails(XIAOMI__NOTIFICATION_DETAILS);
+
+    assert.equal(parsedXML.xiaomiOutcomeCounts?.length, 2);
+    assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
+    assert.equal(parsedXML.targetPlatforms, "xiaomi");
+    assert.equal(
+      parsedXML.location,
+      "sb://{Your namespace}.servicebus.windows.net/{your hub name}/messages/{your message id}?api-version=2015-04",
+    );
+    assert.equal(parsedXML.state, "Completed");
+    assert.equal(parsedXML.notificationId, "{Your message id}");
+    assert.equal(parsedXML.notificationBody, `{"message":{"alert":"hello"}}`);
+    assert.isUndefined(parsedXML.apnsOutcomeCounts);
+    assert.isUndefined(parsedXML.admOutcomeCounts);
+    assert.isUndefined(parsedXML.baiduOutcomeCounts);
+    assert.isUndefined(parsedXML.browserOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.wnsOutcomeCounts);
+  });
+
+  it("should parse WNS notification details", async () => {
+    const parsedXML = await parseNotificationDetails(WNS_NOTIFICATION_DETAILS);
 
     assert.equal(parsedXML.wnsOutcomeCounts?.length, 2);
     assert.equal(parsedXML.pnsErrorDetailsUrl, "{Blob uri}");
@@ -48,5 +356,7 @@ describe("parseNotificationDetails", () => {
     assert.isUndefined(parsedXML.baiduOutcomeCounts);
     assert.isUndefined(parsedXML.browserOutcomeCounts);
     assert.isUndefined(parsedXML.fcmOutcomeCounts);
+    assert.isUndefined(parsedXML.fcmV1OutcomeCounts);
+    assert.isUndefined(parsedXML.xiaomiOutcomeCounts);
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/notification-hubs

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Adds parsing for `BrowserOutcomeCounts` and `FcmV1OutcomeCounts` to the notification response details.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
