### PR TITLE
[core] Provide `error` parameter to onResponse callback

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 2.0.1 (Unreleased)
+## 2.1.0 (Unreleased)
 
 ### Features Added
+
+- The `onResponse` callback will now be called when the underlying request results in an error. In this scenario, the error to be thrown will be provided as the second argument to the callback.
 
 ### Breaking Changes
 

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/core-client",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Core library for interfacing with Azure Rest Clients",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-client-rest/review/core-client.api.md
+++ b/sdk/core/core-client-rest/review/core-client.api.md
@@ -154,7 +154,7 @@ export type PathUncheckedResponse = HttpResponse & {
 };
 
 // @public
-export type RawResponseCallback = (rawResponse: FullOperationResponse, error?: unknown) => void;
+export type RawResponseCallback = (rawResponse: FullOperationResponse, error?: unknown, __legacyError?: unknown) => void;
 
 // @public
 export type RequestParameters = {

--- a/sdk/core/core-client-rest/src/common.ts
+++ b/sdk/core/core-client-rest/src/common.ts
@@ -91,8 +91,16 @@ export type RequestParameters = {
  * A function to be called each time a response is received from the server
  * while performing the requested operation.
  * May be called multiple times.
+ *
+ * This callback will be called with two parameters: the raw response, including headers and response body; and an error
+ * object which will be provided if an error was thrown while processing the request.
+ * The third __legacyError parameter is provided for backwards compatability only and will have an identical value to the `error` parameter.
  */
-export type RawResponseCallback = (rawResponse: FullOperationResponse, error?: unknown) => void;
+export type RawResponseCallback = (
+  rawResponse: FullOperationResponse,
+  error?: unknown,
+  __legacyError?: unknown,
+) => void;
 
 /**
  * Wrapper object for http request and response. Deserialized object is stored in

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -122,8 +122,8 @@ function buildPipelineRequest(
     accept: options.accept ?? options.headers?.accept ?? "application/json",
     ...(hasContent &&
       requestContentType && {
-      "content-type": requestContentType,
-    }),
+        "content-type": requestContentType,
+      }),
   });
 
   return createPipelineRequest({

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -12,6 +12,7 @@ import {
   RestError,
   createHttpHeaders,
   createPipelineRequest,
+  isRestError,
 } from "@azure/core-rest-pipeline";
 import { getCachedDefaultHttpsClient } from "./clientHelpers.js";
 import { isReadableStream } from "./helpers/isReadableStream.js";
@@ -36,23 +37,34 @@ export async function sendRequest(
 ): Promise<HttpResponse> {
   const httpClient = customHttpClient ?? getCachedDefaultHttpsClient();
   const request = buildPipelineRequest(method, url, options);
-  const response = await pipeline.sendRequest(httpClient, request);
-  const headers = response.headers.toJSON();
-  const stream = response.readableStreamBody ?? response.browserStreamBody;
-  const parsedBody =
-    options.responseAsStream || stream !== undefined ? undefined : getResponseBody(response);
-  const body = stream ?? parsedBody;
 
-  if (options?.onResponse) {
-    options.onResponse({ ...response, request, rawHeaders: headers, parsedBody });
+  try {
+    const response = await pipeline.sendRequest(httpClient, request);
+    const headers = response.headers.toJSON();
+    const stream = response.readableStreamBody ?? response.browserStreamBody;
+    const parsedBody =
+      options.responseAsStream || stream !== undefined ? undefined : getResponseBody(response);
+    const body = stream ?? parsedBody;
+
+    if (options?.onResponse) {
+      options.onResponse({ ...response, request, rawHeaders: headers, parsedBody });
+    }
+
+    return {
+      request,
+      headers,
+      status: `${response.status}`,
+      body,
+    };
+  } catch (e: unknown) {
+    if (isRestError(e) && e.response && options.onResponse) {
+      const { response } = e;
+      const rawHeaders = response.headers.toJSON();
+      options?.onResponse({ ...response, request, rawHeaders }, e, e);
+    }
+
+    throw e;
   }
-
-  return {
-    request,
-    headers,
-    status: `${response.status}`,
-    body,
-  };
 }
 
 /**
@@ -110,8 +122,8 @@ function buildPipelineRequest(
     accept: options.accept ?? options.headers?.accept ?? "application/json",
     ...(hasContent &&
       requestContentType && {
-        "content-type": requestContentType,
-      }),
+      "content-type": requestContentType,
+    }),
   });
 
   return createPipelineRequest({

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.17.0 (Unreleased)
+## 1.16.1 (Unreleased)
 
 ### Features Added
 
@@ -9,7 +9,6 @@
 ### Bugs Fixed
 
 - Tracing spans will now correctly sanitize query parameters in the http.url span attribute. [#29606](https://github.com/Azure/azure-sdk-for-js/pull/29606)
-- `RestError` content will now be sanitized upon JSON serialization. [#29737](https://github.com/Azure/azure-sdk-for-js/pull/29606)
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.16.1 (Unreleased)
+## 1.17.0 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Tracing spans will now correctly sanitize query parameters in the http.url span attribute. [#29606](https://github.com/Azure/azure-sdk-for-js/pull/29606)
+- `RestError` content will now be sanitized upon JSON serialization. [#29737](https://github.com/Azure/azure-sdk-for-js/pull/29606)
 
 ### Other Changes
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-rest/core-client`

### Describe the problem that is addressed by this PR

Proposal to mitigate a couple of breaking changes between the old and new `core-client` packages:
- `onResponse` is now called when an error is thrown while sending the request. This was not being done by `core-client-rest` but [is being done by `core-client`
](https://github.com/Azure/azure-sdk-for-js/blob/9f03724468521497f8499907433a715b062a9884/sdk/core/core-client/src/serviceClient.ts#L217-L229).
- Updated the type of the `onResponse` callback to be more backwards-compatible with the old Core. The old Core's callback had three parameters (response, flatResponse, and error), but the new package has only two (response and error). The `flatResponse` property does not make sense in the new Core and we have decided not to support this property. In order to enable this, we pass the error twice in the new callback so that we can support passing the `error` through to both the old and new variations of `onResponse`.
