### PR TITLE
[ts-http-runtime] Allow insecure bearer token policy

### DIFF
--- a/sdk/core/ts-http-runtime/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -100,6 +100,11 @@ export interface BearerTokenAuthenticationPolicyOptions {
    * A logger can be sent for debugging purposes.
    */
   logger?: TypeSpecRuntimeLogger;
+  /**
+   * Allows for connecting to HTTP endpoints instead of enforcing HTTPS.
+   * CAUTION: Never use this option in production.
+   */
+  allowInsecureConnection?: boolean;
 }
 
 /**
@@ -171,9 +176,15 @@ export function bearerTokenAuthenticationPolicy(
      */
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       if (!request.url.toLowerCase().startsWith("https://")) {
-        throw new Error(
-          "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.",
-        );
+        if (request.allowInsecureConnection && options.allowInsecureConnection) {
+          coreLogger.warning(
+            "Sending bearer token over insecure transport. Assume any token issued is compromised.",
+          );
+        } else {
+          throw new Error(
+            "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.",
+          );
+        }
       }
 
       await callbacks.authorizeRequest({


### PR DESCRIPTION
### Packages impacted by this PR

`@typespec/ts-http-runtime`

### Describe the problem that is addressed by this PR

For third-party services, there is a desire to allow local bearer authentication over HTTP. While this is not a pattern that Azure would ever use or recommend, it should be allowed at the discretion of a third-party SDK maintainer. 

This PR extends the policy inside `ts-http-runtime` to add an additional option for disabling the transport check.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

It's possible to only consult the existing `allowInsecureConnection` on the pipeline request, but because we have a strong desire to consolidate our Azure-branded core on top of this package, I thought it best to make this switch opt-in at the policy level so we don't accidentally end up enabling it for Azure SDKs.

### Are there test cases added in this PR? 

Yes

### Provide a list of related PRs

https://github.com/Azure/azure-sdk-for-js/pull/17749
