### PR TITLE
[CODEOWNERS] Adding js-core team to specific sdk/core sub folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,16 +33,16 @@
 /sdk/core/ @Azure/azure-sdk-for-js-core
 
 # PRLabel: %Azure.Core
-/sdk/core/core-amqp/ @jeremymeng @deyaaeldeen @HarshaNalluru
+/sdk/core/core-amqp/ @jeremymeng @deyaaeldeen @HarshaNalluru @Azure/azure-sdk-for-js-core
 
 # PRLabel: %Azure.Core
-/sdk/core/core-client-rest/ @joheredi @jeremymeng @deyaaeldeen @timovv
+/sdk/core/core-client-rest/ @joheredi @timovv @Azure/azure-sdk-for-js-core
 
 # PRLabel: %Azure.Core
-/sdk/core/core-lro/ @deyaaeldeen @joheredi
+/sdk/core/core-lro/ @deyaaeldeen @joheredi @Azure/azure-sdk-for-js-core
 
 # PRLabel: %Azure.Core
-/sdk/core/core-tracing/ @maorleger @jeremymeng @mpodwysocki
+/sdk/core/core-tracing/ @maorleger @mpodwysocki @Azure/azure-sdk-for-js-core
 
 # ServiceLabel: %Azure.Core
 # AzureSdkOwners: @Azure/azure-sdk-for-js-core


### PR DESCRIPTION
while still keeping individual owners as Subject Matter Experts