### PR TITLE
[ServiceBus] add retry for link initialization

### DIFF
--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -11,6 +11,7 @@ import {
   RetryConfig,
   RetryOperationType,
   retry,
+  RetryOptions,
 } from "@azure/core-amqp";
 import { AccessToken } from "@azure/core-auth";
 import { ConnectionContext } from "../connectionContext";
@@ -211,7 +212,11 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    * @returns A Promise that resolves when the link has been properly initialized
    * @throws `AbortError` if the link has been closed via 'close'
    */
-  async initLink(options: LinkOptionsT<LinkT>, abortSignal?: AbortSignalLike): Promise<void> {
+  async initLink(
+    options: LinkOptionsT<LinkT>,
+    retryOptions?: RetryOptions,
+    abortSignal?: AbortSignalLike,
+  ): Promise<void> {
     // we'll check that the connection isn't in the process of recycling (and if so, wait for it to complete)
     await this._context.readyToOpenLink();
 
@@ -227,7 +232,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
         const retryConfig: RetryConfig<void> = {
           connectionId: this._context.connectionId,
           operationType: RetryOperationType.receiverLink,
-          retryOptions: undefined,
+          retryOptions,
           abortSignal,
           operation: () => this._initLinkImpl(options, abortSignal),
         };

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -344,6 +344,7 @@ export class ManagementClient extends LinkEntity<RequestResponseLink> {
           senderOptions: sropt,
           receiverOptions: rxopt,
         },
+        undefined,
         abortSignal,
       );
     } catch (err: any) {

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -140,6 +140,11 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
    */
   protected _lockRenewer: LockRenewer | undefined;
 
+  /**
+   *Retry policy options that determine the mode, number of retries, retry interval etc.
+   */
+  protected _retryOptions: RetryOptions;
+
   constructor(
     public identifier: string,
     context: ConnectionContext,
@@ -154,6 +159,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
 
     this.receiverType = receiverType;
     this.receiveMode = options.receiveMode || "peekLock";
+    this._retryOptions = options.retryOptions || {};
 
     // If explicitly set to false then autoComplete is false else true (default).
     this.autoComplete =
@@ -191,7 +197,7 @@ export abstract class MessageReceiver extends LinkEntity<Receiver> {
    */
   protected async _init(options: ReceiverOptions, abortSignal?: AbortSignalLike): Promise<void> {
     try {
-      await this.initLink(options, abortSignal);
+      await this.initLink(options, this._retryOptions, abortSignal);
 
       // It is possible for someone to close the receiver and then start it again.
       // Thus make sure that the receiver is present in the client cache.

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -282,7 +282,7 @@ export class MessageSender extends LinkEntity<AwaitableSender> {
       if (!options) {
         options = this._createSenderOptions();
       }
-      await this.initLink(options, abortSignal);
+      await this.initLink(options, this._retryOptions, abortSignal);
     } catch (err: any) {
       const translatedError = translateServiceBusError(err);
       logger.logError(

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -7,12 +7,7 @@ import { ConnectionContext } from "../connectionContext";
 import { ReceiverHelper } from "./receiverHelper";
 
 import { throwErrorIfConnectionClosed } from "../util/errors";
-import {
-  RetryOperationType,
-  MessagingError,
-  RetryOptions,
-  ConditionErrorNameMapper,
-} from "@azure/core-amqp";
+import { RetryOperationType, MessagingError, ConditionErrorNameMapper } from "@azure/core-amqp";
 import { OperationOptionsBase } from "../modelsToBeSharedWithEventHubs";
 import { receiverLogger as logger } from "../log";
 import { AmqpError, EventContext, OnAmqpEvent } from "rhea-promise";
@@ -61,10 +56,6 @@ export class StreamingReceiver extends MessageReceiver {
    * to bring its link back up due to a retryable issue.
    */
   private _isDetaching: boolean = false;
-  /**
-   *Retry policy options that determine the mode, number of retries, retry interval etc.
-   */
-  private _retryOptions: RetryOptions;
 
   private _receiverHelper: ReceiverHelper;
 
@@ -144,8 +135,6 @@ export class StreamingReceiver extends MessageReceiver {
     if (typeof options?.maxConcurrentCalls === "number" && options?.maxConcurrentCalls > 0) {
       this.maxConcurrentCalls = options.maxConcurrentCalls;
     }
-
-    this._retryOptions = options?.retryOptions || {};
 
     this._receiverHelper = new ReceiverHelper(() => ({
       receiver: this.link,

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -321,7 +321,7 @@ export class MessageSession extends LinkEntity<Receiver> {
   ): Promise<void> {
     try {
       const sessionOptions = this._createMessageSessionOptions(this.identifier, opts.timeoutInMs);
-      await this.initLink(sessionOptions, opts.abortSignal);
+      await this.initLink(sessionOptions, this._retryOptions, opts.abortSignal);
 
       if (!this.link) {
         throw new Error("INTERNAL ERROR: failed to create receiver but without an error.");

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -341,7 +341,8 @@ describe("AbortSignal", () => {
         await messageReceiver["_init"]({} as ReceiverOptions, abortSignal);
         assert.fail("Should have thrown an AbortError");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        // with retry
+        assert.equal(err.message, `Error 0: AbortError: ${StandardAbortMessage}`);
         assert.equal(err.name, "AbortError");
       }
     });
@@ -371,7 +372,8 @@ describe("AbortSignal", () => {
         await messageReceiver["_init"]({} as ReceiverOptions, abortSignal);
         assert.fail("Should have thrown an AbortError");
       } catch (err: any) {
-        assert.equal(err.message, StandardAbortMessage);
+        // with retry
+        assert.equal(err.message, `Error 0: AbortError: ${StandardAbortMessage}`);
         assert.equal(err.name, "AbortError");
       }
     });

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -111,7 +111,7 @@ describe("LinkEntity unit tests", () => {
         connectionContext["isConnectionClosing"] = () => true;
 
         try {
-          await linkEntity.initLink({});
+          await linkEntity.initLink({}, { maxRetries: 1 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -126,7 +126,7 @@ describe("LinkEntity unit tests", () => {
             old.apply(linkEntity);
           };
 
-          await linkEntity.initLink({});
+          await linkEntity.initLink({}, { maxRetries: 1 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -141,7 +141,7 @@ describe("LinkEntity unit tests", () => {
             old.apply(linkEntity);
           };
 
-          await linkEntity.initLink({});
+          await linkEntity.initLink({}, { maxRetries: 1 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -156,7 +156,7 @@ describe("LinkEntity unit tests", () => {
             connectionContext["isConnectionClosing"] = () => true;
           };
 
-          await linkEntity.initLink({});
+          await linkEntity.initLink({}, { maxRetries: 1 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -228,7 +228,7 @@ describe("LinkEntity unit tests", () => {
       };
 
       try {
-        await linkEntity.initLink({});
+        await linkEntity.initLink({}, { maxRetries: 1 });
         assert.fail("Should have thrown");
       } catch (err: any) {
         assert.equal(err.message, "SPECIAL ERROR THROWN FROM NEGOTIATECLAIM");
@@ -237,7 +237,7 @@ describe("LinkEntity unit tests", () => {
 
     it("abortSignal - simple abort signal flow", async () => {
       try {
-        await linkEntity.initLink({}, {
+        await linkEntity.initLink({}, undefined, {
           aborted: true,
         } as AbortSignalLike);
         assert.fail("Should have thrown.");
@@ -264,7 +264,7 @@ describe("LinkEntity unit tests", () => {
       };
 
       try {
-        await linkEntity.initLink({}, abortController.signal);
+        await linkEntity.initLink({}, undefined, abortController.signal);
         assert.fail("Should have thrown");
       } catch (err: any) {
         assert.equal(err.name, "AbortError");
@@ -298,7 +298,7 @@ describe("LinkEntity unit tests", () => {
           return old.call(linkEntity, props);
         };
 
-        await linkEntity.initLink({}, abortController.signal);
+        await linkEntity.initLink({}, undefined, abortController.signal);
         assert.fail("Should have thrown");
       } catch (err: any) {
         assert.isTrue(sawAbortSignal, "Should have seen the abortSignal.");

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -80,7 +80,7 @@ describe("LinkEntity unit tests", () => {
         await linkEntity.initLink({});
         assert.fail("Should have thrown");
       } catch (err: any) {
-        assert.equal(err.message, "Link has been permanently closed. Not reopening.");
+        assert.equal(err.message, "Error 0: AbortError: Link has been permanently closed. Not reopening.");
         assert.equal(err.name, "AbortError");
       }
       assertLinkEntityClosedPermanently();
@@ -111,7 +111,7 @@ describe("LinkEntity unit tests", () => {
         connectionContext["isConnectionClosing"] = () => true;
 
         try {
-          await linkEntity.initLink({}, { maxRetries: 1 });
+          await linkEntity.initLink({}, { maxRetries: 0 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -126,7 +126,7 @@ describe("LinkEntity unit tests", () => {
             old.apply(linkEntity);
           };
 
-          await linkEntity.initLink({}, { maxRetries: 1 });
+          await linkEntity.initLink({}, { maxRetries: 0 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -141,7 +141,7 @@ describe("LinkEntity unit tests", () => {
             old.apply(linkEntity);
           };
 
-          await linkEntity.initLink({}, { maxRetries: 1 });
+          await linkEntity.initLink({}, { maxRetries: 0 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -156,7 +156,7 @@ describe("LinkEntity unit tests", () => {
             connectionContext["isConnectionClosing"] = () => true;
           };
 
-          await linkEntity.initLink({}, { maxRetries: 1 });
+          await linkEntity.initLink({}, { maxRetries: 0 });
           assert.fail("Should have thrown");
         } catch (err: any) {
           assertInitAbortError(err);
@@ -164,7 +164,7 @@ describe("LinkEntity unit tests", () => {
       });
 
       function assertInitAbortError(err: any): void {
-        assert.equal(err.message, "Connection is reopening, aborting link initialization.");
+        assert.equal(err.message, "Error 0: ServiceBusError: Connection is reopening, aborting link initialization.");
         assert.equal(err.name, "ServiceBusError");
         assert.isTrue(
           err.retryable,
@@ -216,7 +216,7 @@ describe("LinkEntity unit tests", () => {
         await linkEntity.initLink({});
         assert.fail("Should throw");
       } catch (err: any) {
-        assert.equal("Link has been permanently closed. Not reopening.", err.message);
+        assert.equal("Error 0: AbortError: Link has been permanently closed. Not reopening.", err.message);
         assert.isFalse(linkEntity.isOpen(), "Link was closed and will remain closed");
         assert.isFalse(negotiateClaimSpy.called, "We shouldn't attempt to reopen the link.");
       }
@@ -228,10 +228,10 @@ describe("LinkEntity unit tests", () => {
       };
 
       try {
-        await linkEntity.initLink({}, { maxRetries: 1 });
+        await linkEntity.initLink({}, { maxRetries: 0 });
         assert.fail("Should have thrown");
       } catch (err: any) {
-        assert.equal(err.message, "SPECIAL ERROR THROWN FROM NEGOTIATECLAIM");
+        assert.equal(err.message, "Error 0: Error: SPECIAL ERROR THROWN FROM NEGOTIATECLAIM");
       }
     });
 
@@ -304,7 +304,7 @@ describe("LinkEntity unit tests", () => {
         assert.isTrue(sawAbortSignal, "Should have seen the abortSignal.");
         assert.deepNestedInclude(err, {
           name: "AbortError",
-          message: "The operation was aborted.",
+          message: "Error 0: AbortError: The operation was aborted.",
         });
       }
     });

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -106,7 +106,7 @@ describe("Receiver unit tests", () => {
         await messageReceiver2["_init"]({} as ReceiverOptions);
         assert.fail("Should throw");
       } catch (err: any) {
-        assert.equal("Link has been permanently closed. Not reopening.", err.message);
+        assert.equal("Error 0: AbortError: Link has been permanently closed. Not reopening.", err.message);
         assert.equal(err.name, "AbortError");
         assert.isFalse(negotiateClaimWasCalled);
       }


### PR DESCRIPTION
There are cases where we want to retry on the errors thrown when initializing a
link. For example, when the connection is recovering, `checkIfConnectionReady()`
would throw a retryable error. We should retry on it first and only surface the
error to users after retries exhausted

This PR wraps `this._initLinkImpl()` call with a retry operation.

### Packages impacted by this PR
`@azure/service-bus`