### PR TITLE
[communication] Use Identity 4.2.1

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1566,28 +1566,6 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@azure/identity@3.4.2:
-    resolution: {integrity: sha512-0q5DL4uyR0EZ4RXQKD8MadGH6zTIcloUoS/RVbCpNpej4pwte0xpqYxk8K97Py2RiuUvI7F4GXpoT4046VfufA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.7.2
-      '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.16.0
-      '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
-      '@azure/msal-browser': 3.17.0
-      '@azure/msal-node': 2.9.2
-      events: 3.3.0
-      jws: 4.0.0
-      open: 8.4.2
-      stoppable: 1.1.0
-      tslib: 2.6.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@azure/identity@4.2.1:
     resolution: {integrity: sha512-U8hsyC9YPcEIzoaObJlRDvp7KiF0MGS7xcWbyJSVvXRkC/HXo1f0oYeBYmEvVgRfacw7GHf6D6yAoh9JHz6A5Q==}
     engines: {node: '>=18.0.0'}
@@ -19504,14 +19482,14 @@ packages:
     dev: false
 
   file:projects/communication-messages.tgz:
-    resolution: {integrity: sha512-bkn+U65q9nFSnYE8eLlstXs2qP2MaBaj4gWnQugCP3v+yqFgruH49Qn11wSQbXp4wPQfHZQK27w72xsYimr+ig==, tarball: file:projects/communication-messages.tgz}
+    resolution: {integrity: sha512-FBiUAbxXx8WErurGj7LYnT9V2OdEUjlKXeP4zj6fcgoZlFFzif4MtoXHLcLCzwoMzGwMc9MOCoYgzs9q89s5bQ==, tarball: file:projects/communication-messages.tgz}
     name: '@rush-temp/communication-messages'
     version: 0.0.0
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure-tools/test-credential': 1.1.0
       '@azure-tools/test-recorder': 3.5.1
-      '@azure/identity': 3.4.2
+      '@azure/identity': 4.2.1
       '@microsoft/api-extractor': 7.47.0(@types/node@18.19.34)
       '@types/chai': 4.3.16
       '@types/mocha': 10.0.6

--- a/sdk/communication/communication-messages-rest/package.json
+++ b/sdk/communication/communication-messages-rest/package.json
@@ -82,7 +82,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure-tools/test-credential": "^1.0.0",
-    "@azure/identity": "^3.3.0",
+    "@azure/identity": "^4.2.1",
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
Resolves dependabot alerts and ensure the repo is on 4.2.1
