### PR TITLE
[Eng Sys] Update default config for preview cloud for live tests

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -48,6 +48,9 @@ parameters:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePaths: 
+          - eng/common/TestResources/sub-config/AzurePublicMsft.json
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: centraluseuap

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -48,9 +48,7 @@ parameters:
           - eng/common/TestResources/sub-config/AzurePublicMsft.json
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        ServiceConnection: azure-sdk-tests
-        SubscriptionConfigurationFilePaths: 
-          - eng/common/TestResources/sub-config/AzurePublicMsft.json
+        ServiceConnection: azure-sdk-tests-preview
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: centraluseuap


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
When we enable Federated Auth, `ServiceConnection` is a required parameter in `AzurePowerShell@5` task. Without this variable, the Deploy Test Resources tasks will fail. This PR aims to set this variable by default for the `Preview` cloud.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
