### PR TITLE
[eslint-plugin] set package version back to 3.0.0

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk-helper/package.json
+++ b/common/tools/eslint-plugin-azure-sdk-helper/package.json
@@ -15,7 +15,7 @@
     "eslint-plugin-markdown": "^5.0.0"
   },
   "dependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^3.1.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@eslint/compat": "^1.0.1",
     "@eslint/js": "~9.2.0",
     "@typescript-eslint/typescript-estree": "~7.10.0",

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "3.1.0",
+  "version": "3.0.0",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "sdk-type": "utility",
   "private": true,

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -96,7 +96,7 @@
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",
-    "@azure/eslint-plugin-azure-sdk": "^3.1.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.0.1",
     "@azure/logger": "^1.0.0",
     "@microsoft/api-extractor": "^7.31.1",

--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -68,7 +68,7 @@
     "@azure/core-client": "^1.7.0",
     "@azure/core-util": "^1.6.0",
     "@azure/dev-tool": "^1.0.0",
-    "@azure/eslint-plugin-azure-sdk": "^3.1.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/logger": "^1.0.4",
     "@azure-tools/test-utils": "^1.0.1",
     "@azure-tools/test-recorder": "^3.0.0",


### PR DESCRIPTION
to fix broken nightly pipelines where we update `@azure` package versions to
nightly versions and dependency versions to a range for their nightly versions.
Version `^3.0.0` would not get updated because of the following check in
`set-dev.js` then `rush install` would fail to find matching one and report error.

https://github.com/Azure/azure-sdk-for-js/blob/9488fe4bd780306e2f00eaa1509eba20982215f4/eng/tools/versioning/set-dev.js#L80