### PR TITLE
[identity] Skip expired cert tests

### DIFF
--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -37,6 +37,10 @@ describe("MsalClient", function () {
     });
 
     it("supports getTokenByClientSecret", async function () {
+      if (isLiveMode()) {
+        // https://github.com/Azure/azure-sdk-for-js/issues/29929
+        this.skip();
+      }
       const scopes = ["https://vault.azure.net/.default"];
       const clientSecret = env.IDENTITY_SP_CLIENT_SECRET || env.AZURE_CLIENT_SECRET!;
       const clientId = env.IDENTITY_SP_CLIENT_ID || env.AZURE_CLIENT_ID!;

--- a/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/clientCertificateCredential.spec.ts
@@ -6,7 +6,7 @@
 import * as path from "path";
 
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
-import { Recorder, delay, env, isPlaybackMode } from "@azure-tools/test-recorder";
+import { Recorder, delay, env, isLiveMode, isPlaybackMode } from "@azure-tools/test-recorder";
 
 import { AbortController } from "@azure/abort-controller";
 import { ClientCertificateCredential } from "../../../src";
@@ -26,6 +26,10 @@ describe("ClientCertificateCredential", function () {
     cleanup = setup.cleanup;
     recorder = setup.recorder;
     await recorder.setMatcher("BodilessMatcher");
+    if (isLiveMode()) {
+      // https://github.com/Azure/azure-sdk-for-js/issues/29929
+      this.skip();
+    }
   });
   afterEach(async function () {
     await cleanup();


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

#29929

### Describe the problem that is addressed by this PR

Identity relies on a set of static resources for some of its tests. The
cert/secret for one of these resources expired and we cannot renew the
credentials until we use test / ephemeral tenants.

This PR skips those tests in live mode as per our discussion with the Identity
feature crew
