### PR TITLE
[identity] Define MsalClientOptions

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -4,8 +4,9 @@
 import * as msal from "@azure/msal-node";
 
 import { AccessToken, GetTokenOptions } from "@azure/core-auth";
+import { AuthenticationRecord, CertificateParts } from "../types";
+import { CredentialLogger, credentialLogger, formatSuccess } from "../../util/logging";
 import { PluginConfiguration, msalPlugins } from "./msalPlugins";
-import { credentialLogger, formatSuccess } from "../../util/logging";
 import {
   defaultLoggerCallback,
   ensureValidMsalToken,
@@ -18,13 +19,14 @@ import {
 } from "../utils";
 
 import { AuthenticationRequiredError } from "../../errors";
-import { AuthenticationRecord, CertificateParts } from "../types";
+import { BrokerOptions } from "./brokerOptions";
+import { DeviceCodePromptCallback } from "../../credentials/deviceCodeCredentialOptions";
 import { IdentityClient } from "../../client/identityClient";
-import { MsalNodeOptions } from "./msalNodeCommon";
+import { MultiTenantTokenCredentialOptions } from "../../credentials/multiTenantTokenCredentialOptions";
+import { TokenCachePersistenceOptions } from "./tokenCachePersistenceOptions";
 import { calculateRegionalAuthority } from "../../regionalAuthority";
 import { getLogLevel } from "@azure/logger";
 import { resolveTenantId } from "../../util/tenantIdUtils";
-import { DeviceCodePromptCallback } from "../../credentials/deviceCodeCredentialOptions";
 
 /**
  * The logger for all MsalClient instances.
@@ -145,11 +147,49 @@ export interface MsalClient {
 }
 
 /**
- * Options for creating an instance of the MsalClient.
+ * Represents the options for configuring the MsalClient.
  */
-export type MsalClientOptions = Partial<
-  Omit<MsalNodeOptions, "clientId" | "tenantId" | "disableAutomaticAuthentication">
->;
+export interface MsalClientOptions {
+  /**
+   * Parameters that enable WAM broker authentication in the InteractiveBrowserCredential.
+   */
+  brokerOptions?: BrokerOptions;
+
+  /**
+   * Parameters that enable token cache persistence in the Identity credentials.
+   */
+  tokenCachePersistenceOptions?: TokenCachePersistenceOptions;
+
+  /**
+   * A custom authority host.
+   */
+  authorityHost?: string;
+
+  /**
+   * Allows users to configure settings for logging policy options, allow logging account information and personally identifiable information for customer support.
+   */
+  loggingOptions?: IdentityClient["tokenCredentialOptions"]["loggingOptions"];
+
+  /**
+   * Determines whether instance discovery is disabled.
+   */
+  disableInstanceDiscovery?: boolean;
+
+  /**
+   * The logger for the MsalClient.
+   */
+  logger?: CredentialLogger;
+
+  /**
+   * The authentication record for the MsalClient.
+   */
+  authenticationRecord?: AuthenticationRecord;
+
+  /**
+   * The token credential options for the MsalClient.
+   */
+  tokenCredentialOptions?: MultiTenantTokenCredentialOptions;
+}
 
 /**
  * Generates the configuration for MSAL (Microsoft Authentication Library).

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -14,14 +14,14 @@ import { Recorder, env, isLiveMode } from "@azure-tools/test-recorder";
 
 import { AbortError } from "@azure/abort-controller";
 import { AuthenticationRequiredError } from "../../../src/errors";
+import { Context } from "mocha";
+import { DeveloperSignOnClientId } from "../../../src/constants";
 import { IdentityClient } from "../../../src/client/identityClient";
 import { assert } from "@azure-tools/test-utils";
 import { credentialLogger } from "../../../src/util/logging";
+import { getUsernamePasswordStaticResources } from "../../msalTestUtils";
 import { msalPlugins } from "../../../src/msal/nodeFlows/msalPlugins";
 import sinon from "sinon";
-import { DeveloperSignOnClientId } from "../../../src/constants";
-import { Context } from "mocha";
-import { getUsernamePasswordStaticResources } from "../../msalTestUtils";
 
 describe("MsalClient", function () {
   describe("recorded tests", function () {
@@ -101,6 +101,22 @@ describe("MsalClient", function () {
 
       const client = msalClient.createMsalClient(clientId, tenantId);
       assert.exists(client);
+    });
+
+    it("can configure a custom logger for the client", async function () {
+      const clientId = "client-id";
+      const tenantId = "tenant-id";
+      const logger = credentialLogger("test");
+      const logSpy = sinon.spy(logger, "info");
+
+      const client = msalClient.createMsalClient(clientId, tenantId, { logger });
+      try {
+        await client.getTokenByClientSecret(["https://vault.azure.net/.default"], "client-secret");
+      } catch (e) {
+        // ignore errors
+      }
+
+      assert.isAbove(logSpy.callCount, 0);
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #29888

### Describe the problem that is addressed by this PR

Now that all credentials have been either migrated or a PR opened with their
migration we can narrow down the type of MsalClientOptions to just the used
options.

In the future, we can further refine this by:
- Renaming tokenCredentialOptions to "identityClientOptions"
- Bucket brokerOptions and persistenceOptions under "pluginOptions"

Etc. 

But the goal here is to just have a new definition of used properties so it can
be refined in the future.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

I could do the above recommendations now, but I'd rather keep the scope small if
possible.

### Are there test cases added in this PR? _(If not, why?)_

Just a refactor

