### PR TITLE
[ServiceBus] close link before throwing error in createRheaLink()

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue where `rhea-promise` receivers are not properly closed in `MessageSession.createRheaLink()` [PR #29954](https://github.com/Azure/azure-sdk-for-js/pull/29954)
+
 ### Other Changes
 
 - upgrade dependency `@azure/abort-controller` version to `^2.1.2`.

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -236,6 +236,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   ): Promise<void> {
     const checkAborted = (): void => {
       if (abortSignal?.aborted) {
+        this._link?.close()
         throw new AbortError(StandardAbortMessage);
       }
     };

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -236,7 +236,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   ): Promise<void> {
     const checkAborted = (): void => {
       if (abortSignal?.aborted) {
-        this._link?.close()
+        this._link?.close();
         throw new AbortError(StandardAbortMessage);
       }
     };

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -279,7 +279,8 @@ export class MessageSession extends LinkEntity<Receiver> {
       ) {
         await delay(1); // yield to eventloop
         if (this._lastSBError) {
-          await link.close();
+          await link.close({ closeSession: true });
+          link.remove();
           throw this._lastSBError;
         }
       }
@@ -298,7 +299,8 @@ export class MessageSession extends LinkEntity<Receiver> {
         condition: ErrorNameConditionMapper.SessionCannotBeLockedError,
       });
       logger.logError(error, this.logPrefix);
-      await link.close();
+      await link.close({ closeSession: true });
+      link.remove();
       throw error;
     }
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -279,6 +279,7 @@ export class MessageSession extends LinkEntity<Receiver> {
       ) {
         await delay(1); // yield to eventloop
         if (this._lastSBError) {
+          await link.close();
           throw this._lastSBError;
         }
       }
@@ -297,6 +298,7 @@ export class MessageSession extends LinkEntity<Receiver> {
         condition: ErrorNameConditionMapper.SessionCannotBeLockedError,
       });
       logger.logError(error, this.logPrefix);
+      await link.close();
       throw error;
     }
 

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -301,7 +301,10 @@ export class MessageSession extends LinkEntity<Receiver> {
         condition: ErrorNameConditionMapper.SessionCannotBeLockedError,
       });
       logger.logError(error, this.logPrefix);
-      logger.verbose("%s cleaning up resources held by intermediate link (SessionCannotBeLockedError)", this.logPrefix);
+      logger.verbose(
+        "%s cleaning up resources held by intermediate link (SessionCannotBeLockedError)",
+        this.logPrefix,
+      );
       await link.close({ closeSession: true });
       link.remove();
       throw error;


### PR DESCRIPTION
This PR fixes a memory leak in `MessageSession.createRheaLink` where in error cases we didn't
close the created `rhea-promise` receiver.  Eventually this would lead to
client exceeding the quota on maximum allowed links on a connection.

The fix is to close the created receiver before we throw errors.