### PR TITLE
[CODEOWNERS] move more specific /common/tools entries after /common/ entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1469,16 +1469,6 @@
 #/<NotInRepo>/          @ccmshowbackdevs
 
 ###########
-# Tools
-###########
-
-# PRLabel: %dev-tool
-/common/tools/dev-tool/ @jeremymeng @mpodwysocki @timovv
-
-# PRLabel: %eslint plugin
-/common/tools/eslint-plugin-azure-sdk/ @deyaaeldeen @jeremymeng
-
-###########
 # Eng Sys
 ###########
 /eng/           @ckairen @mikeharder @weshaggard @benbp
@@ -1492,6 +1482,16 @@
 /common/config/rush/pnpm-lock.yaml @ckairen @jeremymeng @Azure/azure-sdk-js-dev
 # Smoke Tests
 /common/smoke-test/ @mikeharder @ckairen @jeremymeng @deyaaeldeen @benbp
+
+###########
+# Tools
+###########
+
+# PRLabel: %dev-tool
+/common/tools/dev-tool/ @jeremymeng @mpodwysocki @timovv
+
+# PRLabel: %eslint plugin
+/common/tools/eslint-plugin-azure-sdk/ @deyaaeldeen @jeremymeng
 
 /rush.json @mikeharder @ckairen @jeremymeng
 /tsconfig.json @mikeharder @ckairen @jeremymeng @deyaaeldeen


### PR DESCRIPTION
so that they are not overriden by general /common/ entry.