### PR TITLE
[language-conversations] Fix CI

### DIFF
--- a/sdk/cognitivelanguage/ai-language-conversations/package.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/package.json
@@ -112,7 +112,7 @@
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "unit-test:browser": "echo Skipped",
-    "unit-test:node": "echo skipped",
+    "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 \"test/**/*.spec.ts\"",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "sideEffects": false,

--- a/sdk/cognitivelanguage/ai-language-conversations/test/public/utils/recordedClient.ts
+++ b/sdk/cognitivelanguage/ai-language-conversations/test/public/utils/recordedClient.ts
@@ -25,8 +25,8 @@ const envSetupForPlayback: { [k: string]: string } = {
 const recorderStartOptions: RecorderStartOptions = {
   envSetupForPlayback,
   removeCentralSanitizers: [
-    "AZSDK2030",// "operation-location" is not a secret in itself, main endpoint is masked through other sanitizers (envSetupForPlayback)
-  ]
+    "AZSDK2030", // "operation-location" is not a secret in itself, main endpoint is masked through other sanitizers (envSetupForPlayback)
+  ],
 };
 
 export type AuthMethod = "APIKey" | "AAD" | "DummyAPIKey";

--- a/sdk/cognitivelanguage/ai-language-conversations/test/public/utils/recordedClient.ts
+++ b/sdk/cognitivelanguage/ai-language-conversations/test/public/utils/recordedClient.ts
@@ -24,6 +24,9 @@ const envSetupForPlayback: { [k: string]: string } = {
 
 const recorderStartOptions: RecorderStartOptions = {
   envSetupForPlayback,
+  removeCentralSanitizers: [
+    "AZSDK2030",// "operation-location" is not a secret in itself, main endpoint is masked through other sanitizers (envSetupForPlayback)
+  ]
 };
 
 export type AuthMethod = "APIKey" | "AAD" | "DummyAPIKey";


### PR DESCRIPTION
Skip central sanitizer "AZSDK2030" 
- "operation-location" is not a secret in itself, main endpoint is masked through other sanitizers (envSetupForPlayback)