### PR TITLE
[core] add EdgeRuntime telemetry info

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/core-rest-pipeline/src/util/userAgentPlatform-browser.mts
@@ -33,6 +33,11 @@ interface NavigatorEx extends Navigator {
   };
 }
 
+declare const globalThis: {
+  navigator?: NavigatorEx;
+  EdgeRuntime?: unknown;
+};
+
 function getBrowserInfo(userAgent: string): BrowserBrand | undefined {
   const browserRegexes = [
     { name: "Firefox", regex: /Firefox\/([\d.]+)/ },
@@ -84,6 +89,8 @@ export async function setPlatformSpecificData(map: Map<string, string>): Promise
     if (brand) {
       map.set(brand.brand, brand.version);
     }
+  } else if (typeof globalThis.EdgeRuntime === "string") {
+    map.set("EdgeRuntime", globalThis.EdgeRuntime);
   }
 
   map.set("OS", osPlatform);

--- a/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
+++ b/sdk/core/ts-http-runtime/src/util/userAgentPlatform-browser.mts
@@ -33,6 +33,11 @@ interface NavigatorEx extends Navigator {
   };
 }
 
+declare const globalThis: {
+  navigator?: NavigatorEx;
+  EdgeRuntime?: unknown;
+};
+
 function getBrowserInfo(userAgent: string): BrowserBrand | undefined {
   const browserRegexes = [
     { name: "Firefox", regex: /Firefox\/([\d.]+)/ },
@@ -66,7 +71,7 @@ function getBrandVersionString(brands: BrowserBrand[]): BrowserBrand | undefined
 export async function setPlatformSpecificData(map: Map<string, string>): Promise<void> {
   const localNavigator = globalThis.navigator as NavigatorEx;
   let osPlatform = "unknown";
-  if (localNavigator.userAgentData) {
+  if (localNavigator?.userAgentData) {
     const entropyValues = await localNavigator.userAgentData.getHighEntropyValues([
       "architecture",
       "platformVersion",
@@ -84,6 +89,8 @@ export async function setPlatformSpecificData(map: Map<string, string>): Promise
     if (brand) {
       map.set(brand.brand, brand.version);
     }
+  } else if (typeof globalThis.EdgeRuntime === "string") {
+    map.set("EdgeRuntime", globalThis.EdgeRuntime);
   }
 
   map.set("OS", osPlatform);


### PR DESCRIPTION
currently the property only holds a string `edge-runtime` but in the future
hopefully it would contain more useful info.

while at it also port PR https://github.com/Azure/azure-sdk-for-js/pull/30194 to ts-http-runtime

-------

### Packages impacted by this PR
`@azure/core-rest-pipeline`, `@typespec/ts-http-runtime`