### PR TITLE
[@azure/eventgrid-system-events][@azure/eventgrid-namespaces] Rename eventSubscriptionName to subscriptionName, Remove topicName subscriptionName as optional, Update CI YML

### DIFF
--- a/sdk/eventgrid/ci.yml
+++ b/sdk/eventgrid/ci.yml
@@ -36,3 +36,5 @@ extends:
         safeName: azureeventgrid
       - name: azure-eventgrid-namespaces
         safeName: azureeventgridnamespaces
+      - name: azure-eventgrid-system-events
+        safeName: azureeventgridsystemevents

--- a/sdk/eventgrid/eventgrid-namespaces/README.md
+++ b/sdk/eventgrid/eventgrid-namespaces/README.md
@@ -96,12 +96,15 @@ const { DefaultAzureCredential } = require("@azure/identity");
 
 const eventGridSenderClient = new EventGridSenderClient(
   "<endpoint>",
-  new DefaultAzureCredential()
+  new DefaultAzureCredential(),
+  "<topicName>"
 );
 
 const eventGridReceiverClient = new EventGridReceiverClient(
   "<endpoint>",
-  new DefaultAzureCredential()
+  new DefaultAzureCredential(),
+  "<topicName>",
+  "<subscriptionName>"
 );
 ```
 
@@ -114,7 +117,8 @@ const eventGridReceiverClient = new EventGridReceiverClient(
 ```js
 const eventGridSenderClient = new EventGridSenderClient(
   "<endpoint>",
-  new AzureKeyCredential("<API Key>")
+  new AzureKeyCredential("<API Key>"),
+  "<topicName>"
 );
 ```
 
@@ -123,7 +127,9 @@ const eventGridSenderClient = new EventGridSenderClient(
 ```js
 const eventGridReceiverClient = new EventGridReceiverClient(
   "<endpoint>",
-  new AzureKeyCredential("<API Key>")
+  new AzureKeyCredential("<API Key>"),
+  "<topicName>",
+  "<subscriptionName>"
 );
 ```
 
@@ -144,7 +150,8 @@ const { EventGridSenderClient, AzureKeyCredential } = require("@azure/eventgrid-
 
 const client = new EventGridSenderClient(
   "<endpoint>",
-  new AzureKeyCredential("<API key>")
+  new AzureKeyCredential("<API key>"),
+  "<topicName>"
 );
 
 const cloudEvent: CloudEvent = {
@@ -158,7 +165,7 @@ const cloudEvent: CloudEvent = {
   specversion: "1.0",
 };
 // Publish the Cloud Event
-await client.sendEvents(cloudEvent, topicName);
+await client.sendEvents(cloudEvent);
 ```
 
 ## Troubleshooting

