### PR TITLE
[core] Adding additional browsers to detection list

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
@@ -31,24 +31,13 @@ interface NavigatorEx extends Navigator {
 function getBrandVersionString(
   brands: { brand: string; version: string }[],
 ): { brand: string; version: string } | undefined {
-  // Check for Microsoft Edge
-  const edge = brands.find((b) => b.brand === "Microsoft Edge");
-  if (edge) {
-    return edge;
+  const brandOrder = ["Google Chrome", "Microsoft Edge", "Brave", "Chromium"];
+  for (const brand of brandOrder) {
+    const foundBrand = brands.find((b) => b.brand === brand);
+    if (foundBrand) {
+      return foundBrand;
+    }
   }
-
-  // Check for Chrome
-  const chrome = brands.find((b) => b.brand === "Google Chrome");
-  if (chrome) {
-    return chrome;
-  }
-
-  // Check for Chromium
-  const chromium = brands.find((b) => b.brand === "Chromium");
-  if (chromium) {
-    return chromium;
-  }
-
   return undefined;
 }
 

--- a/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
@@ -31,24 +31,13 @@ interface NavigatorEx extends Navigator {
 function getBrandVersionString(
   brands: { brand: string; version: string }[],
 ): { brand: string; version: string } | undefined {
-  // Check for Microsoft Edge
-  const edge = brands.find((b) => b.brand === "Microsoft Edge");
-  if (edge) {
-    return edge;
+  const brandOrder = ["Google Chrome", "Microsoft Edge", "Brave", "Chromium"];
+  for (const brand of brandOrder) {
+    const foundBrand = brands.find((b) => b.brand === brand);
+    if (foundBrand) {
+      return foundBrand;
+    }
   }
-
-  // Check for Chrome
-  const chrome = brands.find((b) => b.brand === "Google Chrome");
-  if (chrome) {
-    return chrome;
-  }
-
-  // Check for Chromium
-  const chromium = brands.find((b) => b.brand === "Chromium");
-  if (chromium) {
-    return chromium;
-  }
-
   return undefined;
 }
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-rest-pipeline
- @typespec/ts-http-runtime

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Adds additional browsers for detection.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
