### PR TITLE
[CODEOWNERS] Add timovv as code owner for core-client-rest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 # PRLabel: %Azure.Core
 # ServiceLabel: %Azure.Core
 # AzureSdkOwners: @joheredi @jeremymeng @deyaaeldeen
-/sdk/core/core-client-rest/ @joheredi @jeremymeng @deyaaeldeen
+/sdk/core/core-client-rest/ @joheredi @jeremymeng @deyaaeldeen @timovv
 
 # PRLabel: %Azure.Core
 # ServiceLabel: %Azure.Core


### PR DESCRIPTION
since apparently I can't approve PRs for this package (not sure if there's anyone else we would want to add?)