### PR TITLE
[instrumentation] Export the instrumentation class directly

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0-beta.6 (Unreleased)
+
+- Export the AzureSdkInstrumentation class directly for compatibility with [@opentelemetry/auto-instrumentations-node](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node)
+
 ## 1.0.0-beta.5 (2023-08-09)
 
 ### Other Changes

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.0.0-beta.6 (Unreleased)
 
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 - Export the AzureSdkInstrumentation class directly for compatibility with [@opentelemetry/auto-instrumentations-node](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node)
 
 ## 1.0.0-beta.5 (2023-08-09)

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/opentelemetry-instrumentation-azure-sdk",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Instrumentation client for the Azure SDK.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/review/opentelemetry-instrumentation-azure-sdk.api.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/review/opentelemetry-instrumentation-azure-sdk.api.md
@@ -6,7 +6,15 @@
 
 import { AzureLogger } from '@azure/logger';
 import { Instrumentation } from '@opentelemetry/instrumentation';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
+
+// @public
+export class AzureSdkInstrumentation extends InstrumentationBase {
+    constructor(options?: AzureSdkInstrumentationOptions);
+    protected init(): void | InstrumentationModuleDefinition | InstrumentationModuleDefinition[];
+}
 
 // @public
 export interface AzureSdkInstrumentationOptions extends InstrumentationConfig {

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/configuration.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/configuration.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.0.0-beta.5";
+export const SDK_VERSION: string = "1.0.0-beta.6";
 
 /**
  * @internal

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumentation.browser.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumentation.browser.ts
@@ -6,6 +6,7 @@ import {
   InstrumentationBase,
   InstrumentationConfig,
 } from "@opentelemetry/instrumentation";
+
 import { OpenTelemetryInstrumenter } from "./instrumenter";
 import { SDK_VERSION } from "./configuration";
 import { useInstrumenter } from "@azure/core-tracing";
@@ -18,7 +19,7 @@ export interface AzureSdkInstrumentationOptions extends InstrumentationConfig {}
 /**
  * The instrumentation module for the Azure SDK. Implements OpenTelemetry's {@link Instrumentation}.
  */
-class AzureSdkInstrumentation extends InstrumentationBase {
+export class AzureSdkInstrumentation extends InstrumentationBase {
   constructor(options: AzureSdkInstrumentationOptions = {}) {
     super(
       "@azure/opentelemetry-instrumentation-azure-sdk",

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumentation.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/instrumentation.ts
@@ -8,6 +8,7 @@ import {
   InstrumentationModuleDefinition,
   InstrumentationNodeModuleDefinition,
 } from "@opentelemetry/instrumentation";
+
 import { OpenTelemetryInstrumenter } from "./instrumenter";
 import { SDK_VERSION } from "./configuration";
 
@@ -19,7 +20,7 @@ export interface AzureSdkInstrumentationOptions extends InstrumentationConfig {}
 /**
  * The instrumentation module for the Azure SDK. Implements OpenTelemetry's {@link Instrumentation}.
  */
-class AzureSdkInstrumentation extends InstrumentationBase {
+export class AzureSdkInstrumentation extends InstrumentationBase {
   constructor(options: AzureSdkInstrumentationOptions = {}) {
     super(
       "@azure/opentelemetry-instrumentation-azure-sdk",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/opentelemetry-instrumentation-azure-sdk

### Issues associated with this PR

#27510

### Describe the problem that is addressed by this PR

In order to onboard to OTel's auto-instrumentation-node metapackage we need to
export the instrumentation class directly in order to add ourselves to the
[map](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/src/utils.ts#L95) of instrumentations.

Avoiding breaking changes by continuing to export the factory function ensures
that Azure Monitor is not impacted.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

It's possible that OTel does not accept a PR with a 3rd party dependency - if
that's the case we may end up deprecating this package in favor of a new one
under the OTel namespace
