### PR TITLE
[Monitor OpenTelemetry] Enable Live Metrics by Default

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Other Changes
 
 - Add support for tracking Application Insights shim usage to statsbeat.
+- Live Metrics is enabled by default.
 
 ## 1.5.0 (2024-05-10)
 

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -97,7 +97,7 @@ useAzureMonitor(options);
 | browserSdkLoaderOptions| Allow configuration of Web Instrumentations. | { enabled: false, connectionString: "" } |
 | resource       | Opentelemetry Resource. [More info here](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources) ||
 | samplingRatio              | Sampling ratio must take a value in the range [0,1], 1 meaning all data will sampled and 0 all Tracing data will be sampled out. |1|
-| enableLiveMetrics          | Enable/Disable Live Metrics. |false|
+| enableLiveMetrics          | Enable/Disable Live Metrics. |true|
 | enableStandardMetrics      | Enable/Disable Standard Metrics. |true|
 | logRecordProcessors        | Array of log record processors to register to the global logger provider. ||
 | spanProcessors             | Array of span processors to register to the global tracer provider. ||

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
@@ -4,8 +4,17 @@
 import { Attributes } from "@opentelemetry/api";
 import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import {
-  SemanticAttributes,
-  SemanticResourceAttributes,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMATTRS_PEER_SERVICE,
+  SEMATTRS_HTTP_HOST,
+  SEMATTRS_HTTP_URL,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_IP,
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_TYPE,
+  SEMATTRS_HTTP_USER_AGENT,
 } from "@opentelemetry/semantic-conventions";
 import {
   MetricDependencyDimensions,
@@ -61,8 +70,8 @@ export function getBaseDimensions(resource: Resource): StandardMetricBaseDimensi
   dimensions.IsAutocollected = "True";
   if (resource) {
     const spanResourceAttributes = resource.attributes;
-    const serviceName = spanResourceAttributes[SemanticResourceAttributes.SERVICE_NAME];
-    const serviceNamespace = spanResourceAttributes[SemanticResourceAttributes.SERVICE_NAMESPACE];
+    const serviceName = spanResourceAttributes[SEMRESATTRS_SERVICE_NAME];
+    const serviceNamespace = spanResourceAttributes[SEMRESATTRS_SERVICE_NAMESPACE];
     if (serviceName) {
       if (serviceNamespace) {
         dimensions.cloudRoleName = `${serviceNamespace}.${serviceName}`;
@@ -70,8 +79,7 @@ export function getBaseDimensions(resource: Resource): StandardMetricBaseDimensi
         dimensions.cloudRoleName = String(serviceName);
       }
     }
-    const serviceInstanceId =
-      spanResourceAttributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID];
+    const serviceInstanceId = spanResourceAttributes[SEMRESATTRS_SERVICE_INSTANCE_ID];
     dimensions.cloudRoleInstance = String(serviceInstanceId);
   }
   return dimensions;
