### PR TITLE
Wire up SubscriptionConfigurationFilePaths

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -83,6 +83,7 @@ jobs:
             SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
             SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
             EnvVars: ${{ parameters.EnvVars }}
+            SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
 
         - ${{ if parameters.TestResourceDirectories }}:
           - ${{ each directory in parameters.TestResourceDirectories }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests-isolated.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests-isolated.yml
@@ -129,3 +129,4 @@ stages:
                 ServiceConnection: ${{ cloud.value.ServiceConnection }}
                 Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
                 Cloud: ${{ cloud.key }}
+                SubscriptionConfigurationFilePaths: ${{ cloud.value.SubscriptionConfigurationFilePaths }}


### PR DESCRIPTION
After merging eng/common changes, those changes need to be wired up. 

Traced yaml through to invocation of `build-test-resource-config.yml` 