### PR TITLE
[dev-tool] fix linting error

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -239,7 +239,7 @@ function fixSourceFiles(packageFolder: string): void {
         { pattern: /sinon\.stub/gi, replace: "vi.spyOn" },
         { pattern: /\(this: Context\)/g, replace: "(ctx)" },
         { pattern: /\(this\.currentTest\)/g, replace: "(ctx)" },
-        { pattern: /\(!this\.currentTest\?\.\isPending\(\)\)/g, replace: "(!ctx.task.pending)" },
+        { pattern: /\(!this\.currentTest\?\.isPending\(\)\)/g, replace: "(!ctx.task.pending)" },
         { pattern: /this\.skip\(\);/g, replace: "ctx.task.skip();" },
       ];
 


### PR DESCRIPTION
of

>/datadrive/git/jssdk/common/tools/dev-tool/src/commands/admin/migrate-package.ts
  242:45  error  Unnecessary escape character: \i  no-useless-escape