--- a/sdk/eventgrid/eventgrid-namespaces/review/eventgrid-namespaces.api.md
+++ b/sdk/eventgrid/eventgrid-namespaces/review/eventgrid-namespaces.api.md
@@ -16,8 +16,6 @@ export interface AcknowledgeEventsOptionalParams extends OperationOptions {
 
 // @public
 export interface AcknowledgeEventsOptions extends AcknowledgeEventsOptionalParams {
-    eventSubscriptionName?: string;
-    topicName?: string;
 }
 
 // @public
@@ -61,7 +59,7 @@ export class EventGridDeserializer {
 
 // @public
 export class EventGridReceiverClient {
-    constructor(endpoint: string, credential: AzureKeyCredential | TokenCredential, options?: EventGridReceiverClientOptions);
+    constructor(endpoint: string, credential: AzureKeyCredential | TokenCredential, topicName: string, subscriptionName: string, options?: EventGridReceiverClientOptions);
     acknowledgeEvents(lockTokens: string[], options?: AcknowledgeEventsOptions): Promise<AcknowledgeResult>;
     receiveEvents<T>(options?: ReceiveEventsOptions): Promise<ReceiveResult<T>>;
     rejectEvents(lockTokens: string[], options?: RejectEventsOptions): Promise<RejectResult>;
@@ -71,19 +69,16 @@ export class EventGridReceiverClient {
 
 // @public
 export interface EventGridReceiverClientOptions extends EventGridClientOptions {
-    eventSubscriptionName?: string;
-    topicName?: string;
 }
 
 // @public
 export class EventGridSenderClient {
-    constructor(endpoint: string, credential: AzureKeyCredential | TokenCredential, options?: EventGridSenderClientOptions);
+    constructor(endpoint: string, credential: AzureKeyCredential | TokenCredential, topicName: string, options?: EventGridSenderClientOptions);
     sendEvents<T>(events: CloudEvent<T>[] | CloudEvent<T>, options?: SendEventsOptions): Promise<void>;
 }
 
 // @public
 export interface EventGridSenderClientOptions extends EventGridClientOptions {
-    topicName?: string;
 }
 
 // @public
@@ -117,8 +112,6 @@ export interface ReceiveEventsOptionalParams extends OperationOptions {
 
 // @public
 export interface ReceiveEventsOptions extends ReceiveEventsOptionalParams {
-    eventSubscriptionName?: string;
-    topicName?: string;
 }
 
 // @public
@@ -132,8 +125,6 @@ export interface RejectEventsOptionalParams extends OperationOptions {
 
 // @public
 export interface RejectEventsOptions extends RejectEventsOptionalParams {
-    eventSubscriptionName?: string;
-    topicName?: string;
 }
 
 // @public
@@ -147,9 +138,7 @@ export type ReleaseDelay = string;
 
 // @public
 export interface ReleaseEventsOptions extends OperationOptions {
-    eventSubscriptionName?: string;
     releaseDelay?: ReleaseDelay;
-    topicName?: string;
 }
 
 // @public
@@ -164,8 +153,6 @@ export interface RenewEventLocksOptionalParams extends OperationOptions {
 
 // @public
 export interface RenewEventLocksOptions extends RenewEventLocksOptionalParams {
-    eventSubscriptionName?: string;
-    topicName?: string;
 }
 
 // @public
@@ -186,7 +173,6 @@ export interface SendEventsOptionalParams extends OperationOptions {
 
 // @public
 export interface SendEventsOptions extends SendEventOptionalParams {
-    topicName?: string;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/eventgrid/eventgrid-namespaces/samples-dev/namespaceActivities.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/samples-dev/namespaceActivities.ts
@@ -26,8 +26,13 @@ const topicName = process.env["TOPIC_NAME"] ?? "testtopic1";
 
 export async function main(): Promise<void> {
   // Create the client used to publish events
-  const senderClient = new EventGridSenderClient(endpoint, new AzureKeyCredential(key));
-  const receiverClient = new EventGridReceiverClient(endpoint, new AzureKeyCredential(key));
+  const senderClient = new EventGridSenderClient(endpoint, new AzureKeyCredential(key), topicName);
+  const receiverClient = new EventGridReceiverClient(
+    endpoint,
+    new AzureKeyCredential(key),
+    topicName,
+    eventSubscriptionName,
+  );
 
   // publishes a single cloud event
   const eventId: string = `singleEventIdV210001`;
@@ -42,12 +47,9 @@ export async function main(): Promise<void> {
     specVersion: "1.0",
   };
   // Publish the Cloud Event
-  await senderClient.sendEvents(cloudEvent, { topicName });
+  await senderClient.sendEvents(cloudEvent);
   // Receive the Published Cloud Event
-  const receiveResult: ReceiveResult<any> = await receiverClient.receiveEvents({
-    topicName,
-    eventSubscriptionName,
-  });
+  const receiveResult: ReceiveResult<any> = await receiverClient.receiveEvents();
   // The Received Cloud Event ID must be equal to the ID of the Event that was published.
   console.log(`Received Event ID: ${receiveResult.details[0].event.id}`);
 }

--- a/sdk/eventgrid/eventgrid-namespaces/samples/v1/javascript/namespaceActivities.js
+++ b/sdk/eventgrid/eventgrid-namespaces/samples/v1/javascript/namespaceActivities.js
@@ -20,8 +20,13 @@ const topicName = process.env["TOPIC_NAME"] ?? "testtopic1";
 
 async function main() {
   // Create the client used to publish events
-  const senderClient = new EventGridSenderClient(endpoint, new AzureKeyCredential(key));
-  const receiverClient = new EventGridReceiverClient(endpoint, new AzureKeyCredential(key));
+  const senderClient = new EventGridSenderClient(endpoint, new AzureKeyCredential(key), topicName);
+  const receiverClient = new EventGridReceiverClient(
+    endpoint,
+    new AzureKeyCredential(key),
+    topicName,
+    eventSubscriptionName,
+  );
 
   // publishes a single cloud event
   const eventId = `singleEventIdV210001`;
@@ -36,12 +41,9 @@ async function main() {
     specVersion: "1.0",
   };
   // Publish the Cloud Event
-  await senderClient.sendEvents(cloudEvent, { topicName });
+  await senderClient.sendEvents(cloudEvent);
   // Receive the Published Cloud Event
-  const receiveResult = await receiverClient.receiveEvents({
-    topicName,
-    eventSubscriptionName,
-  });
+  const receiveResult = await receiverClient.receiveEvents();
   // The Received Cloud Event ID must be equal to the ID of the Event that was published.
   console.log(`Received Event ID: ${receiveResult.details[0].event.id}`);
 }

--- a/sdk/eventgrid/eventgrid-namespaces/samples/v1/typescript/src/namespaceActivities.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/samples/v1/typescript/src/namespaceActivities.ts
@@ -25,8 +25,13 @@ const topicName = process.env["TOPIC_NAME"] ?? "testtopic1";
 
 export async function main(): Promise<void> {
   // Create the client used to publish events
-  const senderClient = new EventGridSenderClient(endpoint, new AzureKeyCredential(key));
-  const receiverClient = new EventGridReceiverClient(endpoint, new AzureKeyCredential(key));
+  const senderClient = new EventGridSenderClient(endpoint, new AzureKeyCredential(key), topicName);
+  const receiverClient = new EventGridReceiverClient(
+    endpoint,
+    new AzureKeyCredential(key),
+    topicName,
+    eventSubscriptionName,
+  );
 
   // publishes a single cloud event
   const eventId: string = `singleEventIdV210001`;
@@ -41,12 +46,9 @@ export async function main(): Promise<void> {
     specVersion: "1.0",
   };
   // Publish the Cloud Event
-  await senderClient.sendEvents(cloudEvent, { topicName });
+  await senderClient.sendEvents(cloudEvent);
   // Receive the Published Cloud Event
-  const receiveResult: ReceiveResult<any> = await receiverClient.receiveEvents({
-    topicName,
-    eventSubscriptionName,
-  });
+  const receiveResult: ReceiveResult<any> = await receiverClient.receiveEvents();
   // The Received Cloud Event ID must be equal to the ID of the Event that was published.
   console.log(`Received Event ID: ${receiveResult.details[0].event.id}`);
 }

--- a/sdk/eventgrid/eventgrid-namespaces/src/models.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/src/models.ts
@@ -23,73 +23,31 @@ export interface SendEventOptions extends OperationOptions {
 }
 
 /** Event Grid Sender Client Options */
-export interface EventGridSenderClientOptions extends EventGridOptions {
-  /** Topic name */
-  topicName?: string;
-}
+export interface EventGridSenderClientOptions extends EventGridOptions {}
 
 /** Event Grid Receiver Client Options */
-export interface EventGridReceiverClientOptions extends EventGridOptions {
-  /** Topic name */
-  topicName?: string;
-
-  /** Event Subscription name */
-  eventSubscriptionName?: string;
-}
+export interface EventGridReceiverClientOptions extends EventGridOptions {}
 
 /** Send Events Options */
-export interface SendEventsOptions extends PublishCloudEventOptionalParams {
-  /** Topic name */
-  topicName?: string;
-}
+export interface SendEventsOptions extends PublishCloudEventOptionalParams {}
 
 /** Receive Events Options */
-export interface ReceiveEventsOptions extends ReceiveCloudEventsOptionalParams {
-  /** Topic name */
-  topicName?: string;
-
-  /** Event Subscription name */
-  eventSubscriptionName?: string;
-}
+export interface ReceiveEventsOptions extends ReceiveCloudEventsOptionalParams {}
 
 /** Acknowledge Events Options */
-export interface AcknowledgeEventsOptions extends AcknowledgeCloudEventsOptionalParams {
-  /** Topic name */
-  topicName?: string;
-
-  /** Event Subscription name */
-  eventSubscriptionName?: string;
-}
+export interface AcknowledgeEventsOptions extends AcknowledgeCloudEventsOptionalParams {}
 
 /** Release Events Options */
 export interface ReleaseEventsOptions extends OperationOptions {
-  /** Topic name */
-  topicName?: string;
-
-  /** Event Subscription name */
-  eventSubscriptionName?: string;
-
   /** Release events with the specified delay in seconds. */
   releaseDelay?: ReleaseDelay;
 }
 
 /** Reject Events Options */
-export interface RejectEventsOptions extends RejectCloudEventsOptionalParams {
-  /** Topic name */
-  topicName?: string;
-
-  /** Event Subscription name */
-  eventSubscriptionName?: string;
-}
+export interface RejectEventsOptions extends RejectCloudEventsOptionalParams {}
 
 /** Renew Event Locks Options */
-export interface RenewEventLocksOptions extends RenewCloudEventLocksOptionalParams {
-  /** Topic name */
-  topicName?: string;
-
-  /** Event Subscription name */
-  eventSubscriptionName?: string;
-}
+export interface RenewEventLocksOptions extends RenewCloudEventLocksOptionalParams {}
 
 /** Known values of {@link ReleaseDelay} that the service accepts. */
 export const enum KnownReleaseDelay {

--- a/sdk/eventgrid/eventgrid-namespaces/test/public/utils/recordedClient.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/test/public/utils/recordedClient.ts
@@ -38,6 +38,8 @@ export async function createRecordedClient(
   currentTest: Test | undefined,
   endpointEnv: string,
   apiKeyEnv: string,
+  topicName: string,
+  subscriptionName: string,
   options: {
     additionalPolicies?: AdditionalPolicyConfig[];
   } = {},
@@ -49,6 +51,7 @@ export async function createRecordedClient(
     senderClient: new EventGridSenderClient(
       assertEnvironmentVariable(endpointEnv),
       new AzureKeyCredential(assertEnvironmentVariable(apiKeyEnv)),
+      topicName,
       recorder.configureClientOptions({
         additionalPolicies: options.additionalPolicies,
       }),
@@ -56,6 +59,8 @@ export async function createRecordedClient(
     receiverClient: new EventGridReceiverClient(
       assertEnvironmentVariable(endpointEnv),
       new AzureKeyCredential(assertEnvironmentVariable(apiKeyEnv)),
+      topicName,
+      subscriptionName,
       recorder.configureClientOptions({
         additionalPolicies: options.additionalPolicies,
       }),


### PR DESCRIPTION
### Packages impacted by this PR

1. @azure/eventgrid-system-events
2. @azure/eventgrid-namespaces

### Issues associated with this PR

None

### Describe the problem that is addressed by this PR

#### @azure/eventgrid-namespaces

The 2 clients `EventGridSenderClient` & `EventGridReceiverClient` have the parameters `topicName` and `eventSubscriptionName` as optional. In order to be consistent with all the languages, these 2 parameters must be changed to mandatory. Also, the parameter `eventSubscriptionName` must be changed to `eventSubscriptionName`.

#### @azure/eventgrid-system-events

The `ci.yml` file must be updated to generate the artifact for release. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

No special design considerations

### Are there test cases added in this PR? _(If not, why?)_

No test cases are required.

### Provide a list of related PRs _(if any)_

None

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)

@maorleger @jeremymeng  Please review and approve the PR