### PR TITLE
[keyvault] Migrate to federated credentials

### DIFF
--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.abort.spec.ts
@@ -9,7 +9,8 @@ import { authenticate } from "./utils/authentication";
 import { testPollerProperties } from "./utils/recorder";
 import { assertThrowsAbortError, getSasToken, getServiceVersion } from "./utils/common";
 
-describe("Aborting KeyVaultBackupClient's requests", () => {
+// TODO: https://github.com/Azure/azure-sdk-for-js/issues/30273
+describe.skip("Aborting KeyVaultBackupClient's requests", () => {
   let client: KeyVaultBackupClient;
   let recorder: Recorder;
   let blobStorageUri: string;

--- a/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
+++ b/sdk/keyvault/keyvault-admin/test/public/backupClient.spec.ts
@@ -11,7 +11,8 @@ import { delay } from "@azure/core-util";
 import { assert } from "@azure-tools/test-utils";
 import { KeyClient } from "@azure/keyvault-keys";
 
-describe("KeyVaultBackupClient", () => {
+// TODO: https://github.com/Azure/azure-sdk-for-js/issues/30273
+describe.skip("KeyVaultBackupClient", () => {
   let client: KeyVaultBackupClient;
   let keyClient: KeyClient;
 

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -22,7 +22,3 @@ extends:
         # the live tests weekly.
         MatrixFilters:
           - ArmTemplateParameters=^(?!.*enableHsm.*true)
-      EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -10,6 +10,7 @@ extends:
       # instances per region per subscription) so we're only running
       # live tests against a single instance.
       Location: eastus2
+      UseFederatedAuth: true
       MatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-admin/platform-matrix.json

--- a/sdk/keyvault/keyvault-certificates/tests.yml
+++ b/sdk/keyvault/keyvault-certificates/tests.yml
@@ -13,8 +13,3 @@ extends:
            Path: sdk/keyvault/keyvault-certificates/platform-matrix.json
            Selection: sparse
            GenerateVMJobs: true
-      EnvVars:
-        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
-        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
-        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
-        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID)

--- a/sdk/keyvault/keyvault-certificates/tests.yml
+++ b/sdk/keyvault/keyvault-certificates/tests.yml
@@ -7,6 +7,7 @@ extends:
       ServiceDirectory: keyvault
       TimeoutInMinutes: 90
       SupportedClouds: 'Public,UsGov,China'
+      UseFederatedAuth: true
       AdditionalMatrixConfigs:
          - Name: Keyvault_live_test_base
            Path: sdk/keyvault/keyvault-certificates/platform-matrix.json

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -13,6 +13,8 @@ extends:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           Location: 'eastus2'
           ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFiles:
+          - sdk/storage/sub-config-azure-preview.json
         UsGov:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           MatrixFilters:

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -10,11 +10,11 @@ extends:
       UseFederatedAuth: true
       CloudConfig:
         Public:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           Location: 'eastus2'
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ServiceConnection: azure-sdk-tests
-          SubscriptionConfigurationFiles:
-          - sdk/storage/sub-config-azure-preview.json
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
         UsGov:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           MatrixFilters:

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -7,6 +7,7 @@ extends:
       ServiceDirectory: keyvault
       TimeoutInMinutes: 90
       SupportedClouds: 'Public,UsGov,China'
+      UseFederatedAuth: true
       CloudConfig:
         Public:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -12,12 +12,15 @@ extends:
         Public:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           Location: 'eastus2'
+          ServiceConnection: azure-sdk-tests
         UsGov:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
+          ServiceConnection: usgov_azure-sdk-tests
         China:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          ServiceConnection: china_azure-sdk-tests
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
       # KV HSM limitation prevents us from running live tests

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -39,8 +39,3 @@ extends:
       ${{ if not(contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
         MatrixFilters:
           - ArmTemplateParameters=^(?!.*enableHsm.*true)
-      EnvVars:
-        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
-        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
-        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
-        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID) 

--- a/sdk/keyvault/keyvault-secrets/tests.yml
+++ b/sdk/keyvault/keyvault-secrets/tests.yml
@@ -13,8 +13,3 @@ extends:
           Path: sdk/keyvault/keyvault-secrets/platform-matrix.json
           Selection: sparse
           GenerateVMJobs: true
-      EnvVars:
-        AZURE_CLIENT_ID: $(KEYVAULT_CLIENT_ID)
-        AZURE_TENANT_ID: $(KEYVAULT_TENANT_ID)
-        AZURE_CLIENT_SECRET: $(KEYVAULT_CLIENT_SECRET)
-        AZURE_SUBSCRIPTION_ID: $(KEYVAULT_SUBSCRIPTION_ID)

--- a/sdk/keyvault/keyvault-secrets/tests.yml
+++ b/sdk/keyvault/keyvault-secrets/tests.yml
@@ -7,6 +7,7 @@ extends:
       ServiceDirectory: keyvault
       TimeoutInMinutes: 59
       SupportedClouds: 'Public,UsGov,China'
+      UseFederatedAuth: true
       AdditionalMatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-secrets/platform-matrix.json

--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -76,10 +76,6 @@ if (!$DeploymentOutputs['AZURE_MANAGEDHSM_URI']) {
 [Uri] $hsmUrl = $DeploymentOutputs['AZURE_MANAGEDHSM_URI']
 $hsmName = $hsmUrl.Host.Substring(0, $hsmUrl.Host.IndexOf('.'))
 
-$tenant = $DeploymentOutputs['KEYVAULT_TENANT_ID']
-$username = $DeploymentOutputs['KEYVAULT_CLIENT_ID']
-$password = $DeploymentOutputs['KEYVAULT_CLIENT_SECRET']
-
 Log 'Creating 3 X509 certificates to activate security domain'
 $wrappingFiles = foreach ($i in 0..2) {
     $certificate = New-X509Certificate2 "CN=$($hsmUrl.Host)"

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -309,14 +309,6 @@
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('primaryAccountName'))).primaryEndpoints.blob]"
     },
-    "BLOB_PRIMARY_STORAGE_ACCOUNT_KEY": {
-      "type": "string",
-      "value": "[listKeys(variables('primaryAccountName'), variables('mgmtApiVersion')).keys[0].value]"
-    },
-    "BLOB_STORAGE_SAS_TOKEN": {
-      "type": "string",
-      "value": "[listAccountSas(variables('primaryAccountName'), '2019-06-01', variables('accountSasProperties')).accountSasToken]"
-    },
     "BLOB_CONTAINER_NAME": {
       "type": "string",
       "value": "[variables('blobContainerName')]"


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/keyvault-admin`
`@azure/keyvault-keys`
`@azure/keyvault-certificates`
`@azure/keyvault-secrets`

### Issues associated with this PR

#29699

### Describe the problem that is addressed by this PR

Migrates keyvault packages to use federated credentials and the test credential.


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Re-recording tests is something I have seen folks do but the tests all pass unchanged (probably because we only changed AAD traffic) so I did not re-record


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

#29833

