### PR TITLE
Fix playback for communication-chat SDK

### DIFF
--- a/sdk/communication/communication-chat/assets.json
+++ b/sdk/communication/communication-chat/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-chat",
-  "Tag": "js/communication/communication-chat_84b871fc00"
+  "Tag": "js/communication/communication-chat_1b48192a9d"
 }

--- a/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
@@ -13,13 +13,12 @@ import {
 import { ChatClient } from "../../../src";
 import {
   AzureCommunicationTokenCredential,
-  CommunicationTokenCredential,
   CommunicationUserIdentifier,
   parseClientArguments,
 } from "@azure/communication-common";
 import { CommunicationIdentityClient, CommunicationUserToken } from "@azure/communication-identity";
 import { generateToken } from "./connectionUtils";
-import { AccessToken } from "@azure/core-auth";
+import { NoOpCredential } from "@azure-tools/test-credential";
 
 export interface RecordedClient {
   chatClient: ChatClient;
@@ -94,13 +93,7 @@ export function createChatClient(userToken: string, recorder: Recorder): ChatCli
  *
  * Using this NoOpAzureCommunicationTokenCredential as your credential in playback mode would help you bypass the AAD traffic.
  */
-export class NoOpAzureCommunicationTokenCredential implements CommunicationTokenCredential {
-  getToken(): Promise<AccessToken> {
-    return Promise.resolve({
-      token: "SecretPlaceholder",
-      expiresOnTimestamp: Date.now() + 86400 * 1000,
-    });
-  }
+export class NoOpAzureCommunicationTokenCredential extends NoOpCredential {
   public dispose(): void {
     /* intentionally empty */
   }

--- a/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
@@ -8,15 +8,18 @@ import {
   RecorderStartOptions,
   assertEnvironmentVariable,
   env,
+  isPlaybackMode,
 } from "@azure-tools/test-recorder";
 import { ChatClient } from "../../../src";
 import {
   AzureCommunicationTokenCredential,
+  CommunicationTokenCredential,
   CommunicationUserIdentifier,
   parseClientArguments,
 } from "@azure/communication-common";
 import { CommunicationIdentityClient, CommunicationUserToken } from "@azure/communication-identity";
 import { generateToken } from "./connectionUtils";
+import { AccessToken } from "@azure/core-auth";
 
 export interface RecordedClient {
   chatClient: ChatClient;
@@ -27,7 +30,7 @@ const envSetupForPlayback: { [k: string]: string } = {
   COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
 };
 
-const fakeToken = generateToken();
+const fakeToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MTc2MzQ4MDguMTd9.Rx6RqlnKsM09viqebSbPDKRcUp3EIKDEHNVXq3Wb0ms";
 export const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback,
   sanitizerOptions: {
@@ -40,6 +43,7 @@ export const recorderOptions: RecorderStartOptions = {
     bodyKeySanitizers: [{ jsonPath: "$.accessToken.token", value: fakeToken }],
   },
   removeCentralSanitizers: [
+    "AZSDK4001", // url need not be sanitized, fake conn string handles it already
     "AZSDK3493", // .name in the body is not a secret and is listed below in the beforeEach section
     "AZSDK3430", // .id in the body is not a secret and is listed below in the beforeEach section
   ],
@@ -78,7 +82,26 @@ export function createChatClient(userToken: string, recorder: Recorder): ChatCli
 
   return new ChatClient(
     url,
-    new AzureCommunicationTokenCredential(userToken),
+    isPlaybackMode() ? new NoOpAzureCommunicationTokenCredential() : new AzureCommunicationTokenCredential(userToken),
     recorder.configureClientOptions({}),
   );
+}
+
+/**
+ * `TokenCredential` implementation for playback.
+ * If your regular AAD credentials don't take the recorder httpClient option, the AAD traffic won't be recorded.
+ * In this case, you'll need to bypass the AAD requests with no-op.
+ *
+ * Using this NoOpAzureCommunicationTokenCredential as your credential in playback mode would help you bypass the AAD traffic.
+ */
+export class NoOpAzureCommunicationTokenCredential implements CommunicationTokenCredential {
+  getToken(): Promise<AccessToken> {
+    return Promise.resolve({
+      token: "SecretPlaceholder",
+      expiresOnTimestamp: Date.now() + 86400 * 1000,
+    });
+  }
+  public dispose(): void {
+    /* intentionally empty */
+  }
 }


### PR DESCRIPTION
### Changes
1. remove central sanitizer "AZSDK4001", // url need not be sanitized, fake conn string handles it already
2. Predictable `const fakeToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MTc2MzQ4MDguMTd9.Rx6RqlnKsM09viqebSbPDKRcUp3EIKDEHNVXq3Wb0ms";`
3. New `NoOpAzureCommunicationTokenCredential` that implements `AzureCommunicationTokenCredential` and extends `NoOpCredential`