### PR TITLE
[Monitor OpenTelemetry] Update Success/Failure Status Codes for Standard Metrics

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -267,7 +267,9 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
 function createRequestData(span: ReadableSpan): RequestData {
   const requestData: RequestData = {
     id: `${span.spanContext().spanId}`,
-    success: span.status.code !== SpanStatusCode.ERROR,
+    success:
+      span.status.code !== SpanStatusCode.ERROR &&
+      (Number(span.attributes[SEMATTRS_HTTP_STATUS_CODE]) || 0) < 400,
     responseCode: "0",
     duration: msToTimeSpan(hrTimeToMilliseconds(span.duration)),
     version: 2,

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Setting the sampling ratio to 0 now correctly applies the value instead of defaulting to 1.
+- Fixed standard metrics reported success/failure status for dependencies/requests.
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
@@ -32,7 +32,7 @@ export function getRequestDimensions(span: ReadableSpan): Attributes {
   dimensions.metricId = StandardMetricIds.REQUEST_DURATION;
   const statusCode = String(span.attributes["http.status_code"]);
   dimensions.requestResultCode = statusCode;
-  dimensions.requestSuccess = statusCode === "200" ? "True" : "False";
+  dimensions.requestSuccess = Number(statusCode) < 500 ? "True" : "False";
   if (isSyntheticLoad(span)) {
     dimensions.operationSynthetic = "True";
   }
@@ -46,7 +46,7 @@ export function getDependencyDimensions(span: ReadableSpan): Attributes {
   dimensions.dependencyTarget = getDependencyTarget(span.attributes);
   dimensions.dependencyResultCode = statusCode;
   dimensions.dependencyType = "http";
-  dimensions.dependencySuccess = statusCode === "200" ? "True" : "False";
+  dimensions.dependencySuccess = Number(statusCode) < 400 ? "True" : "False";
   if (isSyntheticLoad(span)) {
     dimensions.operationSynthetic = "True";
   }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
@@ -35,10 +35,7 @@ export function getRequestDimensions(span: ReadableSpan): Attributes {
   dimensions.requestResultCode = statusCode;
   // OTel treats 4xx request responses as UNSET SpanStatusCode, but we should count them as failed
   dimensions.requestSuccess =
-    span.status.code !== SpanStatusCode.ERROR &&
-    (Number(statusCode) || 0) < 400
-      ? "True"
-      : "False";
+    span.status.code !== SpanStatusCode.ERROR && (Number(statusCode) || 0) < 400 ? "True" : "False";
   if (isSyntheticLoad(span)) {
     dimensions.operationSynthetic = "True";
   }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
@@ -32,7 +32,7 @@ export function getRequestDimensions(span: ReadableSpan): Attributes {
   dimensions.metricId = StandardMetricIds.REQUEST_DURATION;
   const statusCode = String(span.attributes["http.status_code"]);
   dimensions.requestResultCode = statusCode;
-  dimensions.requestSuccess = Number(statusCode) < 500 ? "True" : "False";
+  dimensions.requestSuccess = Number(statusCode) < 400 ? "True" : "False";
   if (isSyntheticLoad(span)) {
     dimensions.operationSynthetic = "True";
   }

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/standardMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/standardMetrics.test.ts
@@ -137,7 +137,7 @@ describe("#StandardMetricsHandler", () => {
     assert.strictEqual(metrics[0].dataPoints[1].attributes["_MS.IsAutocollected"], "True");
     assert.strictEqual(metrics[0].dataPoints[1].attributes["_MS.MetricId"], "requests/duration");
     assert.strictEqual(metrics[0].dataPoints[1].attributes["request/resultCode"], "400");
-    assert.strictEqual(metrics[0].dataPoints[1].attributes["Request.Success"], "True");
+    assert.strictEqual(metrics[0].dataPoints[1].attributes["Request.Success"], "False");
 
     // Dependencies
     assert.strictEqual(metrics[1].dataPoints.length, 2, "dataPoints count");

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/standardMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/standardMetrics.test.ts
@@ -137,7 +137,7 @@ describe("#StandardMetricsHandler", () => {
     assert.strictEqual(metrics[0].dataPoints[1].attributes["_MS.IsAutocollected"], "True");
     assert.strictEqual(metrics[0].dataPoints[1].attributes["_MS.MetricId"], "requests/duration");
     assert.strictEqual(metrics[0].dataPoints[1].attributes["request/resultCode"], "400");
-    assert.strictEqual(metrics[0].dataPoints[1].attributes["Request.Success"], "False");
+    assert.strictEqual(metrics[0].dataPoints[1].attributes["Request.Success"], "True");
 
     // Dependencies
     assert.strictEqual(metrics[1].dataPoints.length, 2, "dataPoints count");


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
Fixes #29398

### Describe the problem that is addressed by this PR
Success/failure on standard metrics collection for dependencies and requests should follow the spec:
< 400 is success

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Updated test cases that already use the dividing line between success/failure (status code 400)

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
