### PR TITLE
[core-client-rest] Deprecate apiVersion option

### DIFF
--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -77,6 +77,7 @@
     "@azure/core-util": "^1.0.0",
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-tracing": "^1.0.1",
+    "@azure/logger": "^1.0.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/sdk/core/core-client-rest/src/apiVersionPolicy.ts
+++ b/sdk/core/core-client-rest/src/apiVersionPolicy.ts
@@ -8,6 +8,7 @@ export const apiVersionPolicyName = "ApiVersionPolicy";
 
 /**
  * Creates a policy that sets the apiVersion as a query parameter on every request
+ * @deprecated - This policy will be removed in a future version.
  * @param options - Client options
  * @returns Pipeline policy that sets the apiVersion as a query parameter on every request
  */

--- a/sdk/core/core-client-rest/src/clientHelpers.ts
+++ b/sdk/core/core-client-rest/src/clientHelpers.ts
@@ -12,6 +12,7 @@ import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-a
 
 import { ClientOptions } from "./common.js";
 import { apiVersionPolicy } from "./apiVersionPolicy.js";
+import { logger } from "./log.js";
 import { keyCredentialAuthenticationPolicy } from "./keyCredentialAuthenticationPolicy.js";
 
 let cachedHttpClient: HttpClient | undefined;
@@ -71,7 +72,12 @@ export function createDefaultPipeline(
 ): Pipeline {
   const pipeline = createPipelineFromOptions(options);
 
-  pipeline.addPolicy(apiVersionPolicy(options));
+  if (options.apiVersion) {
+    logger.warning(
+      "The apiVersion option for SDK REST Clients has been deprecated and should be handled in the client package.",
+    );
+    pipeline.addPolicy(apiVersionPolicy(options));
+  }
 
   addCredentialPipelinePolicy(pipeline, endpoint, { credential, clientOptions: options });
   return pipeline;

--- a/sdk/core/core-client-rest/src/common.ts
+++ b/sdk/core/core-client-rest/src/common.ts
@@ -327,6 +327,7 @@ export type ClientOptions = PipelineOptions & {
   endpoint?: string;
   /**
    * Options for setting a custom apiVersion.
+   * @deprecated - This should be handled by the client instead.
    */
   apiVersion?: string;
   /**

--- a/sdk/core/core-client-rest/src/log.ts
+++ b/sdk/core/core-client-rest/src/log.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("core-client-rest");

--- a/sdk/core/core-client-rest/test/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/clientHelpers.spec.ts
@@ -27,8 +27,8 @@ describe("clientHelpers", () => {
     );
   });
 
-  it("should create a default pipeline with apiVersion policy", () => {
-    const pipeline = createDefaultPipeline(mockBaseUrl);
+  it("should create a pipeline with apiVersion policy when one is defined", () => {
+    const pipeline = createDefaultPipeline(mockBaseUrl, undefined, {apiVersion: "123"});
     const policies = pipeline.getOrderedPolicies();
 
     assert.isDefined(policies, "default pipeline should contain policies");

--- a/sdk/core/ts-http-runtime/src/client/apiVersionPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/client/apiVersionPolicy.ts
@@ -8,6 +8,7 @@ export const apiVersionPolicyName = "ApiVersionPolicy";
 
 /**
  * Creates a policy that sets the apiVersion as a query parameter on every request
+ * @deprecated - This policy will be removed in a future version.
  * @param options - Client options
  * @returns Pipeline policy that sets the apiVersion as a query parameter on every request
  */

--- a/sdk/core/ts-http-runtime/src/client/clientHelpers.ts
+++ b/sdk/core/ts-http-runtime/src/client/clientHelpers.ts
@@ -11,6 +11,7 @@ import { KeyCredential, isKeyCredential } from "../auth/keyCredential.js";
 import { ClientOptions } from "./common.js";
 import { apiVersionPolicy } from "./apiVersionPolicy.js";
 import { keyCredentialAuthenticationPolicy } from "./keyCredentialAuthenticationPolicy.js";
+import { logger } from "../log.js";
 
 let cachedHttpClient: HttpClient | undefined;
 
@@ -69,7 +70,12 @@ export function createDefaultPipeline(
 ): Pipeline {
   const pipeline = createPipelineFromOptions(options);
 
-  pipeline.addPolicy(apiVersionPolicy(options));
+  if (options.apiVersion) {
+    logger.warning(
+      "The apiVersion option for SDK REST Clients has been deprecated and should be handled in the client package.",
+    );
+    pipeline.addPolicy(apiVersionPolicy(options));
+  }
 
   addCredentialPipelinePolicy(pipeline, endpoint, { credential, clientOptions: options });
   return pipeline;

--- a/sdk/core/ts-http-runtime/src/client/common.ts
+++ b/sdk/core/ts-http-runtime/src/client/common.ts
@@ -326,6 +326,7 @@ export type ClientOptions = PipelineOptions & {
   endpoint?: string;
   /**
    * Options for setting a custom apiVersion.
+   * @deprecated - This should be handled by the client instead.
    */
   apiVersion?: string;
   /**

--- a/sdk/core/ts-http-runtime/test/client/clientHelpers.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/clientHelpers.spec.ts
@@ -27,8 +27,8 @@ describe("clientHelpers", () => {
     );
   });
 
-  it("should create a default pipeline with apiVersion policy", () => {
-    const pipeline = createDefaultPipeline(mockBaseUrl);
+  it("should create a pipeline with apiVersion policy when one is defined", () => {
+    const pipeline = createDefaultPipeline(mockBaseUrl, undefined, { apiVersion: "123" });
     const policies = pipeline.getOrderedPolicies();
 
     assert.isDefined(policies, "default pipeline should contain policies");


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/core-client`
`@typespec/ts-http-runtime`


### Issues associated with this PR

Fixes #29883

### Describe the problem that is addressed by this PR

Currently RLCs can pass a client-level option for overriding the API version parameter. We'd like to move this behavior out of Core and into the emitter so that the package can intelligently handle this as needed.

This PR marks the property as deprecated and logs a warning at runtime so that we can remove it in a future major.