### PR TITLE
[generate-doc] skipping doc generation for non-package files

### DIFF
--- a/eng/tools/generate-doc/index.ts
+++ b/eng/tools/generate-doc/index.ts
@@ -1,7 +1,4 @@
-import { promises as fsPromises } from "fs";
-const readFile = fsPromises.readFile;
-const readDir = fsPromises.readdir;
-const statFile = fsPromises.stat;
+import { readFile, readdir as readDir, stat as statFile } from "fs/promises";
 import * as path from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -94,6 +91,9 @@ async function executeTypedoc(serviceDir: string) {
 
     if (checks.isPrivate) {
       console.log("...SKIPPING Since package marked as private...");
+      continue;
+    } else if (!checks.packageName) {
+      console.error("...SKIPPING Since it is not a package...");
       continue;
     } else if (!checks.srcPresent) {
       console.log("...SKIPPING Since src folder could not be found.....");


### PR DESCRIPTION
We have shared source code directories like storage-common which are not real packages. They
now cause latest `typedoc` to crash.  We don't have a usage scenario so this PR
skips directories that don't have a package name.