### PR TITLE
[core-client-rest] Update Serialization Check Logic

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 2.1.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-- Update the serialization order before sending the request. 
+## 2.2.0 (2024-07-11)
 
 ### Other Changes
+
+- Update serialization to not serialize Uint8Array if the content type is "application/json". 
 
 ## 2.1.0 (2024-06-27)
 

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Add an option to skip serialization for the request body when sending request.
+
 ### Other Changes
 
 ## 2.1.0 (2024-06-27)

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Add an option to skip serialization for the request body when sending request.
+- Update the serialization order before sending the request. 
 
 ### Other Changes
 

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/core-client",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Core library for interfacing with Azure Rest Clients",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -108,7 +108,7 @@ export interface InternalRequestParameters extends RequestParameters {
   responseAsStream?: boolean;
 
   /** Skip serialization option for string body request */
-  skipSerialization?: boolean
+  skipSerialization?: boolean;
 }
 
 function buildPipelineRequest(
@@ -156,9 +156,17 @@ interface RequestBody {
 /**
  * Prepares the body before sending the request
  */
-function getRequestBody(body?: unknown, contentType: string = "", options: InternalRequestParameters = {}): RequestBody {
+function getRequestBody(
+  body?: unknown,
+  contentType: string = "",
+  options: InternalRequestParameters = {},
+): RequestBody {
   if (body === undefined) {
     return { body: undefined };
+  }
+
+  if (options.skipSerialization) {
+    return { body: body as RequestBodyType };
   }
 
   if (typeof FormData !== "undefined" && body instanceof FormData) {
@@ -166,10 +174,6 @@ function getRequestBody(body?: unknown, contentType: string = "", options: Inter
   }
 
   if (isReadableStream(body)) {
-    return { body };
-  }
-
-  if (options.skipSerialization && typeof body === "string") {
     return { body };
   }
 

--- a/sdk/core/core-client-rest/src/sendRequest.ts
+++ b/sdk/core/core-client-rest/src/sendRequest.ts
@@ -106,6 +106,9 @@ function getContentType(body: any): string | undefined {
 
 export interface InternalRequestParameters extends RequestParameters {
   responseAsStream?: boolean;
+
+  /** Skip serialization option for string body request */
+  skipSerialization?: boolean
 }
 
 function buildPipelineRequest(
@@ -114,7 +117,7 @@ function buildPipelineRequest(
   options: InternalRequestParameters = {},
 ): PipelineRequest {
   const requestContentType = getRequestContentType(options);
-  const { body, multipartBody } = getRequestBody(options.body, requestContentType);
+  const { body, multipartBody } = getRequestBody(options.body, requestContentType, options);
   const hasContent = body !== undefined || multipartBody !== undefined;
 
   const headers = createHttpHeaders({
@@ -153,7 +156,7 @@ interface RequestBody {
 /**
  * Prepares the body before sending the request
  */
-function getRequestBody(body?: unknown, contentType: string = ""): RequestBody {
+function getRequestBody(body?: unknown, contentType: string = "", options: InternalRequestParameters = {}): RequestBody {
   if (body === undefined) {
     return { body: undefined };
   }
@@ -163,6 +166,10 @@ function getRequestBody(body?: unknown, contentType: string = ""): RequestBody {
   }
 
   if (isReadableStream(body)) {
+    return { body };
+  }
+
+  if (options.skipSerialization && typeof body === "string") {
     return { body };
   }
 

--- a/sdk/core/core-client-rest/test/sendRequest.spec.ts
+++ b/sdk/core/core-client-rest/test/sendRequest.spec.ts
@@ -363,6 +363,21 @@ describe("sendRequest", () => {
     });
   });
 
+  it("should send request without serialization for the string body request", async () => {
+    const mockPipeline: Pipeline = createEmptyPipeline();
+    const expectedBody = JSON.stringify({ foo: "foo" });
+    mockPipeline.sendRequest = async (_client, request) => {
+      assert.equal(request.body, expectedBody);
+      return { headers: createHttpHeaders() } as PipelineResponse;
+    };
+
+    await sendRequest("POST", mockBaseUrl, mockPipeline, {
+      body: expectedBody,
+      contentType: "application/json",
+      skipSerialization: true,
+    });
+  });
+
   it("should send request with undefined body", async () => {
     const mockPipeline: Pipeline = createEmptyPipeline();
     mockPipeline.sendRequest = async (_client, request) => {

--- a/sdk/core/core-client-rest/test/sendRequest.spec.ts
+++ b/sdk/core/core-client-rest/test/sendRequest.spec.ts
@@ -363,21 +363,6 @@ describe("sendRequest", () => {
     });
   });
 
-  it("should send request without serialization for the string body request", async () => {
-    const mockPipeline: Pipeline = createEmptyPipeline();
-    const expectedBody = JSON.stringify({ foo: "foo" });
-    mockPipeline.sendRequest = async (_client, request) => {
-      assert.equal(request.body, expectedBody);
-      return { headers: createHttpHeaders() } as PipelineResponse;
-    };
-
-    await sendRequest("POST", mockBaseUrl, mockPipeline, {
-      body: expectedBody,
-      contentType: "application/json",
-      skipSerialization: true,
-    });
-  });
-
   it("should send request with undefined body", async () => {
     const mockPipeline: Pipeline = createEmptyPipeline();
     mockPipeline.sendRequest = async (_client, request) => {


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
Currently, all request body that has content types that start with "application/json" will be serialized by the `getRequestBody` function. This is an issue for Schema Registry because the request body has already been serialized and the content type also starts with "application/json". Reordering the serialization method to check for `Uint8Array` before checking for "application/json" would eliminate this problem.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
- Add an option called `skipSerialization` in the internal options bag for sending request. It'll affect the RLC experience and force the customer to use this option to make a successful request 
- Check for specific content types. It'll be limited in scope and affect other services that also has a similar content type format

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
