### PR TITLE
Revert "[test-util] Move core-tracing to peerDependencies (#29775)"

### DIFF
--- a/common/tools/dev-tool/src/commands/run/bundle.ts
+++ b/common/tools/dev-tool/src/commands/run/bundle.ts
@@ -100,7 +100,6 @@ export default leafCommand(commandInfo, async (options) => {
         ...nodeBuiltins,
         ...Object.keys(info.packageJson.dependencies),
         ...Object.keys(info.packageJson.devDependencies),
-        ...Object.keys(info.packageJson.peerDependencies ?? {}),
       ],
       preserveSymlinks: false,
       plugins: [nodeResolve(), sourcemaps()],

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -60,7 +60,6 @@ declare global {
     private: boolean;
 
     dependencies: Record<string, string>;
-    peerDependencies?: Record<string, string>;
     devDependencies: Record<string, string>;
 
     [METADATA_KEY]?: AzureSdkMetadata;

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -58,6 +58,7 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-rest-pipeline": "^1.1.0",
+    "@azure/core-tracing": "^1.0.0",
     "@opentelemetry/api": "^1.8.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.4",
@@ -66,9 +67,6 @@
     "chai-exclude": "^2.1.0",
     "mocha": "^10.0.0",
     "tslib": "^2.2.0"
-  },
-  "peerDependencies": {
-    "@azure/core-tracing": "^1.0.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",


### PR DESCRIPTION
This reverts commit 11da2154832fdaba7fc1a62590d6285f779960ca.

Unfortunately, rush does not play well with peerDeps and I am bumping into https://github.com/microsoft/rushstack/issues/1415

I really wanted this to work but rather than continue going down this path I think it's safer to revert and find an alternative
given the issues with rush and pnpm