### PR TITLE
[dependency-test] only add vitest config for migrated packages

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -403,7 +403,9 @@ async function main(argv) {
     testFolder,
   );
   await insertTsConfigJson(targetPackagePath, testFolder);
-  copyVitestConfig(targetPackagePath, testFolder);
+  if (packageJsonContents.scripts["integration-test:node"].includes("vitest")) {
+    copyVitestConfig(targetPackagePath, testFolder);
+  }
   if (dryRun) {
     console.log("Dry run only, no changes");
     return;


### PR DESCRIPTION
as packages not migrated yet would be broken when they build using tsc
and the *config.ts are included as source.