### PR TITLE
Use federated auth for ACS SDKs

### DIFF
--- a/sdk/communication/arm-communication/sample.env
+++ b/sdk/communication/arm-communication/sample.env
@@ -1,4 +1,0 @@
-# App registration secret for AAD authentication
-AZURE_CLIENT_SECRET=
-AZURE_CLIENT_ID=
-AZURE_TENANT_ID= 

--- a/sdk/communication/communication-alpha-ids/tests.yml
+++ b/sdk/communication/communication-alpha-ids/tests.yml
@@ -5,10 +5,13 @@ extends:
     parameters:
       PackageName: "@azure-tools/communication-alpha-ids"
       ServiceDirectory: communication
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
         PPE:

--- a/sdk/communication/communication-alpha-ids/tests.yml
+++ b/sdk/communication/communication-alpha-ids/tests.yml
@@ -14,16 +14,6 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-js)
-          MatrixFilters:
-            - TestType=^(?!(browser|sample)).*
-      Clouds: Public,PPE,Int
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/communication-call-automation/tests.yml
+++ b/sdk/communication/communication-call-automation/tests.yml
@@ -16,10 +16,4 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-js)
-          MatrixFilters:
-            - TestType=^(?!browser).*
-      Clouds: Public,Int
+      Clouds: Public

--- a/sdk/communication/communication-call-automation/tests.yml
+++ b/sdk/communication/communication-call-automation/tests.yml
@@ -7,10 +7,13 @@ extends:
       ServiceDirectory: communication
       MatrixFilters:
         - DependencyVersion=^$
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
         Int:

--- a/sdk/communication/communication-chat/tests.yml
+++ b/sdk/communication/communication-chat/tests.yml
@@ -9,20 +9,12 @@ extends:
         - DependencyVersion=^$
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-js)
-          MatrixFilters:
-            - TestType=^(?!browser).*
-      Clouds: Public,PPE,Int
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/communication-chat/tests.yml
+++ b/sdk/communication/communication-chat/tests.yml
@@ -7,6 +7,7 @@ extends:
       ServiceDirectory: communication
       MatrixFilters:
         - DependencyVersion=^$
+      UseFederatedAuth: true
       CloudConfig:
         Public:
           ServiceConnection: azure-sdk-tests

--- a/sdk/communication/communication-common/tests.yml
+++ b/sdk/communication/communication-common/tests.yml
@@ -5,10 +5,13 @@ extends:
     parameters:
       PackageName: "@azure/communication-common"
       ServiceDirectory: communication
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
           MatrixFilters:

--- a/sdk/communication/communication-common/tests.yml
+++ b/sdk/communication/communication-common/tests.yml
@@ -16,19 +16,6 @@ extends:
             - $(sub-config-communication-services-cloud-test-resources-js)
           MatrixFilters:
             - DependencyVersion=^.+$  
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
-          MatrixFilters:
-            - DependencyVersion=^.+$  
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-js)
-          MatrixFilters:
-            - TestType=^(?!browser).*
-            - DependencyVersion=^.+$
-      Clouds: Public,PPE,Int
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/communication-identity/tests.yml
+++ b/sdk/communication/communication-identity/tests.yml
@@ -5,10 +5,13 @@ extends:
     parameters:
       PackageName: "@azure/communication-identity"
       ServiceDirectory: communication
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
         PPE:

--- a/sdk/communication/communication-identity/tests.yml
+++ b/sdk/communication/communication-identity/tests.yml
@@ -14,16 +14,6 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-js)
-          MatrixFilters:
-            - TestType=^(?!browser).*
-      Clouds: Public,PPE,Int
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/communication-rooms/tests.yml
+++ b/sdk/communication/communication-rooms/tests.yml
@@ -7,10 +7,13 @@ extends:
       ServiceDirectory: communication
       MatrixFilters:
         - DependencyVersion=^$
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
         PPE:

--- a/sdk/communication/communication-rooms/tests.yml
+++ b/sdk/communication/communication-rooms/tests.yml
@@ -16,10 +16,6 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
-      Clouds: Public,PPE
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/communication-short-codes/tests.yml
+++ b/sdk/communication/communication-short-codes/tests.yml
@@ -5,10 +5,13 @@ extends:
     parameters:
       PackageName: "@azure-tools/communication-short-codes"
       ServiceDirectory: communication
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
         PPE:

--- a/sdk/communication/communication-short-codes/tests.yml
+++ b/sdk/communication/communication-short-codes/tests.yml
@@ -14,16 +14,6 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
-        PPE:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-ppe-test-resources-common)
-            - $(sub-config-communication-ppe-test-resources-js)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-js)
-          MatrixFilters:
-            - TestType=^(?!(browser|sample)).*
-      Clouds: Public,PPE,Int
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/communication-tiering/tests.yml
+++ b/sdk/communication/communication-tiering/tests.yml
@@ -5,10 +5,13 @@ extends:
     parameters:
       PackageName: "@azure-tools/communication-tiering"
       ServiceDirectory: communication
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
         Int:

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -34,12 +34,6 @@
       "metadata": {
         "description": "The application client id used to run tests."
       }
-    },
-    "testApplicationSecret": {
-      "type": "String",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
     }
   },
   "variables": {

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -68,18 +68,6 @@
     }
   ],
   "outputs": {
-    "AZURE_TENANT_ID": {
-      "type": "String",
-      "value": "[parameters('tenantId')]"
-    },
-    "AZURE_CLIENT_ID": {
-      "type": "String",
-      "value": "[parameters('testApplicationId')]"
-    },
-    "AZURE_CLIENT_SECRET": {
-      "type": "String",
-      "value": "[parameters('testApplicationSecret')]"
-    },
     "COMMUNICATION_CONNECTION_STRING": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31').primaryConnectionString]"


### PR DESCRIPTION
Changes:
In order to move away from Secret based authentication, we want to adopt FIC.
For the same azure-sdk team has added the support and we need to use service connection for our live test pipelines to access our test resources.