### PR TITLE
[Vite Browser Map] Fix types

### DIFF
--- a/common/tools/vite-plugin-browser-test-map/package.json
+++ b/common/tools/vite-plugin-browser-test-map/package.json
@@ -20,8 +20,10 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "types/"
   ],
   "scripts": {
     "build": "tsc -p .",

--- a/common/tools/vite-plugin-browser-test-map/src/index.ts
+++ b/common/tools/vite-plugin-browser-test-map/src/index.ts
@@ -18,7 +18,11 @@ function rewriteDistPath(path: string): string {
   });
 }
 
-export default function browserTestMap() {
+export default function browserTestMap(): {
+  name: string;
+  enforce: "pre";
+  configResolved: (config: Record<string, unknown>) => void;
+} {
   return {
     name: "browser-test-config",
     enforce: "pre",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/-tools/vite-plugin-browser-test-map

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The type declaration file wasn't set in package.json and the return type of the plugin function was too permissive causing type errors when imported.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A

### Are there test cases added in this PR? _(If not, why?)_

N/A

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
