### PR TITLE
Updated core client version to fix the base uri conflict

### DIFF
--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.5.1 (2024-06-12)
 
-- Updated @azure/core-client version.
+- Updated @azure/core-client and @azure/core-rest-pipeline version.
 
 ## 1.5.0 (2024-04-15)
 

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 1.6.0 (upcoming)
+## 1.5.1 (2024-06-12)
 
-### Features Added
+- Updated @azure/core-client version.
 
 ## 1.5.0 (2024-04-15)
 

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-chat",
-  "version": "1.6.0",
+  "version": "1.5.1",
   "description": "Azure client library for Azure Communication Chat services",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -66,7 +66,7 @@
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-signaling": "1.0.0-beta.26",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-client": "^1.3.0",
+    "@azure/core-client": "^1.6.0",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-rest-pipeline": "^1.3.0",
     "@azure/core-tracing": "^1.0.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -68,7 +68,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.6.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-rest-pipeline": "^1.3.0",
+    "@azure/core-rest-pipeline": "^1.9.0",
     "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -2255,6 +2255,7 @@ matrix(
             },
           });
           assert.equal(serialized, expectedSerialized);
+          assert.exists(poller.operationState);
           assert.equal(poller.operationState.status, "succeeded");
           const restoredPoller = createTestPoller({
             routes: [],
@@ -2263,7 +2264,7 @@ matrix(
             throwOnNon2xxResponse,
           });
           assert.equal(serialized, await restoredPoller.serialize());
-          assert.equal(poller.operationState.status, "succeeded");
+          assert.equal(poller.operationState!.status, "succeeded");
           assert.deepEqual(poller.result, retResult);
         });
 
@@ -2324,7 +2325,8 @@ matrix(
             },
           });
           assert.equal(serialized, expectedSerialized);
-          assert.equal(poller.operationState.status, "running");
+          assert.isNotNull(poller.operationState);
+          assert.equal(poller.operationState!.status, "running");
           pollCount = 0;
           const restoredPoller = createTestPoller({
             routes: pollingRoutes,
@@ -2734,7 +2736,8 @@ matrix(
           const result = await poller;
           assert.deepEqual(retResult, result);
           assert.equal(pollCount, 11);
-          assert.equal(poller.operationState.status, "succeeded");
+          assert.isNotNull(poller.operationState);
+          assert.equal(poller.operationState!.status, "succeeded");
           assert.deepEqual(poller.result, retResult);
           assert.equal(poller.result, result);
           // duplicate awaitting would not trigger extra pollings
@@ -2950,7 +2953,8 @@ matrix(
           assert.isUndefined(poller.operationState);
           await poller.submitted();
           assert.equal(pollCount, 0);
-          assert.equal(poller.operationState.status, "running");
+          assert.isNotNull(poller.operationState);
+          assert.equal(poller.operationState!.status, "running");
         });
       });
 


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/communication-chat 

### Issues associated with this PR
### Describe the problem that is addressed by this PR

Customer escalated the issue:
The issue was introduced from the @azure/communication-chat@1.4.0.  Chat client updated the internal API client by generating the new service client version with the `endpoint` param to replace the `baseUri` and kept the dependency version  @azure/core-client@1.3.0 and higher. While the `endpoint` is introduced only in @azure/core-client@1.6.0.
Customer see error "baseUrl is not specified" if the dependency version not updated.

Update the @azure/core-client version to fix the issue


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
