### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,13 +14,13 @@
 
 /.devcontainer/ @jeremymeng
 /documentation/ @jeremymeng
-/samples/       @jeremymeng @witemple-msft
+/samples/       @jeremymeng
 
 ################
 # Architecture
 ################
 
-/design/ @bterlson @mpodwysocki @joheredi @jeremymeng @witemple-msft
+/design/ @bterlson @mpodwysocki @joheredi @jeremymeng @maorleger
 
 ###########
 # SDK
@@ -253,6 +253,11 @@
 # AzureSdkOwners: @KarishmaGhiya
 /sdk/metricsadvisor/ @KarishmaGhiya @jeremymeng
 
+# PRLabel: %Notification Hub
+# ServiceLabel: %Notification Hub
+# AzureSdkOwners: @mpodwysocki
+/sdk/notificationhubs/notification-hubs @mpodwysocki @jeremymeng
+
 # PRLabel: %Cognitive - Content Safety
 # ServiceLabel: %Cognitive - Content Safety
 /sdk/contentsafety/ @xirzec
@@ -274,12 +279,8 @@
 # ServiceLabel: %Maps
 /sdk/maps/ @dubiety @andykao1213
 
-# Smoke Tests
-/common/smoke-test/ @xirzec @jeremymeng
-
 # API review files
-/sdk/**/review/*api.md @bterlson @xirzec @jeremymeng @mpodwysocki @maorleger
-
+/sdk/**/review/*api.md @bterlson @xirzec @jeremymeng @mpodwysocki @maorleger @joheredi
 
 # Management Plane
 # PRLabel: %Mgmt
@@ -1477,10 +1478,10 @@
 ###########
 
 # PRLabel: %dev-tool
-/common/tools/dev-tool/ @witemple-msft
+/common/tools/dev-tool/ @jeremymeng @mpodwysocki
 
 # PRLabel: %eslint plugin
-/common/tools/eslint-plugin-azure-sdk/ @deyaaeldeen
+/common/tools/eslint-plugin-azure-sdk/ @deyaaeldeen @jeremymeng
 
 ###########
 # Eng Sys
@@ -1491,19 +1492,20 @@
 ###########
 # Config
 ###########
-/.vscode/ @mikeharder @ckairen @deyaaeldeen
-/common/ @mikeharder @ckairen @deyaaeldeen
-/common/config/rush/pnpm-lock.yaml @ckairen @deyaaeldeen @jeremymeng
-/common/smoke-test/ @mikeharder @ckairen @witemple-msft @deyaaeldeen @benbp
+/.vscode/ @mikeharder @ckairen @deyaaeldeen @jeremymeng
+/common/ @mikeharder @ckairen @deyaaeldeen @jeremymeng
+/common/config/rush/pnpm-lock.yaml @ckairen @jeremymeng @Azure/azure-sdk-js-dev
+# Smoke Tests
+/common/smoke-test/ @mikeharder @ckairen @jeremymeng @deyaaeldeen @benbp
 
-/rush.json @mikeharder @ckairen
-/tsconfig.json @mikeharder @ckairen @witemple-msft @deyaaeldeen
-/**/tsconfig.json @witemple-msft @deyaaeldeen
+/rush.json @mikeharder @ckairen @jeremymeng
+/tsconfig.json @mikeharder @ckairen @jeremymeng @deyaaeldeen
+/**/tsconfig.json @jeremymeng @deyaaeldeen
 /**/tsconfig.strict.json @deyaaeldeen
 /.scripts/ @mikeharder @ckairen
 
 # Add owners for notifications for specific pipelines
-/eng/pipelines/aggregate-reports.yml         @xirzec @jeremymeng
+/eng/pipelines/aggregate-reports.yml         @jeremymeng @xirzec
 /eng/common/pipelines/codeowners-linter.yml  @xirzec @jeremymeng
 
 # PRLabel: %Mgmt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,18 +31,13 @@
 
 # PRLabel: %Azure.Core
 # ServiceLabel: %Azure.Core
-# AzureSdkOwners: @xirzec @jeremymeng @deyaaeldeen @timovv @mpodwysocki
-/sdk/core/ @xirzec @jeremymeng @deyaaeldeen @timovv @mpodwysocki
+# AzureSdkOwners: @Azure/azure-sdk-for-js-core
+/sdk/core/ @Azure/azure-sdk-for-js-core
 
 # PRLabel: %Azure.Core
 # ServiceLabel: %Azure.Core
 # AzureSdkOwners:  @jeremymeng @deyaaeldeen @HarshaNalluru
 /sdk/core/core-amqp/ @jeremymeng @deyaaeldeen @HarshaNalluru
-
-# PRLabel: %Azure.Core
-# ServiceLabel: %Azure.Core
-# AzureSdkOwners: @jeremymeng @deyaaeldeen
-/sdk/core/core-auth/ @jeremymeng @deyaaeldeen
 
 # PRLabel: %Azure.Core
 # ServiceLabel: %Azure.Core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1478,7 +1478,7 @@
 ###########
 
 # PRLabel: %dev-tool
-/common/tools/dev-tool/ @jeremymeng @mpodwysocki
+/common/tools/dev-tool/ @jeremymeng @mpodwysocki @timovv
 
 # PRLabel: %eslint plugin
 /common/tools/eslint-plugin-azure-sdk/ @deyaaeldeen @jeremymeng


### PR DESCRIPTION
- avoid spamming Will's inbox
- update owners for tooling, design docs, api reports, etc.
- add notification-hubs dataplane entry
- remove duplicate /common/smoke-test/ entry