### PR TITLE
[Recorder] Fixes connectionStringSanitizer regression - incorrect bodies

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bugs Fixed
 
-- Fixes connectionStringSanitizer regression stemmed from batch sanitizers migration, where the request bodies are formatted incorrectly.
+- Fixes connectionStringSanitizer regression stemmed from batch sanitizers migration, where the request bodies are incorrect.
 
 ## 4.0.0 (2024-04-09)
 

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Added support for the TestProxy/addSanitizers API, which improves the recording of tests by reducing flakiness and timeouts caused by concurrent requests. This helps to speed up the recording process and reduces the burden on the test proxy.
 - Adds `removeCentralSanitizers` option to the `RecorderStartOptions` to allow users pass in the central sanitizer ids to skip the specific santiizers at the test proxy level.
 
+### Bugs Fixed
+
+- Fixes connectionStringSanitizer regression stemmed from batch sanitizers migration, where the request bodies are formatted incorrectly.
+
 ## 4.0.0 (2024-04-09)
 
 ### Features Added

--- a/sdk/test-utils/recorder/test/sanitizers.spec.ts
+++ b/sdk/test-utils/recorder/test/sanitizers.spec.ts
@@ -130,6 +130,38 @@ import { env } from "../src/index.js";
         );
       });
 
+      it("Connection string sanitizer - singular", async () => {
+        await recorder.start({
+          envSetupForPlayback: {},
+          sanitizerOptions: {
+            connectionStringSanitizers: [
+              {
+                fakeConnString: "endpoint=https://endpoint/;accesskey=banana",
+                actualConnString: "endpoint=https://realEndpoint/;accessKey=realBanana",
+              },
+            ],
+          },
+        });
+      });
+
+      it("Connection string sanitizer - multiple", async () => {
+        await recorder.start({
+          envSetupForPlayback: {},
+          sanitizerOptions: {
+            connectionStringSanitizers: [
+              {
+                fakeConnString: "endpoint=https://endpoint/;accessKey=banana",
+                actualConnString: "endpoint=https://realEndpoint/;accessKey=realBanana",
+              },
+              {
+                fakeConnString: "endpoint2=https://randomEndpoint/;Key3=banana",
+                actualConnString: "endpoint2=https://finalEndpoint/;Key3=realBanana",
+              },
+            ],
+          },
+        });
+      });
+
       it("BodyKeySanitizer", async () => {
         secretValue = "ab12cd34ef";
         await recorder.start({


### PR DESCRIPTION
`{    target : value   }` being sent to test proxy instead of `  {  target: target, value: value  } `

Regression happened when we migrated to batch sanitizers.
Added a couple of tests as well to make sure the requests are hit at the test-proxy level and it doesn't error out.
