### PR TITLE
[engsys] fix inconsistent `tsx` version in pnpn-lock.yaml

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -15371,7 +15371,7 @@ packages:
       rimraf: 5.0.7
       ts-node: 10.9.2(@types/node@18.19.33)(typescript@5.4.5)
       tslib: 2.6.2
-      tsx: 4.10.2
+      tsx: 4.10.5
       typescript: 5.4.5
       uglify-js: 3.17.4
     transitivePeerDependencies:


### PR DESCRIPTION
all other occurrences of `tsx` have version 4.10.5. The older version of 4.10.2
may have been introduced during PR merge and it is causing warnings/errors when
running `rush update`.  This PR change the version to be consistent.