### PR TITLE
[CODEOWNERS] Avoid bottleneck in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 ###########
 
 # Catch all
-/sdk/ @xirzec
+/sdk/ @xirzec @Azure/azure-sdk-js-dev
 
 # PRLabel: %Azure.Core
 # ServiceLabel: %Azure.Core
@@ -1498,7 +1498,7 @@
 
 /eng/tools/dependency-testing @KarishmaGhiya @jeremymeng
 
-/rush.json @mikeharder @ckairen @jeremymeng
+/rush.json @mikeharder @ckairen @jeremymeng @Azure/azure-sdk-for-js-core
 /tsconfig.json @mikeharder @ckairen @jeremymeng @deyaaeldeen
 /**/tsconfig.json @jeremymeng @deyaaeldeen
 /**/tsconfig.strict.json @deyaaeldeen


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

The issue tracking system works in a way that more specific paths override more general ones. This means that a rule like `/sdk/ @xirzec` will be overridden by a more specific rule like `/sdk/foo @someOwner` when assigning issues.

~~However, when considering required reviewers based on CODEOWNERS, GitHub does *not* take this approach, leading to the catch-all person needing to approve *all* reviews that touch that path.~~

This creates a problem when introducing a new service folder as nobody is assigned to approve it. To avoid myself becoming the bottleneck in such cases, we can add the group to this line as it does not have notifications enabled. I also added more approvers for `rush.json` which is affected by new package generation.