### PR TITLE
[core] fix ERR_INVALID_URL in sanitizer

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -119,6 +119,15 @@ export class Sanitizer {
           // When using sendOperationRequest, the request carries a massive
           // field with the autorest spec. No need to log it.
           return undefined;
+        } else if (
+          key === "_httpMessage" ||
+          key === "_readableState" ||
+          key === "_writableState" ||
+          key === "_parent" ||
+          key === "_tlsOptions"
+        ) {
+          // some proxy agent internal properties that we don't need to log.
+          return undefined;
         } else if (Array.isArray(value) || isObject(value)) {
           if (seen.has(value)) {
             return "[Circular]";

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -142,7 +142,7 @@ export class Sanitizer {
   }
 
   public sanitizeUrl(value: string): string {
-    if (typeof value !== "string" || value === null) {
+    if (typeof value !== "string" || value === null || value === "") {
       return value;
     }
 

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -119,15 +119,6 @@ export class Sanitizer {
           // When using sendOperationRequest, the request carries a massive
           // field with the autorest spec. No need to log it.
           return undefined;
-        } else if (
-          key === "_httpMessage" ||
-          key === "_readableState" ||
-          key === "_writableState" ||
-          key === "_parent" ||
-          key === "_tlsOptions"
-        ) {
-          // some proxy agent internal properties that we don't need to log.
-          return undefined;
         } else if (Array.isArray(value) || isObject(value)) {
           if (seen.has(value)) {
             return "[Circular]";

--- a/sdk/core/core-rest-pipeline/test/sanitizer.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/sanitizer.spec.ts
@@ -14,6 +14,15 @@ describe("Sanitizer", function () {
     assert.strictEqual(result, expected);
   });
 
+  it("Ignores url of empty string", function () {
+    const expected = `{
+  "url": ""
+}`;
+    const sanitizer = new Sanitizer();
+    const result = sanitizer.sanitize({ url: "" });
+    assert.strictEqual(result, expected);
+  });
+
   it("Handles recursive data structures", function () {
     const recursive: { a: number; b: unknown } = {
       a: 42,

--- a/sdk/core/ts-http-runtime/src/util/sanitizer.ts
+++ b/sdk/core/ts-http-runtime/src/util/sanitizer.ts
@@ -119,6 +119,15 @@ export class Sanitizer {
           // When using sendOperationRequest, the request carries a massive
           // field with the autorest spec. No need to log it.
           return undefined;
+        } else if (
+          key === "_httpMessage" ||
+          key === "_readableState" ||
+          key === "_writableState" ||
+          key === "_parent" ||
+          key === "_tlsOptions"
+        ) {
+          // some proxy agent internal properties that we don't need to log.
+          return undefined;
         } else if (Array.isArray(value) || isObject(value)) {
           if (seen.has(value)) {
             return "[Circular]";

--- a/sdk/core/ts-http-runtime/src/util/sanitizer.ts
+++ b/sdk/core/ts-http-runtime/src/util/sanitizer.ts
@@ -142,7 +142,7 @@ export class Sanitizer {
   }
 
   public sanitizeUrl(value: string): string {
-    if (typeof value !== "string" || value === null) {
+    if (typeof value !== "string" || value === null || value === "") {
       return value;
     }
 

--- a/sdk/core/ts-http-runtime/src/util/sanitizer.ts
+++ b/sdk/core/ts-http-runtime/src/util/sanitizer.ts
@@ -119,15 +119,6 @@ export class Sanitizer {
           // When using sendOperationRequest, the request carries a massive
           // field with the autorest spec. No need to log it.
           return undefined;
-        } else if (
-          key === "_httpMessage" ||
-          key === "_readableState" ||
-          key === "_writableState" ||
-          key === "_parent" ||
-          key === "_tlsOptions"
-        ) {
-          // some proxy agent internal properties that we don't need to log.
-          return undefined;
         } else if (Array.isArray(value) || isObject(value)) {
           if (seen.has(value)) {
             return "[Circular]";

--- a/sdk/core/ts-http-runtime/test/sanitizer.spec.ts
+++ b/sdk/core/ts-http-runtime/test/sanitizer.spec.ts
@@ -14,6 +14,15 @@ describe("Sanitizer", function () {
     assert.strictEqual(result, expected);
   });
 
+  it("Ignores url of empty string", function () {
+    const expected = `{
+  "url": ""
+}`;
+    const sanitizer = new Sanitizer();
+    const result = sanitizer.sanitize({ url: "" });
+    assert.strictEqual(result, expected);
+  });
+
   it("Handles recursive data structures", function () {
     const recursive: { a: number; b: unknown } = {
       a: 42,


### PR DESCRIPTION
when `url` key has a value of empty string.

Associated issues: https://github.com/Azure/azure-sdk-for-js/issues/30291 https://github.com/Azure/azure-sdk-for-js/issues/30304