### PR TITLE
[dev-tool] Create migration tool

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/index.ts
+++ b/common/tools/dev-tool/src/commands/admin/index.ts
@@ -8,5 +8,6 @@ export const commandInfo = makeCommandInfo("admin", "run administrative tasks fo
 export default subCommand(commandInfo, {
   "create-migration": () => import("./create-migration"),
   "stage-migrations": () => import("./stage-migrations"),
+  "migrate-package": () => import("./migrate-package"),
   list: () => import("./list"),
 });

--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -304,6 +304,7 @@ async function upgradePackageJson(projectFolder: string, packageJsonPath: string
   await renameFieldFiles("browser", "browser", projectFolder, packageJson);
   await renameFieldFiles("react-native", "native", projectFolder, packageJson);
   packageJson.browser = "./dist/browser/index.js";
+  delete packageJson["react-native"];
 
   // Save the updated package.json
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));

--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -1,0 +1,383 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license
+
+import { leafCommand, makeCommandInfo } from "../../framework/command";
+import { Project, SourceFile } from "ts-morph";
+import { createPrinter } from "../../util/printer";
+import { resolveRoot } from "../../util/resolveProject";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import { existsSync, lstatSync } from "node:fs";
+import { basename, resolve } from "node:path";
+import { run } from "../../util/run";
+import stripJsonComments from "strip-json-comments";
+
+const log = createPrinter("migrate-package");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _rushJson: any = undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getRushJson(): Promise<any> {
+  if (_rushJson) return _rushJson;
+
+  const rushJsonText = await readFile(resolve(__dirname, "../../../../../../rush.json"), "utf-8");
+
+  return (_rushJson = JSON.parse(stripJsonComments(rushJsonText)));
+}
+
+/**
+ * The shape of a rush.json `projects` entry.
+ */
+export interface RushJsonProject {
+  /**
+   * The name of the package.
+   */
+  packageName: string;
+  /**
+   * The path to the project, relative to the monorepo root.
+   */
+  projectFolder: string;
+
+  /**
+   * The version policy name.
+   */
+  versionPolicyName: string;
+}
+
+export const commandInfo = makeCommandInfo(
+  "migrate-package",
+  "migrates a package to ESM and vitest",
+  {
+    "package-name": {
+      description: "The name of the package to migrate",
+      kind: "string",
+    },
+  },
+);
+
+export default leafCommand(commandInfo, async ({ "package-name": packageName }) => {
+  const root = await resolveRoot();
+
+  const rushJson = await getRushJson();
+  const projects = rushJson.projects;
+
+  const project = projects.find((p: RushJsonProject) => p.packageName === packageName);
+  if (!project) {
+    log.error(`Package ${packageName} not found in rush.json`);
+    return false;
+  }
+
+  const projectFolder = resolve(root, project.projectFolder);
+
+  await upgradePackageJson(resolve(projectFolder, "package.json"));
+  await upgradeTypeScriptConfig(resolve(projectFolder, "tsconfig.json"));
+  await fixApiExtractorConfig(resolve(projectFolder, "api-extractor.json"));
+  await cleanupFiles(projectFolder);
+  fixSourceFiles(projectFolder);
+  fixTestingImports(projectFolder);
+
+  // TODO: Check if browser supported
+  await writeBrowserTestConfig(projectFolder);
+  await writeFile(resolve(projectFolder, "vitest.config.ts"), VITEST_CONFIG);
+  await writeFile(resolve(projectFolder, "vitest.browser.config.ts"), VITEST_BROWSER_CONFIG);
+
+  return true;
+});
+
+const VITEST_CONFIG = `
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "../../../vitest.shared.config.ts";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      include: ["test/**/*.spec.ts"],
+    },
+  }),
+);
+`;
+
+const VITEST_BROWSER_CONFIG = `
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "../../../vitest.browser.shared.config.ts";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      include: [
+        "dist-test/browser/test/**/*.spec.js",
+      ],
+    },
+  }),
+);
+`;
+
+async function writeBrowserTestConfig(packageFolder: string): Promise<void> {
+  const testConfig = {
+    extends: "./.tshy/build.json",
+    include: ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts"],
+    exclude: ["./test/**/node/**/*.ts"],
+    compilerOptions: {
+      outDir: "./dist-test/browser",
+      rootDir: ".",
+      skipLibCheck: true,
+    },
+  };
+
+  await writeFile(
+    resolve(packageFolder, "test.browser.config.json"),
+    JSON.stringify(testConfig, null, 2),
+  );
+}
+
+function fixTestingImports(packageFolder: string): void {
+  // Create a new project
+  const project = new Project({
+    tsConfigFilePath: resolve(packageFolder, "tsconfig.json"),
+  });
+
+  // Iterate over all the source files
+  for (const sourceFile of project.getSourceFiles()) {
+    // If the file ends with .spec.ts, add the import statement
+    if (sourceFile.getBaseName().endsWith(".spec.ts")) {
+      sourceFile.addImportDeclaration({
+        namedImports: ["describe", "it", "assert"],
+        moduleSpecifier: "vitest",
+      });
+    }
+
+    // Iterate over all the import declarations
+    for (const importDeclaration of sourceFile.getImportDeclarations()) {
+      const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+      // If the module specifier is legacy, remove the import declaration
+      if (
+        moduleSpecifier === "chai" ||
+        moduleSpecifier === "chai-as-promised" ||
+        moduleSpecifier === "sinon"
+      ) {
+        importDeclaration.remove();
+      }
+    }
+    // Save the changes to the source file
+    sourceFile.saveSync();
+  }
+}
+
+function fixSourceFiles(packageFolder: string): void {
+  // Create a new project
+  const project = new Project({
+    tsConfigFilePath: resolve(packageFolder, "tsconfig.json"),
+  });
+
+  // Iterate over all the source files
+  for (const sourceFile of project.getSourceFiles()) {
+    // Iterate over all the statements in the source file
+    for (const statement of sourceFile.getStatements()) {
+      // If the statement is "const should = chai.should();", remove it
+      if (statement.getText() === "const should = chai.should();") {
+        statement.remove();
+      }
+    }
+
+    // Iterate over all the import declarations
+    for (const importExportDeclaration of sourceFile.getImportDeclarations()) {
+      let moduleSpecifier = importExportDeclaration.getModuleSpecifierValue();
+      moduleSpecifier = fixDeclaration(sourceFile, moduleSpecifier);
+      importExportDeclaration.setModuleSpecifier(moduleSpecifier);
+    }
+
+    // iterate over all the export declarations
+    for (const exportDeclaration of sourceFile.getExportDeclarations()) {
+      let moduleSpecifier = exportDeclaration.getModuleSpecifierValue();
+      if (moduleSpecifier) {
+        moduleSpecifier = fixDeclaration(sourceFile, moduleSpecifier);
+        exportDeclaration.setModuleSpecifier(moduleSpecifier);
+      }
+    }
+    // Save the changes to the source file
+    sourceFile.saveSync();
+  }
+}
+
+function fixDeclaration(sourceFile: SourceFile, moduleSpecifier: string): string {
+  if (moduleSpecifier.startsWith("./") || moduleSpecifier.startsWith("../")) {
+    if (!moduleSpecifier.endsWith(".js")) {
+      // If the module specifier ends with "/", add "index.js", otherwise add ".js"
+      if (moduleSpecifier.endsWith("/")) {
+        moduleSpecifier += "index.js";
+      } else {
+        // Check if the module specifier is a directory
+        const path = resolve(sourceFile.getDirectoryPath(), moduleSpecifier);
+        if (existsSync(path) && lstatSync(path).isDirectory()) {
+          moduleSpecifier += "/index.js";
+        } else {
+          moduleSpecifier += ".js";
+        }
+      }
+    }
+  }
+  return moduleSpecifier;
+}
+
+async function fixApiExtractorConfig(apiExtractorJsonPath: string): Promise<void> {
+  const apiExtractorJson = JSON.parse(await readFile(apiExtractorJsonPath, "utf-8"));
+
+  const oldPath = apiExtractorJson.dtsRollup.publicTrimmedFilePath;
+  const projectName = basename(oldPath, ".d.ts");
+
+  apiExtractorJson.mainEntryPointFilePath = "dist/esm/index.d.ts";
+  apiExtractorJson.dtsRollup.publicTrimmedFilePath = `dist/${projectName}.d.ts`;
+
+  // TODO: Clean up the betaTrimmedFilePath
+  delete apiExtractorJson.dtsRollup.betaTrimmedFilePath;
+
+  await writeFile(apiExtractorJsonPath, JSON.stringify(apiExtractorJson, null, 2));
+}
+
+async function cleanupFiles(projectFolder: string): Promise<void> {
+  // Remove the old test files
+  const filesToRemove = ["karma.conf.js", ".nycrc"];
+  for (const file of filesToRemove) {
+    try {
+      await unlink(resolve(projectFolder, file));
+    } catch {
+      log.warn(`Could not remove ${file}`);
+    }
+  }
+}
+
+async function upgradeTypeScriptConfig(tsconfigPath: string): Promise<void> {
+  const tsConfig = JSON.parse(await readFile(tsconfigPath, "utf-8"));
+
+  // Set module resolution
+  tsConfig.compilerOptions.module = "NodeNext";
+  tsConfig.compilerOptions.moduleResolution = "NodeNext";
+  tsConfig.compilerOptions.rootDir = ".";
+
+  // Remove old options
+  delete tsConfig.compilerOptions.outDir;
+  delete tsConfig.compilerOptions.declarationDir;
+
+  await writeFile(tsconfigPath, JSON.stringify(tsConfig, null, 2));
+}
+
+async function upgradePackageJson(packageJsonPath: string): Promise<void> {
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
+
+  // Change the module type to ESM
+  packageJson.type = "module";
+
+  // Remove the legacy packages
+  removeLegacyPackages(packageJson);
+
+  // Add the new packages
+  await addNewPackages(packageJson);
+
+  // Sort the devDependencies
+  sortDevDependencies(packageJson);
+
+  // Add tshy
+  addTypeScriptHybridizer(packageJson);
+
+  // Set files
+  setFilesSection(packageJson);
+
+  // Set scripts
+  setScriptsSection(packageJson);
+
+  // Save the updated package.json
+  await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
+function setScriptsSection(packageJson: any): void {
+  packageJson.scripts["build"] = "npm run clean && tshy && dev-tool run extract-api";
+
+  // TODO: Check if web package or not
+  packageJson.scripts["unit-test:browser"] =
+    "npm run clean && tshy && dev-tool run build-test && dev-tool run test:vitest --no-test-proxy --browser";
+  packageJson.scripts["unit-test:node"] = "dev-tool run test:vitest --no-test-proxy";
+}
+
+function setFilesSection(packageJson: any): void {
+  packageJson.files = ["dist/", "README.md", "LICENSE"];
+}
+
+function addTypeScriptHybridizer(packageJson: any): void {
+  packageJson["tshy"] = {
+    exports: {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts",
+    },
+    dialects: ["esm", "commonjs"],
+    esmDialects: ["browser", "react-native"],
+    selfLink: false,
+  };
+}
+
+async function addNewPackages(packageJson: any): Promise<void> {
+  const newPackages = [
+    "@vitest/browser",
+    "@vitest/coverage-istanbul",
+    "playwright",
+    "tshy",
+    "vitest",
+  ];
+
+  for (const newPackage of newPackages) {
+    const latestVersion = await run(["npm", "view", newPackage, "version"], {
+      captureOutput: true,
+    });
+    packageJson.devDependencies[newPackage] = `^${latestVersion.replace("\n", "")}`;
+  }
+}
+
+function removeLegacyPackages(packageJson: any): void {
+  const legacyPackages = [
+    "chai",
+    "chai-as-promised",
+    "chai-exclude",
+    "mocha",
+    "sinon",
+    "karma",
+    "karma-chrome-launcher",
+    "karma-coverage",
+    "karma-env-preprocessor",
+    "karma-firefox-launcher",
+    "karma-junit-reporter",
+    "karma-mocha",
+    "karma-mocha-reporter",
+    "karma-sourcemap-loader",
+    "nyc",
+    "puppeteer",
+    "ts-node",
+    "uglify-js",
+    "@types/chai-as-promised",
+    "@types/mocha",
+    "@types/chai",
+    "@types/sinon",
+  ];
+  for (const legacyPackage of legacyPackages) {
+    if (packageJson.devDependencies[legacyPackage]) {
+      delete packageJson.devDependencies[legacyPackage];
+    }
+  }
+}
+
+function sortObjectByKeys(unsortedObj: { [key: string]: string }): { [key: string]: string } {
+  const sortedEntries = Object.entries(unsortedObj).sort((a, b) => a[0].localeCompare(b[0]));
+  return Object.fromEntries(sortedEntries);
+}
+
+function sortDevDependencies(packageJson: any): void {
+  if (packageJson.devDependencies) {
+    packageJson.devDependencies = sortObjectByKeys(packageJson.devDependencies);
+  }
+}

--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -310,6 +310,7 @@ async function upgradePackageJson(projectFolder: string, packageJsonPath: string
   await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setScriptsSection(packageJson: any): void {
   packageJson.scripts["build"] = "npm run clean && tshy && dev-tool run extract-api";
 
@@ -319,10 +320,12 @@ function setScriptsSection(packageJson: any): void {
   packageJson.scripts["unit-test:node"] = "dev-tool run test:vitest --no-test-proxy";
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setFilesSection(packageJson: any): void {
   packageJson.files = ["dist/", "README.md", "LICENSE"];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function addTypeScriptHybridizer(packageJson: any): void {
   packageJson["tshy"] = {
     exports: {
@@ -335,6 +338,7 @@ function addTypeScriptHybridizer(packageJson: any): void {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function addNewPackages(packageJson: any): Promise<void> {
   const newPackages = [
     "@vitest/browser",
@@ -352,6 +356,7 @@ async function addNewPackages(packageJson: any): Promise<void> {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function removeLegacyPackages(packageJson: any): void {
   const legacyPackages = [
     "chai",
@@ -389,6 +394,7 @@ function sortObjectByKeys(unsortedObj: { [key: string]: string }): { [key: strin
   return Object.fromEntries(sortedEntries);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function sortDevDependencies(packageJson: any): void {
   if (packageJson.devDependencies) {
     packageJson.devDependencies = sortObjectByKeys(packageJson.devDependencies);
@@ -399,6 +405,7 @@ async function renameFieldFiles(
   field: string,
   altFieldName: string,
   packageFolder: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJson: any,
 ): Promise<void> {
   if (packageJson[field]) {

--- a/common/tools/dev-tool/src/templates/sampleReadme.md.ts
+++ b/common/tools/dev-tool/src/templates/sampleReadme.md.ts
@@ -81,8 +81,9 @@ function resourceLinks(info: SampleReadmeConfiguration) {
 function resources(info: SampleReadmeConfiguration) {
   const resources = Object.entries(info.requiredResources ?? {});
 
-  const header = `You need [an Azure subscription][freesub] ${resources.length > 0 ? "and the following Azure resources " : ""
-    }to run these sample programs${resources.length > 0 ? ":\n\n" : "."}`;
+  const header = `You need [an Azure subscription][freesub] ${
+    resources.length > 0 ? "and the following Azure resources " : ""
+  }to run these sample programs${resources.length > 0 ? ":\n\n" : "."}`;
 
   return (
     header + resources.map(([name]) => `- [${name}][${resourceNameToLinkSlug(name)}]`).join("\n")
@@ -115,7 +116,7 @@ function table(info: SampleReadmeConfiguration) {
       ? relativeSourcePath
       : relativeSourcePath.replace(/\.ts$/, ".js");
     if (summary && summary.includes("|")) {
-      summary = summary.replace(/\|/g, "\\|")
+      summary = summary.replace(/\|/g, "\\|");
     }
     return `| [${fileName}][${sampleLinkTag(relativeSourcePath)}] | ${summary} |`;
   });
@@ -136,8 +137,9 @@ function exampleNodeInvocation(info: SampleReadmeConfiguration) {
     .map((envVar) => `${envVar}="<${envVar.replace(/_/g, " ").toLowerCase()}>"`)
     .join(" ");
 
-  return `${envVars} node ${info.useTypeScript ? "dist/" : ""
-    }${firstModule.relativeSourcePath.replace(/\.ts$/, ".js")}`;
+  return `${envVars} node ${
+    info.useTypeScript ? "dist/" : ""
+  }${firstModule.relativeSourcePath.replace(/\.ts$/, ".js")}`;
 }
 
 /**
@@ -167,7 +169,8 @@ export default (info: SampleReadmeConfiguration): Promise<string> => {
 
 ${info.customSnippets?.header ?? ""}
 
-These sample programs show how to use the ${language} client libraries for ${info.productName
+These sample programs show how to use the ${language} client libraries for ${
+      info.productName
     } in some common scenarios.
 
 ${table(info)}
@@ -177,17 +180,17 @@ ${table(info)}
 The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
 
 ${(() => {
-      if (info.useTypeScript) {
-        return [
-          "Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:",
-          "",
-          fence("bash", "npm install -g typescript"),
-          "",
-        ].join("\n");
-      } else {
-        return "";
-      }
-    })()}\
+  if (info.useTypeScript) {
+    return [
+      "Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:",
+      "",
+      fence("bash", "npm install -g typescript"),
+      "",
+    ].join("\n");
+  } else {
+    return "";
+  }
+})()}\
 ${resources(info)}
 
 ${info.customSnippets?.prerequisites ?? ""}
@@ -204,28 +207,28 @@ ${step("Install the dependencies using `npm`:")}
 
 ${fence("bash", "npm install")}
 ${(() => {
-      if (info.useTypeScript) {
-        return [step("Compile the samples:"), "", fence("bash", "npm run build"), ""].join("\n");
-      } else {
-        return "";
-      }
-    })()}
+  if (info.useTypeScript) {
+    return [step("Compile the samples:"), "", fence("bash", "npm run build"), ""].join("\n");
+  } else {
+    return "";
+  }
+})()}
 ${step(
-      "Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.",
-    )}
+  "Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.",
+)}
 
 ${step(
-      "Run whichever samples you like (note that some samples may require additional setup, see the table above):",
-    )}
+  "Run whichever samples you like (note that some samples may require additional setup, see the table above):",
+)}
 
 ${fence(
-      "bash",
-      `node ${(() => {
-        const firstSource = filterModules(info)[0].relativeSourcePath;
-        const filePath = info.useTypeScript ? "dist/" : "";
-        return filePath + firstSource.replace(/\.ts$/, ".js");
-      })()}`,
-    )}
+  "bash",
+  `node ${(() => {
+    const firstSource = filterModules(info)[0].relativeSourcePath;
+    const filePath = info.useTypeScript ? "dist/" : "";
+    return filePath + firstSource.replace(/\.ts$/, ".js");
+  })()}`,
+)}
 
 Alternatively, run a single sample with the correct environment variables set (setting up the \`.env\` file is not required if you do this), for example (cross-platform):
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Creates a starter migration toolkit for projects to move to ESM and vitest.  This project for dev-tool introduces a tool invoked such as the following to migrate service-bus

```
dev-tool admin migrate-package --package-name=@azure/service-bus
```

This does the following:
- Changes the package.json for the following:
  - Removes chai/mocha/karma
  - Adds vitest and tshy
  - Modifies the build and test commands
  - Renames the mapped files to the proper output type such as `-browser.mts`
- Changes the tsconfig.json for the following:
  - Moves module and moduleResolution to NodeNext
  - Removes outDir and declarationDir
- Fixes the source files
  - Uses extension for files such as "foo.js" instead of "foo"
  - Removes "chai" usage
  - Adds vitest usage for spec files
- Fixes api-extractor.json
  - Fixes input path for source
  - Fixes output trimmed path
- Migrate Testing
  - Writes for both browser and node unit tests
  - Writes config for building browser bundle     
  - Removes .nycrc and Karma configuration

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
