### PR TITLE
[identity] Use MSAL for Managed Identity

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- `ManagedIdentityCredential` migrated to use [MSAL](https://www.npmjs.com/package/@azure/msal-node) for handling the majority of the managed identity implementation. [#30172](https://github.com/Azure/azure-sdk-for-js/pull/30172)
+
 ## 4.4.0 (2024-07-16)
 
 ### Features Added

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -286,6 +286,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
       method: "POST",
       body: options?.body,
       headers: createHttpHeaders(options?.headers),
+      allowInsecureConnection: this.allowInsecureConnection,
       // MSAL doesn't send the correlation ID on the get requests.
       abortSignal: this.generateAbortSignal(this.getCorrelationId(options)),
     });

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -67,6 +67,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
   public authorityHost: string;
   private allowLoggingAccountIdentifiers?: boolean;
   private abortControllers: Map<string, AbortController[] | undefined>;
+  private allowInsecureConnection: boolean = false;
   // used for WorkloadIdentity
   private tokenCredentialOptions: TokenCredentialOptions;
 
@@ -98,6 +99,11 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
     this.allowLoggingAccountIdentifiers = options?.loggingOptions?.allowLoggingAccountIdentifiers;
     // used for WorkloadIdentity
     this.tokenCredentialOptions = { ...options };
+
+    // used for ManagedIdentity
+    if (options?.allowInsecureConnection) {
+      this.allowInsecureConnection = options.allowInsecureConnection;
+    }
   }
 
   async sendTokenRequest(request: PipelineRequest): Promise<TokenResponse | null> {
@@ -255,6 +261,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
       url,
       method: "GET",
       body: options?.body,
+      allowInsecureConnection: this.allowInsecureConnection,
       headers: createHttpHeaders(options?.headers),
       abortSignal: this.generateAbortSignal(noCorrelationId),
     });

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsRetryPolicy.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsRetryPolicy.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { PipelinePolicy, retryPolicy } from "@azure/core-rest-pipeline";
+import { getRandomIntegerInclusive } from "@azure/core-util";
+import { MSIConfiguration } from "./models";
+
+// Matches the default retry configuration in expontentialRetryStrategy.ts
+const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1000 * 64;
+
+/**
+ * An additional policy that retries on 404 errors. The default retry policy does not retry on
+ * 404s, but the IMDS endpoint can return 404s when the token is not yet available. This policy
+ * will retry on 404s with an exponential backoff.
+ *
+ * @param msiRetryConfig - The retry configuration for the MSI credential.
+ * @returns - The policy that will retry on 404s.
+ */
+export function imdsRetryPolicy(msiRetryConfig: MSIConfiguration["retryConfig"]): PipelinePolicy {
+  return retryPolicy(
+    [
+      {
+        name: "Retry404",
+        retry: ({ retryCount, response }) => {
+          if (response?.status !== 404) {
+            return { skipStrategy: true };
+          }
+
+          // Exponentially increase the delay each time
+          const exponentialDelay = msiRetryConfig.startDelayInMs * Math.pow(2, retryCount);
+
+          // Don't let the delay exceed the maximum
+          const clampedExponentialDelay = Math.min(
+            DEFAULT_CLIENT_MAX_RETRY_INTERVAL,
+            exponentialDelay,
+          );
+
+          // Allow the final value to have some "jitter" (within 50% of the delay size) so
+          // that retries across multiple clients don't occur simultaneously.
+          const retryAfterInMs =
+            clampedExponentialDelay / 2 + getRandomIntegerInclusive(0, clampedExponentialDelay / 2);
+
+          return { retryAfterInMs };
+        },
+      },
+    ],
+    {
+      maxRetries: msiRetryConfig.maxRetries,
+    },
+  );
+}

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsRetryPolicy.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsRetryPolicy.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 import { PipelinePolicy, retryPolicy } from "@azure/core-rest-pipeline";
-import { getRandomIntegerInclusive } from "@azure/core-util";
+
 import { MSIConfiguration } from "./models";
