### PR TITLE
[EngSys] fix generate-doc installation error

### DIFF
--- a/eng/tools/generate-doc/index.ts
+++ b/eng/tools/generate-doc/index.ts
@@ -17,7 +17,6 @@ async function runTypeDoc({ outputFolder, cwd }: { outputFolder: string; cwd: st
     excludeInternal: true,
     excludePrivate: true,
     skipErrorChecking: true,
-    gaID: "UA-62780441-43",
     theme: "azureSdk",
   }, [
     new TSConfigReader(),

--- a/eng/tools/generate-doc/package.json
+++ b/eng/tools/generate-doc/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "typedoc": "^0.25.4",
+    "typedoc": "^0.26.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
upgrade `typedoc` version to ^0.26.3 to support typescript 5.5