### PR TITLE
[storage-queue] add back missing `abortSignal` option

### DIFF
--- a/sdk/storage/storage-queue/review/storage-queue.api.md
+++ b/sdk/storage/storage-queue/review/storage-queue.api.md
@@ -499,6 +499,7 @@ export interface QueueItem {
 
 // @public
 export interface QueuePeekMessagesOptions extends MessagesPeekOptionalParams, CommonOptions {
+    abortSignal?: AbortSignalLike;
 }
 
 // @public
@@ -508,6 +509,7 @@ export type QueuePeekMessagesResponse = WithResponse<{
 
 // @public
 export interface QueueReceiveMessageOptions extends MessagesDequeueOptionalParams, CommonOptions {
+    abortSignal?: AbortSignalLike;
 }
 
 // @public
@@ -539,6 +541,7 @@ export interface QueueSASSignatureValues {
 
 // @public
 export interface QueueSendMessageOptions extends MessagesEnqueueOptionalParams, CommonOptions {
+    abortSignal?: AbortSignalLike;
 }
 
 // @public

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -199,7 +199,13 @@ export interface MessagesEnqueueOptionalParams extends CommonOptions {
 /**
  * Options to configure {@link QueueClient.sendMessage} operation
  */
-export interface QueueSendMessageOptions extends MessagesEnqueueOptionalParams, CommonOptions {}
+export interface QueueSendMessageOptions extends MessagesEnqueueOptionalParams, CommonOptions {
+  /**
+   * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
+   */
+  abortSignal?: AbortSignalLike;
+}
 
 /** Optional parameters. */
 export interface MessagesDequeueOptionalParams extends CommonOptions {
@@ -216,7 +222,13 @@ export interface MessagesDequeueOptionalParams extends CommonOptions {
 /**
  * Options to configure {@link QueueClient.receiveMessages} operation
  */
-export interface QueueReceiveMessageOptions extends MessagesDequeueOptionalParams, CommonOptions {}
+export interface QueueReceiveMessageOptions extends MessagesDequeueOptionalParams, CommonOptions {
+  /**
+   * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
+   */
+  abortSignal?: AbortSignalLike;
+}
 
 /** Optional parameters. */
 export interface MessagesPeekOptionalParams extends CommonOptions {
@@ -231,7 +243,13 @@ export interface MessagesPeekOptionalParams extends CommonOptions {
 /**
  * Options to configure {@link QueueClient.peekMessages} operation
  */
-export interface QueuePeekMessagesOptions extends MessagesPeekOptionalParams, CommonOptions {}
+export interface QueuePeekMessagesOptions extends MessagesPeekOptionalParams, CommonOptions {
+  /**
+   * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
+   */
+  abortSignal?: AbortSignalLike;
+}
 
 /**
  * Contains the response data for the {@link QueueClient.sendMessage} operation.


### PR DESCRIPTION
It was lost in our previous code refactoring and caused TypeScript compilation
errors.

Related issue: #30101 