### PR TITLE
[web pub sub] update express to ESM

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21663,7 +21663,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-RBEpLP5B1aAAf4iTK9r4N6g77n24F4zeaVZ0z9E6PFacbszFJ3h9I08r+w7KjSPKITOquC0+otdOJw2j/zsxvw==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-bez1TxrezRQsChge0JC8h1Yw+30+LfyTUCDwfZUEt5qSwigyIoAY+c1JP6ETGRZ0ZhWqPcKZEHchn8923jACug==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -21698,7 +21698,7 @@ packages:
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-h+uhqPeVXpFWuwP2hECZ/VtNUBMda9US9itPi481shpCIS9lIXaTElGhR6+cdiasEfBgjOn5OW1jRks01yP2vw==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-uHI/C3l3+w6e1PwyU3lcaw+ZIkkAnMVEwkS25/O1Bh/nJT5XWZWJeS5r6nK5bASCRJ9h/5VouPnwme45uiWOwA==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -21746,7 +21746,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-HbWJ6LVOP5aHHrp0Ve4YP6TJ1sbzFMenebQu2Uy1OlsxjjxfZr0FbSj20aHxliyVxMGhMN107PL9YeoLqExrYQ==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-+SUfKUZID+J5rONvscLV2mFT8ARnOiDhvDyiKtdBs8sauB/ht8rCY5Fvx2MTqwfIxeCxwNzVh9imhRTnFUPu/Q==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -21935,7 +21935,7 @@ packages:
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-JZIZCjOmPbiKTkvQF7JtUNfbomWa6GE4a9ot6hvFA8PQmwN3WPb+0u7iEPt/rMIAASE+a6JkgHchQ+Q4PgOujA==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-odT/FVeffhudC/PGQIjGfFf83o5xvelcfY2GmfsffV6urdfJt+lEbd2ZpVa7iamWQQPeqBP1MDjTwrLXm1ygYQ==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -22272,7 +22272,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-CcTaHO08tDr9UWe44ob9/YIl4PpsYsQ7GczD6UAprlHR/Rcb3+XP2VKktNr4QcUZhsu6KHM8Dui6KbLmtmUtMg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-L0p8dt8jdIoONSVU73sloWfrAU8M2Avaug9lVEM6kRdqwejCeQ6rwad78GIH0aGoxOOBH2/mRd0flReeo4Vrvw==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -23924,7 +23924,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-F6zi+OEVdbjyA9WHbPYJ5IPxwqV4GftEL9ts0Un9XI69az7MRx4AzDqjBT2fMRRQqBev8nwSsFuaFjO/Ie5cDg==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-ict/z75N78D5XK7o3CQg/Iqy1KENQJYBu00zeOV8T2uo7LUpewOptrvHbgHTwXGvzDWNNqFuWtar+wKlMThxjw==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -23936,6 +23936,8 @@ packages:
       '@types/mocha': 10.0.6
       '@types/node': 18.19.33
       '@types/sinon': 17.0.3
+      '@vitest/browser': 1.6.0(playwright@1.44.1)(vitest@1.6.0)
+      '@vitest/coverage-istanbul': 1.6.0(vitest@1.6.0)
       chai: 4.3.10
       cross-env: 7.0.3
       dotenv: 16.4.5
@@ -23948,14 +23950,25 @@ packages:
       sinon: 17.0.1
       source-map-support: 0.5.21
       ts-node: 10.9.2(@types/node@18.19.33)(typescript@5.4.5)
+      tshy: 1.14.0
       tslib: 2.6.2
       typescript: 5.4.5
+      vitest: 1.6.0(@types/node@18.19.33)(@vitest/browser@1.6.0)
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - bufferutil
+      - '@edge-runtime/vm'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - lightningcss
+      - playwright
+      - safaridriver
+      - sass
+      - stylus
+      - sugarss
       - supports-color
-      - utf-8-validate
+      - terser
+      - webdriverio
     dev: false
 
   file:projects/web-pubsub.tgz:

--- a/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
+++ b/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
@@ -1,8 +1,13 @@
 {
-  "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "plugins": [
+    "@azure/azure-sdk"
+  ],
+  "extends": [
+    "plugin:@azure/azure-sdk/azure-sdk-base"
+  ],
   "rules": {
     "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off"
+    "@azure/azure-sdk/ts-package-json-types": "off",
+    "@azure/azure-sdk/ts-package-json-files-required": "off"
   }
 }

