### PR TITLE
[Monitor OpenTelemetry Exporter] Client Exception Span Events Should Not Create Trace Telemetry

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- Span event exceptions no longer generate trace telemetry.
+- Client generated Span event exceptions no longer generate trace telemetry.
 
 ## 1.0.0-beta.23 (2024-05-10)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## (Unreleased)
+
+### Other Changes
+
+- Span event exceptions no longer generate trace telemetry.
+
 ## 1.0.0-beta.23 (2024-05-10)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## (Unreleased)
+## 1.0.0-beta.24 Unreleased
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -376,40 +376,45 @@ export function spanEventsToEnvelopes(span: ReadableSpan, ikey: string): Envelop
       }
 
       // Only generate exception telemetry for incoming requests
-      if (event.name === "exception" && span.kind === SpanKind.SERVER) {
-        name = "Microsoft.ApplicationInsights.Exception";
-        baseType = "ExceptionData";
-        let typeName = "";
-        let message = "Exception";
-        let stack = "";
-        let hasFullStack = false;
-        if (event.attributes) {
-          typeName = String(event.attributes[SEMATTRS_EXCEPTION_TYPE]);
-          stack = String(event.attributes[SEMATTRS_EXCEPTION_STACKTRACE]);
-          if (stack) {
-            hasFullStack = true;
+      if (event.name === "exception") {
+        if (span.kind === SpanKind.SERVER) {
+          name = "Microsoft.ApplicationInsights.Exception";
+          baseType = "ExceptionData";
+          let typeName = "";
+          let message = "Exception";
+          let stack = "";
+          let hasFullStack = false;
+          if (event.attributes) {
+            typeName = String(event.attributes[SEMATTRS_EXCEPTION_TYPE]);
+            stack = String(event.attributes[SEMATTRS_EXCEPTION_STACKTRACE]);
+            if (stack) {
+              hasFullStack = true;
+            }
+            const exceptionMsg = event.attributes[SEMATTRS_EXCEPTION_MESSAGE];
+            if (exceptionMsg) {
+              message = String(exceptionMsg);
+            }
+            const escaped = event.attributes[SEMATTRS_EXCEPTION_ESCAPED];
+            if (escaped !== undefined) {
+              properties[SEMATTRS_EXCEPTION_ESCAPED] = String(escaped);
+            }
           }
-          const exceptionMsg = event.attributes[SEMATTRS_EXCEPTION_MESSAGE];
-          if (exceptionMsg) {
-            message = String(exceptionMsg);
-          }
-          const escaped = event.attributes[SEMATTRS_EXCEPTION_ESCAPED];
-          if (escaped !== undefined) {
-            properties[SEMATTRS_EXCEPTION_ESCAPED] = String(escaped);
-          }
+          const exceptionDetails: TelemetryExceptionDetails = {
+            typeName: typeName,
+            message: message,
+            stack: stack,
+            hasFullStack: hasFullStack,
+          };
+          const exceptionData: TelemetryExceptionData = {
+            exceptions: [exceptionDetails],
+            version: 2,
+            properties: properties,
+          };
+          baseData = exceptionData;
+        } else {
+          // Drop non-server exception span events
+          return;
         }
-        const exceptionDetails: TelemetryExceptionDetails = {
-          typeName: typeName,
-          message: message,
-          stack: stack,
-          hasFullStack: hasFullStack,
-        };
-        const exceptionData: TelemetryExceptionData = {
-          exceptions: [exceptionDetails],
-          version: 2,
-          properties: properties,
-        };
-        baseData = exceptionData;
       } else {
         name = "Microsoft.ApplicationInsights.Message";
         baseType = "MessageData";

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.test.ts
@@ -16,7 +16,13 @@ import {
 import { Tags, Properties, Measurements } from "../../src/types";
 import { Context, getInstance } from "../../src/platform";
 import { readableSpanToEnvelope, spanEventsToEnvelopes } from "../../src/utils/spanUtils";
-import { RemoteDependencyData, RequestData, KnownContextTagKeys, TelemetryExceptionData } from "../../src/generated";
+import {
+  RemoteDependencyData,
+  RequestData,
+  KnownContextTagKeys,
+  TelemetryExceptionData,
+  MessageData,
+} from "../../src/generated";
 import { TelemetryItem as Envelope } from "../../src/generated";
 import { DependencyTypes } from "../../src/utils/constants/applicationinsights";
 import { hrTimeToDate } from "../../src/utils/common";
@@ -1095,7 +1101,8 @@ describe("spanUtils.ts", () => {
     });
   });
   describe("#spanEventsToEnvelopes", () => {
-    it("should create exception envelope for exception events", () => {
+    it("should create exception envelope for server exception events", () => {
+      const testError = new Error("test error");
       const span = new Span(
         tracer,
         ROOT_CONTEXT,
@@ -1104,15 +1111,15 @@ describe("spanUtils.ts", () => {
         SpanKind.SERVER,
         "parentSpanId",
       );
-      span.recordException(new Error("test error"));
+      span.recordException(testError);
       span.end();
-      const envelope = spanEventsToEnvelopes(span, "ikey");
+      const envelopes = spanEventsToEnvelopes(span, "ikey");
 
       const expectedTags: Tags = {};
       expectedTags[KnownContextTagKeys.AiOperationId] = span.spanContext().traceId;
       expectedTags[KnownContextTagKeys.AiOperationParentId] = "spanId";
       const expectedProperties = {};
-      const testErrorStack = new Error("test error").stack;
+      const testErrorStack = testError.stack;
       const expectedBaseData: Partial<TelemetryExceptionData> = {
         exceptions: [
           {
@@ -1120,14 +1127,14 @@ describe("spanUtils.ts", () => {
             message: "test error",
             stack: testErrorStack,
             typeName: "Error",
-          }
+          },
         ],
         version: 2,
         properties: {},
       };
 
       assertEnvelope(
-        envelope[0],
+        envelopes[0],
         "Microsoft.ApplicationInsights.Exception",
         100,
         "ExceptionData",
@@ -1137,5 +1144,58 @@ describe("spanUtils.ts", () => {
         expectedBaseData,
       );
     });
+    it("should not create an envelope for client exception span events", () => {
+      const testError = new Error("test error");
+      const span = new Span(
+        tracer,
+        ROOT_CONTEXT,
+        "parent span",
+        { traceId: "traceid", spanId: "spanId", traceFlags: 0 },
+        SpanKind.CLIENT,
+        "parentSpanId",
+      );
+      span.recordException(testError);
+      span.end();
+      const envelopes = spanEventsToEnvelopes(span, "ikey");
+
+      const expectedTags: Tags = {};
+      expectedTags[KnownContextTagKeys.AiOperationId] = span.spanContext().traceId;
+      expectedTags[KnownContextTagKeys.AiOperationParentId] = "spanId";
+      assert.ok(envelopes.length === 0);
+    });
+  });
+  it("should create message envelope for span events", () => {
+    const span = new Span(
+      tracer,
+      ROOT_CONTEXT,
+      "parent span",
+      { traceId: "traceid", spanId: "spanId", traceFlags: 0 },
+      SpanKind.SERVER,
+      "parentSpanId",
+    );
+    span.addEvent("test event");
+    span.end();
+    const envelopes = spanEventsToEnvelopes(span, "ikey");
+
+    const expectedTags: Tags = {};
+    expectedTags[KnownContextTagKeys.AiOperationId] = span.spanContext().traceId;
+    expectedTags[KnownContextTagKeys.AiOperationParentId] = "spanId";
+    const expectedProperties = {};
+    const expectedBaseData: Partial<MessageData> = {
+      message: "test event",
+      properties: expectedProperties,
+      version: 2,
+    };
+
+    assertEnvelope(
+      envelopes[0],
+      "Microsoft.ApplicationInsights.Message",
+      100,
+      "MessageData",
+      expectedTags,
+      expectedProperties,
+      undefined,
+      expectedBaseData,
+    );
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## Unreleased ()
+## 1.5.1 Unreleased
 
 ### Bugs Fixed
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Currently only server Span error event will generate Exception telemetry in Application Insights, client spans are generating Trace telemetry by default, we should suppress this, as this data is not useful for customers.

### Are there test cases added in this PR? _(If not, why?)_
Yes, added test cases for each of the control paths related to the span event envelope creation logic.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
