### PR TITLE
[identity] Fix build failures

### DIFF
--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -25,12 +25,7 @@ $sshKey = Get-Content $PSScriptRoot/sshKey.pub
 $templateFileParameters['sshPubKey'] = $sshKey
 
 # Get the max version that is not preview and then get the name of the patch version with the max value
-az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
-$versions = az aks get-versions -l westus -o json | ConvertFrom-Json
-Write-Host "AKS versions: $($versions | ConvertTo-Json -Depth 100)"
-$patchVersions = $versions.values | Where-Object { $_.isPreview -eq $null } | Select-Object -ExpandProperty patchVersions
-Write-Host "AKS patch versions: $($patchVersions | ConvertTo-Json -Depth 100)"
-$latestAksVersion = $patchVersions | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
+$latestAksVersion = Get-AzAksVersion -Location westus | Where-Object { $_.isPreview -eq $null } | Select-Object -ExpandProperty OrchestratorVersion | Sort-Object -Descending | Select-Object -First 1
 Write-Host "Latest AKS version: $latestAksVersion"
 $templateFileParameters['latestAksVersion'] = $latestAksVersion
 

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -15,7 +15,7 @@ param testApplicationOid string
 param acrName string = 'acr${uniqueString(resourceGroup().id)}'
 
 @description('The latest AKS version available in the region.')
-param latestAksVersion string = '1.27.7'
+param latestAksVersion string
 
 @description('The SSH public key to use for the Linux VMs.')
 param sshPubKey string


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A nightly failures

### Describe the problem that is addressed by this PR

on 7/1 AKS released a new patch version, but we have the older version hardcoded. As a result, deploy-test-resources started failing.

This PR updates the test-resources-pre script to fetch the latest available AKS version.
