### PR TITLE
[Monitor OpenTelemetry] Fix Zero Sampling Ratio

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased ()
 
+### Bugs Fixed
+
+- Setting the sampling ratio to 0 now correctly applies the value instead of defaulting to 1.
+
 ### Other Changes
 
 - Add support for tracking Application Insights shim usage to statsbeat.

--- a/sdk/monitor/monitor-opentelemetry/src/browserSdkLoader/browserSdkLoader.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/browserSdkLoader/browserSdkLoader.ts
@@ -9,6 +9,7 @@ import { ConnectionStringParser } from "../utils/connectionStringParser";
 import { IncomingMessage, ServerResponse } from "http";
 import { Logger } from "../shared/logging/logger";
 import { BROWSER_SDK_LOADER_DEFAULT_SOURCE } from "../types";
+import { diag } from "@opentelemetry/api";
 
 export class BrowserSdkLoader {
   private static _instance: BrowserSdkLoader | null;
@@ -21,9 +22,7 @@ export class BrowserSdkLoader {
 
   constructor(config: InternalConfig) {
     if (!!BrowserSdkLoader._instance) {
-      throw new Error(
-        "Browser SDK Loader should be configured from the applicationInsights object",
-      );
+      diag.warn("Browser SDK Loader should be configured from the applicationInsights object");
     }
 
     BrowserSdkLoader._instance = this;

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -91,7 +91,9 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
         options.instrumentationOptions,
       );
       this.resource = Object.assign(this.resource, options.resource);
-      this.samplingRatio = options.samplingRatio || this.samplingRatio;
+      if (typeof(options.samplingRatio) === "number") {
+        this.samplingRatio = options.samplingRatio;
+      }
       this.browserSdkLoaderOptions = Object.assign(
         this.browserSdkLoaderOptions,
         options.browserSdkLoaderOptions,

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -91,9 +91,8 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
         options.instrumentationOptions,
       );
       this.resource = Object.assign(this.resource, options.resource);
-      if (typeof options.samplingRatio === "number") {
-        this.samplingRatio = options.samplingRatio;
-      }
+      this.samplingRatio =
+        options.samplingRatio !== undefined ? options.samplingRatio : this.samplingRatio;
       this.browserSdkLoaderOptions = Object.assign(
         this.browserSdkLoaderOptions,
         options.browserSdkLoaderOptions,

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -91,7 +91,7 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
         options.instrumentationOptions,
       );
       this.resource = Object.assign(this.resource, options.resource);
-      if (typeof(options.samplingRatio) === "number") {
+      if (typeof options.samplingRatio === "number") {
         this.samplingRatio = options.samplingRatio;
       }
       this.browserSdkLoaderOptions = Object.assign(

--- a/sdk/monitor/monitor-opentelemetry/src/traces/sampler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/sampler.ts
@@ -19,7 +19,11 @@ export class ApplicationInsightsSampler implements Sampler {
    */
   constructor(samplingRatio: number = 1) {
     this._samplingRatio = samplingRatio;
-    if (this._samplingRatio > 1 || this._samplingRatio < 0 || !Number.isFinite(this._samplingRatio)) {
+    if (
+      this._samplingRatio > 1 ||
+      this._samplingRatio < 0 ||
+      !Number.isFinite(this._samplingRatio)
+    ) {
       diag.warn("Invalid sampling rate, sampling rate must be a value in the range [0,1].");
     }
     this._sampleRate = Math.round(this._samplingRatio * 100);

--- a/sdk/monitor/monitor-opentelemetry/src/traces/sampler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/sampler.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Link, Attributes, SpanKind, Context } from "@opentelemetry/api";
+import { Link, Attributes, SpanKind, Context, diag } from "@opentelemetry/api";
 import { Sampler, SamplingDecision, SamplingResult } from "@opentelemetry/sdk-trace-base";
 
 /**
@@ -20,7 +20,7 @@ export class ApplicationInsightsSampler implements Sampler {
   constructor(samplingRatio: number = 1) {
     this._samplingRatio = samplingRatio;
     if (this._samplingRatio > 1 || this._samplingRatio < 0 || !Number.isFinite(this._samplingRatio)) {
-      throw new Error("Invalid sampling rate, sampling rate must be a value in the range [0,1].");
+      diag.warn("Invalid sampling rate, sampling rate must be a value in the range [0,1].");
     }
     this._sampleRate = Math.round(this._samplingRatio * 100);
   }

--- a/sdk/monitor/monitor-opentelemetry/src/traces/sampler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/sampler.ts
@@ -19,7 +19,7 @@ export class ApplicationInsightsSampler implements Sampler {
    */
   constructor(samplingRatio: number = 1) {
     this._samplingRatio = samplingRatio;
-    if (this._samplingRatio > 1) {
+    if (this._samplingRatio > 1 || this._samplingRatio < 0 || !Number.isFinite(this._samplingRatio)) {
       throw new Error("Invalid sampling rate, sampling rate must be a value in the range [0,1].");
     }
     this._sampleRate = Math.round(this._samplingRatio * 100);

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -256,6 +256,12 @@ describe("Library/Config", () => {
       assert.ok(typeof config.samplingRatio === "number");
     });
 
+    it("should accept zero sampling ratio", () => {
+      const config = new InternalConfig();
+      config.samplingRatio = 0;
+      assert.strictEqual(config.samplingRatio, 0);
+    });
+
     it("instrumentation key validation-valid key passed", () => {
       const warnStub = sandbox.stub(console, "warn");
       const config = new InternalConfig();


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
Currently setting a 0 sampling ratio will fall back to the default sampling ratio of 1.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
