### PR TITLE
[identity] patch changelog

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 - Managed identity bug fixes
 
+## 4.2.1 (2024-06-10)
+
+### Bugs Fixed
+
+- Managed identity bug fixes
+
 ## 4.3.0-beta.1 (2024-05-08)
 
 ### Features Added


### PR DESCRIPTION
This PR just brings the changelog entry for 4.2.1 into `main`
