### PR TITLE
[Event Hubs] Fix earliest definitiion

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.13.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.13.0-beta.2 (2024-06-27)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fix the definition of the earliest event position.
 
 ## 5.13.0-beta.1 (2024-06-06)
 

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -93,7 +93,7 @@ export function isLatestPosition(eventPosition: EventPosition): boolean {
  * first event in the partition which has not expired due to the retention policy.
  */
 export const earliestEventPosition: EventPosition = {
-  offset: "-1",
+  offset: "-1:-1",
 };
 
 /**

--- a/sdk/eventhub/event-hubs/test/internal/eventPosition.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventPosition.spec.ts
@@ -56,7 +56,7 @@ testWithServiceTypes(() => {
       // });
 
       it("should create from an offset from start", function (done: Mocha.Done): void {
-        const result = "amqp.annotation.x-opt-offset > '-1'";
+        const result = "amqp.annotation.x-opt-offset > '-1:-1'";
         const pos = earliestEventPosition;
         result.should.equal(getEventPositionFilter(pos));
         done();

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
@@ -504,7 +504,7 @@ describe("Blob Checkpoint Store", function (): void {
         checkpoint.consumerGroup.should.equal("testConsumerGroup");
         checkpoint.eventHubName.should.equal("testEventHub");
         checkpoint.sequenceNumber!.should.equal(100 + i);
-        checkpoint.offset!.should.equal(1023 + i);
+        checkpoint.offset!.should.equal(`${1023 + i}`);
 
         // now update it
         checkpoint.offset = addToOffset(checkpoint.offset, 1);
@@ -530,7 +530,7 @@ describe("Blob Checkpoint Store", function (): void {
         checkpoint.consumerGroup.should.equal("testConsumerGroup");
         checkpoint.eventHubName.should.equal("testEventHub");
         checkpoint.sequenceNumber!.should.equal(100 + i + 1);
-        checkpoint.offset!.should.equal(1023 + i + 1);
+        checkpoint.offset!.should.equal(`${1023 + i + 1}`);
       }
     });
 
@@ -783,7 +783,7 @@ describe("Blob Checkpoint Store", function (): void {
 
     checkpoints.length.should.equal(1);
     checkpoints[0].sequenceNumber.should.equal(0);
-    checkpoints[0].offset.should.equal(0);
+    checkpoints[0].offset.should.equal("0");
     checkpoints[0].partitionId.should.equal("0");
   });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/event-hubs

### Issues associated with this PR

Fixes https://github.com/Azure/azure-sdk-for-js/issues/30056

### Describe the problem that is addressed by this PR

The earliest position definition should be `-1:-1`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A

### Are there test cases added in this PR? _(If not, why?)_

N/A

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
