### PR TITLE
[eventgrid-namespaces] move core-client to direct dependencies list

### DIFF
--- a/sdk/eventgrid/eventgrid-namespaces/package.json
+++ b/sdk/eventgrid/eventgrid-namespaces/package.json
@@ -72,6 +72,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.7.0",
+    "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.1.3",
     "@azure-rest/core-client": "^1.3.1",
     "@azure/logger": "^1.0.0",
@@ -82,7 +83,6 @@
   },
   "devDependencies": {
     "@azure/identity": "^4.1.0",
-    "@azure/core-client": "^1.5.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/service-bus": "^7.0.0",


### PR DESCRIPTION
It is used in run time so should be in "dependencies" instead.

### Packages impacted by this PR
@azure/eventgrid-namespaces