### PR TITLE
[amqp messaging] Use zero length byte array for missing message body

### DIFF
--- a/sdk/eventhub/event-hubs/test/internal/dataTransformer.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/dataTransformer.spec.ts
@@ -79,7 +79,7 @@ testWithServiceTypes(() => {
       it("should correctly encode/decode a null message body", (done) => {
         const encoded: any = transformer.encode(nullBody, "data");
         encoded.typecode.should.equal(117);
-        isBuffer(encoded.content).should.equal(false);
+        isBuffer(encoded.content).should.equal(true);
         const { body: decoded, bodyType: decodedType } = transformer.decode(encoded, false);
         should.equal(decodedType, bodyType);
         should.equal(decoded, nullBody);
@@ -89,7 +89,7 @@ testWithServiceTypes(() => {
       it("should correctly encode/decode an undefined message body", (done) => {
         const encoded: any = transformer.encode(undefinedBody, "data");
         encoded.typecode.should.equal(117);
-        isBuffer(encoded.content).should.equal(false);
+        isBuffer(encoded.content).should.equal(true);
         const { body: decoded, bodyType: decodedType } = transformer.decode(encoded, false);
         should.equal(decodedType, bodyType);
         should.equal(decoded, nullBody);

--- a/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
@@ -151,6 +151,15 @@ testWithServiceTypes((serviceVersion) => {
         const event = await receiveEvent(startingPositions);
         should.equal(event.body, testEvent.body, "Unexpected body on the received event.");
       });
+
+      it(`undefined body is coerced to null`, async () => {
+        const startingPositions = await getStartingPositionsForTests(consumerClient);
+        const testEvent: EventData = { body: undefined };
+        await producerClient.sendBatch([testEvent]);
+
+        const event = await receiveEvent(startingPositions);
+        should.equal(event.body, null, "Unexpected body on the received event.");
+      });
     });
   });
 });

--- a/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/amqpUnitTests.spec.ts
@@ -151,11 +151,9 @@ describe("AMQP message encoding", () => {
 
       const rheaMessage = toRheaMessage(serviceBusReceivedMessage, defaultDataTransformer);
 
-      if (!isRheaAmqpSection(rheaMessage.body)) {
-        throw new Error("rheaMessage.body was not a rhea section");
-      }
-
-      assert.equal(rheaMessage.body.typecode, dataSectionTypeCode);
+      console.dir(rheaMessage.body);
+      assert.equal(rheaMessage.body.typecode, 117);
+      assert.deepEqual(rheaMessage.body.content, Buffer.alloc(0));
     });
 
     it("ServiceBusReceivedMessage (but was decoded from 'value')", () => {

--- a/sdk/servicebus/service-bus/test/internal/unit/dataTransformer.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/dataTransformer.spec.ts
@@ -81,8 +81,9 @@ describe("DataTransformer", function () {
     const encoded: any = transformer.encode(nullBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
-    const decoded: any = transformer.decode(encoded, false);
-    should.equal(decoded, nullBody);
+    const decoded: any = transformer.decodeWithType(encoded, false);
+    should.equal(decoded.body, nullBody);
+    should.equal(decoded.bodyType, "data");
     done();
   });
 
@@ -90,8 +91,9 @@ describe("DataTransformer", function () {
     const encoded: any = transformer.encode(undefinedBody, "data");
     encoded.typecode.should.equal(117);
     isBuffer(encoded.content).should.equal(true);
-    const decoded: any = transformer.decode(encoded, false);
-    should.equal(decoded, nullBody);
+    const decoded: any = transformer.decodeWithType(encoded, false);
+    should.equal(decoded.body, nullBody);
+    should.equal(decoded.bodyType, "data");
     done();
   });
 
@@ -134,7 +136,6 @@ describe("DataTransformer", function () {
   it("should correctly encode/decode a Uint8Array message body", function (done) {
     const encoded: any = transformer.encode(uint8ArrayBody, "data");
     encoded.typecode.should.equal(117);
-    console.dir({ encoded });
     (encoded.content instanceof Uint8Array).should.equal(true);
     (encoded.content as Uint8Array).length.should.equal(4);
     const decoded: any = transformer.decode(encoded, false);


### PR DESCRIPTION
Currently we send a data section of `null` when message body is `null` or `undefined`.  This works fine within JS land but cause interop issues with other languages because they don't expect a data section of null marker.

This PR changes to use empty byte array to denote body that doesn't exist, which is the prevailing approach in Amqp space. Internally when data type is `data`, we send a data section of `Buffer.alloc(0)` to indicate empty body, and decode `Buffer` of zero byteLength as null on the receiving side.

### Packages impacted by this PR
@azure/event-hubs and @azure/service-bus
