### PR TITLE
[Test][ServiceBus] update expected error message

### DIFF
--- a/sdk/servicebus/service-bus/test/internal/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/managementClient.spec.ts
@@ -29,7 +29,10 @@ describe("ManagementClient unit tests", () => {
 
       chai.assert.fail("_makeManagementRequest should have failed");
     } catch (error: any) {
-      chai.assert.equal(error.message, "The management request timed out. Please try again later.");
+      chai.assert.equal(
+        error.message,
+        "The initialization of management client timed out. Please try again later.",
+      );
     }
     await mgmtClient.close();
   });


### PR DESCRIPTION
This particular error message was updated in PR #29853 but the test wasn't and
since it's a live test, the CI didn't catch it. This PR fixes the test failure
by updating the expected error message.