### PR TITLE
[core] Adding Browser and Version to platform data

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
@@ -28,7 +28,7 @@ interface NavigatorEx extends Navigator {
   };
 }
 
-function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } {
+function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } | undefined {
   // Check for Microsoft Edge
   const edge = brands.find((b) => b.brand === "Microsoft Edge");
   if (edge) {
@@ -47,7 +47,7 @@ function getBrandVersionString(brands: { brand: string, version: string }[]): { 
     return chromium;
   }
 
-  throw new Error("No known brand found");
+  return undefined;
 }
 
 /**
@@ -64,8 +64,10 @@ export async function setPlatformSpecificData(map: Map<string, string>): Promise
     osPlatform = `${entropyValues.architecture}-${entropyValues.platform}-${entropyValues.platformVersion}`;
 
     // Get the brand and version
-    const { brand, version } = getBrandVersionString(entropyValues.brands);
-    map.set(brand, version);
+    const brand = getBrandVersionString(entropyValues.brands);
+    if (brand) {
+      map.set(brand.brand, brand.version);
+    }
   } else if (localNavigator?.platform) {
     osPlatform = localNavigator.platform;
   }

--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/*
- * NOTE: When moving this file, please update "browser" section in package.json.
- */
-
 /**
  * @internal
  */
@@ -32,6 +28,28 @@ interface NavigatorEx extends Navigator {
   };
 }
 
+function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } {
+  // Check for Microsoft Edge
+  const edge = brands.find((b) => b.brand === "Microsoft Edge");
+  if (edge) {
+    return edge;
+  }
+
+  // Check for Chrome
+  const chrome = brands.find((b) => b.brand === "Google Chrome");
+  if (chrome) {
+    return chrome;
+  }
+
+  // Check for Chromium
+  const chromium = brands.find((b) => b.brand === "Chromium");
+  if (chromium) {
+    return chromium;
+  }
+
+  throw new Error("No known brand found");
+}
+
 /**
  * @internal
  */
@@ -44,6 +62,10 @@ export async function setPlatformSpecificData(map: Map<string, string>): Promise
       "platformVersion",
     ]);
     osPlatform = `${entropyValues.architecture}-${entropyValues.platform}-${entropyValues.platformVersion}`;
+
+    // Get the brand and version
+    const { brand, version } = getBrandVersionString(entropyValues.brands);
+    map.set(brand, version);
   } else if (localNavigator?.platform) {
     osPlatform = localNavigator.platform;
   }

--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
@@ -28,7 +28,9 @@ interface NavigatorEx extends Navigator {
   };
 }
 
-function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } | undefined {
+function getBrandVersionString(
+  brands: { brand: string; version: string }[],
+): { brand: string; version: string } | undefined {
   // Check for Microsoft Edge
   const edge = brands.find((b) => b.brand === "Microsoft Edge");
   if (edge) {

--- a/sdk/core/core-rest-pipeline/test/browser/userAgentPlatform.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/browser/userAgentPlatform.spec.ts
@@ -12,4 +12,13 @@ describe("userAgentPlatform", () => {
 
     assert.ok(map.has("OS"));
   });
+
+  it("should set the Browser Type", async () => {
+    const map = new Map<string, string>();
+
+    await setPlatformSpecificData(map);
+
+    // Switch if we're using a different browser runner
+    assert.ok(map.has("Chromium"));
+  });
 });

--- a/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
@@ -28,7 +28,7 @@ interface NavigatorEx extends Navigator {
   };
 }
 
-function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } {
+function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } | undefined {
   // Check for Microsoft Edge
   const edge = brands.find((b) => b.brand === "Microsoft Edge");
   if (edge) {
@@ -47,7 +47,7 @@ function getBrandVersionString(brands: { brand: string, version: string }[]): { 
     return chromium;
   }
 
-  throw new Error("No known brand found");
+  return undefined;
 }
 
 /**
@@ -64,8 +64,10 @@ export async function setPlatformSpecificData(map: Map<string, string>): Promise
     osPlatform = `${entropyValues.architecture}-${entropyValues.platform}-${entropyValues.platformVersion}`;
 
     // Get the brand and version
-    const { brand, version } = getBrandVersionString(entropyValues.brands);
-    map.set(brand, version);
+    const brand = getBrandVersionString(entropyValues.brands);
+    if (brand) {
+      map.set(brand.brand, brand.version);
+    }
   } else if (localNavigator?.platform) {
     osPlatform = localNavigator.platform;
   }

--- a/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/*
- * NOTE: When moving this file, please update "browser" section in package.json.
- */
-
 /**
  * @internal
  */
@@ -32,6 +28,28 @@ interface NavigatorEx extends Navigator {
   };
 }
 
+function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } {
+  // Check for Microsoft Edge
+  const edge = brands.find((b) => b.brand === "Microsoft Edge");
+  if (edge) {
+    return edge;
+  }
+
+  // Check for Chrome
+  const chrome = brands.find((b) => b.brand === "Google Chrome");
+  if (chrome) {
+    return chrome;
+  }
+
+  // Check for Chromium
+  const chromium = brands.find((b) => b.brand === "Chromium");
+  if (chromium) {
+    return chromium;
+  }
+
+  throw new Error("No known brand found");
+}
+
 /**
  * @internal
  */
@@ -44,6 +62,10 @@ export async function setPlatformSpecificData(map: Map<string, string>): Promise
       "platformVersion",
     ]);
     osPlatform = `${entropyValues.architecture}-${entropyValues.platform}-${entropyValues.platformVersion}`;
+
+    // Get the brand and version
+    const { brand, version } = getBrandVersionString(entropyValues.brands);
+    map.set(brand, version);
   } else if (localNavigator?.platform) {
     osPlatform = localNavigator.platform;
   }

--- a/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
@@ -28,7 +28,9 @@ interface NavigatorEx extends Navigator {
   };
 }
 
-function getBrandVersionString(brands: { brand: string, version: string }[]): { brand: string, version: string } | undefined {
+function getBrandVersionString(
+  brands: { brand: string; version: string }[],
+): { brand: string; version: string } | undefined {
   // Check for Microsoft Edge
   const edge = brands.find((b) => b.brand === "Microsoft Edge");
   if (edge) {

--- a/sdk/core/ts-http-runtime/test/browser/userAgentPlatform.spec.ts
+++ b/sdk/core/ts-http-runtime/test/browser/userAgentPlatform.spec.ts
@@ -12,4 +12,13 @@ describe("userAgentPlatform", () => {
 
     assert.ok(map.has("OS"));
   });
+
+  it("should set the Browser Type", async () => {
+    const map = new Map<string, string>();
+
+    await setPlatformSpecificData(map);
+
+    // Switch if we're using a different browser runner
+    assert.ok(map.has("Chromium"));
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-rest-pipeline
- @typespec/ts-http-runtime

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Adds support for capturing the browser name and version from the `userAgentData` in addition to the OS data we already capture.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
