### PR TITLE
[AI] [Inference] add image url test

### DIFF
--- a/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
@@ -41,7 +41,10 @@ describe("chat test suite", () => {
     assert.isNotEmpty(completion.choices);
     assert.isDefined(completion.choices[0].message);
     assert.isDefined(completion.choices[0].message.content);
-  });
+  },
+    {
+      timeout: 50000
+    });
 
   it("function calling test", async function () {
     const getCurrentWeather = {
@@ -90,6 +93,38 @@ describe("chat test suite", () => {
     assert.isDefined(toolCall.function);
     assert.isNotEmpty(toolCall.function.name);
     assert.isTrue(toolCall.function.arguments.includes("location"));
-  });
+  },
+    {
+      timeout: 50000
+    });
+
+  it("image url test", async function () {
+    const url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+
+    const response = await client.path("/chat/completions").post({
+      body: {
+        messages: [{
+          role: "user", content: [{
+            type: "image_url",
+            image_url: {
+              url,
+              detail: "auto"
+            }
+          }]
+        }, { role: "user", content: "describe the image" }],
+      }
+    });
+
+    assert.isFalse(isUnexpected(response));
+
+    const completion = response.body as ChatCompletionsOutput;
+    assert.isDefined(completion);
+    assert.isNotEmpty(completion.choices);
+    assert.isDefined(completion.choices[0].message);
+    assert.isDefined(completion.choices[0].message.content);
+  },
+    {
+      timeout: 50000
+    });
 
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/ai-inference

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Adds a test for vision model to read and describe an image url

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
