### PR TITLE
[identity] Migrate AuthorizationCodeCredential to MSALClient

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - `DeviceCodeCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29405](https://github.com/Azure/azure-sdk-for-js/pull/29405)
 - `UsernamePasswordCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29656](https://github.com/Azure/azure-sdk-for-js/pull/29656)
-
+- `AuthorizationCodeCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29831](https://github.com/Azure/azure-sdk-for-js/pull/29831)
 
 ## 4.2.0 (2024-04-30)
 

--- a/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
@@ -128,16 +128,6 @@ export class AuthorizationCodeCredential implements TokenCredential {
       logger,
       tokenCredentialOptions: options ?? {},
     });
-    // this.msalFlow = new MsalAuthorizationCode({
-    //   ...options,
-    //   clientSecret,
-    //   clientId,
-    //   tenantId,
-    //   tokenCredentialOptions: options || {},
-    //   logger,
-    //   redirectUri: this.redirectUri,
-    //   authorizationCode: this.authorizationCode,
-    // });
   }
 
   /**
@@ -171,9 +161,6 @@ export class AuthorizationCodeCredential implements TokenCredential {
             disableAutomaticAuthentication: this.disableAutomaticAuthentication,
           },
         );
-        // return this.msalFlow.getToken(arrayScopes, {
-        //   ...newOptions,
-        // });
       },
     );
   }

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -70,6 +70,7 @@ export class DeviceCodeCredential implements TokenCredential {
     this.userPromptCallback = options?.userPromptCallback ?? defaultDeviceCodePromptCallback;
     this.msalClient = createMsalClient(clientId, tenantId, {
       ...options,
+      logger,
       tokenCredentialOptions: options || {},
     });
     this.disableAutomaticAuthentication = options?.disableAutomaticAuthentication;

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -577,9 +577,13 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
   ): Promise<AccessToken> {
     msalLogger.getToken.info(`Attempting to acquire token using authorization code`);
 
-    state.msalConfig.auth.clientSecret = clientSecret;
-
-    const msalApp = await getConfidentialApp(options);
+    let msalApp: msal.ConfidentialClientApplication | msal.PublicClientApplication;
+    if (clientSecret) {
+      state.msalConfig.auth.clientSecret = clientSecret;
+      msalApp = await getConfidentialApp(options);
+    } else {
+      msalApp = await getPublicApp(options);
+    }
 
     return withSilentAuthentication(msalApp, scopes, options, () => {
       return msalApp.acquireTokenByCode({

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -117,6 +117,26 @@ export interface MsalClient {
   ): Promise<AccessToken>;
 
   /**
+   * Retrieves an access token by using an authorization code flow.
+   *
+   * @param scopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param authorizationCode - An authorization code that was received from following the
+                              authorization code flow.  This authorization code must not
+                              have already been used to obtain an access token.
+   * @param redirectUri - The redirect URI that was used to request the authorization code.
+                        Must be the same URI that is configured for the App Registration.
+   * @param clientSecret - An optional client secret that was generated for the App Registration.
+   * @param options - Additional options that may be provided to the method.
+   */
+  getTokenByAuthorizationCode(
+    scopes: string[],
+    redirectUri: string,
+    authorizationCode: string,
+    clientSecret?: string,
+    options?: GetTokenWithSilentAuthOptions,
+  ): Promise<AccessToken>;
+
+  /**
    * Retrieves the last authenticated account. This method expects an authentication record to have been previously loaded.
    *
    * An authentication record could be loaded by calling the `getToken` method, or by providing an `authenticationRecord` when creating a credential.
@@ -548,6 +568,30 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     return msalToPublic(clientId, state.cachedAccount);
   }
 
+  async function getTokenByAuthorizationCode(
+    scopes: string[],
+    redirectUri: string,
+    authorizationCode: string,
+    clientSecret?: string,
+    options: GetTokenWithSilentAuthOptions = {},
+  ): Promise<AccessToken> {
+    msalLogger.getToken.info(`Attempting to acquire token using authorization code`);
+
+    state.msalConfig.auth.clientSecret = clientSecret;
+
+    const msalApp = await getConfidentialApp(options);
+
+    return withSilentAuthentication(msalApp, scopes, options, () => {
+      return msalApp.acquireTokenByCode({
+        scopes,
+        redirectUri,
+        code: authorizationCode,
+        authority: state.msalConfig.auth.authority,
+        claims: options?.claims,
+      });
+    });
+  }
+
   return {
     getActiveAccount,
     getTokenByClientSecret,
@@ -555,5 +599,6 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     getTokenByClientCertificate,
     getTokenByDeviceCode,
     getTokenByUsernamePassword,
+    getTokenByAuthorizationCode,
   };
 }

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -579,6 +579,8 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
 
     let msalApp: msal.ConfidentialClientApplication | msal.PublicClientApplication;
     if (clientSecret) {
+      // If a client secret is provided, we need to use a confidential client application
+      // See https://learn.microsoft.com/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-access-token-with-a-client_secret
       state.msalConfig.auth.clientSecret = clientSecret;
       msalApp = await getConfidentialApp(options);
     } else {

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -164,18 +164,13 @@ describe("MsalClient", function () {
   });
 
   describe("CAE support", function () {
-    let sandbox: sinon.SinonSandbox;
     let subject: msalClient.MsalClient;
 
     const clientId = "client-id";
     const tenantId = "tenant-id";
 
     afterEach(async function () {
-      sandbox.restore();
-    });
-
-    beforeEach(async function () {
-      sandbox = sinon.createSandbox();
+      sinon.restore();
     });
 
     describe("when CAE is enabled", function () {
@@ -191,7 +186,7 @@ describe("MsalClient", function () {
           beforeCacheAccess: sinon.stub(),
         };
 
-        sandbox.stub(msalPlugins, "generatePluginConfiguration").returns({
+        sinon.stub(msalPlugins, "generatePluginConfiguration").returns({
           broker: {
             isEnabled: false,
             enableMsaPassthrough: false,
@@ -235,7 +230,7 @@ describe("MsalClient", function () {
           beforeCacheAccess: sinon.stub(),
         };
 
-        sandbox.stub(msalPlugins, "generatePluginConfiguration").returns({
+        sinon.stub(msalPlugins, "generatePluginConfiguration").returns({
           broker: {
             isEnabled: false,
             enableMsaPassthrough: false,
@@ -268,9 +263,71 @@ describe("MsalClient", function () {
     });
   });
 
-  describe("#getTokenByDeviceCode", function () {
-    let sandbox: sinon.SinonSandbox;
+  describe("#getTokenByAuthorizationCode", function () {
+    const clientId = "client-id";
+    const tenantId = "tenant-id";
+    const fakeTokenResponse = {
+      accessToken: "token",
+      expiresOn: new Date(Date.now() + 3600 * 1000),
+      account: {
+        environment: "environment",
+        homeAccountId: "homeAccountId",
+        localAccountId: "localAccountId",
+        tenantId: "tenantId",
+        username: "username",
+      },
+    };
+    const scopes = ["https://vault.azure.net/.default"];
 
+    afterEach(async function () {
+      sinon.restore();
+    });
+
+    describe("with clientSecret", function () {
+      it("uses a confidentialClientApplication", async function () {
+        const client = msalClient.createMsalClient(clientId, tenantId);
+
+        const publicClientStub = sinon.stub(
+          PublicClientApplication.prototype,
+          "acquireTokenByCode",
+        );
+        const confidentialClientStub = sinon
+          .stub(ConfidentialClientApplication.prototype, "acquireTokenByCode")
+          .resolves(fakeTokenResponse as AuthenticationResult);
+
+        await client.getTokenByAuthorizationCode(scopes, "code", "redirectUri", "clientSecret");
+
+        assert.equal(publicClientStub.callCount, 0);
+        assert.equal(confidentialClientStub.callCount, 1);
+      });
+    });
+
+    describe("without clientSecret", function () {
+      it("uses a publicClientApplication", async function () {
+        const client = msalClient.createMsalClient(clientId, tenantId);
+
+        const publicClientStub = sinon
+          .stub(PublicClientApplication.prototype, "acquireTokenByCode")
+          .resolves(fakeTokenResponse as AuthenticationResult);
+        const confidentialClientStub = sinon.stub(
+          ConfidentialClientApplication.prototype,
+          "acquireTokenByCode",
+        );
+
+        await client.getTokenByAuthorizationCode(
+          scopes,
+          "code",
+          "redirectUri",
+          undefined /* clientSecret */,
+        );
+
+        assert.equal(publicClientStub.callCount, 1);
+        assert.equal(confidentialClientStub.callCount, 0);
+      });
+    });
+  });
+
+  describe("#getTokenByDeviceCode", function () {
     const clientId = "client-id";
     const tenantId = "tenant-id";
     const deviceCodeCallback: () => void = () => {
@@ -278,11 +335,7 @@ describe("MsalClient", function () {
     };
 
     afterEach(async function () {
-      sandbox.restore();
-    });
-
-    beforeEach(async function () {
-      sandbox = sinon.createSandbox();
+      sinon.restore();
     });
 
     describe("with silent authentication", function () {
@@ -299,7 +352,7 @@ describe("MsalClient", function () {
           authenticationRecord,
         });
 
-        const silentAuthSpy = sandbox
+        const silentAuthSpy = sinon
           .stub(ClientApplication.prototype, "acquireTokenSilent")
           .resolves({
             accessToken: "token",
@@ -319,14 +372,14 @@ describe("MsalClient", function () {
       });
 
       it("attempts silent authentication without AuthenticationRecord", async function () {
-        const silentAuthStub = sandbox
+        const silentAuthStub = sinon
           .stub(ClientApplication.prototype, "acquireTokenSilent")
           .resolves({
             accessToken: "token",
             expiresOn: new Date(),
           } as AuthenticationResult);
 
-        const clientCredentialAuthStub = sandbox
+        const clientCredentialAuthStub = sinon
           .stub(PublicClientApplication.prototype, "acquireTokenByDeviceCode")
           .resolves({
             accessToken: "token",
@@ -371,7 +424,7 @@ describe("MsalClient", function () {
           },
         });
 
-        sandbox
+        sinon
           .stub(ClientApplication.prototype, "acquireTokenSilent")
           .rejects(new AbortError("operation has been aborted")); // AbortErrors should get re-thrown
 
@@ -385,7 +438,7 @@ describe("MsalClient", function () {
 
       it("throws when silentAuthentication fails and disableAutomaticAuthentication is true", async function () {
         const scopes = ["https://vault.azure.net/.default"];
-        sandbox
+        sinon
           .stub(ClientApplication.prototype, "acquireTokenSilent")
           .rejects(new AuthenticationRequiredError({ scopes }));
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #29406

### Describe the problem that is addressed by this PR

Following the existing patterns, this PR migrates AuthorizationCodeCredential to
the MSALClient, moving away from MSALNodeCommon

### Are there test cases added in this PR? _(If not, why?)_

It's a tricky flow to test end-to-end; however, I plan to add tests either here
or in a follow-up PR where possible.

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
