### PR TITLE
[eslint-plugin] update to check whether package is ESM

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-apiextractor-json-types.ts
@@ -5,7 +5,7 @@
  * @file Rule to force the inclusion of type declarations in the package.
  */
 
-import { createRule, getVerifiers, stripPath, usesTshy } from "../utils";
+import { createRule, getVerifiers, stripPath, isEsmPackage } from "../utils";
 import { TSESTree } from "@typescript-eslint/utils";
 import { VerifierMessages, stripFileName } from "../utils/verifiers";
 
@@ -42,7 +42,7 @@ export default createRule({
     if (stripPath(fileName) !== "api-extractor.json") {
       return {};
     }
-    if (usesTshy(context.filename)) {
+    if (isEsmPackage(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -12,7 +12,7 @@ import {
   createRule,
   getVerifiers,
   stripPath,
-  usesTshy,
+  isEsmPackage,
 } from "../utils";
 
 //------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ export default createRule({
     if (stripPath(context.filename) !== "package.json") {
       return {};
     }
-    if (usesTshy(context.filename)) {
+    if (isEsmPackage(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -7,7 +7,7 @@
  */
 
 import { TSESTree } from "@typescript-eslint/utils";
-import { VerifierMessages, createRule, getVerifiers, stripPath, usesTshy } from "../utils";
+import { VerifierMessages, createRule, getVerifiers, stripPath, isEsmPackage } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -38,7 +38,7 @@ export default createRule({
     if (stripPath(context.filename) !== "package.json") {
       return {};
     }
-    if (usesTshy(context.filename)) {
+    if (isEsmPackage(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
@@ -7,7 +7,7 @@
  */
 
 import { TSESTree } from "@typescript-eslint/utils";
-import { VerifierMessages, createRule, getVerifiers, stripPath, usesTshy } from "../utils";
+import { VerifierMessages, createRule, getVerifiers, stripPath, isEsmPackage } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -38,7 +38,7 @@ export default createRule({
     if (stripPath(context.filename) !== "package.json") {
       return {};
     }
-    if (usesTshy(context.filename)) {
+    if (isEsmPackage(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-types.ts
@@ -7,7 +7,7 @@
  */
 
 import { TSESTree } from "@typescript-eslint/utils";
-import { createRule, getVerifiers, stripPath, usesTshy } from "../utils";
+import { createRule, getVerifiers, stripPath, isEsmPackage } from "../utils";
 import { VerifierMessages, stripFileName } from "../utils/verifiers";
 
 //------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ export default createRule({
     if (stripPath(context.filename) !== "package.json") {
       return {};
     }
-    if (usesTshy(context.filename)) {
+    if (isEsmPackage(context.filename)) {
       return {};
     }
     return {

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/index.ts
@@ -11,7 +11,7 @@ export {
   arrayToString,
   getVerifiers,
   stripPath,
-  usesTshy,
+  isEsmPackage,
   VerifierMessages,
   type VerifierMessageIds,
 } from "./verifiers";

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -6,7 +6,7 @@
  */
 
 import { TSESTree, TSESLint } from "@typescript-eslint/utils";
-import { statSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import * as path from "node:path";
 
 interface StructureData {
@@ -44,14 +44,18 @@ export type VerifierMessageIds = keyof typeof VerifierMessages;
 export const stripPath = (pathOrFileName: string): string =>
   pathOrFileName.replace(/^.*[\\\/]/, "");
 
-export function usesTshy(packageJsonPath: string): boolean {
-  const dotTshy = path.join(path.dirname(packageJsonPath), ".tshy");
-  try {
-    statSync(dotTshy);
-    return true;
-  } catch {
-    return false;
-  }
+/**
+ * Checks whether a package is ESM, given a file path that is at the root directory. For example,
+ *    - /path/to/repository/sdk/core/core-rest-pipeline/package.json
+ *    - /path/to/repository/sdk/core/core-rest-pipeline/api-extractor.json
+ * @param filePath the input path
+ * @return true if the package has "type": "module"; false otherwise.
+ */
+export function isEsmPackage(filePath: string): boolean {
+  const packageJsonPath = filePath.endsWith("package.json") ? filePath : path.join(path.dirname(filePath), "package.json");
+  const packageJsonContent = readFileSync(packageJsonPath, "utf-8");
+  const packageJson = JSON.parse(packageJsonContent);
+  return packageJson["type"] === "module";
 }
 /**
  * Get the directory of a filename

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -6,7 +6,7 @@
  */
 
 import { TSESTree, TSESLint } from "@typescript-eslint/utils";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import * as path from "node:path";
 
 interface StructureData {
@@ -53,9 +53,14 @@ export const stripPath = (pathOrFileName: string): string =>
  */
 export function isEsmPackage(filePath: string): boolean {
   const packageJsonPath = filePath.endsWith("package.json") ? filePath : path.join(path.dirname(filePath), "package.json");
-  const packageJsonContent = readFileSync(packageJsonPath, "utf-8");
-  const packageJson = JSON.parse(packageJsonContent);
-  return packageJson["type"] === "module";
+  try {
+    statSync(filePath);
+    const packageJsonContent = readFileSync(packageJsonPath, "utf-8");
+    const packageJson = JSON.parse(packageJsonContent);
+    return packageJson["type"] === "module";
+  } catch {
+    return false;
+  }
 }
 /**
  * Get the directory of a filename


### PR DESCRIPTION
Previously it was checking the existence of .tshy directory. Now that we removed
all .tshy the code is broken.  This PR updates to check the package.json instead.
