### PR TITLE
[EngSys] remove `downlevelIteration` typescript option

### DIFF
--- a/common/tools/dev-tool/tsconfig.json
+++ b/common/tools/dev-tool/tsconfig.json
@@ -14,7 +14,6 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "downlevelIteration": true,
 
     "resolveJsonModule": true,
     "skipLibCheck": true

--- a/sdk/appconfiguration/app-configuration/tsconfig.json
+++ b/sdk/appconfiguration/app-configuration/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "downlevelIteration": true,
     "paths": {
       "@azure/app-configuration": ["./src/index"]
     }

--- a/sdk/core/logger/tsconfig.json
+++ b/sdk/core/logger/tsconfig.json
@@ -4,7 +4,6 @@
     "paths": {
       "@azure/logger": ["./src/index.ts"]
     },
-    "downlevelIteration": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "rootDir": "."

--- a/sdk/eventhub/event-hubs/tsconfig.json
+++ b/sdk/eventhub/event-hubs/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "downlevelIteration": true,
     "noFallthroughCasesInSwitch": false,
     "paths": {
       "@azure/event-hubs": ["./src/index"]

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declarationDir": "./typings",
     "outDir": "./dist-esm",
-    "downlevelIteration": true,
     "paths": {
       "@azure/eventhubs-checkpointstore-blob": ["./src/index"]
     }

--- a/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
@@ -4,9 +4,7 @@
     "declarationDir": "./typings",
     "outDir": "./dist-esm",
     "paths": {
-      "@azure/eventhubs-checkpointstore-table": [
-        "./src/index"
-      ]
+      "@azure/eventhubs-checkpointstore-table": ["./src/index"]
     }
   },
   "exclude": ["node_modules", "./types/**/*.d.ts", "./samples/**/*.ts"],

--- a/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "declarationDir": "./typings",
     "outDir": "./dist-esm",
-    "downlevelIteration": true
+    "paths": {
+      "@azure/eventhubs-checkpointstore-table": [
+        "./src/index"
+      ]
+    }
   },
   "exclude": ["node_modules", "./types/**/*.d.ts", "./samples/**/*.ts"],
   "include": ["./src/**/*.ts", "./test/**/*.ts"]

--- a/sdk/eventhub/mock-hub/tsconfig.json
+++ b/sdk/eventhub/mock-hub/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "outDir": "./dist",
     "declarationDir": "./types",
-    "downlevelIteration": true,
     "sourceMap": true,
     "strict": true,
     "declaration": true,

--- a/sdk/servicebus/service-bus/tsconfig.json
+++ b/sdk/servicebus/service-bus/tsconfig.json
@@ -6,7 +6,6 @@
     "declarationDir": "./types",
     "outDir": "./dist-esm",
     "lib": ["dom", "ES2018.AsyncIterable"],
-    "downlevelIteration": true,
     "paths": {
       "@azure/service-bus": ["./src/index"]
     }


### PR DESCRIPTION
It helps old JS runtimes that only support ES 5 but we moved to ES 6 long time ago
and now moved to ES2017.  Most of our packages don't have this option. This PR
removes its usage.