### PR TITLE
[ts-http-runtime] Allow insecure bearer token policy

### DIFF
--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -92,6 +92,7 @@ export const bearerTokenAuthenticationPolicyName = "bearerTokenAuthenticationPol
 
 // @public
 export interface BearerTokenAuthenticationPolicyOptions {
+    allowInsecureConnection?: boolean;
     challengeCallbacks?: ChallengeCallbacks;
     credential?: TokenCredential;
     logger?: TypeSpecRuntimeLogger;

--- a/sdk/core/ts-http-runtime/src/client/clientHelpers.ts
+++ b/sdk/core/ts-http-runtime/src/client/clientHelpers.ts
@@ -45,6 +45,7 @@ export function addCredentialPipelinePolicy(
     const tokenPolicy = bearerTokenAuthenticationPolicy({
       credential,
       scopes: clientOptions?.credentials?.scopes ?? `${endpoint}/.default`,
+      allowInsecureConnection: clientOptions?.allowInsecureConnection ?? false,
     });
     pipeline.addPolicy(tokenPolicy);
   } else if (isKeyCredential(credential)) {


### PR DESCRIPTION
### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

For third-party services, there is a desire to allow local bearer authentication over HTTP. While this is not a pattern that Azure would ever use or recommend, it should be allowed at the discretion of a third-party SDK maintainer.

This PR extends the policy inside ts-http-runtime to add an additional option for disabling the transport check.

What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
It's possible to only consult the existing allowInsecureConnection on the pipeline request, but because we have a strong desire to consolidate our Azure-branded core on top of this package, I thought it best to make this switch opt-in at the policy level so we don't accidentally end up enabling it for Azure SDKs.

Are there test cases added in this PR?
Yes

### Provide a list of related PRs

Builds off of #30193

#17749
