### PR TITLE
[dev-tool] fix samples typescript source to include sub directory

### DIFF
--- a/common/tools/dev-tool/src/util/samples/info.ts
+++ b/common/tools/dev-tool/src/util/samples/info.ts
@@ -34,7 +34,7 @@ export const DEFAULT_TYPESCRIPT_CONFIG = {
     outDir: "dist",
     rootDir: "src",
   },
-  include: ["src/**.ts"],
+  include: ["src/**/*.ts"],
 };
 
 /**

--- a/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/special-characters/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/special-characters/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/sdk/servicebus/service-bus/samples/v7/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/advanced/sessionRoundRobin.js
@@ -11,10 +11,7 @@
  */
 
 const { ServiceBusClient, delay, isServiceBusError } = require("@azure/service-bus");
-const dotenv = require("dotenv");
-const { AbortController } = require("@azure/abort-controller");
-
-dotenv.config();
+require("dotenv").config();
 
 const serviceBusConnectionString =
   process.env.SERVICEBUS_CONNECTION_STRING || "<connection string>";

--- a/sdk/servicebus/service-bus/samples/v7/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/package.json
@@ -29,8 +29,7 @@
     "dotenv": "latest",
     "ws": "^8.0.0",
     "https-proxy-agent": "^7.0.0",
-    "@azure/identity": "^4.2.1",
-    "@azure/core-auth": "^1.3.0",
-    "@azure/abort-controller": "^2.1.2"
+    "@azure/identity": "^4.0.1",
+    "@azure/core-auth": "^1.3.0"
   }
 }

--- a/sdk/servicebus/service-bus/samples/v7/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/package.json
@@ -33,9 +33,8 @@
     "dotenv": "latest",
     "ws": "^8.0.0",
     "https-proxy-agent": "^7.0.0",
-    "@azure/identity": "^4.2.1",
-    "@azure/core-auth": "^1.3.0",
-    "@azure/abort-controller": "^2.1.2"
+    "@azure/identity": "^4.0.1",
+    "@azure/core-auth": "^1.3.0"
   },
   "devDependencies": {
     "@types/ws": "^7.2.4",

--- a/sdk/servicebus/service-bus/samples/v7/typescript/tsconfig.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }


### PR DESCRIPTION
Sample source structure used to be flat but later nested directories are supported as well. This PR fix the glob pattern to also include sub directories.

- also re-publish samples for @azure/service-bus

I didn't update all the other samples as there are no complaints. They can get new update in their next publish.