### PR TITLE
[dev-tool] Add additional fixes for the migration tool

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -146,10 +146,23 @@ function fixTestingImports(packageFolder: string): void {
 
   // Iterate over all the source files
   for (const sourceFile of project.getSourceFiles()) {
-    // If the file ends with .spec.ts, add the import statement
+    console.log(`Fixing imports in ${sourceFile.getFilePath()}`);
+
     if (sourceFile.getBaseName().endsWith(".spec.ts")) {
+      // If the file ends with .spec.ts, add the import statement
+      const hasMocking = sourceFile.getImportDeclarations().some((importDeclaration) => {
+        const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+        return moduleSpecifier === "sinon";
+      });
+
+      const viTestImports = ["describe", "it", "assert"];
+      // Insert typical mocking imports if needed
+      if (hasMocking) {
+        viTestImports.push("expect, vi, beforeEach, afterEach");
+      }
+
       sourceFile.addImportDeclaration({
-        namedImports: ["describe", "it", "assert"],
+        namedImports: viTestImports,
         moduleSpecifier: "vitest",
       });
     }
@@ -162,6 +175,18 @@ function fixTestingImports(packageFolder: string): void {
       // If the module specifier is legacy, remove the import declaration
       if (modulesToRemove.includes(moduleSpecifier)) {
         importDeclaration.remove();
+      } else if (moduleSpecifier === "@azure-tools/test-utils") {
+        // If the module specifier is "@azure-tools/test-utils", remove the "assert" named import
+        const namedImports = importDeclaration.getNamedImports();
+        const assertImport = namedImports.find((namedImport) => namedImport.getName() === "assert");
+        if (assertImport) {
+          assertImport.remove();
+        }
+
+        // If there are no named imports left, remove the entire import declaration
+        if (importDeclaration.getNamedImports().length === 0) {
+          importDeclaration.remove();
+        }
       }
     }
     // Save the changes to the source file
@@ -220,7 +245,7 @@ function fixSourceFiles(packageFolder: string): void {
 }
 
 function fixDeclaration(sourceFile: SourceFile, moduleSpecifier: string): string {
-  if (moduleSpecifier.startsWith("./") || moduleSpecifier.startsWith("../")) {
+  if (moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("..")) {
     if (!moduleSpecifier.endsWith(".js")) {
       // If the module specifier ends with "/", add "index.js", otherwise add ".js"
       if (moduleSpecifier.endsWith("/")) {

--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -437,6 +437,7 @@ function removeLegacyPackages(packageJson: any): void {
     "karma-sourcemap-loader",
     "nyc",
     "puppeteer",
+    "source-map-support",
     "ts-node",
     "uglify-js",
     "@types/chai-as-promised",

--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -146,7 +146,22 @@ function fixTestingImports(packageFolder: string): void {
 
   // Iterate over all the source files
   for (const sourceFile of project.getSourceFiles()) {
-    console.log(`Fixing imports in ${sourceFile.getFilePath()}`);
+    // Remove if the file is a test utility for chai
+    if (
+      sourceFile.getFilePath().includes("/test") &&
+      !sourceFile.getBaseName().endsWith(".spec.ts")
+    ) {
+      for (const importDeclaration of sourceFile.getImportDeclarations()) {
+        const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+        if (["chai", "assert"].includes(moduleSpecifier)) {
+          importDeclaration.remove();
+          sourceFile.addImportDeclaration({
+            namedImports: ["assert"],
+            moduleSpecifier: "vitest",
+          });
+        }
+      }
+    }
 
     if (sourceFile.getBaseName().endsWith(".spec.ts")) {
       // If the file ends with .spec.ts, add the import statement


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Adds updates for the following:
- Changes assert to only use `vitest` for now and not sure the `@azure-tools/test-utils`
- Any utility in the `/test` folders will be updated to use `vitest` for assertions
- Add `beforeEach`, `afterEach`, `vi` and `expect` to any test class using `sinon` for easy replacement
- Fix pathing issue so that `import { foo } from "..";` is translated to `import { foo } from "../index.js";`
- Removes `source-map-support` as we're not using Karma.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
