### PR TITLE
Update sessionRoundRobin.ts

### DIFF
--- a/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/sessionRoundRobin.ts
@@ -95,6 +95,7 @@ async function receiveFromNextSession(): Promise<void> {
       (err.code === "SessionCannotBeLocked" || err.code === "ServiceTimeout")
     ) {
       console.log(`INFO: no available sessions, sleeping for ${delayOnErrorMs}`);
+      await serviceBusClient.close();
       serviceBusClient = new ServiceBusClient(serviceBusConnectionString);
     } else {
       await processError(err, undefined);


### PR DESCRIPTION
Workaround issue of links being kept alive when there are no seesions avaiable and we get ServiceTimeout errors.

