### PR TITLE
[dependency-test] support packages that moved to vitest

### DIFF
--- a/eng/tools/dependency-testing/templates/package.json
+++ b/eng/tools/dependency-testing/templates/package.json
@@ -4,13 +4,13 @@
   "version": "0.1.0",
   "description": "Azure client library tests for TypeScript",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "tsc -p .",
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "mocha --require tsx --require source-map-support/register --reporter mocha-multi-reporter.js  --reporter-option output=test-results.xml --timeout 350000 --full-trace \"dist-esm/**/{,!(browser)/**/}*.spec.js\" --exit",
-    "integration-test": "npm run integration-test:node && npm run integration-test:browser"
+    "integration-test": "npm run integration-test:node && echo skipped: npm run integration-test:browser"
   },
   "repository": {
     "type": "git",

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "../../../../../vitest.shared.config.ts";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      include: ["./**/*.spec.ts"],
+      exclude: ["**/node_modules/**"],
+    },
+  }),
+);


### PR DESCRIPTION
by writing a copy of vitest config file to the test/public project and update
related commands to run vitest.

This PR addresses NodeJs only.

Related issue: https://github.com/Azure/azure-sdk-for-js/issues/29867