### PR TITLE
fix(eventhub): replace `polyfill.io` with Cloudflare equivalent

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-table/karma.conf.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/karma.conf.js
@@ -23,9 +23,6 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Uncomment the cdn link below for the polyfill service to support IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdnjs.cloudflare.com/polyfill/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ],

--- a/sdk/eventhub/eventhubs-checkpointstore-table/karma.conf.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
     files: [
       // Uncomment the cdn link below for the polyfill service to support IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
+      // "https://cdnjs.cloudflare.com/polyfill/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
       { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ],


### PR DESCRIPTION
### Packages impacted by this PR

@azure/eventhubs-checkpointstore-table

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/issues/30222

### Describe the problem that is addressed by this PR

> polyfill.io, a popular JavaScript library service, can no longer be trusted and should be removed from websites.

Source: [https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We can replace the URL with one from Fastly, Cloudflare or self-host it. Replacing the CDN link with Cloudflare seemed like a fast option.

### Are there test cases added in this PR? _(If not, why?)_

There aren't any changes done to the actual code. The replaced library is also 100% compatible with existing one.

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
