### PR TITLE
[eslint-plugin] skip some package json linting for packages using tshy

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/list/esm-migrations.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/esm-migrations.ts
@@ -88,6 +88,7 @@ function createMigrationResult(): MigrationResult {
 }
 
 function setMigrationResult(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJson: any,
   project: RushJsonProject,
   results: MigrationResult,

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
@@ -5,7 +5,7 @@
  * @file Rule to force the inclusion of type declarations in the package.
  */
 
-import { createRule, getVerifiers, stripPath } from "../utils";
+import { createRule, getVerifiers, stripPath, usesTshy } from "../utils";
 import { TSESTree } from "@typescript-eslint/utils";
 import { VerifierMessages, stripFileName } from "../utils/verifiers";
 
@@ -40,6 +40,9 @@ export default createRule({
     });
     const fileName = context.filename;
     if (stripPath(fileName) !== "api-extractor.json") {
+      return {};
+    }
+    if (usesTshy(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -6,7 +6,7 @@
  *
  */
 import { TSESTree } from "@typescript-eslint/utils";
-import { VerifierMessages, arrayToString, createRule, getVerifiers, stripPath } from "../utils";
+import { VerifierMessages, arrayToString, createRule, getVerifiers, stripPath, usesTshy } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -73,6 +73,9 @@ export default createRule({
       outer: "files",
     });
     if (stripPath(context.filename) !== "package.json") {
+      return {};
+    }
+    if (usesTshy(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -6,7 +6,14 @@
  *
  */
 import { TSESTree } from "@typescript-eslint/utils";
-import { VerifierMessages, arrayToString, createRule, getVerifiers, stripPath, usesTshy } from "../utils";
+import {
+  VerifierMessages,
+  arrayToString,
+  createRule,
+  getVerifiers,
+  stripPath,
+  usesTshy,
+} from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -7,7 +7,7 @@
  */
 
 import { TSESTree } from "@typescript-eslint/utils";
-import { VerifierMessages, createRule, getVerifiers, stripPath } from "../utils";
+import { VerifierMessages, createRule, getVerifiers, stripPath, usesTshy } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -36,6 +36,9 @@ export default createRule({
       outer: "main",
     });
     if (stripPath(context.filename) !== "package.json") {
+      return {};
+    }
+    if (usesTshy(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
@@ -7,7 +7,7 @@
  */
 
 import { TSESTree } from "@typescript-eslint/utils";
-import { VerifierMessages, createRule, getVerifiers, stripPath } from "../utils";
+import { VerifierMessages, createRule, getVerifiers, stripPath, usesTshy } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -36,6 +36,9 @@ export default createRule({
       outer: "module",
     });
     if (stripPath(context.filename) !== "package.json") {
+      return {};
+    }
+    if (usesTshy(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
@@ -7,7 +7,7 @@
  */
 
 import { TSESTree } from "@typescript-eslint/utils";
-import { createRule, getVerifiers, stripPath } from "../utils";
+import { createRule, getVerifiers, stripPath, usesTshy } from "../utils";
 import { VerifierMessages, stripFileName } from "../utils/verifiers";
 
 //------------------------------------------------------------------------------
@@ -40,6 +40,9 @@ export default createRule({
     });
     const fileName = context.filename;
     if (stripPath(context.filename) !== "package.json") {
+      return {};
+    }
+    if (usesTshy(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/index.ts
@@ -11,6 +11,7 @@ export {
   arrayToString,
   getVerifiers,
   stripPath,
+  usesTshy,
   VerifierMessages,
   type VerifierMessageIds,
 } from "./verifiers";

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -44,7 +44,7 @@ export type VerifierMessageIds = keyof typeof VerifierMessages;
 export const stripPath = (pathOrFileName: string): string =>
   pathOrFileName.replace(/^.*[\\\/]/, "");
 
-export function usesTshy(packageJsonPath: string) : boolean {
+export function usesTshy(packageJsonPath: string): boolean {
   const dotTshy = path.join(path.dirname(packageJsonPath), ".tshy");
   try {
     statSync(dotTshy);

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -6,6 +6,8 @@
  */
 
 import { TSESTree, TSESLint } from "@typescript-eslint/utils";
+import { statSync } from "node:fs";
+import * as path from "node:path";
 
 interface StructureData {
   outer: string;
@@ -42,6 +44,15 @@ export type VerifierMessageIds = keyof typeof VerifierMessages;
 export const stripPath = (pathOrFileName: string): string =>
   pathOrFileName.replace(/^.*[\\\/]/, "");
 
+export function usesTshy(packageJsonPath: string) : boolean {
+  const dotTshy = path.join(path.dirname(packageJsonPath), ".tshy");
+  try {
+    statSync(dotTshy);
+    return true;
+  } catch {
+    return false;
+  }
+}
 /**
  * Get the directory of a filename
  * @param pathOrFileName the input path or file name

--- a/sdk/.eslintrc.json
+++ b/sdk/.eslintrc.json
@@ -1,10 +1,5 @@
 {
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "ignorePatterns": ["**/test/perf/track-1"],
-  "rules": {
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off"}
+  "ignorePatterns": ["**/test/perf/track-1"]
 }

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/.eslintrc.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/.eslintrc.json
@@ -2,9 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-types": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-module": "off"
   },
   "ignorePatterns": [],
   "overrides": [

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/.eslintrc.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/.eslintrc.json
@@ -1,8 +1,6 @@
 {
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-  },
   "ignorePatterns": [],
   "overrides": [
     {

--- a/sdk/apimanagement/api-management-custom-widgets-tools/.eslintrc.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/.eslintrc.json
@@ -2,11 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-types": "off",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-engine-is-present": "off"
   },
   "ignorePatterns": []
 }

--- a/sdk/apimanagement/api-management-custom-widgets-tools/.eslintrc.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/.eslintrc.json
@@ -1,7 +1,5 @@
 {
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-  },
   "ignorePatterns": []
 }

--- a/sdk/core/abort-controller/.eslintrc.json
+++ b/sdk/core/abort-controller/.eslintrc.json
@@ -1,11 +1,4 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "@azure/azure-sdk/ts-package-json-types": "off",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-engine-is-present": "off"
-  }
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
 }

--- a/sdk/core/core-amqp/.eslintrc.json
+++ b/sdk/core/core-amqp/.eslintrc.json
@@ -2,10 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@typescript-eslint/no-duplicate-enum-values": "warn",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off"
+    "@typescript-eslint/no-duplicate-enum-values": "warn"
   }
 }

--- a/sdk/core/core-paging/.eslintrc.json
+++ b/sdk/core/core-paging/.eslintrc.json
@@ -1,11 +1,4 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-    "@azure/azure-sdk/ts-package-json-sideeffects": "off",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off"
-  }
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
 }

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -53,7 +53,7 @@
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
-  "sideEffects": true,
+  "sideEffects": false,
   "private": false,
   "scripts": {
     "build:samples": "echo Obsolete",

--- a/sdk/core/core-util/.eslintrc.json
+++ b/sdk/core/core-util/.eslintrc.json
@@ -1,6 +1,4 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-  }
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
 }

--- a/sdk/core/core-util/.eslintrc.json
+++ b/sdk/core/core-util/.eslintrc.json
@@ -2,9 +2,5 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off"
   }
 }

--- a/sdk/core/ts-http-runtime/.eslintrc.json
+++ b/sdk/core/ts-http-runtime/.eslintrc.json
@@ -2,11 +2,6 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-engine-is-present": "off",
-    "@azure/azure-sdk/ts-package-json-name": "off",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off"
+    "@azure/azure-sdk/ts-package-json-engine-is-present": "off"
   }
 }

--- a/sdk/core/ts-http-runtime/.eslintrc.json
+++ b/sdk/core/ts-http-runtime/.eslintrc.json
@@ -2,6 +2,7 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-engine-is-present": "off"
+    "@azure/azure-sdk/ts-package-json-engine-is-present": "off",
+    "@azure/azure-sdk/ts-package-json-name": "off"
   }
 }

--- a/sdk/devcenter/developer-devcenter-rest/.eslintrc.json
+++ b/sdk/devcenter/developer-devcenter-rest/.eslintrc.json
@@ -4,11 +4,6 @@
   "rules": {
     "@azure/azure-sdk/ts-modules-only-named": "warn",
     "@azure/azure-sdk/ts-apiextractor-json-types": "warn",
-    "@azure/azure-sdk/ts-package-json-types": "warn",
-    "@azure/azure-sdk/ts-package-json-engine-is-present": "warn",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
     "tsdoc/syntax": "warn"
   }
 }

