### PR TITLE
[dev-tool] Update migration tool to include beforeEach fixes

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -167,7 +167,7 @@ function fixTestingImports(packageFolder: string): void {
       // If the file ends with .spec.ts, add the import statement
       const hasMocking = sourceFile.getImportDeclarations().some((importDeclaration) => {
         const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
-        return moduleSpecifier === "sinon";
+        return moduleSpecifier === "sinon" || moduleSpecifier === "@azure-tools/test-recorder";
       });
 
       const viTestImports = ["describe", "it", "assert"];
@@ -234,8 +234,13 @@ function fixSourceFiles(packageFolder: string): void {
       }
 
       // If statement is a beforeEach, then fix the function
-      if (statement.getText() == "beforeEach(async function (this: Context) {") {
+      if (statement.getText().includes("beforeEach(async function (this: Context) {")) {
         statement.replaceWithText(statement.getText().replace("(this: Context)", "(ctx)"));
+      }
+
+      // If statement has a recorder, fix the context
+      if (statement.getText().includes("recorder = new Recorder(this.currentTest);")) {
+        statement.replaceWithText(statement.getText().replace("this.currentTest", "ctx"));
       }
     }
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Fixed the `beforeEach` statements to get rid of the Mocha `Context` and replace with `vitest` context and fixes the test-recorder creation.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