--- a/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
+++ b/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
@@ -1,10 +1,6 @@
 {
-  "plugins": [
-    "@azure/azure-sdk"
-  ],
-  "extends": [
-    "plugin:@azure/azure-sdk/azure-sdk-base"
-  ],
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
     "@azure/azure-sdk/ts-package-json-module": "off",
     "@azure/azure-sdk/ts-package-json-types": "off",

--- a/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
+++ b/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
@@ -1,4 +1,8 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
+  "rules": {
+    "@azure/azure-sdk/ts-package-json-module": "off",
+    "@azure/azure-sdk/ts-package-json-types": "off"
+  }
 }

--- a/sdk/web-pubsub/web-pubsub-express/.tshy/build.json
+++ b/sdk/web-pubsub/web-pubsub-express/.tshy/build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../src",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/sdk/web-pubsub/web-pubsub-express/.tshy/commonjs.json
+++ b/sdk/web-pubsub/web-pubsub-express/.tshy/commonjs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.cts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [
+    "../src/**/*.mts"
+  ],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/commonjs"
+  }
+}

--- a/sdk/web-pubsub/web-pubsub-express/.tshy/esm.json
+++ b/sdk/web-pubsub/web-pubsub-express/.tshy/esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./build.json",
+  "include": [
+    "../src/**/*.ts",
+    "../src/**/*.mts",
+    "../src/**/*.tsx"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "outDir": "../.tshy-build/esm"
+  }
+}

--- a/sdk/web-pubsub/web-pubsub-express/api-extractor.json
+++ b/sdk/web-pubsub/web-pubsub-express/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "types/src/index.d.ts",
+  "mainEntryPointFilePath": "dist/esm/index.d.ts",
   "docModel": {
     "enabled": true
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/web-pubsub-express.d.ts"
+    "publicTrimmedFilePath": "./dist/web-pubsub-express.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -31,8 +31,7 @@
   "files": [
     "dist/",
     "README.md",
-    "LICENSE",
-    "dist-esm/src"
+    "LICENSE"
   ],
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -3,21 +3,18 @@
   "version": "1.0.6",
   "description": "Azure Web PubSub CloudEvents handlers",
   "sdk-type": "client",
-  "main": "dist/index.js",
-  "module": "dist-esm/src/index.js",
-  "types": "types/web-pubsub-express.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo \"Browser is not supported.\" && exit 0",
-    "build:node": "tsc -p . && dev-tool run bundle --browser-test=false",
+    "build:node": "tshy",
     "build:samples": "echo Obsolete.",
-    "build:test": "tsc -p . && dev-tool run bundle --browser-test=false",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle --browser-test=false && dev-tool run extract-api",
+    "build:test": "tshy",
+    "build": "npm run clean && tshy && dev-tool run bundle --browser-test=false && dev-tool run extract-api",
     "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf --glob dist dist-esm test-dist temp types *.tgz *.log",
     "execute:samples": "dev-tool samples run samples-dev",
-    "extract-api": "tsc -p . && dev-tool run extract-api",
+    "extract-api": "tshy && dev-tool run extract-api",
     "integration-test:browser": "echo \"Browser is not supported.\" && exit 0",
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
@@ -28,16 +25,14 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo \"Browser is not supported.\" && exit 0",
-    "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy",
+    "unit-test:node": "dev-tool run test:vitest --no-test-proxy",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [
     "dist/",
-    "dist-esm/",
-    "types/web-pubsub-express.d.ts",
-    "types/web-pubsub-express.d.ts.map",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "dist-esm/src"
   ],
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
@@ -55,38 +50,58 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/web-pubsub/web-pubsub-express/README.md",
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^2.2.0",
-    "@azure/logger": "^1.0.0"
+    "@azure/logger": "^1.1.2",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@microsoft/api-extractor": "^7.31.1",
-    "@types/chai": "^4.1.6",
     "@types/express": "^4.16.0",
     "@types/express-serve-static-core": "^4.17.19",
     "@types/jsonwebtoken": "^9.0.0",
-    "@types/mocha": "^10.0.0",
     "@types/node": "^18.0.0",
-    "@types/sinon": "^17.0.0",
-    "chai": "^4.2.0",
-    "cross-env": "^7.0.2",
+    "@vitest/browser": "^1.6.0",
+    "@vitest/coverage-istanbul": "^1.6.0",
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "express": "^4.16.3",
-    "mocha": "^10.0.0",
-    "nyc": "^15.1.0",
-    "puppeteer": "^22.2.0",
     "rimraf": "^5.0.5",
-    "sinon": "^17.0.0",
-    "source-map-support": "^0.5.9",
+    "tshy": "^1.14.0",
     "typescript": "~5.4.5",
-    "ts-node": "^10.0.0"
+    "vitest": "^1.6.0"
   },
   "//sampleConfiguration": {
     "productName": "Azure Web PubSub CloudEvents Handlers for Express",
     "productSlugs": [
       "azure"
     ]
-  }
+  },
+  "tshy": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "dialects": [
+      "esm",
+      "commonjs"
+    ],
+    "selfLink": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  },
+  "main": "dist/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "type": "module"
 }

