### PR TITLE
[Identity] Update error messages for AzurePipelinesCredential

### DIFF
--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -146,20 +146,17 @@ export class AzurePipelinesCredential implements TokenCredential {
         });
       }
     } catch (e: any) {
-      //azure:identity:error AzurePipelinesCredential => AzurePipelinesCredential: Authentication Failed. oidcToken field not detected in the response.Response = {"$id":"1","innerException":null,"message":"No service connection found with identifier 8089d38c-c287-4289-8012-c3c1fc775efd.","typeName":"Microsoft.TeamFoundation.DistributedTask.WebApi.EndpointNotFoundException, Microsoft.TeamFoundation.DistributedTask.WebApi","typeKey":"EndpointNotFoundException","errorCode":0,"eventId":3000}
-
-      logger.error(e.message);
-      logger.error(
-        `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${text}`,
-      );
-      let errorName = "";
+      let errorDetails =  `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
+      logger.error(`Response = ${text} and error message = ${e.message}`);
+      logger.error(errorDetails);
+      
       if(text?.includes("No service connection found")){
-        errorName = "${credentialName}: Authentication Failed. Please check if you are using one of the Devops tasks or the correct subscriptionName assigned to the Devops task. Please refer to TSG"
+        errorDetails = `${credentialName}: Authentication Failed. Please check if you are using one of the supported Azure Pipelines tasks and assigning the sercice connection name to the "subscriptionName" field in the current task. See the troubleshooting guide for more information: https://aka.ms/azsdk/js/identity/azurepipelinescredential/troubleshoot`
       }
       throw new AuthenticationError(
         response.status,
         {
-          error: `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`,
+          error: errorDetails,
           error_description: `${text}`
         }
       );

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -114,7 +114,7 @@ export class AzurePipelinesCredential implements TokenCredential {
       }),
     });
     const response = await this.identityClient.sendRequest(request);
-    return await handleOidcResponse(response);
+    return handleOidcResponse(response);
   }
 }
 