--- a/sdk/face/ai-vision-face-rest/.eslintrc.json
+++ b/sdk/face/ai-vision-face-rest/.eslintrc.json
@@ -4,11 +4,6 @@
   "rules": {
     "@azure/azure-sdk/ts-modules-only-named": "warn",
     "@azure/azure-sdk/ts-apiextractor-json-types": "warn",
-    "@azure/azure-sdk/ts-package-json-types": "warn",
-    "@azure/azure-sdk/ts-package-json-engine-is-present": "warn",
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
     "tsdoc/syntax": "warn"
   }
 }

--- a/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
+++ b/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
@@ -1,6 +1,4 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
-  "rules": {
-  }
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
 }

--- a/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
+++ b/sdk/web-pubsub/web-pubsub-express/.eslintrc.json
@@ -2,9 +2,5 @@
   "plugins": ["@azure/azure-sdk"],
   "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"],
   "rules": {
-    "@azure/azure-sdk/ts-package-json-module": "off",
-    "@azure/azure-sdk/ts-package-json-types": "off",
-    "@azure/azure-sdk/ts-package-json-files-required": "off",
-    "@azure/azure-sdk/ts-package-json-main-is-cjs": "off"
   }
 }


### PR DESCRIPTION
as packages using tshy has been migrated to ESM and these rules no longer apply to them.
This PR skip these rules to avoid having to turn them off for individual packages.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
We could remove these rules too. Although it's still nice to have them before we migrage all packages to ESM with tshy.