--- a/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
+++ b/sdk/web-pubsub/web-pubsub-express/samples-dev/server.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates handling Web PubSub CloudEvents with Express
@@ -21,7 +21,7 @@ const handler = new WebPubSubEventHandler("chat", {
     console.log(connectedRequest);
   },
   handleUserEvent(req, res) {
-    var calledTime = req.context.states.calledTime++;
+    const calledTime = req.context.states.calledTime++;
     console.log(calledTime);
     // You can also set the state here
     res.setState("calledTime", calledTime);

--- a/sdk/web-pubsub/web-pubsub-express/samples-dev/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-express/samples-dev/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "module": "CommonJS"
-  },
-  "include": ["*.ts"],
-  "exclude": []
-}

--- a/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/cloudEventsDispatcher.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as utils from "./utils";
-import { IncomingMessage, ServerResponse } from "http";
-import { URL } from "url";
-import { logger } from "./logger";
+import * as utils from "./utils.js";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { URL } from "node:url";
+import { logger } from "./logger.js";
 
-import {
+import type {
   ConnectRequest,
   ConnectResponse,
   ConnectedRequest,
@@ -16,7 +16,7 @@ import {
   UserEventRequest,
   UserEventResponseHandler,
   WebPubSubEventHandlerOptions,
-} from "./cloudEventsProtocols";
+} from "./cloudEventsProtocols.js";
 
 enum EventType {
   Connect,

--- a/sdk/web-pubsub/web-pubsub-express/src/index.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-export { WebPubSubEventHandler } from "./webPubSubEventHandler";
+export { WebPubSubEventHandler } from "./webPubSubEventHandler.js";
 
-export * from "./cloudEventsProtocols";
+export * from "./cloudEventsProtocols.js";

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IncomingMessage } from "http";
+import { IncomingMessage } from "node:http";
 
 function isJsonObject(obj: any): boolean {
   return obj && typeof obj === "object" && !Array.isArray(obj);

--- a/sdk/web-pubsub/web-pubsub-express/src/webPubSubEventHandler.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/webPubSubEventHandler.ts
@@ -3,8 +3,8 @@
 
 import express from "express-serve-static-core";
 
-import { CloudEventsDispatcher } from "./cloudEventsDispatcher";
-import { WebPubSubEventHandlerOptions } from "./cloudEventsProtocols";
+import { CloudEventsDispatcher } from "./cloudEventsDispatcher.js";
+import { WebPubSubEventHandlerOptions } from "./cloudEventsProtocols.js";
 
 /**
  * The handler to handle incoming CloudEvents messages

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint-disable no-invalid-this */
-import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher";
-import { assert } from "chai";
-import { IncomingMessage, ServerResponse } from "http";
+
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
+import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher.js";
+import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "net";
-import * as sinon from "sinon";
-import { toBase64JsonString } from "../src/utils";
+import { toBase64JsonString } from "../src/utils.js";
 
 function buildRequest(
   req: IncomingMessage,
@@ -47,48 +47,48 @@ describe("Can handle connect event", function () {
   });
 
   it("Should not handle the request if request is not cloud events", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = vi.spyOn(res, "end");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should not handle the request if hub does not match", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should response with 200 when option is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub");
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {});
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response with error when handler returns error", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -100,12 +100,12 @@ describe("Can handle connect event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(400, res.statusCode, "should be error");
   });
 
   it("Should response with success when handler returns success", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -117,12 +117,12 @@ describe("Can handle connect event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
   });
 
   it("Should response with success when handler returns success value", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -134,12 +134,12 @@ describe("Can handle connect event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
   });
 
   it("Should be able to set connection state", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -155,7 +155,7 @@ describe("Can handle connect event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(
       toBase64JsonString({
         key1: ["val3"],
@@ -168,7 +168,7 @@ describe("Can handle connect event", function () {
   });
 
   it("Should be able to get the connection states if it exists in the header", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     const states = toBase64JsonString({
       key1: ["val3"],
       key2: "val2",
@@ -187,12 +187,12 @@ describe("Can handle connect event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
   });
 
   it("Invalid state header gets ignored", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub1", "conn1", undefined, "");
     const dispatcher = new CloudEventsDispatcher("hub1", {
       handleConnect: (request, response) => {
@@ -204,7 +204,7 @@ describe("Can handle connect event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
   });
 });

--- a/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint-disable no-invalid-this */
-import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher";
-import { assert } from "chai";
-import { IncomingMessage, ServerResponse } from "http";
-import { Socket } from "net";
-import * as sinon from "sinon";
+
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
+import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher.js";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 
 function buildRequest(
   req: IncomingMessage,
@@ -44,48 +44,48 @@ describe("Can handle connected event", function () {
   });
 
   it("Should not handle the request if request is not cloud events", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = vi.spyOn(res, "end");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should not handle the request if hub does not match", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should response with 200 when option is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub");
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {});
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response 200 even the event handler throws", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -97,7 +97,7 @@ describe("Can handle connected event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be error");
   });
 });

--- a/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint-disable no-invalid-this */
-import { WebPubSubEventHandler } from "../src/webPubSubEventHandler";
-import { assert } from "chai";
 
-describe("Can creat event handler", function () {
+import { describe, it, assert } from "vitest";
+import { WebPubSubEventHandler } from "../src/webPubSubEventHandler.js";
+
+describe("Can create event handler", function () {
   it("Can provide default path", function () {
     const dispatcher = new WebPubSubEventHandler("hub");
     assert.equal("/api/webpubsub/hubs/hub/", dispatcher.path);

--- a/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint-disable no-invalid-this */
+
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
 import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher";
-import { assert } from "chai";
-import { IncomingMessage, ServerResponse } from "http";
-import { Socket } from "net";
-import * as sinon from "sinon";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 
 function buildRequest(
   req: IncomingMessage,
@@ -44,52 +44,52 @@ describe("Can handle disconnected event", function () {
   });
 
   it("Should not handle the request if request is not cloud events", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = vi.spyOn(res, "end");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should not handle the request if hub does not match", async function () {
-    const endSpy = sinon.spy(res.end);
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should response with 200 when option is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub");
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {});
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response 200 even the event handler throws", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
-      onConnected: async (_) => {
+      onConnected: async () => {
         throw new Error();
       },
     });
@@ -97,7 +97,7 @@ describe("Can handle disconnected event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be error");
   });
 });

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint-disable no-invalid-this */
-import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher";
-import { assert } from "chai";
-import { IncomingMessage, ServerResponse } from "http";
-import { Socket } from "net";
-import * as sinon from "sinon";
+
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
+import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher.js";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 
 function buildRequest(
   req: IncomingMessage,
@@ -49,25 +49,25 @@ describe("Can handle user event", function () {
   });
 
   it("Should not handle the request if request is not cloud events", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should not handle the request if hub does not match", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub1");
     const result = await dispatcher.handleRequest(req, res);
     assert.isFalse(result);
-    assert.isTrue(endSpy.notCalled);
+    expect(endSpy).not.toBeCalled();
   });
 
   it("Should handle number requests", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -84,11 +84,11 @@ describe("Can handle user event", function () {
 
     assert.isTrue(result);
     assert.equal(200, res.statusCode, "should be 200");
-    assert.isTrue(endSpy.calledOnce);
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should handle boolean requests", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -105,11 +105,11 @@ describe("Can handle user event", function () {
 
     assert.isTrue(result);
     assert.equal(200, res.statusCode, "should be 200");
-    assert.isTrue(endSpy.calledOnce);
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should handle complex object requests", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -125,11 +125,11 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result);
-    assert.isTrue(endSpy.calledOnce);
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should handle complex array requests", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -146,11 +146,11 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result);
-    assert.isTrue(endSpy.calledOnce);
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should handle binary requests", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1", "user1", "application/octet-stream");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -171,11 +171,11 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result, "should be able to process");
-    assert.isTrue(endSpy.calledOnce, "should be called once");
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should handle text requests", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1", "user1", "text/plain");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -192,11 +192,11 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result, "should be able to process");
-    assert.isTrue(endSpy.calledOnce, "should be called once");
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should handle text requests with charset", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1", "user1", "text/plain; charset=UTF-8;");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -213,33 +213,33 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result, "should be able to process");
-    assert.isTrue(endSpy.calledOnce, "should be called once");
+    expect(endSpy).toBeCalledTimes(1);
   });
 
   it("Should response with 200 when option is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub");
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {});
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be 200");
   });
 
   it("Should response with error when handler returns error", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -251,12 +251,12 @@ describe("Can handle user event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(500, res.statusCode, "should be error");
   });
 
   it("Should response with success when handler returns success", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -268,12 +268,12 @@ describe("Can handle user event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
   });
 
   it("Should response with success when returns success binary", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -285,13 +285,13 @@ describe("Can handle user event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
     assert.equal("application/octet-stream", res.getHeader("content-type"), "should be binary");
   });
 
   it("Should response with success when returns success text", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -303,13 +303,13 @@ describe("Can handle user event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
     assert.equal("text/plain; charset=utf-8", res.getHeader("content-type"), "should be text");
   });
 
   it("Should response with success when returns success json", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -321,7 +321,7 @@ describe("Can handle user event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
     assert.equal(
       "application/json; charset=utf-8",
@@ -331,7 +331,7 @@ describe("Can handle user event", function () {
   });
 
   it("Should be able to set connection state", async function () {
-    const endSpy = sinon.spy(res, "end");
+    const endSpy = vi.spyOn(res, "end");
     buildRequest(req, "hub", "conn1");
 
     const dispatcher = new CloudEventsDispatcher("hub", {
@@ -347,7 +347,7 @@ describe("Can handle user event", function () {
     mockBody(req, JSON.stringify({}));
     const result = await process;
     assert.isTrue(result, "should handle");
-    assert.isTrue(endSpy.calledOnce, "should call once");
+    expect(endSpy).toBeCalledTimes(1);
     assert.equal(200, res.statusCode, "should be success");
 
     assert.equal(

--- a/sdk/web-pubsub/web-pubsub-express/test/validate.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/validate.spec.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint-disable no-invalid-this */
-import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher";
-import { assert } from "chai";
-import { IncomingMessage, ServerResponse } from "http";
-import { Socket } from "net";
+
+import { describe, it, assert } from "vitest";
+import { CloudEventsDispatcher } from "../src/cloudEventsDispatcher.js";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 
 describe("Abuse protection works", function () {
   it("Only requests with valid header will be processed", function () {

--- a/sdk/web-pubsub/web-pubsub-express/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-express/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
-    "outDir": "./dist-esm",
-    "declarationDir": "./types",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
     "paths": {
-      "@azure/web-pubsub-express": ["./src/index"]
+      "@azure/web-pubsub-express": ["./src/index.ts"]
     }
   },
-  "include": ["src/**/*.ts", "test/**/*.ts", "samples-dev/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.cts", "src/**/*.mts", "test/**/*.ts", "samples-dev/**/*.ts"]
 }

--- a/sdk/web-pubsub/web-pubsub-express/vitest.config.ts
+++ b/sdk/web-pubsub/web-pubsub-express/vitest.config.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    reporters: ["basic", "junit"],
+    outputFile: {
+      junit: "test-results.xml",
+    },
+    fakeTimers: {
+      toFake: ["setTimeout", "Date"],
+    },
+    watch: false,
+    include: ["test/**/*.spec.ts"],
+    exclude: ["test/**/browser/*.spec.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*-browser.mts",
+        "src/**/*-react-native.mts",
+        "vitest*.config.ts",
+        "samples-dev/**/*.ts",
+      ],
+      provider: "istanbul",
+      reporter: ["text", "json", "html"],
+      reportsDirectory: "coverage",
+    },
+  },
+});


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/web-pubsub-express

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Updates to ESM via `tshy` and moves from Mocha/Chai/Sinon to `vitest`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