@@ -81,11 +89,11 @@ export function getDependencyTarget(attributes: Attributes): string {
   if (!attributes) {
     return "";
   }
-  const peerService = attributes[SemanticAttributes.PEER_SERVICE];
-  const httpHost = attributes[SemanticAttributes.HTTP_HOST];
-  const httpUrl = attributes[SemanticAttributes.HTTP_URL];
-  const netPeerName = attributes[SemanticAttributes.NET_PEER_NAME];
-  const netPeerIp = attributes[SemanticAttributes.NET_PEER_IP];
+  const peerService = attributes[SEMATTRS_PEER_SERVICE];
+  const httpHost = attributes[SEMATTRS_HTTP_HOST];
+  const httpUrl = attributes[SEMATTRS_HTTP_URL];
+  const netPeerName = attributes[SEMATTRS_NET_PEER_NAME];
+  const netPeerIp = attributes[SEMATTRS_NET_PEER_IP];
   if (peerService) {
     return String(peerService);
   } else if (httpHost) {
@@ -106,8 +114,8 @@ export function isExceptionTelemetry(logRecord: LogRecord) {
   if (baseType && baseType === "ExceptionData") {
     return true;
   } else if (
-    logRecord.attributes[SemanticAttributes.EXCEPTION_MESSAGE] ||
-    logRecord.attributes[SemanticAttributes.EXCEPTION_TYPE]
+    logRecord.attributes[SEMATTRS_EXCEPTION_MESSAGE] ||
+    logRecord.attributes[SEMATTRS_EXCEPTION_TYPE]
   ) {
     return true;
   }
@@ -120,8 +128,8 @@ export function isTraceTelemetry(logRecord: LogRecord) {
   if (baseType && baseType === "MessageData") {
     return true;
   } else if (
-    !logRecord.attributes[SemanticAttributes.EXCEPTION_MESSAGE] &&
-    !logRecord.attributes[SemanticAttributes.EXCEPTION_TYPE]
+    !logRecord.attributes[SEMATTRS_EXCEPTION_MESSAGE] &&
+    !logRecord.attributes[SEMATTRS_EXCEPTION_TYPE]
   ) {
     return true;
   }
@@ -129,7 +137,7 @@ export function isTraceTelemetry(logRecord: LogRecord) {
 }
 
 export function isSyntheticLoad(record: LogRecord | ReadableSpan): boolean {
-  const userAgent = String(record.attributes[SemanticAttributes.HTTP_USER_AGENT]);
+  const userAgent = String(record.attributes[SEMATTRS_HTTP_USER_AGENT]);
   return userAgent !== null && userAgent.includes("AlwaysOn") ? true : false;
 }
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -62,7 +62,7 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
     // Default values
     this.azureMonitorExporterOptions = {};
     this.samplingRatio = 1;
-    this.enableLiveMetrics = false;
+    this.enableLiveMetrics = true;
     this.enableStandardMetrics = true;
     this.enableTraceBasedSamplingForLogs = true;
     this.instrumentationOptions = {

--- a/sdk/monitor/monitor-opentelemetry/test/utils/basic.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/utils/basic.ts
@@ -4,8 +4,12 @@
 import * as opentelemetry from "@opentelemetry/api";
 import { Resource } from "@opentelemetry/resources";
 import {
-  SemanticResourceAttributes,
-  SemanticAttributes,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMATTRS_EXCEPTION_TYPE,
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
 } from "@opentelemetry/semantic-conventions";
 import { SeverityNumber, logs } from "@opentelemetry/api-logs";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -191,9 +195,9 @@ export class TraceBasicScenario implements Scenario {
 export class MetricBasicScenario implements Scenario {
   prepare(): void {
     const testResource = new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: "my-helloworld-service",
-      [SemanticResourceAttributes.SERVICE_NAMESPACE]: "my-namespace",
-      [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: "my-instance",
+      [SEMRESATTRS_SERVICE_NAME]: "my-helloworld-service",
+      [SEMRESATTRS_SERVICE_NAMESPACE]: "my-namespace",
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: "my-instance",
     });
     useAzureMonitor({
       azureMonitorExporterOptions: {
@@ -399,9 +403,9 @@ export class LogBasicScenario implements Scenario {
     });
     // emit a exception record
     let attributes: any = [];
-    attributes[SemanticAttributes.EXCEPTION_TYPE] = "test exception type";
-    attributes[SemanticAttributes.EXCEPTION_MESSAGE] = "test exception message";
-    attributes[SemanticAttributes.EXCEPTION_STACKTRACE] = "test exception stack";
+    attributes[SEMATTRS_EXCEPTION_TYPE] = "test exception type";
+    attributes[SEMATTRS_EXCEPTION_MESSAGE] = "test exception message";
+    attributes[SEMATTRS_EXCEPTION_STACKTRACE] = "test exception stack";
     logger.emit({
       severityNumber: SeverityNumber.ERROR,
       severityText: "ERROR",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
* We should align with the spec and enable live metrics by default.
* Update our semantic convention imports.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
