### PR TITLE
[identity] Fix support for cross-tenant federation

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where cross-tenant federation did not honor the request's tenant ID. [#30266](https://github.com/Azure/azure-sdk-for-js/pull/30266)
+
 ### Other Changes
 
 - `OnBehalfOfCredential` migrated to use MSALClient internally instead of MSALNode flow. This is an internal refactoring and should not result in any behavioral changes. [#29890](https://github.com/Azure/azure-sdk-for-js/pull/29890)

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -465,6 +465,17 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
   }
 
   /**
+   * Builds an authority URL for the given request. The authority may be different than the one used when creating the MSAL client
+   * if the user is creating cross-tenant requests
+   */
+  function calculateRequestAuthority(options?: GetTokenOptions): string | undefined {
+    if (options?.tenantId) {
+      return getAuthority(options.tenantId, createMsalClientOptions.authorityHost);
+    }
+    return state.msalConfig.auth.authority;
+  }
+
+  /**
    * Performs silent authentication using MSAL to acquire an access token.
    * If silent authentication fails, falls back to interactive authentication.
    *
@@ -532,7 +543,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     try {
       const response = await msalApp.acquireTokenByClientCredential({
         scopes,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         azureRegion: calculateRegionalAuthority(),
         claims: options?.claims,
       });
@@ -563,7 +574,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     try {
       const response = await msalApp.acquireTokenByClientCredential({
         scopes,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         azureRegion: calculateRegionalAuthority(),
         claims: options?.claims,
         clientAssertion,
@@ -594,7 +605,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     try {
       const response = await msalApp.acquireTokenByClientCredential({
         scopes,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         azureRegion: calculateRegionalAuthority(),
         claims: options?.claims,
       });
@@ -625,7 +636,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         scopes,
         cancel: options?.abortSignal?.aborted ?? false,
         deviceCodeCallback,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         claims: options?.claims,
       };
       const deviceCodeRequest = msalApp.acquireTokenByDeviceCode(requestOptions);
@@ -654,7 +665,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         scopes,
         username,
         password,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         claims: options?.claims,
       };
 
@@ -693,7 +704,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
         scopes,
         redirectUri,
         code: authorizationCode,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         claims: options?.claims,
       });
     });
@@ -725,7 +736,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
     try {
       const response = await msalApp.acquireTokenOnBehalfOf({
         scopes,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         claims: options.claims,
         oboAssertion: userAssertionToken,
       });
@@ -802,7 +813,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
           await interactiveBrowserMockable.open(url, { wait: true, newInstance: true });
         },
         scopes,
-        authority: state.msalConfig.auth.authority,
+        authority: calculateRequestAuthority(options),
         claims: options?.claims,
         loginHint: options?.loginHint,
         errorTemplate: options?.browserCustomizationOptions?.errorMessage,


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

#30230

### Describe the problem that is addressed by this PR

As part of the MSALClient migration we need to continue supporting cross-tenant
federation.

This PR addressed that scenario by ensuring we always recalculate the authority
using the same logic we do initially but using the secondary tenant as input.

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
