### PR TITLE
[Storage] fix broken unit-test after typescript 5.5.3 upgrade

### DIFF
--- a/sdk/storage/storage-common/src/index.ts
+++ b/sdk/storage/storage-common/src/index.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export * from "./BufferScheduler";
+export { OutgoingHandler, BufferScheduler } from "./BufferScheduler";


### PR DESCRIPTION
Not exactly sure what changes cause this error:

>[node-tests]  Exception during run: ../storage-common/src/index.ts(4,1): error TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.

It seems to only happen for shared source when running unit tests and could be
related to `tsx` loader since normal tsc build works fine.

This PR change `export *` to export items explicitly.

-------

### Packages impacted by this PR
`@azure/storage-*`