### PR TITLE
Ported from #29897 - conn string sanitizer fix

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 3.5.1 (2024-06-04)
+
+### Bugs Fixed
+
+- Fixes connectionStringSanitizer regression stemmed from batch sanitizers migration, where the request bodies are incorrect. Ported from [#29897](https://github.com/Azure/azure-sdk-for-js/pull/29897)
+
 ## 3.5.0 (2024-05-13)
 
 ### Breaking Changes

--- a/sdk/test-utils/recorder/test/sanitizers.spec.ts
+++ b/sdk/test-utils/recorder/test/sanitizers.spec.ts
@@ -128,6 +128,38 @@ import { randomUUID } from "@azure/core-util";
         );
       });
 
+      it("Connection string sanitizer - singular", async () => {
+        await recorder.start({
+          envSetupForPlayback: {},
+          sanitizerOptions: {
+            connectionStringSanitizers: [
+              {
+                fakeConnString: "endpoint=https://endpoint/;accesskey=banana",
+                actualConnString: "endpoint=https://realEndpoint/;accessKey=realBanana",
+              },
+            ],
+          },
+        });
+      });
+
+      it("Connection string sanitizer - multiple", async () => {
+        await recorder.start({
+          envSetupForPlayback: {},
+          sanitizerOptions: {
+            connectionStringSanitizers: [
+              {
+                fakeConnString: "endpoint=https://endpoint/;accessKey=banana",
+                actualConnString: "endpoint=https://realEndpoint/;accessKey=realBanana",
+              },
+              {
+                fakeConnString: "endpoint2=https://randomEndpoint/;Key3=banana",
+                actualConnString: "endpoint2=https://finalEndpoint/;Key3=realBanana",
+              },
+            ],
+          },
+        });
+      });
+
       it("BodyKeySanitizer", async () => {
         const secretValue = "ab12cd34ef";
         await recorder.start({


### PR DESCRIPTION
### Packages impacted by this PR
`@azure-tools/test-recorder@3.x`
 and all the packages relying on it

### Issues associated with this PR
Ported from #29897

### Describe the problem that is addressed by this PR
Fixes connectionStringSanitizer regression stemmed from batch sanitizers migration, where the request bodies are incorrect.
