### PR TITLE
[@azure/arm-newrelicobservability] Fix the Test Case

### DIFF
--- a/sdk/newrelicobservability/arm-newrelicobservability/test/newrelicobservability_operations_test.spec.ts.ts
+++ b/sdk/newrelicobservability/arm-newrelicobservability/test/newrelicobservability_operations_test.spec.ts.ts
@@ -29,6 +29,7 @@ const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback: replaceableVariables,
   removeCentralSanitizers: [
     "AZSDK4001", // url should not be over-sanitized, fake env setup handles it already
+    "AZSDK3493",
   ],
 };
 
@@ -51,7 +52,7 @@ describe("NewRelicObservability test", () => {
     subscriptionId = env.NewRelic_SUBSCRIPTION_ID || "";
     tenantId = env.NewRelic_TENANT_ID || "";
     const credentialOptions: CreateTestCredentialOptions = {
-      tenantId: tenantId,
+      tenantId,
     };
     // This is an example of how the environment variables are used
     const credential = createTestCredential(credentialOptions);

--- a/sdk/newrelicobservability/arm-newrelicobservability/test/newrelicobservability_operations_test.spec.ts.ts
+++ b/sdk/newrelicobservability/arm-newrelicobservability/test/newrelicobservability_operations_test.spec.ts.ts
@@ -22,11 +22,11 @@ const replaceableVariables: Record<string, string> = {
   NewRelic_CLIENT_ID: "azure_client_id",
   NewRelic_CLIENT_SECRET: "azure_client_secret",
   NewRelic_TENANT_ID: "88888888-8888-8888-8888-888888888888",
-  NewRelic_SUBSCRIPTION_ID: "azure_subscription_id"
+  NewRelic_SUBSCRIPTION_ID: "azure_subscription_id",
 };
 
 const recorderOptions: RecorderStartOptions = {
-  envSetupForPlayback: replaceableVariables
+  envSetupForPlayback: replaceableVariables,
 };
 
 export const testPollingOptions = {
@@ -36,9 +36,7 @@ export const testPollingOptions = {
 describe("NewRelicObservability test", () => {
   let recorder: Recorder;
   let subscriptionId: string;
-  let clientId: string;
   let tenantId: string;
-  let clientSecret: string;
   let client: NewRelicObservability;
   let location: string;
   let resourceGroup: string;
@@ -47,22 +45,21 @@ describe("NewRelicObservability test", () => {
   beforeEach(async function (this: Context) {
     recorder = new Recorder(this.currentTest);
     await recorder.start(recorderOptions);
-    subscriptionId = env.NewRelic_SUBSCRIPTION_ID || '';
-    clientId = env.NewRelic_CLIENT_ID || '';
-    tenantId = env.NewRelic_TENANT_ID || '';
-    clientSecret = env.NewRelic_CLIENT_SECRET || '';
+    subscriptionId = env.NewRelic_SUBSCRIPTION_ID || "";
+    tenantId = env.NewRelic_TENANT_ID || "";
     const credentialOptions: CreateTestCredentialOptions = {
       tenantId,
-      clientId,
-      clientSecret
-    }
+    };
     // This is an example of how the environment variables are used
-    const credential = createTestCredential(undefined, credentialOptions);
-    client = new NewRelicObservability(credential, subscriptionId, recorder.configureClientOptions({}));
+    const credential = createTestCredential(credentialOptions);
+    client = new NewRelicObservability(
+      credential,
+      subscriptionId,
+      recorder.configureClientOptions({}),
+    );
     location = "centraluseuap";
     resourceGroup = "myjstest";
     resourcename = "resourcetest1";
-
   });
 
   afterEach(async function () {
@@ -86,22 +83,23 @@ describe("NewRelicObservability test", () => {
           firstName: "ZiWei",
           lastName: "Chen (WICRESOFT NORTH AMERICA LTD)",
           emailAddress: "v-ziweichen@microsoft.com",
-          phoneNumber: ""
+          phoneNumber: "",
         },
         planData: {
           usageType: "PAYG",
           billingCycle: "MONTHLY",
-          planDetails: "newrelic-pay-as-you-go-free-live@TIDgmz7xq9ge3py@PUBIDnewrelicinc1635200720692.newrelic_liftr_payg"
+          planDetails:
+            "newrelic-pay-as-you-go-free-live@TIDgmz7xq9ge3py@PUBIDnewrelicinc1635200720692.newrelic_liftr_payg",
         },
       },
-      testPollingOptions);
+      testPollingOptions,
+    );
     assert.equal(res.name, resourcename);
-    await delay(100000)
+    await delay(100000);
   });
 
   it("monitors get test", async function () {
-    const res = await client.monitors.get(resourceGroup,
-      resourcename);
+    const res = await client.monitors.get(resourceGroup, resourcename);
     assert.equal(res.name, resourcename);
   });
 
@@ -115,12 +113,14 @@ describe("NewRelicObservability test", () => {
 
   it("monitors delete test", async function () {
     const resArray = new Array();
-    const res = await client.monitors.beginDeleteAndWait(resourceGroup, "v-ziweichen@microsoft.com", resourcename
-    )
+    const res = await client.monitors.beginDeleteAndWait(
+      resourceGroup,
+      "v-ziweichen@microsoft.com",
+      resourcename,
+    );
     for await (let item of client.monitors.listByResourceGroup(resourceGroup)) {
       resArray.push(item);
     }
     assert.equal(resArray.length, 1);
   });
-
-})
+});

--- a/sdk/newrelicobservability/arm-newrelicobservability/test/newrelicobservability_operations_test.spec.ts.ts
+++ b/sdk/newrelicobservability/arm-newrelicobservability/test/newrelicobservability_operations_test.spec.ts.ts
@@ -27,6 +27,9 @@ const replaceableVariables: Record<string, string> = {
 
 const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback: replaceableVariables,
+  removeCentralSanitizers: [
+    "AZSDK4001", // url should not be over-sanitized, fake env setup handles it already
+  ],
 };
 
 export const testPollingOptions = {
@@ -48,7 +51,7 @@ describe("NewRelicObservability test", () => {
     subscriptionId = env.NewRelic_SUBSCRIPTION_ID || "";
     tenantId = env.NewRelic_TENANT_ID || "";
     const credentialOptions: CreateTestCredentialOptions = {
-      tenantId,
+      tenantId: tenantId,
     };
     // This is an example of how the environment variables are used
     const credential = createTestCredential(credentialOptions);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/arm-newrelicobservability

### Issues associated with this PR

None

### Describe the problem that is addressed by this PR

On June 6, 2024, an issue was reported by Manik Khandelwal as the `rushx build` command is failing for the `@azure/arm-newrelicobservability` SDK. The following error is reported:

```
test/newrelicobservability_operations_test.spec.ts.ts(56,7): error TS2353: Object literal may only specify known properties, and 'clientId' does not exist in type 'CreateTestCredentialOptions'.
test/newrelicobservability_operations_test.spec.ts.ts(60,56): error TS2554: Expected 0-1 arguments, but got 2.
```

This PR has been created to fix this issue. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Looking at the root cause of the issue, the current code changes in the `newrelicobservability_operations_test.spec.ts.ts` (with client id & client secret) are added on March 21, 2024 (Refer https://github.com/Azure/azure-sdk-for-js/pull/28829). At that time, there was no problem with the code and it was working fine. 

On May 6, 2024 some changes have been done in the `@azure-tools/test-credential` in which the `clientId` and `clientSecret` have been removed. Thus the reported error is happening. (Now, Ideally I would have expected that such issues would have been flagged by our CI while merging the changes for `@azure-tools/test-credential`. But, that did not happen. Refer the CI run in https://github.com/Azure/azure-sdk-for-js/pull/29577. @HarshaNalluru for further investigation) 

In order to resolve the issue, I have removed the extra parameters. The `playback` mode is also running fine. The CI could be seen at https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3868221&view=results. Because of the artifact already exists, the check enforcer is not completing. But that is not a serious issue. I am overriding the check enforcer.

### Are there test cases added in this PR? _(If not, why?)_

No. The issue itself is in the test case.

### Provide a list of related PRs _(if any)_

1. https://github.com/Azure/azure-sdk-for-js/pull/28829
2. https://github.com/Azure/azure-sdk-for-js/pull/29577

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)

@xirzec @joheredi Please review and approve the PR