### PR TITLE
[Monitor OpenTelemetry Exporter] Fix OTel Version and Resolve Async Issues with Logs Test

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/log.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/log.test.ts
@@ -30,7 +30,6 @@ describe("Log Exporter Scenarios", () => {
     after(() => {
       scenario.cleanup();
       nock.cleanAll();
-      ingest = [];
     });
 
     it("should work", (done) => {
@@ -39,9 +38,11 @@ describe("Log Exporter Scenarios", () => {
         .then(() => {
           // promisify doesn't work on this, so use callbacks/done for now
           return scenario.flush().then(() => {
-            assertLogExpectation(ingest, scenario.expectation);
-            assertCount(ingest, scenario.expectation);
-            done();
+            setTimeout(() => {
+              assertLogExpectation(ingest, scenario.expectation);
+              assertCount(ingest, scenario.expectation);
+              done();
+            }, 1);
           });
         })
         .catch((e) => {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -650,5 +650,5 @@ const testAttributes: any = {
   "service.name": "unknown_service:node",
   "telemetry.sdk.language": "nodejs",
   "telemetry.sdk.name": "opentelemetry",
-  "telemetry.sdk.version": "1.25.0",
+  "telemetry.sdk.version": "1.25.1",
 };


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Fix failing exporter test for logs.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
