### PR TITLE
Update the Core Client Version and Test Recorder

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1231,18 +1231,6 @@ packages:
       - supports-color
     dev: false
 
-  /@azure-tools/test-recorder@3.5.1:
-    resolution: {integrity: sha512-ts6YITiT3dtTg1+dIqBm0JzD14Lh4KHZg050jPZ3If60QQp7lVaELc0sc6O7d8UfdaGF1IT2XcPQbs0LQCYpQA==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@azure/core-auth': 1.7.2
-      '@azure/core-rest-pipeline': 1.16.0
-      '@azure/core-util': 1.9.0
-      '@azure/logger': 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@azure/abort-controller@1.1.0:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1231,6 +1231,18 @@ packages:
       - supports-color
     dev: false
 
+  /@azure-tools/test-recorder@3.5.1:
+    resolution: {integrity: sha512-ts6YITiT3dtTg1+dIqBm0JzD14Lh4KHZg050jPZ3If60QQp7lVaELc0sc6O7d8UfdaGF1IT2XcPQbs0LQCYpQA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@azure/core-auth': 1.7.2
+      '@azure/core-rest-pipeline': 1.16.0
+      '@azure/core-util': 1.9.0
+      '@azure/logger': 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@azure/abort-controller@1.1.0:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
@@ -19275,7 +19287,7 @@ packages:
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-LsbGjr9EW8VTWF/5INwJsD2jzswejO0PtWkeP9T3VW/gU7HjW6IrwSw0pvEeJJqgSAES/He5SJVkvmUrZRCpww==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-Ig3CWKQBXnEfG9ukjexA74Yq+ZXRdSeHAv1owp0ynN3rCgy89SLaXi3ZmlDQIxQK59djz3Xj3/HtkQZNT/T7rg==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.6.0 (upcoming)
+## 1.5.1 (2024-06-12)
 
-### Features Added
+### Bugs Fixed
+
+- Updated @azure/core-client and @azure/core-rest-pipeline version.
 
 ## 1.5.0 (2024-04-15)
 

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.6.0 (upcoming)
+
+### Features Added
+
+
 ## 1.5.1 (2024-06-12)
 
 ### Bugs Fixed

--- a/sdk/communication/communication-chat/assets.json
+++ b/sdk/communication/communication-chat/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-chat",
-  "Tag": "js/communication/communication-chat_829a1529fe"
+  "Tag": "js/communication/communication-chat_5593dd2de6"
 }

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-chat",
-  "version": "1.6.0",
+  "version": "1.5.1",
   "description": "Azure client library for Azure Communication Chat services",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -66,9 +66,9 @@
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-signaling": "1.0.0-beta.26",
     "@azure/core-auth": "^1.3.0",
-    "@azure/core-client": "^1.3.0",
+    "@azure/core-client": "^1.6.0",
     "@azure/core-paging": "^1.1.1",
-    "@azure/core-rest-pipeline": "^1.3.0",
+    "@azure/core-rest-pipeline": "^1.9.0",
     "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@azure-tools/test-credential": "^1.0.0",
-    "@azure-tools/test-recorder": "^3.0.0",
+    "@azure-tools/test-recorder": "^3.5.1",
     "@azure/communication-identity": "^1.1.0-beta.2",
     "@azure/core-util": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-chat",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Azure client library for Azure Communication Chat services",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/communication/communication-chat/test.env
+++ b/sdk/communication/communication-chat/test.env
@@ -1,4 +1,4 @@
-COMMUNICATION_LIVETEST_STATIC_CONNECTION_STRING="endpoint=<endpoint>;accessKey=<accessKey>"
+COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING="endpoint=<endpoint>;accessKey=<accessKey>"
 
 # Our tests assume that TEST_MODE is "playback" by default. You can
 # change it to "record" to generate new recordings, or "live" to bypass the recorder entirely.

--- a/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
+++ b/sdk/communication/communication-chat/test/public/utils/recordedClient.ts
@@ -29,7 +29,8 @@ const envSetupForPlayback: { [k: string]: string } = {
   COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING: "endpoint=https://endpoint/;accesskey=banana",
 };
 
-const fakeToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MTc2MzQ4MDguMTd9.Rx6RqlnKsM09viqebSbPDKRcUp3EIKDEHNVXq3Wb0ms";
+const fakeToken =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MTc2MzQ4MDguMTd9.Rx6RqlnKsM09viqebSbPDKRcUp3EIKDEHNVXq3Wb0ms";
 export const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback,
   sanitizerOptions: {
@@ -81,7 +82,9 @@ export function createChatClient(userToken: string, recorder: Recorder): ChatCli
 
   return new ChatClient(
     url,
-    isPlaybackMode() ? new NoOpAzureCommunicationTokenCredential() : new AzureCommunicationTokenCredential(userToken),
+    isPlaybackMode()
+      ? new NoOpAzureCommunicationTokenCredential()
+      : new AzureCommunicationTokenCredential(userToken),
     recorder.configureClientOptions({}),
   );
 }


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/communication-chat 

### Issues associated with this PR
### Describe the problem that is addressed by this PR

Customer escalated the issue:
The issue was introduced from the @azure/communication-chat@1.4.0.  Chat client updated the internal API client by generating the new service client version with the `endpoint` param to replace the `baseUri` and kept the dependency version  @azure/core-client@1.3.0 and higher. While the `endpoint` is introduced only in @azure/core-client@1.6.0.
Customer see error "baseUrl is not specified" if the dependency version not updated.

Update the @azure/core-client version to fix the issue


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