@@ -122,12 +122,12 @@ export async function handleOidcResponse(response: PipelineResponse): Promise<st
   const text = response.bodyAsText;
   if (!text) {
     logger.error(
-      `${credentialName}: Authenticated Failed. Received null token from OIDC request. Response status- ${
+      `${credentialName}: Authentication Failed. Received null token from OIDC request. Response status- ${
         response.status
       }. Complete response - ${JSON.stringify(response)}`
     );
     throw new AuthenticationError(response.status, {
-      error: `${credentialName}: Authenticated Failed. Received null token from OIDC request.`,
+      error: `${credentialName}: Authentication Failed. Received null token from OIDC request.`,
       error_description: `${JSON.stringify(
         response
       )}. See the troubleshooting guide for more information: https://aka.ms/azsdk/js/identity/azurepipelinescredential/troubleshoot`,
@@ -153,7 +153,7 @@ export async function handleOidcResponse(response: PipelineResponse): Promise<st
       });
     }
   } catch (e: any) {
-    let errorDetails = `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
+    const errorDetails = `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
     logger.error(`Response from service = ${text} and error message = ${e.message}`);
     logger.error(errorDetails);
     throw new AuthenticationError(response.status, {

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -118,7 +118,7 @@ export class AzurePipelinesCredential implements TokenCredential {
   }
 }
 
-export async function handleOidcResponse(response: PipelineResponse): Promise<string> {
+export function handleOidcResponse(response: PipelineResponse): string {
   const text = response.bodyAsText;
   if (!text) {
     logger.error(

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -133,7 +133,7 @@ export class AzurePipelinesCredential implements TokenCredential {
       if (result?.oidcToken) {
         return result.oidcToken;
       } else {
-        let errorMessage = `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
+        const errorMessage = `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
         let errorDescription = ``;
         if (response.status !== 200) {
           errorDescription = `Complete response - ${JSON.stringify(result)}`

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -120,13 +120,10 @@ export class AzurePipelinesCredential implements TokenCredential {
           response.status
         }. Complete response - ${JSON.stringify(response)}`,
       );
-      throw new AuthenticationError(
-        response.status,
-        {
-          error:  `${credentialName}: Authenticated Failed. Received null token from OIDC request.`,
-          error_description: `${JSON.stringify(response)}`
-        }
-      );
+      throw new AuthenticationError(response.status, {
+        error: `${credentialName}: Authenticated Failed. Received null token from OIDC request.`,
+        error_description: `${JSON.stringify(response)}`,
+      });
     }
     try {
       const result = JSON.parse(text);
@@ -136,30 +133,27 @@ export class AzurePipelinesCredential implements TokenCredential {
         const errorMessage = `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
         let errorDescription = ``;
         if (response.status !== 200) {
-          errorDescription = `Complete response - ${JSON.stringify(result)}`
+          errorDescription = `Complete response - ${JSON.stringify(result)}`;
         }
         logger.error(errorMessage);
         logger.error(errorDescription);
         throw new AuthenticationError(response.status, {
           error: errorMessage,
-          error_description: errorDescription
+          error_description: errorDescription,
         });
       }
     } catch (e: any) {
-      let errorDetails =  `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
+      let errorDetails = `${credentialName}: Authentication Failed. oidcToken field not detected in the response.`;
       logger.error(`Response = ${text} and error message = ${e.message}`);
       logger.error(errorDetails);
-      
-      if(text?.includes("No service connection found")){
-        errorDetails = `${credentialName}: Authentication Failed. Please check if you are using one of the supported Azure Pipelines tasks and assigning the sercice connection name to the "subscriptionName" field in the current task. See the troubleshooting guide for more information: https://aka.ms/azsdk/js/identity/azurepipelinescredential/troubleshoot`
+
+      if (text?.includes("No service connection found")) {
+        errorDetails = `${credentialName}: Authentication Failed. Please check if you are using one of the supported Azure Pipelines tasks and assigning the sercice connection name to the "subscriptionName" field in the current task. See the troubleshooting guide for more information: https://aka.ms/azsdk/js/identity/azurepipelinescredential/troubleshoot`;
       }
-      throw new AuthenticationError(
-        response.status,
-        {
-          error: errorDetails,
-          error_description: `${text}`
-        }
-      );
+      throw new AuthenticationError(response.status, {
+        error: errorDetails,
+        error_description: `${text}`,
+      });
     }
   }
 }

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -36,33 +36,33 @@ export class AzurePipelinesCredential implements TokenCredential {
     clientId: string,
     serviceConnectionId: string,
     systemAccessToken: string,
-    options?: AzurePipelinesCredentialOptions
+    options?: AzurePipelinesCredentialOptions,
   ) {
     if (!clientId || !tenantId || !serviceConnectionId || !systemAccessToken) {
       throw new CredentialUnavailableError(
-        `${credentialName}: is unavailable. tenantId, clientId, serviceConnectionId, and systemAccessToken are required parameters.`
+        `${credentialName}: is unavailable. tenantId, clientId, serviceConnectionId, and systemAccessToken are required parameters.`,
       );
     }
     this.identityClient = new IdentityClient(options);
     checkTenantId(logger, tenantId);
     logger.info(
-      `Invoking AzurePipelinesCredential with tenant ID: ${tenantId}, client ID: ${clientId}, and service connection ID: ${serviceConnectionId}`
+      `Invoking AzurePipelinesCredential with tenant ID: ${tenantId}, client ID: ${clientId}, and service connection ID: ${serviceConnectionId}`,
     );
     if (!process.env.SYSTEM_OIDCREQUESTURI) {
       throw new CredentialUnavailableError(
-        `${credentialName}: is unavailable. Ensure that you're running this task in an Azure Pipeline, so that following missing system variable(s) can be defined- "SYSTEM_OIDCREQUESTURI"`
+        `${credentialName}: is unavailable. Ensure that you're running this task in an Azure Pipeline, so that following missing system variable(s) can be defined- "SYSTEM_OIDCREQUESTURI"`,
       );
     }
 
     const oidcRequestUrl = `${process.env.SYSTEM_OIDCREQUESTURI}?api-version=${OIDC_API_VERSION}&serviceConnectionId=${serviceConnectionId}`;
     logger.info(
-      `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, client ID: ${clientId} and service connection ID: ${serviceConnectionId}`
+      `Invoking ClientAssertionCredential with tenant ID: ${tenantId}, client ID: ${clientId} and service connection ID: ${serviceConnectionId}`,
     );
     this.clientAssertionCredential = new ClientAssertionCredential(
       tenantId,
       clientId,
       this.requestOidcToken.bind(this, oidcRequestUrl, systemAccessToken),
-      options
+      options,
     );
   }
 
@@ -76,7 +76,7 @@ export class AzurePipelinesCredential implements TokenCredential {
    */
   public async getToken(
     scopes: string | string[],
-    options?: GetTokenOptions
+    options?: GetTokenOptions,
   ): Promise<AccessToken> {
     if (!this.clientAssertionCredential) {
       const errorMessage = `${credentialName}: is unavailable. To use Federation Identity in Azure Pipelines, the following parameters are required - 
@@ -101,7 +101,7 @@ export class AzurePipelinesCredential implements TokenCredential {
    */
   private async requestOidcToken(
     oidcRequestUrl: string,
-    systemAccessToken: string
+    systemAccessToken: string,
   ): Promise<string> {
     logger.info("Requesting OIDC token from Azure Pipelines...");
     logger.info(oidcRequestUrl);
@@ -124,12 +124,12 @@ export function handleOidcResponse(response: PipelineResponse): string {
     logger.error(
       `${credentialName}: Authentication Failed. Received null token from OIDC request. Response status- ${
         response.status
-      }. Complete response - ${JSON.stringify(response)}`
+      }. Complete response - ${JSON.stringify(response)}`,
     );
     throw new AuthenticationError(response.status, {
       error: `${credentialName}: Authentication Failed. Received null token from OIDC request.`,
       error_description: `${JSON.stringify(
-        response
+        response,
       )}. See the troubleshooting guide for more information: https://aka.ms/azsdk/js/identity/azurepipelinescredential/troubleshoot`,
     });
   }
@@ -142,7 +142,7 @@ export function handleOidcResponse(response: PipelineResponse): string {
       let errorDescription = ``;
       if (response.status !== 200) {
         errorDescription = `Complete response - ${JSON.stringify(
-          result
+          result,
         )}. See the troubleshooting guide for more information: https://aka.ms/azsdk/js/identity/azurepipelinescredential/troubleshoot`;
       }
       logger.error(errorMessage);

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -140,6 +140,8 @@ export class AzurePipelinesCredential implements TokenCredential {
         throw new AuthenticationError(response.status, errorMessage);
       }
     } catch (e: any) {
+      //azure:identity:error AzurePipelinesCredential => AzurePipelinesCredential: Authentication Failed. oidcToken field not detected in the response.Response = {"$id":"1","innerException":null,"message":"No service connection found with identifier 8089d38c-c287-4289-8012-c3c1fc775efd.","typeName":"Microsoft.TeamFoundation.DistributedTask.WebApi.EndpointNotFoundException, Microsoft.TeamFoundation.DistributedTask.WebApi","typeKey":"EndpointNotFoundException","errorCode":0,"eventId":3000}
+
       logger.error(e.message);
       logger.error(
         `${credentialName}: Authentication Failed. oidcToken field not detected in the response. Response = ${text}`,

--- a/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import {
   PipelineResponse,
   createHttpHeaders,
@@ -7,25 +10,30 @@ import { handleOidcResponse } from "../../../src/credentials/azurePipelinesCrede
 import { assert } from "@azure-tools/test-utils";
 
 describe("AzurePipelinesCredential (internal)", function () {
-  it("throws expected error message with a service connection not found error", async function () {
-    const response: PipelineResponse = {
-      request: createPipelineRequest({
-        url: "https://domoreexp.visualstudio.com/11ac29bc-5a99-400b-b225-01839ab0c9df/_apis/distributedtask/hubs/build/plans/f8b9f114-0f05-49aa-bd84-d1f0197f47a1/jobs/30ea8d6c-7fd8-521d-25e4-72f1dd901d33/oidctoken?api-version=7.1&serviceConnectionId=REDACTED",
-        headers: createHttpHeaders({
-          "content-type": "application/json",
-          authorization: "REDACTED",
-          "accept-encoding": "gzip,deflate",
-          "user-agent":
-            "azsdk-js-identity/4.3.0-beta.3 core-rest-pipeline/1.12.0 Node/v20.11.0 OS/(x64-Linux-5.15.0-1067-azure)",
-          "x-ms-client-request-id": "54730b40-5c44-48db-ad98-666c8dabb48d",
-        }),
-        method: "POST",
+  const response: PipelineResponse = {
+    request: createPipelineRequest({
+      url: "https://domoreexp.visualstudio.com/11ac29bc-5a99-400b-b225-01839ab0c9df/_apis/distributedtask/hubs/build/plans/f8b9f114-0f05-49aa-bd84-d1f0197f47a1/jobs/30ea8d6c-7fd8-521d-25e4-72f1dd901d33/oidctoken?api-version=7.1&serviceConnectionId=REDACTED",
+      headers: createHttpHeaders({
+        "content-type": "application/json",
+        authorization: "REDACTED",
+        "accept-encoding": "gzip,deflate",
+        "user-agent":
+          "azsdk-js-identity/4.3.0-beta.3 core-rest-pipeline/1.12.0 Node/v20.11.0 OS/(x64-Linux-5.15.0-1067-azure)",
+        "x-ms-client-request-id": "54730b40-5c44-48db-ad98-666c8dabb48d",
       }),
-      status: 400,
-      headers: createHttpHeaders(),
-      bodyAsText: "No service connection found with identifier frwerhq-241242-vsdkf-jw",
-    };
-
+      method: "POST",
+    }),
+    status: 400,
+    headers: createHttpHeaders(),
+  };
+  it("throws expected Authentication Error", async function () {
+    await assert.isRejected(
+      handleOidcResponse(response),
+      /AzurePipelinesCredential: Authentication Failed. Received null token from OIDC request. Status code: 400/
+    );
+  });
+  it("throws expected error message with a service connection not found error", async function () {
+    response.bodyAsText = "No service connection found with identifier frwerhq-241242-vsdkf-jw";
     await assert.isRejected(
       handleOidcResponse(response),
       /No service connection found with identifier/

--- a/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
@@ -33,14 +33,14 @@ describe("AzurePipelinesCredential (internal)", function () {
   it("throws expected Authentication Error", function () {
     assert.throws(
       () => handleOidcResponse(response),
-      /AzurePipelinesCredential: Authentication Failed. Received null token from OIDC request. Status code: 400/
+      /AzurePipelinesCredential: Authentication Failed. Received null token from OIDC request. Status code: 400/,
     );
   });
   it("throws expected error message with a service connection not found error", function () {
     response.bodyAsText = "No service connection found with identifier frwerhq-241242-vsdkf-jw";
     assert.throws(
       () => handleOidcResponse(response),
-      /AzurePipelinesCredential: Authentication Failed. oidcToken field not detected in the response. Status code: 400[\s\S]*No service connection found with identifier/
+      /AzurePipelinesCredential: Authentication Failed. oidcToken field not detected in the response. Status code: 400[\s\S]*No service connection found with identifier/,
     );
   });
 });

--- a/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
@@ -1,0 +1,15 @@
+import { PipelineResponse } from "@azure/core-rest-pipeline";
+import { handleOidcResponse } from "../../../src/credentials/azurePipelinesCredential";
+
+//TODO: complete this
+describe("AzurePipelinesCredential (internal)", function () {
+  it("throws expected error message with a service connection not found error", function () {
+    const response: PipelineResponse = {
+        request: {
+
+    }
+        status: 400
+    };
+    await handleOidcResponse(response);
+  });
+});

--- a/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
@@ -10,33 +10,37 @@ import { handleOidcResponse } from "../../../src/credentials/azurePipelinesCrede
 import { assert } from "@azure-tools/test-utils";
 
 describe("AzurePipelinesCredential (internal)", function () {
-  const response: PipelineResponse = {
-    request: createPipelineRequest({
-      url: "https://domoreexp.visualstudio.com/11ac29bc-5a99-400b-b225-01839ab0c9df/_apis/distributedtask/hubs/build/plans/f8b9f114-0f05-49aa-bd84-d1f0197f47a1/jobs/30ea8d6c-7fd8-521d-25e4-72f1dd901d33/oidctoken?api-version=7.1&serviceConnectionId=REDACTED",
-      headers: createHttpHeaders({
-        "content-type": "application/json",
-        authorization: "REDACTED",
-        "accept-encoding": "gzip,deflate",
-        "user-agent":
-          "azsdk-js-identity/4.3.0-beta.3 core-rest-pipeline/1.12.0 Node/v20.11.0 OS/(x64-Linux-5.15.0-1067-azure)",
-        "x-ms-client-request-id": "54730b40-5c44-48db-ad98-666c8dabb48d",
+  let response: PipelineResponse;
+  beforeEach(function () {
+    response = {
+      request: createPipelineRequest({
+        url: "https://domoreexp.visualstudio.com/11ac29bc-5a99-400b-b225-01839ab0c9df/_apis/distributedtask/hubs/build/plans/f8b9f114-0f05-49aa-bd84-d1f0197f47a1/jobs/30ea8d6c-7fd8-521d-25e4-72f1dd901d33/oidctoken?api-version=7.1&serviceConnectionId=REDACTED",
+        headers: createHttpHeaders({
+          "content-type": "application/json",
+          authorization: "REDACTED",
+          "accept-encoding": "gzip,deflate",
+          "user-agent":
+            "azsdk-js-identity/4.3.0-beta.3 core-rest-pipeline/1.12.0 Node/v20.11.0 OS/(x64-Linux-5.15.0-1067-azure)",
+          "x-ms-client-request-id": "54730b40-5c44-48db-ad98-666c8dabb48d",
+        }),
+        method: "POST",
       }),
-      method: "POST",
-    }),
-    status: 400,
-    headers: createHttpHeaders(),
-  };
-  it("throws expected Authentication Error", async function () {
-    await assert.isRejected(
-      handleOidcResponse(response),
+      status: 400,
+      headers: createHttpHeaders(),
+    };
+  });
+
+  it("throws expected Authentication Error", function () {
+    assert.throws(
+      () => handleOidcResponse(response),
       /AzurePipelinesCredential: Authentication Failed. Received null token from OIDC request. Status code: 400/
     );
   });
-  it("throws expected error message with a service connection not found error", async function () {
+  it("throws expected error message with a service connection not found error", function () {
     response.bodyAsText = "No service connection found with identifier frwerhq-241242-vsdkf-jw";
-    await assert.isRejected(
-      handleOidcResponse(response),
-      /No service connection found with identifier/
+    assert.throws(
+      () => handleOidcResponse(response),
+      /AzurePipelinesCredential: Authentication Failed. oidcToken field not detected in the response. Status code: 400[\s\S]*No service connection found with identifier/
     );
   });
 });

--- a/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePipelinesCredential.spec.ts
@@ -1,15 +1,34 @@
-import { PipelineResponse } from "@azure/core-rest-pipeline";
+import {
+  PipelineResponse,
+  createHttpHeaders,
+  createPipelineRequest,
+} from "@azure/core-rest-pipeline";
 import { handleOidcResponse } from "../../../src/credentials/azurePipelinesCredential";
+import { assert } from "@azure-tools/test-utils";
 
-//TODO: complete this
 describe("AzurePipelinesCredential (internal)", function () {
-  it("throws expected error message with a service connection not found error", function () {
+  it("throws expected error message with a service connection not found error", async function () {
     const response: PipelineResponse = {
-        request: {
-
-    }
-        status: 400
+      request: createPipelineRequest({
+        url: "https://domoreexp.visualstudio.com/11ac29bc-5a99-400b-b225-01839ab0c9df/_apis/distributedtask/hubs/build/plans/f8b9f114-0f05-49aa-bd84-d1f0197f47a1/jobs/30ea8d6c-7fd8-521d-25e4-72f1dd901d33/oidctoken?api-version=7.1&serviceConnectionId=REDACTED",
+        headers: createHttpHeaders({
+          "content-type": "application/json",
+          authorization: "REDACTED",
+          "accept-encoding": "gzip,deflate",
+          "user-agent":
+            "azsdk-js-identity/4.3.0-beta.3 core-rest-pipeline/1.12.0 Node/v20.11.0 OS/(x64-Linux-5.15.0-1067-azure)",
+          "x-ms-client-request-id": "54730b40-5c44-48db-ad98-666c8dabb48d",
+        }),
+        method: "POST",
+      }),
+      status: 400,
+      headers: createHttpHeaders(),
+      bodyAsText: "No service connection found with identifier frwerhq-241242-vsdkf-jw",
     };
-    await handleOidcResponse(response);
+
+    await assert.isRejected(
+      handleOidcResponse(response),
+      /No service connection found with identifier/
+    );
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- Seeing that customers get 400 (authority_not_found) error (that is written by us) instead of the actual errors thrown by the AuthenticationError constructor.
- An example where the customer was using a different task like a "script" task, but the error it throws is different from the error detected -
![image](https://github.com/user-attachments/assets/fb052903-c749-4671-886d-aa3159dbda36)


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
