### PR TITLE
[test-recorder] ignore `Accept-Encoding` header

### DIFF
--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -444,10 +444,10 @@ export class Recorder {
 
       // See discussion in https://github.com/Azure/azure-sdk-tools/pull/6152
       // Ideally this should be handled by the test-proxy.  However, it was suggested that
-      // there may be scenarios where it is desired to include this header.
-      // Thus we are ignoring Accept-Language header  in recorder for browser.
+      // there may be scenarios where it is desired to include these headers.
+      // Thus we are ignoring Accept-Language and Accept-Encountered headers in recorder for browser.
       const excludedHeaders = isBrowser
-        ? (options.excludedHeaders ?? []).concat("Accept-Language")
+        ? (options.excludedHeaders ?? []).concat("Accept-Language", "Accept-Encoding")
         : options.excludedHeaders;
 
       const updatedOptions = {


### PR DESCRIPTION
In most scenarios our SDK doesn't use or depend on this header.