### PR TITLE
[Eng] Update Env Var for Execute Samples Task

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -250,6 +250,7 @@ jobs:
           displayName: "Execute Samples"
           env:
             TEST_MODE: "live"
+            AZURE_POD_IDENTITY_AUTHORITY_HOST: "FakeAuthorityHost" 
             ${{ insert }}: ${{ parameters.EnvVars }}
           condition: and(succeeded(),eq(variables['TestType'],'sample'))
 
@@ -282,6 +283,7 @@ jobs:
           workingDirectory: $(PackagePath)
           env:
             TEST_MODE: "live"
+            AZURE_POD_IDENTITY_AUTHORITY_HOST: "FakeAuthorityHost" 
             ${{ insert }}: ${{ parameters.EnvVars }}
           condition: and(succeeded(),eq(variables['TestType'],'sample'))
 

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -252,6 +252,8 @@ jobs:
           displayName: "Execute Samples"
           env:
             TEST_MODE: "live"
+            # Set fake authority host to ensure Managed Identity fail for Default Azure Credential
+            # so "execute samples" step correctly picks up Powershell credential.
             AZURE_POD_IDENTITY_AUTHORITY_HOST: "FakeAuthorityHost" 
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             ${{ insert }}: ${{ parameters.EnvVars }}
@@ -286,6 +288,8 @@ jobs:
           workingDirectory: $(PackagePath)
           env:
             TEST_MODE: "live"
+            # Set fake authority host to ensure Managed Identity fail for Default Azure Credential
+            # so "execute samples" step correctly picks up Powershell credential.
             AZURE_POD_IDENTITY_AUTHORITY_HOST: "FakeAuthorityHost" 
             ${{ insert }}: ${{ parameters.EnvVars }}
           condition: and(succeeded(),eq(variables['TestType'],'sample'))


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
Our samples currently use `DefaultAzureCredential` to authenticate the client. This causes a problem running samples live in the pipeline because Managed Identity does not work in the live pipeline. This is a short term work around: we create a fake authority host so that Managed Identity fail and it will succeed with the new credentials.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
We do not want to change the samples to use a different credentials because we want our customers to use DAC. We are discussing a long-term solution by potentially adding exclude managed identity property similar to Python/ .NET

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
