### PR TITLE
[@azure/monitor-query] Provide sovereign cloud support for monitor SDKs

### DIFF
--- a/sdk/monitor/monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/monitor-ingestion/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.1.0 (2024-06-11)
 
 ### Features Added
 
-### Breaking Changes
+- Added `audience` support for the ingestion client  to specify the audience for the authentication token. This is useful when working  in sovereign clouds. Refer [#27280](https://github.com/Azure/azure-sdk-for-js/issues/27280) for further details.
 
 ### Bugs Fixed
 
 - React-Native support for `zlib` via the `pako` package.
-
-### Other Changes
 
 ## 1.0.0 (2023-02-15)
 

--- a/sdk/monitor/monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/monitor-ingestion/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `audience` support for the ingestion client  to specify the audience for the authentication token. This is useful when working  in sovereign clouds. Refer [#27280](https://github.com/Azure/azure-sdk-for-js/issues/27280) for further details.
+- Added `audience` support for the logs ingestion client to specify the audience for the authentication token. This feature is necessary to use a sovereign cloud. Refer to [#27280](https://github.com/Azure/azure-sdk-for-js/issues/27280) for further details.
 
 ### Bugs Fixed
 

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -261,9 +261,6 @@ const logsIngestionClient = new LogsIngestionClient(logsIngestionEndpoint, crede
 });
 ```
 
-**Note**: Currently, `MetricsQueryClient` uses the Azure Resource Manager (ARM) endpoint for querying metrics. You need the corresponding management endpoint for your cloud when using this client. This detail is subject to change in the future.
-
-
 ## Troubleshooting
 
 For details on diagnosing various failure scenarios, see our [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/TROUBLESHOOTING.md).

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -244,7 +244,7 @@ Logs uploaded using the Monitor Ingestion client library can be retrieved using 
 
 #### Configure client for Azure sovereign cloud
 
-By default, the clients is configured to use the Azure public cloud. To use a sovereign cloud, provide the correct endpoint and audience value while instantiating the client. For example:
+By default, the client is configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct endpoint and audience value when instantiating the client. For example:
 
 ```ts
 import { DefaultAzureCredential } from "@azure/identity";

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -47,6 +47,25 @@ const credential = new DefaultAzureCredential();
 const logsIngestionClient = new LogsIngestionClient(logsIngestionEndpoint, credential);
 ```
 
+#### Configure client for Azure sovereign cloud
+
+By default, the client is configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct endpoint and audience value when instantiating the client. For example:
+
+```ts
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient } from "@azure/monitor-ingestion";
+
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+
+const credential = new DefaultAzureCredential();
+const logsIngestionClient = new LogsIngestionClient(logsIngestionEndpoint, credential, {
+  audience: "https://api.loganalytics.azure.cn/.default",
+});
+```
+
 ## Key concepts
 
 ### Data Collection Endpoint
@@ -241,25 +260,6 @@ module.exports = { main };
 ### Retrieve logs
 
 Logs uploaded using the Monitor Ingestion client library can be retrieved using the [Monitor Query client library][monitor_query].
-
-#### Configure client for Azure sovereign cloud
-
-By default, the client is configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct endpoint and audience value when instantiating the client. For example:
-
-```ts
-import { DefaultAzureCredential } from "@azure/identity";
-import { LogsIngestionClient } from "@azure/monitor-ingestion";
-
-import * as dotenv from "dotenv";
-dotenv.config();
-
-const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
-
-const credential = new DefaultAzureCredential();
-const logsIngestionClient = new LogsIngestionClient(logsIngestionEndpoint, credential, {
-  audience: "https://api.loganalytics.azure.cn/.default",
-});
-```
 
 ## Troubleshooting
 

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -242,6 +242,28 @@ module.exports = { main };
 
 Logs uploaded using the Monitor Ingestion client library can be retrieved using the [Monitor Query client library][monitor_query].
 
+#### Configure client for Azure sovereign cloud
+
+By default, the clients is configured to use the Azure public cloud. To use a sovereign cloud, provide the correct endpoint and audience value while instantiating the client. For example:
+
+```ts
+import { DefaultAzureCredential } from "@azure/identity";
+import { LogsIngestionClient } from "@azure/monitor-ingestion";
+
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const logsIngestionEndpoint = process.env.LOGS_INGESTION_ENDPOINT || "logs_ingestion_endpoint";
+
+const credential = new DefaultAzureCredential();
+const logsIngestionClient = new LogsIngestionClient(logsIngestionEndpoint, credential, {
+  audience: "https://api.loganalytics.azure.cn/.default",
+});
+```
+
+**Note**: Currently, `MetricsQueryClient` uses the Azure Resource Manager (ARM) endpoint for querying metrics. You need the corresponding management endpoint for your cloud when using this client. This detail is subject to change in the future.
+
+
 ## Troubleshooting
 
 For details on diagnosing various failure scenarios, see our [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/TROUBLESHOOTING.md).

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-ingestion",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Azure Monitor Ingestion library",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/monitor/monitor-ingestion/review/monitor-ingestion.api.md
+++ b/sdk/monitor/monitor-ingestion/review/monitor-ingestion.api.md
@@ -21,6 +21,13 @@ export const AggregateLogsUploadErrorName = "AggregateLogsUploadError";
 export function isAggregateLogsUploadError(e: unknown): e is AggregateLogsUploadError;
 
 // @public
+export enum KnownMonitorAudience {
+    AzureChina = "https://monitor.azure.cn",
+    AzureGovernment = "https://monitor.azure.us",
+    AzurePublicCloud = "https://monitor.azure.com"
+}
+
+// @public
 export class LogsIngestionClient {
     constructor(endpoint: string, tokenCredential: TokenCredential, options?: LogsIngestionClientOptions);
     upload(ruleId: string, streamName: string, logs: Record<string, unknown>[], options?: LogsUploadOptions): Promise<void>;
@@ -29,6 +36,7 @@ export class LogsIngestionClient {
 // @public
 export interface LogsIngestionClientOptions extends CommonClientOptions {
     apiVersion?: string;
+    audience?: string;
 }
 
 // @public

--- a/sdk/monitor/monitor-ingestion/src/constants.ts
+++ b/sdk/monitor/monitor-ingestion/src/constants.ts
@@ -5,3 +5,21 @@
  * @internal
  */
 export const SDK_VERSION: string = "1.0.1";
+
+/**
+ * Known values for Monitor Audience
+ */
+export enum KnownMonitorAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://monitor.azure.cn",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://monitor.azure.us",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://monitor.azure.com",
+}

--- a/sdk/monitor/monitor-ingestion/src/index.ts
+++ b/sdk/monitor/monitor-ingestion/src/index.ts
@@ -7,3 +7,4 @@
  */
 export * from "./logsIngestionClient";
 export * from "./models";
+export { KnownMonitorAudience } from "./constants";

--- a/sdk/monitor/monitor-ingestion/src/logsIngestionClient.ts
+++ b/sdk/monitor/monitor-ingestion/src/logsIngestionClient.ts
@@ -18,7 +18,7 @@ export interface LogsIngestionClientOptions extends CommonClientOptions {
   apiVersion?: string;
 
   /**
-   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * The Audience to use for authentication with Microsoft Entra ID. The
    * audience is not considered when using a shared key.
    * {@link KnownMonitorAudience} can be used interchangeably with audience
    */

--- a/sdk/monitor/monitor-ingestion/src/logsIngestionClient.ts
+++ b/sdk/monitor/monitor-ingestion/src/logsIngestionClient.ts
@@ -9,14 +9,21 @@ import { GZippingPolicy } from "./gZippingPolicy";
 import { concurrentRun } from "./utils/concurrentPoolHelper";
 import { splitDataToChunks } from "./utils/splitDataToChunksHelper";
 import { isError } from "@azure/core-util";
+import { KnownMonitorAudience } from "./constants";
 /**
  * Options for Monitor Logs Ingestion Client
  */
 export interface LogsIngestionClientOptions extends CommonClientOptions {
   /** Api Version */
   apiVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   * {@link KnownMonitorAudience} can be used interchangeably with audience
+   */
+  audience?: string;
 }
-const defaultIngestionScope = "https://monitor.azure.com//.default";
 const DEFAULT_MAX_CONCURRENCY = 5;
 
 /**
@@ -39,10 +46,14 @@ export class LogsIngestionClient {
     tokenCredential: TokenCredential,
     options?: LogsIngestionClientOptions,
   ) {
+    const scope: string = options?.audience
+      ? `${options.audience}/.default`
+      : `${KnownMonitorAudience.AzurePublicCloud}/.default`;
+
     this.endpoint = endpoint;
     this._dataClient = new GeneratedMonitorIngestionClient(tokenCredential, this.endpoint, {
       ...options,
-      credentialScopes: defaultIngestionScope,
+      credentialScopes: scope,
     });
     // adding gzipping policy because this is a single method client which needs gzipping
     this._dataClient.pipeline.addPolicy(GZippingPolicy);

--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `audience` support for all the clients  to specify the audience for the authentication token. This is useful when working  in sovereign clouds. Refer [#28821](https://github.com/Azure/azure-sdk-for-js/issues/28821) for further details.
+- Added `audience` support for all the clients to specify the audience for the authentication token. This is useful when working in sovereign clouds. Refer to [#28821](https://github.com/Azure/azure-sdk-for-js/issues/28821) for further details.
 
 ## 1.2.0 (2024-03-25)
 

--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.3.0 (2024-06-11)
+
+### Features Added
+
+- Added `audience` support for all the clients  to specify the audience for the authentication token. This is useful when working  in sovereign clouds. Refer [#28821](https://github.com/Azure/azure-sdk-for-js/issues/28821) for further details.
+
 ## 1.2.0 (2024-03-25)
 
 ### Features Added

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -61,7 +61,7 @@ const metricsQueryClient: MetricsQueryClient = new MetricsQueryClient(endPoint, 
 
 #### Configure client for Azure sovereign cloud
 
-By default, all clients are configured to use the Azure public cloud. To use a sovereign cloud, provide the correct endpoint and audience value while instantiating the clients. For example:
+By default, the library's clients are configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct endpoint and audience value when instantiating a client. For example:
 
 ```ts
 import { DefaultAzureCredential } from "@azure/identity";

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -65,7 +65,7 @@ By default, the library's clients are configured to use the Azure Public Cloud. 
 
 ```ts
 import { DefaultAzureCredential } from "@azure/identity";
-import { LogsQueryClient, MetricsQueryClient, metricsClient } from "@azure/monitor-query";
+import { LogsQueryClient, MetricsQueryClient, MetricsClient } from "@azure/monitor-query";
 
 const credential = new DefaultAzureCredential();
 

--- a/sdk/monitor/monitor-query/README.md
+++ b/sdk/monitor/monitor-query/README.md
@@ -61,21 +61,28 @@ const metricsQueryClient: MetricsQueryClient = new MetricsQueryClient(endPoint, 
 
 #### Configure client for Azure sovereign cloud
 
-By default, `LogsQueryClient` and `MetricsQueryClient` are configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct `endpoint` argument. For example:
+By default, all clients are configured to use the Azure public cloud. To use a sovereign cloud, provide the correct endpoint and audience value while instantiating the clients. For example:
 
 ```ts
 import { DefaultAzureCredential } from "@azure/identity";
-import { LogsQueryClient, MetricsQueryClient } from "@azure/monitor-query";
+import { LogsQueryClient, MetricsQueryClient, metricsClient } from "@azure/monitor-query";
 
 const credential = new DefaultAzureCredential();
 
-const logsQueryClient = new LogsQueryClient(credential, {
+const logsQueryClient: LogsQueryClient = new LogsQueryClient(credential, {
   endpoint: "https://api.loganalytics.azure.cn/v1",
+  audience: "https://api.loganalytics.azure.cn/.default",
 });
-
 // or
-const metricsQueryClient = new MetricsQueryClient(credential, {
+const metricsQueryClient: MetricsQueryClient = new MetricsQueryClient(credential, {
   endpoint: "https://management.chinacloudapi.cn",
+  audience: "https://monitor.azure.cn/.default",
+});
+// or
+const endPoint: string = "<YOUR_METRICS_ENDPOINT>"; //for example, https://eastus.metrics.monitor.azure.com/
+
+const metricsClient: MetricsClient = new MetricsClient(endPoint, credential, {
+  audience: "https://monitor.azure.cn/.default",
 });
 ```
 

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-query",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "An isomorphic client library for querying Azure Monitor's Logs and Metrics data sources.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -29,6 +29,13 @@ export const Durations: {
 };
 
 // @public
+export enum KnownMonitorAudience {
+    AzureChina = "https://monitor.azure.cn",
+    AzureGovernment = "https://monitor.azure.us",
+    AzurePublicCloud = "https://monitor.azure.com"
+}
+
+// @public
 export interface ListMetricDefinitionsOptions extends OperationOptions {
     metricNamespace?: string;
 }
@@ -69,6 +76,7 @@ export class LogsQueryClient {
 
 // @public
 export interface LogsQueryClientOptions extends CommonClientOptions {
+    audience?: string;
     endpoint?: string;
 }
 
@@ -175,12 +183,13 @@ export interface MetricNamespace {
 
 // @public
 export class MetricsClient {
-    constructor(endpoint: string, tokenCredential: TokenCredential, options?: CommonClientOptions);
+    constructor(endpoint: string, tokenCredential: TokenCredential, options?: MetricsClientOptions);
     queryResources(resourceIds: string[], metricNames: string[], metricNamespace: string, options?: MetricsQueryResourcesOptions): Promise<MetricsQueryResult[]>;
 }
 
 // @public
 export interface MetricsClientOptions extends CommonClientOptions {
+    audience?: string;
     endpoint?: string;
 }
 

--- a/sdk/monitor/monitor-query/src/constants.ts
+++ b/sdk/monitor/monitor-query/src/constants.ts
@@ -5,3 +5,21 @@
  * @internal
  */
 export const SDK_VERSION: string = "1.2.0";
+
+/**
+ * Known values for Monitor Audience
+ */
+export enum KnownMonitorAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://monitor.azure.cn",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://monitor.azure.us",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://monitor.azure.com",
+}

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -64,3 +64,4 @@ export { NamespaceClassification } from "./generated/metricsnamespaces/src";
 
 export { MetricsQueryResourcesOptions } from "./models/publicBatchModels";
 export { MetricsClient } from "./metricsClient";
+export { KnownMonitorAudience } from "./constants";

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -41,7 +41,7 @@ export interface LogsQueryClientOptions extends CommonClientOptions {
   endpoint?: string;
 
   /**
-   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * The Audience to use for authentication with Microsoft Entra ID. The
    * audience is not considered when using a shared key.
    */
   audience?: string;

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -29,7 +29,7 @@ import { SDK_VERSION } from "./constants";
 import { tracingClient } from "./tracing";
 import { getLogQueryEndpoint } from "./internal/logQueryOptionUtils";
 
-const defaultMonitorScope = "https://api.loganalytics.io/.default";
+const defaultMonitorScope = "https://api.loganalytics.io/";
 
 /**
  * Options for the LogsQueryClient.
@@ -39,6 +39,12 @@ export interface LogsQueryClientOptions extends CommonClientOptions {
    * The host to connect to.
    */
   endpoint?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * audience is not considered when using a shared key.
+   */
+  audience?: string;
 }
 
 /**
@@ -54,17 +60,14 @@ export class LogsQueryClient {
    * @param options - Options for the LogsClient.
    */
   constructor(tokenCredential: TokenCredential, options?: LogsQueryClientOptions) {
-    // This client defaults to using 'https://api.loganalytics.io/' as the
-    // host.
-    let scope;
+    const scope: string = options?.audience
+      ? `${options.audience}/.default`
+      : `${defaultMonitorScope}/.default`;
+
     let endpoint = options?.endpoint;
     if (options?.endpoint) {
-      scope = `${options.endpoint}/.default`;
       endpoint = getLogQueryEndpoint(options);
     }
-    const credentialOptions = {
-      credentialScopes: scope,
-    };
     const packageDetails = `azsdk-js-monitor-query/${SDK_VERSION}`;
     const userAgentPrefix =
       options?.userAgentOptions && options?.userAgentOptions.userAgentPrefix
@@ -74,7 +77,7 @@ export class LogsQueryClient {
       ...options,
       $host: endpoint,
       endpoint: endpoint,
-      credentialScopes: credentialOptions?.credentialScopes ?? defaultMonitorScope,
+      credentialScopes: scope,
       credential: tokenCredential,
       userAgentOptions: {
         userAgentPrefix,

--- a/sdk/monitor/monitor-query/src/metricsClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsClient.ts
@@ -28,10 +28,10 @@ export class MetricsClient {
   private _metricBatchClient: GeneratedMonitorMetricClient;
   private _baseUrl: string;
 
-  // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
   constructor(
     endpoint: string,
     tokenCredential: TokenCredential,
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options?: MetricsQueryClientOptions,
   ) {
     const scope: string = options?.audience

--- a/sdk/monitor/monitor-query/src/metricsClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsClient.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { TokenCredential } from "@azure/core-auth";
-import { CommonClientOptions } from "@azure/core-client";
 import { tracingClient } from "./tracing";
 import {
   AzureMonitorMetricBatch as GeneratedMonitorMetricClient,
@@ -11,11 +10,10 @@ import {
   convertResponseForMetricBatch,
   convertRequestForMetricsBatchQuery,
 } from "./internal/modelConverters";
-import { SDK_VERSION } from "./constants";
+import { SDK_VERSION, KnownMonitorAudience } from "./constants";
 import { MetricsQueryResourcesOptions } from "./models/publicBatchModels";
 import { MetricsQueryResult } from "./models/publicMetricsModels";
-
-const defaultMetricsScope = "https://management.azure.com/.default";
+import { MetricsQueryClientOptions } from "./metricsQueryClient";
 
 export const getSubscriptionFromResourceId = function (resourceId: string): string {
   const startPos: number = resourceId.indexOf("subscriptions/") + 14;
@@ -31,14 +29,15 @@ export class MetricsClient {
   private _baseUrl: string;
 
   // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-  constructor(endpoint: string, tokenCredential: TokenCredential, options?: CommonClientOptions) {
-    let scope;
-    if (endpoint) {
-      scope = `${endpoint}/.default`;
-    }
-    const credentialOptions = {
-      credentialScopes: scope,
-    };
+  constructor(
+    endpoint: string,
+    tokenCredential: TokenCredential,
+    options?: MetricsQueryClientOptions,
+  ) {
+    const scope: string = options?.audience
+      ? `${options.audience}/.default`
+      : `${KnownMonitorAudience.AzurePublicCloud}/.default`;
+
     const packageDetails = `azsdk-js-monitor-query/${SDK_VERSION}`;
     const userAgentPrefix =
       options?.userAgentOptions && options?.userAgentOptions.userAgentPrefix
@@ -48,7 +47,7 @@ export class MetricsClient {
       ...options,
       $host: endpoint,
       endpoint: endpoint,
-      credentialScopes: credentialOptions?.credentialScopes ?? defaultMetricsScope,
+      credentialScopes: scope,
       credential: tokenCredential,
       userAgentOptions: {
         userAgentPrefix,

--- a/sdk/monitor/monitor-query/src/metricsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsQueryClient.ts
@@ -44,7 +44,7 @@ export interface MetricsQueryClientOptions extends CommonClientOptions {
   endpoint?: string;
 
   /**
-   * The Audience to use for authentication with Azure Active Directory (AAD). The
+   * The Audience to use for authentication with Microsoft Entra ID. The
    * audience is not considered when using a shared key.
    * {@link KnownMonitorAudience} can be used interchangeably with audience
    */

--- a/sdk/monitor/perf-tests/monitor-query/package.json
+++ b/sdk/monitor/perf-tests/monitor-query/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/monitor-query": "1.2.0",
+    "@azure/monitor-query": "1.3.0",
     "@azure-tools/test-perf": "^1.0.0",
     "dotenv": "^16.0.0",
     "@azure/identity": "^4.0.1"


### PR DESCRIPTION
### Packages impacted by this PR

1. @azure/monitor-ingestion
2. @azure/monitor-query

### Issues associated with this PR

1. [#27280](https://github.com/Azure/azure-sdk-for-js/issues/27280) 
2. [#28821](https://github.com/Azure/azure-sdk-for-js/issues/28821) 

### Describe the problem that is addressed by this PR

In order to support sovereign clouds, we must be able to allow the SDK users to specify the endpoints and audience parameters. The users could already  specify/modify the endpoint parameter. This PR will enable the users to do the same for audience.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

No special design concerns to discuss.

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-js/pull/22887/

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)

@KarishmaGhiya @srnagar Please review and approve the PR.

@xirzec FYI