+import { getRandomIntegerInclusive } from "@azure/core-util";
 
 // Matches the default retry configuration in expontentialRetryStrategy.ts
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1000 * 64;
@@ -20,7 +21,7 @@ export function imdsRetryPolicy(msiRetryConfig: MSIConfiguration["retryConfig"])
   return retryPolicy(
     [
       {
-        name: "Retry404",
+        name: "imdsRetryPolicy",
         retry: ({ retryCount, response }) => {
           if (response?.status !== 404) {
             return { skipStrategy: true };

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -5,6 +5,7 @@ import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth"
 
 import { LegacyMsiProvider } from "./legacyMsiProvider";
 import { TokenCredentialOptions } from "../../tokenCredentialOptions";
+import { MsalMsiProvider } from "./msalMsiProvider";
 
 /**
  * Options to send on the {@link ManagedIdentityCredential} constructor.
@@ -41,7 +42,7 @@ export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredent
  * https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
  */
 export class ManagedIdentityCredential implements TokenCredential {
-  private implProvider: LegacyMsiProvider;
+  private implProvider: LegacyMsiProvider | MsalMsiProvider;
 
   /**
    * Creates an instance of ManagedIdentityCredential with the client ID of a
@@ -74,7 +75,10 @@ export class ManagedIdentityCredential implements TokenCredential {
       | ManagedIdentityCredentialResourceIdOptions,
     options?: TokenCredentialOptions,
   ) {
-    this.implProvider = new LegacyMsiProvider(clientIdOrOptions, options);
+    // If needed, you may release a hotfix to quickly rollback to the legacy implementation by changing the following line to:
+    // this.implProvider = new LegacyMsiProvider(clientIdOrOptions, options);
+    // Once stabilized, you can remove the legacy implementation and inline the msalMsiProvider code here as a drop-in replacement.
+    this.implProvider = new MsalMsiProvider(clientIdOrOptions, options);
   }
 
   /**

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -75,6 +75,7 @@ export class ManagedIdentityCredential implements TokenCredential {
       | ManagedIdentityCredentialResourceIdOptions,
     options?: TokenCredentialOptions,
   ) {
+    // https://github.com/Azure/azure-sdk-for-js/issues/30189
     // If needed, you may release a hotfix to quickly rollback to the legacy implementation by changing the following line to:
     // this.implProvider = new LegacyMsiProvider(clientIdOrOptions, options);
     // Once stabilized, you can remove the legacy implementation and inline the msalMsiProvider code here as a drop-in replacement.

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/legacyMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/legacyMsiProvider.ts
@@ -30,8 +30,8 @@ const logger = credentialLogger("ManagedIdentityCredential");
 
 // As part of the migration of Managed Identity to MSAL, this legacy provider captures the existing behavior
 // ported over from the ManagedIdentityCredential verbatim. This is to ensure that the existing behavior
-// is maintained while the new implementation is being tested and validated. Part of the migration (tracked in #25253)
-// should include deleting this provider once it is no longer needed.
+// is maintained while the new implementation is being tested and validated.
+// https://github.com/Azure/azure-sdk-for-js/issues/30189  tracks deleting this provider once it is no longer needed.
 
 /**
  * Options to send on the {@link ManagedIdentityCredential} constructor.

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/legacyMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/legacyMsiProvider.ts
@@ -135,7 +135,7 @@ export class LegacyMsiProvider {
       appServiceMsi2019,
       appServiceMsi2017,
       cloudShellMsi,
-      tokenExchangeMsi(),
+      tokenExchangeMsi,
       imdsMsi,
     ];
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -254,11 +254,16 @@ export class MsalMsiProvider {
 }
 
 function isNetworkError(err: any): boolean {
+  // MSAL error
   if (err.errorCode === "network_error") {
     return true;
   }
 
-  // TODO: validate this is still needed or delete
+  // Probe errors
+  if (err.code === "ENETUNREACH" || err.code === "EHOSTUNREACH") {
+    return true;
+  }
+
   // This is a special case for Docker Desktop which responds with a 403 with a message that contains "A socket operation was attempted to an unreachable network" or "A socket operation was attempted to an unreachable host"
   // rather than just timing out, as expected.
   if (err.statusCode === 403 || err.code === 403) {

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -226,7 +226,7 @@ export class MsalMsiProvider {
     msalToken?: MsalToken,
     getTokenOptions?: GetTokenOptions,
   ): asserts msalToken is ValidMsalToken {
-    const error = (message: string): Error => {
+    const createError = (message: string): Error => {
       logger.getToken.info(message);
       return new AuthenticationRequiredError({
         scopes: Array.isArray(scopes) ? scopes : [scopes],
@@ -235,13 +235,13 @@ export class MsalMsiProvider {
       });
     };
     if (!msalToken) {
-      throw error("No response");
+      throw createError("No response");
     }
     if (!msalToken.expiresOn) {
-      throw error(`Response had no "expiresOn" property.`);
+      throw createError(`Response had no "expiresOn" property.`);
     }
     if (!msalToken.accessToken) {
-      throw error(`Response had no "accessToken" property.`);
+      throw createError(`Response had no "accessToken" property.`);
     }
   }
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -15,6 +15,7 @@ import { AuthenticationRequiredError, CredentialUnavailableError } from "../../e
 import { MSIConfiguration } from "./models";
 import { tokenExchangeMsi } from "./tokenExchangeMsi";
 import { imdsMsi } from "./imdsMsi";
+import { imdsRetryPolicy } from "./imdsRetryPolicy";
 
 const logger = credentialLogger("ManagedIdentityCredential(MSAL)");
 
@@ -79,7 +80,10 @@ export class MsalMsiProvider {
       this.msiRetryConfig.maxRetries = _options.retryOptions.maxRetries;
     }
 
-    this.identityClient = new IdentityClient(_options);
+    this.identityClient = new IdentityClient({
+      ..._options,
+      additionalPolicies: [{ policy: imdsRetryPolicy(this.msiRetryConfig), position: "perCall" }],
+    });
     this.managedIdentityApp = new ManagedIdentityApplication({
       managedIdentityIdParams: {
         userAssignedClientId: this.clientId,

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AccessToken, GetTokenOptions } from "@azure/core-auth";
+import { TokenCredentialOptions } from "../../tokenCredentialOptions";
+import { credentialLogger, formatError, formatSuccess } from "../../util/logging";
+import { tracingClient } from "../../util/tracing";
+import { IdentityClient } from "../../client/identityClient";
+import { ManagedIdentityApplication } from "@azure/msal-node";
+import { defaultLoggerCallback, getMSALLogLevel } from "../../msal/utils";
+import { getLogLevel } from "@azure/logger";
+import { mapScopesToResource } from "./utils";
+import { MsalToken, ValidMsalToken } from "../../msal/types";
+import { AuthenticationRequiredError, CredentialUnavailableError } from "../../errors";
+import { MSIConfiguration } from "./models";
+import { tokenExchangeMsi } from "./tokenExchangeMsi";
+import { imdsMsi } from "./imdsMsi";
+
+const logger = credentialLogger("ManagedIdentityCredential(MSAL)");
+
+/**
+ * Options to send on the {@link ManagedIdentityCredential} constructor.
+ * Since this is an internal implementation, uses a looser interface than the public one.
+ */
+interface ManagedIdentityCredentialOptions extends TokenCredentialOptions {
+  /**
+   * The client ID of the user - assigned identity, or app registration(when working with AKS pod - identity).
+   */
+  clientId?: string;
+
+  /**
+   * Allows specifying a custom resource Id.
+   * In scenarios such as when user assigned identities are created using an ARM template,
+   * where the resource Id of the identity is known but the client Id can't be known ahead of time,
+   * this parameter allows programs to use these user assigned identities
+   * without having to first determine the client Id of the created identity.
+   */
+  resourceId?: string;
+}
+
+export class MsalMsiProvider {
+  private managedIdentityApp: ManagedIdentityApplication;
+  private identityClient: IdentityClient;
+  private clientId?: string;
+  private resourceId?: string;
+  private msiRetryConfig: MSIConfiguration["retryConfig"] = {
+    maxRetries: 5,
+    startDelayInMs: 800,
+    intervalIncrement: 2,
+  };
+  private isAvailableIdentityClient: IdentityClient;
+
+  constructor(
+    clientIdOrOptions?: string | ManagedIdentityCredentialOptions,
+    options: ManagedIdentityCredentialOptions = {},
+  ) {
+    // TODO: disambiguate this like we did in keyvault
+    let _options: ManagedIdentityCredentialOptions = {};
+    if (typeof clientIdOrOptions === "string") {
+      this.clientId = clientIdOrOptions;
+      _options = options;
+    } else {
+      this.clientId = clientIdOrOptions?.clientId;
+      _options = clientIdOrOptions ?? {};
+    }
+    this.resourceId = _options?.resourceId;
+
+    // For JavaScript users.
+    if (this.clientId && this.resourceId) {
+      throw new Error(
+        `ManagedIdentityCredential - Client Id and Resource Id can't be provided at the same time.`,
+      );
+    }
+
+    // ManagedIdentity uses http for local requests
+    _options.allowInsecureConnection = true;
+
+    if (_options?.retryOptions?.maxRetries !== undefined) {
+      this.msiRetryConfig.maxRetries = _options.retryOptions.maxRetries;
+    }
+
+    this.identityClient = new IdentityClient(_options);
+    this.managedIdentityApp = new ManagedIdentityApplication({
+      managedIdentityIdParams: {
+        userAssignedClientId: this.clientId,
+        userAssignedResourceId: this.resourceId,
+      },
+      system: {
+        // todo: proxyUrl?
+        disableInternalRetries: true,
+        networkClient: this.identityClient,
+        loggerOptions: {
+          logLevel: getMSALLogLevel(getLogLevel()),
+          piiLoggingEnabled: options.loggingOptions?.enableUnsafeSupportLogging,
+          loggerCallback: defaultLoggerCallback(logger),
+        },
+      },
+    });
+
+    this.isAvailableIdentityClient = new IdentityClient({
+      ..._options,
+      retryOptions: {
+        maxRetries: 0,
+      },
+    });
+  }
+
+  /**
+   * Authenticates with Microsoft Entra ID and returns an access token if successful.
+   * If authentication fails, a {@link CredentialUnavailableError} will be thrown with the details of the failure.
+   * If an unexpected error occurs, an {@link AuthenticationError} will be thrown with the details of the failure.
+   *
+   * @param scopes - The list of scopes for which the token will have access.
+   * @param options - The options used to configure any requests this
+   *                TokenCredential implementation might make.
+   */
+  public async getToken(
+    scopes: string | string[],
+    options: GetTokenOptions = {},
+  ): Promise<AccessToken> {
+    logger.getToken.info("Using the MSAL provider for Managed Identity.");
+    const resource = mapScopesToResource(scopes);
+    if (!resource) {
+      throw new CredentialUnavailableError(
+        `ManagedIdentityCredential: Multiple scopes are not supported. Scopes: ${JSON.stringify(scopes)}`,
+      );
+    }
+
+    return tracingClient.withSpan("ManagedIdentityCredential.getToken", options, async () => {
+      try {
+        const isTokenExchangeMsi = await tokenExchangeMsi.isAvailable({
+          scopes,
+          clientId: this.clientId,
+          getTokenOptions: options,
+          identityClient: this.identityClient,
+          resourceId: this.resourceId,
+        });
+
+        const identitySource = this.managedIdentityApp.getManagedIdentitySource();
+        const isImdsMsi = identitySource === "Imds" || identitySource === "DefaultToImds";
+
+        if (isTokenExchangeMsi) {
+          logger.getToken.info("Using the token exchange managed identity.");
+          const result = await tokenExchangeMsi.getToken({
+            scopes,
+            clientId: this.clientId,
+            identityClient: this.identityClient,
+            retryConfig: this.msiRetryConfig,
+            resourceId: this.resourceId,
+          });
+
+          if (result === null) {
+            throw new CredentialUnavailableError(
+              "The managed identity endpoint was reached, yet no tokens were received.",
+            );
+          }
+
+          return result;
+        } else if (isImdsMsi) {
+          logger.getToken.info("Using the IMDS endpoint to probe for availability.");
+          // first probe, if we're in a DAC scenario, then get the token
+          const isAvailable = await imdsMsi.isAvailable({
+            scopes,
+            clientId: this.clientId,
+            getTokenOptions: options,
+            identityClient: this.isAvailableIdentityClient,
+            resourceId: this.resourceId,
+          });
+
+          if (!isAvailable) {
+            throw new CredentialUnavailableError(
+              `ManagedIdentityCredential: The managed identity endpoint is not available.`,
+            );
+          }
+        }
+
+        // At this point we know that:
+        // - This is not a tokenExchangeMsi,
+        // - We already probed for IMDS endpoint availability if it's an IMDS MSI.
+        // We can proceed normally
+        logger.getToken.info("Calling into MSAL for managed identity token.");
+        const token = await this.managedIdentityApp.acquireToken({
+          resource,
+        });
+
+        // TODO: account caching, etc?
+        // TODO: handle forceRefresh
+        this.ensureValidMsalToken(scopes, token, options);
+        logger.getToken.info(formatSuccess(scopes));
+
+        return {
+          expiresOnTimestamp: token.expiresOn.getTime(),
+          token: token.accessToken,
+        };
+      } catch (err: any) {
+        logger.getToken.error(formatError(scopes, err));
+
+        // AuthenticationRequiredError described as Error to enforce authentication after trying to retrieve a token silently.
+        // TODO: why would this _ever_ happen considering we're not trying the silent request in this flow?
+        if (err.name === "AuthenticationRequiredError") {
+          throw err;
+        }
+
+        if (isNetworkError(err)) {
+          throw new CredentialUnavailableError(
+            `ManagedIdentityCredential: Network unreachable. Message: ${err.message}`,
+          );
+        }
+
+        throw new CredentialUnavailableError(
+          `ManagedIdentityCredential: Authentication failed. Message ${err.message}`,
+        );
+      }
+    });
+  }
+
+  /**
+   * Ensures the validity of the MSAL token
+   */
+  private ensureValidMsalToken(
+    scopes: string | string[],
+    msalToken?: MsalToken,
+    getTokenOptions?: GetTokenOptions,
+  ): asserts msalToken is ValidMsalToken {
+    const error = (message: string): Error => {
+      logger.getToken.info(message);
+      return new AuthenticationRequiredError({
+        scopes: Array.isArray(scopes) ? scopes : [scopes],
+        getTokenOptions,
+        message,
+      });
+    };
+    if (!msalToken) {
+      throw error("No response");
+    }
+    if (!msalToken.expiresOn) {
+      throw error(`Response had no "expiresOn" property.`);
+    }
+    if (!msalToken.accessToken) {
+      throw error(`Response had no "accessToken" property.`);
+    }
+  }
+}
+
+function isNetworkError(err: any): boolean {
+  if (err.errorCode === "network_error") {
+    return true;
+  }
+
+  // TODO: validate this is still needed or delete
+  // This is a special case for Docker Desktop which responds with a 403 with a message that contains "A socket operation was attempted to an unreachable network" or "A socket operation was attempted to an unreachable host"
+  // rather than just timing out, as expected.
+  if (err.statusCode === 403 || err.code === 403) {
+    if (err.message.includes("unreachable")) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts
@@ -13,38 +13,36 @@ const logger = credentialLogger(msiName);
 /**
  * Defines how to determine whether the token exchange MSI is available, and also how to retrieve a token from the token exchange MSI.
  */
-export function tokenExchangeMsi(): MSI {
-  return {
-    name: "tokenExchangeMsi",
-    async isAvailable({ clientId }): Promise<boolean> {
-      const env = process.env;
-      const result = Boolean(
-        (clientId || env.AZURE_CLIENT_ID) &&
-          env.AZURE_TENANT_ID &&
-          process.env.AZURE_FEDERATED_TOKEN_FILE,
+export const tokenExchangeMsi: MSI = {
+  name: "tokenExchangeMsi",
+  async isAvailable({ clientId }): Promise<boolean> {
+    const env = process.env;
+    const result = Boolean(
+      (clientId || env.AZURE_CLIENT_ID) &&
+        env.AZURE_TENANT_ID &&
+        process.env.AZURE_FEDERATED_TOKEN_FILE,
+    );
+    if (!result) {
+      logger.info(
+        `${msiName}: Unavailable. The environment variables needed are: AZURE_CLIENT_ID (or the client ID sent through the parameters), AZURE_TENANT_ID and AZURE_FEDERATED_TOKEN_FILE`,
       );
-      if (!result) {
-        logger.info(
-          `${msiName}: Unavailable. The environment variables needed are: AZURE_CLIENT_ID (or the client ID sent through the parameters), AZURE_TENANT_ID and AZURE_FEDERATED_TOKEN_FILE`,
-        );
-      }
-      return result;
-    },
-    async getToken(
-      configuration: MSIConfiguration,
-      getTokenOptions: GetTokenOptions = {},
-    ): Promise<AccessToken | null> {
-      const { scopes, clientId } = configuration;
-      const identityClientTokenCredentialOptions = {};
-      const workloadIdentityCredential = new WorkloadIdentityCredential({
-        clientId,
-        tenantId: process.env.AZURE_TENANT_ID,
-        tokenFilePath: process.env.AZURE_FEDERATED_TOKEN_FILE,
-        ...identityClientTokenCredentialOptions,
-        disableInstanceDiscovery: true,
-      } as WorkloadIdentityCredentialOptions);
-      const token = await workloadIdentityCredential.getToken(scopes, getTokenOptions);
-      return token;
-    },
-  };
-}
+    }
+    return result;
+  },
+  async getToken(
+    configuration: MSIConfiguration,
+    getTokenOptions: GetTokenOptions = {},
+  ): Promise<AccessToken | null> {
+    const { scopes, clientId } = configuration;
+    const identityClientTokenCredentialOptions = {};
+    const workloadIdentityCredential = new WorkloadIdentityCredential({
+      clientId,
+      tenantId: process.env.AZURE_TENANT_ID,
+      tokenFilePath: process.env.AZURE_FEDERATED_TOKEN_FILE,
+      ...identityClientTokenCredentialOptions,
+      disableInstanceDiscovery: true,
+    } as WorkloadIdentityCredentialOptions);
+    const token = await workloadIdentityCredential.getToken(scopes, getTokenOptions);
+    return token;
+  },
+};

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/tokenExchangeMsi.ts
@@ -42,7 +42,6 @@ export const tokenExchangeMsi: MSI = {
       ...identityClientTokenCredentialOptions,
       disableInstanceDiscovery: true,
     } as WorkloadIdentityCredentialOptions);
-    const token = await workloadIdentityCredential.getToken(scopes, getTokenOptions);
-    return token;
+    return workloadIdentityCredential.getToken(scopes, getTokenOptions);
   },
 };

--- a/sdk/identity/identity/test/internal/node/azureApplicationCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureApplicationCredential.spec.ts
@@ -7,6 +7,8 @@ import { AzureApplicationCredential } from "../../../src/credentials/azureApplic
 import { IdentityTestContext } from "../../httpRequests";
 import { RestError } from "@azure/core-rest-pipeline";
 import { assert } from "chai";
+import * as dac from "../../../src/credentials/defaultAzureCredential";
+import { LegacyMsiProvider } from "../../../src/credentials/managedIdentityCredential/legacyMsiProvider";
 
 describe("AzureApplicationCredential testing Managed Identity (internal)", function () {
   let envCopy: string = "";
@@ -19,7 +21,13 @@ describe("AzureApplicationCredential testing Managed Identity (internal)", funct
     delete process.env.AZURE_CLIENT_SECRET;
     delete process.env.AZURE_TENANT_ID;
     testContext = new IdentityTestContext({});
+    testContext.sandbox
+      .stub(dac, "createDefaultManagedIdentityCredential")
+      .callsFake(
+        (...args) => new LegacyMsiProvider({ ...args, clientId: process.env.AZURE_CLIENT_ID }),
+      );
   });
+
   afterEach(async () => {
     const env = JSON.parse(envCopy);
     process.env.MSI_ENDPOINT = env.MSI_ENDPOINT;

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/imdsRetryPolicy.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/imdsRetryPolicy.spec.ts
@@ -1,21 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { imdsRetryPolicy } from "../../../../src/credentials/managedIdentityCredential/imdsRetryPolicy";
-import { PipelineRequest, SendRequest, createHttpHeaders } from "@azure/core-rest-pipeline";
+import {
+  PipelineRequest,
+  RestError,
+  SendRequest,
+  createHttpHeaders,
+} from "@azure/core-rest-pipeline";
+
 import { MSIConfiguration } from "../../../../src/credentials/managedIdentityCredential/models";
 import { assert } from "@azure-tools/test-utils";
+import { imdsRetryPolicy } from "../../../../src/credentials/managedIdentityCredential/imdsRetryPolicy";
 
 describe("imdsRetryPolicy", () => {
   const mockRetryConfig: MSIConfiguration["retryConfig"] = {
     maxRetries: 3,
-    startDelayInMs: 100,
-    intervalIncrement: 1000,
+    startDelayInMs: 1,
+    intervalIncrement: 1,
   };
 
   it("should retry on 404 errors", async () => {
     const policy = imdsRetryPolicy(mockRetryConfig);
-    const request: PipelineRequest = {
+    const pipelineRequest: PipelineRequest = {
       url: "https://example.com",
       method: "GET",
       headers: createHttpHeaders(),
@@ -28,59 +34,57 @@ describe("imdsRetryPolicy", () => {
 
     let sendRequestCount = 0;
 
-    const sendRequest: SendRequest = async (req) => {
+    const sendRequest: SendRequest = async (request) => {
       sendRequestCount++;
       if (sendRequestCount === 1) {
         // Simulate a 404 error on the first request
-        return {
+        const response = {
           status: 404,
           headers: createHttpHeaders(),
-          request: req,
-          body: undefined,
+          request,
         };
+        throw new RestError("Not found", { statusCode: 404, request, response });
       } else {
         // Return a successful response on subsequent requests
         return {
           status: 200,
           headers: createHttpHeaders(),
-          request: req,
+          request: request,
           body: undefined,
         };
       }
     };
 
-    await policy.sendRequest(request, sendRequest);
+    await policy.sendRequest(pipelineRequest, sendRequest);
 
     assert.strictEqual(sendRequestCount, 2); // Should retry once
   });
 
   it("should respect the maximum number of retries", async () => {
     const policy = imdsRetryPolicy(mockRetryConfig);
-    const request: PipelineRequest = {
+    const pipelineRequest: PipelineRequest = {
       url: "https://example.com",
       method: "GET",
       headers: createHttpHeaders(),
-      body: undefined,
-      abortSignal: undefined,
       timeout: 100,
       requestId: "test",
       withCredentials: false,
     };
 
     let sendRequestCount = 0;
-    const sendRequest: SendRequest = async (req) => {
+    const sendRequest: SendRequest = async (request) => {
       sendRequestCount++;
       // Simulate a 404 error on every request
-      // Simulate a 404 error on the first request
-      return {
+      const response = {
         status: 404,
         headers: createHttpHeaders(),
-        request: req,
+        request,
         body: undefined,
       };
+      throw new RestError("Not found", { statusCode: 404, request, response });
     };
 
-    await assert.isRejected(policy.sendRequest(request, sendRequest), "Not Found");
+    await assert.isRejected(policy.sendRequest(pipelineRequest, sendRequest), "Not found");
     assert.strictEqual(sendRequestCount, mockRetryConfig.maxRetries + 1); // Should retry the maximum number of times
   });
 });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/imdsRetryPolicy.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/imdsRetryPolicy.spec.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { imdsRetryPolicy } from "../../../../src/credentials/managedIdentityCredential/imdsRetryPolicy";
+import { PipelineRequest, SendRequest, createHttpHeaders } from "@azure/core-rest-pipeline";
+import { MSIConfiguration } from "../../../../src/credentials/managedIdentityCredential/models";
+import { assert } from "@azure-tools/test-utils";
+import { IdentityClient } from "../../../../src/client/identityClient";
+
+describe("imdsRetryPolicy", () => {
+  const mockRetryConfig: MSIConfiguration["retryConfig"] = {
+    maxRetries: 3,
+    startDelayInMs: 100,
+    intervalIncrement: 1000,
+  };
+
+  it("should retry on 404 errors", async () => {
+    const policy = imdsRetryPolicy(mockRetryConfig);
+    const request: PipelineRequest = {
+      url: "https://example.com",
+      method: "GET",
+      headers: createHttpHeaders(),
+      body: undefined,
+      abortSignal: undefined,
+      timeout: 100,
+      requestId: "test",
+      withCredentials: false,
+    };
+
+    let sendRequestCount = 0;
+
+    const sendRequest: SendRequest = async (req) => {
+      sendRequestCount++;
+      if (sendRequestCount === 1) {
+        // Simulate a 404 error on the first request
+        return {
+          status: 404,
+          headers: createHttpHeaders(),
+          request: req,
+          body: undefined,
+        };
+      } else {
+        // Return a successful response on subsequent requests
+        return {
+          status: 200,
+          headers: createHttpHeaders(),
+          request: req,
+          body: undefined,
+        };
+      }
+    };
+
+    await policy.sendRequest(request, sendRequest);
+
+    assert.strictEqual(sendRequestCount, 2); // Should retry once
+  });
+
+  it("should respect the maximum number of retries", async () => {
+    const policy = imdsRetryPolicy(mockRetryConfig);
+    const request: PipelineRequest = {
+      url: "https://example.com",
+      method: "GET",
+      headers: createHttpHeaders(),
+      body: undefined,
+      abortSignal: undefined,
+      timeout: 100,
+      requestId: "test",
+      withCredentials: false,
+    };
+
+    let sendRequestCount = 0;
+    const sendRequest: SendRequest = async (req) => {
+      sendRequestCount++;
+      // Simulate a 404 error on every request
+      // Simulate a 404 error on the first request
+      return {
+        status: 404,
+        headers: createHttpHeaders(),
+        request: req,
+        body: undefined,
+      };
+    };
+
+    await assert.isRejected(policy.sendRequest(request, sendRequest), "Not Found");
+    assert.strictEqual(sendRequestCount, mockRetryConfig.maxRetries + 1); // Should retry the maximum number of times
+  });
+});

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/imdsRetryPolicy.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/imdsRetryPolicy.spec.ts
@@ -5,7 +5,6 @@ import { imdsRetryPolicy } from "../../../../src/credentials/managedIdentityCred
 import { PipelineRequest, SendRequest, createHttpHeaders } from "@azure/core-rest-pipeline";
 import { MSIConfiguration } from "../../../../src/credentials/managedIdentityCredential/models";
 import { assert } from "@azure-tools/test-utils";
-import { IdentityClient } from "../../../../src/client/identityClient";
 
 describe("imdsRetryPolicy", () => {
   const mockRetryConfig: MSIConfiguration["retryConfig"] = {

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import Sinon from "sinon";
+import { assert } from "@azure-tools/test-utils";
+import { AuthError, AuthenticationResult, ManagedIdentityApplication } from "@azure/msal-node";
+import { MsalMsiProvider } from "../../../../src/credentials/managedIdentityCredential/msalMsiProvider";
+import { tokenExchangeMsi } from "../../../../src/credentials/managedIdentityCredential/tokenExchangeMsi";
+import { imdsMsi } from "../../../../src/credentials/managedIdentityCredential/imdsMsi";
+import { RestError } from "@azure/core-rest-pipeline";
+import { AuthenticationRequiredError, CredentialUnavailableError } from "../../../../src/errors";
+
+describe("ManagedIdentityCredential (MSAL)", function () {
+  let msal: Sinon.SinonStub;
+  const validAuthenticationResult: Partial<AuthenticationResult> = {
+    accessToken: "test_token",
+    expiresOn: new Date(),
+  };
+
+  afterEach(function () {
+    Sinon.restore();
+  });
+
+  beforeEach(function () {
+    // minimal stub
+    msal = Sinon.stub(ManagedIdentityApplication.prototype, "acquireToken");
+  });
+
+  describe("constructor", function () {
+    it("throws when both clientId and resourceId are provided", function () {
+      assert.throws(
+        () => new MsalMsiProvider({ clientId: "id", resourceId: "id" }),
+        /provided at the same time./,
+      );
+    });
+  });
+
+  describe("#getToken", function () {
+    describe("when getToken is successful", function () {
+      it("returns a token", async function () {
+        msal.resolves(validAuthenticationResult as AuthenticationResult);
+        const provider = new MsalMsiProvider();
+        const token = await provider.getToken("scope");
+        assert.strictEqual(token.token, validAuthenticationResult.accessToken);
+        assert.strictEqual(
+          token.expiresOnTimestamp,
+          validAuthenticationResult.expiresOn?.getTime(),
+        );
+      });
+
+      describe("when using tokenExchangeMsi", function () {
+        it("gets a token using the tokenExchangeMsi implementation", async function () {
+          const validToken = {
+            token: "test_token",
+            expiresOnTimestamp: new Date().getTime(),
+          };
+          Sinon.stub(tokenExchangeMsi, "isAvailable").resolves(true);
+          Sinon.stub(tokenExchangeMsi, "getToken").resolves(validToken);
+
+          const provider = new MsalMsiProvider();
+          const token = await provider.getToken("scope");
+          assert.strictEqual(token.token, validToken.token);
+          assert.strictEqual(token.expiresOnTimestamp, validToken.expiresOnTimestamp);
+        });
+      });
+
+      describe("when using IMDS", function () {
+        it("probes the IMDS endpoint", async function () {
+          Sinon.stub(ManagedIdentityApplication.prototype, "getManagedIdentitySource").returns(
+            "DefaultToImds",
+          );
+          const isAvailableStub = Sinon.stub(imdsMsi, "isAvailable").resolves(true);
+          msal.resolves(validAuthenticationResult as AuthenticationResult);
+
+          const provider = new MsalMsiProvider();
+          await provider.getToken("scope");
+          assert.isTrue(isAvailableStub.calledOnce);
+        });
+      });
+    });
+
+    it("validates multiple scopes are not supported", async function () {
+      const provider = new MsalMsiProvider();
+      await assert.isRejected(provider.getToken(["scope1", "scope2"]), /Multiple scopes/);
+    });
+
+    describe("error handling", function () {
+      it("rethrows AuthenticationRequiredError", async function () {
+        msal.rejects(new AuthenticationRequiredError({ scopes: ["scope"] }));
+        const provider = new MsalMsiProvider();
+        await assert.isRejected(provider.getToken("scope"), AuthenticationRequiredError);
+      });
+
+      it("handles an unreachable network error", async function () {
+        msal.rejects(new AuthError("network_error"));
+        const provider = new MsalMsiProvider();
+        await assert.isRejected(provider.getToken("scope"), CredentialUnavailableError);
+      });
+
+      it("handles a 403 status code", async function () {
+        msal.rejects(
+          new RestError("A socket operation was attempted to an unreachable network", {
+            statusCode: 403,
+          }),
+        );
+        const provider = new MsalMsiProvider();
+        await assert.isRejected(provider.getToken("scope"), /Network unreachable/);
+      });
+
+      it("handles unexpected errors", async function () {
+        msal.rejects(new Error("Some unexpected error"));
+        const provider = new MsalMsiProvider();
+        await assert.isRejected(provider.getToken("scope"), /Authentication failed/);
+      });
+    });
+  });
+});

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -9,21 +9,22 @@ import { tokenExchangeMsi } from "../../../../src/credentials/managedIdentityCre
 import { imdsMsi } from "../../../../src/credentials/managedIdentityCredential/imdsMsi";
 import { RestError } from "@azure/core-rest-pipeline";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../../../../src/errors";
+import { setLogLevel } from "@azure/logger";
+setLogLevel("verbose"); // TODO: delete before merging
 
-describe("ManagedIdentityCredential (MSAL)", function () {
+describe.only("ManagedIdentityCredential (MSAL)", function () {
   let msal: Sinon.SinonStub;
   const validAuthenticationResult: Partial<AuthenticationResult> = {
     accessToken: "test_token",
     expiresOn: new Date(),
   };
 
-  afterEach(function () {
-    Sinon.restore();
+  beforeEach(function () {
+    msal = Sinon.stub(ManagedIdentityApplication.prototype, "acquireToken");
   });
 
-  beforeEach(function () {
-    // minimal stub
-    msal = Sinon.stub(ManagedIdentityApplication.prototype, "acquireToken");
+  afterEach(function () {
+    Sinon.restore();
   });
 
   describe("constructor", function () {

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -14,6 +14,8 @@ setLogLevel("verbose"); // TODO: delete before merging
 
 describe.only("ManagedIdentityCredential (MSAL)", function () {
   let acquireTokenStub: Sinon.SinonStub;
+  let imdsIsAvailableStub: Sinon.SinonStub;
+
   const validAuthenticationResult: Partial<AuthenticationResult> = {
     accessToken: "test_token",
     expiresOn: new Date(),
@@ -21,6 +23,7 @@ describe.only("ManagedIdentityCredential (MSAL)", function () {
 
   beforeEach(function () {
     acquireTokenStub = Sinon.stub(ManagedIdentityApplication.prototype, "acquireToken");
+    imdsIsAvailableStub = Sinon.stub(imdsMsi, "isAvailable").resolves(true); // Skip pinging the IMDS endpoint in tests
   });
 
   afterEach(function () {
@@ -82,12 +85,11 @@ describe.only("ManagedIdentityCredential (MSAL)", function () {
           Sinon.stub(ManagedIdentityApplication.prototype, "getManagedIdentitySource").returns(
             "DefaultToImds",
           );
-          const isAvailableStub = Sinon.stub(imdsMsi, "isAvailable").resolves(true);
           acquireTokenStub.resolves(validAuthenticationResult as AuthenticationResult);
 
           const provider = new MsalMsiProvider();
           await provider.getToken("scope");
-          assert.isTrue(isAvailableStub.calledOnce);
+          assert.isTrue(imdsIsAvailableStub.calledOnce);
         });
       });
     });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -9,10 +9,8 @@ import { tokenExchangeMsi } from "../../../../src/credentials/managedIdentityCre
 import { imdsMsi } from "../../../../src/credentials/managedIdentityCredential/imdsMsi";
 import { RestError } from "@azure/core-rest-pipeline";
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../../../../src/errors";
-import { setLogLevel } from "@azure/logger";
-setLogLevel("verbose"); // TODO: delete before merging
 
-describe.only("ManagedIdentityCredential (MSAL)", function () {
+describe("ManagedIdentityCredential (MSAL)", function () {
   let acquireTokenStub: Sinon.SinonStub;
   let imdsIsAvailableStub: Sinon.SinonStub;
 

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -107,7 +107,7 @@ describe("MsalClient", function () {
       const clientId = "client-id";
       const tenantId = "tenant-id";
       const logger = credentialLogger("test");
-      const logSpy = sinon.spy(logger, "info");
+      const logSpy = sinon.spy(logger.getToken, "info");
 
       const client = msalClient.createMsalClient(clientId, tenantId, { logger });
       try {
@@ -139,33 +139,6 @@ describe("MsalClient", function () {
 
         const config = msalClient.generateMsalConfiguration(clientId, tenantId, {});
         assert.instanceOf(config.system!.networkClient, IdentityClient);
-      });
-
-      it("configures logging options", function () {
-        const clientId = "client-id";
-        const tenantId = "tenant-id";
-        const loggingOptions = {
-          enableUnsafeSupportLogging: true,
-        };
-        const testCorrelationId = "test-correlation-id-1";
-        const logger = credentialLogger("test");
-        const logSpy = sinon.spy(logger, "info");
-
-        const config = msalClient.generateMsalConfiguration(clientId, tenantId, {
-          loggingOptions,
-          logger,
-        });
-        config.auth.clientSecret = "client-secret";
-        const cca = new ConfidentialClientApplication(config);
-
-        assert.equal(config.system!.loggerOptions!.piiLoggingEnabled, true);
-
-        cca.getLogger().info("logging test", testCorrelationId);
-        const loggerCall = logSpy.getCalls().find((c) => c.lastArg.includes(testCorrelationId));
-        assert.exists(
-          loggerCall,
-          `Unable to find logger call with correlation id ${testCorrelationId}`,
-        );
       });
     });
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #25253

### Describe the problem that is addressed by this PR

With MSAL implementing Managed Identity via the ManagedIdentityApplication, we
want to migrate our existing legacy implementation to use MSAL instead.

This PR:
- Creates a msalMsiProvider that implements the MSAL MSI flow
- Moves ManagedIdentityCredential to use msalMsiProvider under the hood

Some implementation details:
- TokenExchangeMsi is _not_ supported by MSAL and we expect to continue
supporting it as a special handler
- IMDS probing is _not_ supported by MSAL and we expect to continue probing and
failing-fast as a special handler

### Provide a list of related PRs _(if any)_

#30045

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).


### Manual validation

1. Every scenario runs against GA identity and this PR
2. Every scenario runs using DAC and MI directly

|scenario|result|notes|
|---|----|----|
|Azure VM|pass||
|Azure Kubernetes|pass|only user assigned MI so far|
|Azure Functions|pass||
|Azure WebApps|pass||
|Azure Cloud Shell|||
