### PR TITLE
[Maps] Migrate test to federated authentication

### DIFF
--- a/sdk/maps/maps-common/sample.env
+++ b/sdk/maps/maps-common/sample.env
@@ -1,7 +1,7 @@
 # Maps subscription key when using AzureKey authentication
 MAPS_SUBSCRIPTION_KEY="<subscription-key>"
 
-# Maps Azure AD authentication
+# Maps Microsoft Entra ID authentication
 AZURE_CLIENT_ID="<client-id>"
 AZURE_CLIENT_SECRET="<client-secret>"
 AZURE_TENANT_ID="<tenant-id>"

--- a/sdk/maps/maps-geolocation-rest/README.md
+++ b/sdk/maps/maps-geolocation-rest/README.md
@@ -40,21 +40,21 @@ npm install @azure-rest/maps-geolocation
 
 ### Create and authenticate a `MapsGeolocationClient`
 
-You'll need a `credential` instance for authentication when creating the `MapsGeolocationClient` instance used to access the Azure Maps render APIs. You can use either an Azure Active Directory (Azure AD) credential or an Azure subscription key to authenticate. For more information on authentication, see [Authentication with Azure Maps][az_map_auth].
+You'll need a `credential` instance for authentication when creating the `MapsGeolocationClient` instance used to access the Azure Maps render APIs. You can use either a Microsoft Entra ID credential or an Azure subscription key to authenticate. For more information on authentication, see [Authentication with Azure Maps][az_map_auth].
 
-#### Using an Azure AD credential
+#### Using an Microsoft Entra ID credential
 
-To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
+To use an [Microsoft Entra ID token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)
+To authenticate with Microsoft Entra ID, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
 can be used to authenticate the client.
 
-You'll need to register the new Azure AD application and grant access to Azure Maps by assigning the required role to your service principal. For more information, see [Host a daemon on non-Azure resources](https://learn.microsoft.com/azure/azure-maps/how-to-secure-daemon-app#host-a-daemon-on-non-azure-resources). Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
+You'll need to register the new Microsoft Entra ID application and grant access to Azure Maps by assigning the required role to your service principal. For more information, see [Host a daemon on non-Azure resources](https://learn.microsoft.com/azure/azure-maps/how-to-secure-daemon-app#host-a-daemon-on-non-azure-resources). Set the values of the client ID, tenant ID, and client secret of the Microsoft Entra ID application as environment variables:
 `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 
 You will also need to specify the Azure Maps resource you intend to use by specifying the `clientId` in the client options.
@@ -99,33 +99,33 @@ npm install @azure/core-auth
 Finally, you can use the SAS token to authenticate the client:
 
 ```javascript
-  const MapsGeolocation = require("@azure-rest/maps-geolocation").default;
-  const { AzureSASCredential } = require("@azure/core-auth");
-  const { DefaultAzureCredential } = require("@azure/identity");
-  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+const MapsGeolocation = require("@azure-rest/maps-geolocation").default;
+const { AzureSASCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
+const { AzureMapsManagementClient } = require("@azure/arm-maps");
 
-  const subscriptionId = "<subscription ID of the map account>"
-  const resourceGroupName = "<resource group name of the map account>";
-  const accountName = "<name of the map account>";
-  const mapsAccountSasParameters = {
-    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
-    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
-    maxRatePerSecond: 500,
-    principalId: "<principle ID (object ID) of the managed identity>",
-    signingKey: "primaryKey",
-  };
-  const credential = new DefaultAzureCredential();
-  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
-  const {accountSasToken} = await managementClient.accounts.listSas(
-    resourceGroupName,
-    accountName,
-    mapsAccountSasParameters
-  );
-  if (accountSasToken === undefined) {
-    throw new Error("No accountSasToken was found for the Maps Account.");
-  }
-  const sasCredential = new AzureSASCredential(accountSasToken);
-  const client = MapsGeolocation(sasCredential);
+const subscriptionId = "<subscription ID of the map account>";
+const resourceGroupName = "<resource group name of the map account>";
+const accountName = "<name of the map account>";
+const mapsAccountSasParameters = {
+  start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+  expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+  maxRatePerSecond: 500,
+  principalId: "<principle ID (object ID) of the managed identity>",
+  signingKey: "primaryKey",
+};
+const credential = new DefaultAzureCredential();
+const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+const { accountSasToken } = await managementClient.accounts.listSas(
+  resourceGroupName,
+  accountName,
+  mapsAccountSasParameters,
+);
+if (accountSasToken === undefined) {
+  throw new Error("No accountSasToken was found for the Maps Account.");
+}
+const sasCredential = new AzureSASCredential(accountSasToken);
+const client = MapsGeolocation(sasCredential);
 ```
 
 ## Key concepts

--- a/sdk/maps/maps-geolocation-rest/assets.json
+++ b/sdk/maps/maps-geolocation-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/maps/maps-geolocation-rest",
-  "Tag": "js/maps/maps-geolocation-rest_006edcd29b"
+  "Tag": "js/maps/maps-geolocation-rest_e8d499d633"
 }

--- a/sdk/maps/maps-geolocation-rest/karma.conf.js
+++ b/sdk/maps/maps-geolocation-rest/karma.conf.js
@@ -51,11 +51,7 @@ module.exports = function (config) {
       // "dist-test/index.js": ["coverage"]
     },
 
-    envPreprocessor: [
-      "TEST_MODE",
-      "MAPS_RESOURCE_CLIENT_ID",
-      "RECORDINGS_RELATIVE_PATH",
-    ],
+    envPreprocessor: ["TEST_MODE", "MAPS_RESOURCE_CLIENT_ID", "RECORDINGS_RELATIVE_PATH"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/maps/maps-geolocation-rest/karma.conf.js
+++ b/sdk/maps/maps-geolocation-rest/karma.conf.js
@@ -53,11 +53,7 @@ module.exports = function (config) {
 
     envPreprocessor: [
       "TEST_MODE",
-      "MAPS_SUBSCRIPTION_KEY",
       "MAPS_RESOURCE_CLIENT_ID",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_CLIENT_ID",
-      "AZURE_TENANT_ID",
       "RECORDINGS_RELATIVE_PATH",
     ],
 

--- a/sdk/maps/maps-geolocation-rest/sample.env
+++ b/sdk/maps/maps-geolocation-rest/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-geolocation-rest/samples-dev/getCountryCodeFromIP.ts
+++ b/sdk/maps/maps-geolocation-rest/samples-dev/getCountryCodeFromIP.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
+
 import MapsGeolocation, { isUnexpected } from "@azure-rest/maps-geolocation";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -9,16 +10,16 @@ dotenv.config();
 /**
  * @summary This sample demonstrates how to get the country code for an IP address using MapsGeolocation.
  */
-async function successfullyRetrieveCountryCodeFromIPAddress() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsGeolocation(credential);
-
-  /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsGeolocation(credential, mapsClientId);
+async function successfullyRetrieveCountryCodeFromIPAddress(): Promise<void> {
+  /** Use Azure AD authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsGeolocation(credential, mapsClientId);
+  
+  /** Or use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsGeolocation(credential);
 
   const result = await client.path("/geolocation/ip/{format}", "json").get({
     queryParameters: { ip: "2001:4898:80e8:b::189" },

--- a/sdk/maps/maps-geolocation-rest/samples-dev/getCountryCodeFromIP.ts
+++ b/sdk/maps/maps-geolocation-rest/samples-dev/getCountryCodeFromIP.ts
@@ -15,7 +15,7 @@ async function successfullyRetrieveCountryCodeFromIPAddress(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsGeolocation(credential, mapsClientId);
-  
+
   /** Or use subscription key authentication */
   // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
   // const credential = new AzureKeyCredential(subscriptionKey);

--- a/sdk/maps/maps-geolocation-rest/samples-dev/getCountryCodeFromIP.ts
+++ b/sdk/maps/maps-geolocation-rest/samples-dev/getCountryCodeFromIP.ts
@@ -11,7 +11,7 @@ dotenv.config();
  * @summary This sample demonstrates how to get the country code for an IP address using MapsGeolocation.
  */
 async function successfullyRetrieveCountryCodeFromIPAddress(): Promise<void> {
-  /** Use Azure AD authentication (Recommended) */
+  /** Use Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsGeolocation(credential, mapsClientId);

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/README.md
@@ -39,7 +39,7 @@ node getCountryCodeFromIP.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node getCountryCodeFromIP.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node getCountryCodeFromIP.js
 ```
 
 ## Next Steps
@@ -47,9 +47,7 @@ npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node getCountryCod
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
 [getcountrycodefromip]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/getCountryCodeFromIP.js
-
-<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-geolocation -->
-
+[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-geolocation
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-geolocation-rest/README.md

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/getCountryCodeFromIP.js
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/getCountryCodeFromIP.js
@@ -1,23 +1,24 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
+
 const MapsGeolocation = require("@azure-rest/maps-geolocation").default,
   { isUnexpected } = require("@azure-rest/maps-geolocation");
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
 /**
  * @summary This sample demonstrates how to get the country code for an IP address using MapsGeolocation.
  */
 async function successfullyRetrieveCountryCodeFromIPAddress() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsGeolocation(credential);
+  /** Use Azure AD authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsGeolocation(credential, mapsClientId);
 
-  /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsGeolocation(credential, mapsClientId);
+  /** Or use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsGeolocation(credential);
 
   const result = await client.path("/geolocation/ip/{format}", "json").get({
     queryParameters: { ip: "2001:4898:80e8:b::189" },

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/getCountryCodeFromIP.js
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/getCountryCodeFromIP.js
@@ -10,7 +10,7 @@ require("dotenv").config();
  * @summary This sample demonstrates how to get the country code for an IP address using MapsGeolocation.
  */
 async function successfullyRetrieveCountryCodeFromIPAddress() {
-  /** Use Azure AD authentication (Recommended) */
+  /** Use Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsGeolocation(credential, mapsClientId);

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/package.json
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/maps-geolocation": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0"
+    "@azure/identity": "^4.0.1"
   }
 }

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/sample.env
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/javascript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/README.md
@@ -51,7 +51,7 @@ node dist/getCountryCodeFromIP.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node dist/getCountryCodeFromIP.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node dist/getCountryCodeFromIP.js
 ```
 
 ## Next Steps
@@ -59,9 +59,7 @@ npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node dist/getCount
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
 [getcountrycodefromip]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/src/getCountryCodeFromIP.ts
-
-<!-- [apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-geolocation -->
-
+[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-geolocation
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-geolocation-rest/README.md

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/maps-geolocation": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0"
+    "@azure/identity": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/sample.env
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/src/getCountryCodeFromIP.ts
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/src/getCountryCodeFromIP.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
+
 import MapsGeolocation, { isUnexpected } from "@azure-rest/maps-geolocation";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -9,16 +10,16 @@ dotenv.config();
 /**
  * @summary This sample demonstrates how to get the country code for an IP address using MapsGeolocation.
  */
-async function successfullyRetrieveCountryCodeFromIPAddress() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsGeolocation(credential);
-
-  /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsGeolocation(credential, mapsClientId);
+async function successfullyRetrieveCountryCodeFromIPAddress(): Promise<void> {
+  /** Use Azure AD authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsGeolocation(credential, mapsClientId);
+  
+  /** Or use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsGeolocation(credential);
 
   const result = await client.path("/geolocation/ip/{format}", "json").get({
     queryParameters: { ip: "2001:4898:80e8:b::189" },

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/src/getCountryCodeFromIP.ts
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/src/getCountryCodeFromIP.ts
@@ -11,7 +11,7 @@ dotenv.config();
  * @summary This sample demonstrates how to get the country code for an IP address using MapsGeolocation.
  */
 async function successfullyRetrieveCountryCodeFromIPAddress(): Promise<void> {
-  /** Use Azure AD authentication (Recommended) */
+  /** Use Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsGeolocation(credential, mapsClientId);

--- a/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/tsconfig.json
+++ b/sdk/maps/maps-geolocation-rest/samples/v1-beta/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
+++ b/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
@@ -81,7 +81,7 @@ export default function MapsGeolocation(
   const options = typeof clientIdOrOptions === "string" ? maybeOptions : clientIdOrOptions;
 
   /**
-   * maps service requires a header "ms-x-client-id", which is different from the standard AAD.
+   * maps service requires a header "ms-x-client-id", which is different from the standard Microsoft Entra ID.
    * So we need to do our own implementation.
    * This customized authentication is following by this guide: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-customization.md#custom-authentication
    */

--- a/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
+++ b/sdk/maps/maps-geolocation-rest/src/MapsGeolocation.ts
@@ -94,7 +94,7 @@ export default function MapsGeolocation(
     client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
-        scopes: `${options.baseUrl || "https://atlas.microsoft.com"}/.default`,
+        scopes: "https://atlas.microsoft.com/.default",
       }),
     );
     client.pipeline.addPolicy(createMapsClientIdPolicy(clientId));

--- a/sdk/maps/maps-geolocation-rest/swagger/README.md
+++ b/sdk/maps/maps-geolocation-rest/swagger/README.md
@@ -27,7 +27,7 @@ source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/maps/data-plane/Geolocation/preview/1.0/geolocation.json
 package-version: 1.0.0-beta.4
 rest-level-client: true
-# Although maps service supports key-credentials and AAD, maps service requires header "ms-x-client-id", which is different from the standard AAD, so we don't generate AAD code and implement ourselves.
+# Although maps service supports key-credentials and Microsoft Entra ID, maps service requires header "ms-x-client-id", which is different from the standard Microsoft Entra ID, so we don't generate Microsoft Entra ID code and implement ourselves.
 # For auth configuration, please refer to: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-quickstart.md#how-to-configure-authentication
 security: AzureKey
 security-header-name: subscription-key

--- a/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts
+++ b/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts
@@ -20,7 +20,7 @@ describe("Authentication", function () {
     await recorder.stop();
   });
 
-  it("should work with AAD authentication", async function () {
+  it("should work with Microsoft Entra ID authentication", async function () {
     /**
      * Skip this test in browser because we have to use InteractiveBrowserCredential in the browser.
      * But it requires user's interaction, which is not testable in karma.

--- a/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts
+++ b/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts
@@ -8,7 +8,6 @@ import { assert } from "chai";
 import { createClient, createRecorder } from "./utils/recordedClient";
 import { Context } from "mocha";
 import MapsGeolocation, { isUnexpected, MapsGeolocationClient } from "../../src";
-import { AzureKeyCredential } from "@azure/core-auth";
 
 describe("Authentication", function () {
   let recorder: Recorder;
@@ -19,16 +18,6 @@ describe("Authentication", function () {
 
   afterEach(async function () {
     await recorder.stop();
-  });
-
-  it("should work with Shared Key authentication", async function () {
-    const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] as string);
-    const client = MapsGeolocation(credential, recorder.configureClientOptions({}));
-
-    const response = await client
-      .path("/geolocation/ip/{format}", "json")
-      .get({ queryParameters: { ip: "2001:4898:80e8:b::189" } });
-    assert.isOk(!isUnexpected(response));
   });
 
   it("should work with AAD authentication", async function () {

--- a/sdk/maps/maps-geolocation-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-geolocation-rest/test/public/utils/recordedClient.ts
@@ -29,10 +29,6 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 
 export function createClient(options?: ClientOptions): MapsGeolocationClient {
   const credential = createTestCredential();
-  const client = MapsGeolocation(
-    credential,
-    env["MAPS_RESOURCE_CLIENT_ID"] as string,
-    options,
-  );
+  const client = MapsGeolocation(credential, env["MAPS_RESOURCE_CLIENT_ID"] as string, options);
   return client;
 }

--- a/sdk/maps/maps-geolocation-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-geolocation-rest/test/public/utils/recordedClient.ts
@@ -6,14 +6,10 @@ import { Recorder, RecorderStartOptions, env } from "@azure-tools/test-recorder"
 import "./env";
 import { ClientOptions } from "@azure-rest/core-client";
 import MapsGeolocation, { MapsGeolocationClient } from "../../../src/";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { createTestCredential } from "@azure-tools/test-credential";
 
 const envSetupForPlayback: Record<string, string> = {
-  AZURE_CLIENT_ID: "azure_client_id",
-  AZURE_CLIENT_SECRET: "azure_client_secret",
-  AZURE_TENANT_ID: "88888888-8888-8888-8888-888888888888",
   MAPS_RESOURCE_CLIENT_ID: "azure_maps_client_id",
-  MAPS_SUBSCRIPTION_KEY: "azure_maps_subscription_key",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {
@@ -32,6 +28,11 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 }
 
 export function createClient(options?: ClientOptions): MapsGeolocationClient {
-  const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] ?? "");
-  return MapsGeolocation(credential, options);
+  const credential = createTestCredential();
+  const client = MapsGeolocation(
+    credential,
+    env["MAPS_RESOURCE_CLIENT_ID"] as string,
+    options,
+  );
+  return client;
 }

--- a/sdk/maps/maps-geolocation-rest/tests.yml
+++ b/sdk/maps/maps-geolocation-rest/tests.yml
@@ -6,8 +6,4 @@ extends:
       PackageName: "@azure-rest/maps-geolocation"
       ServiceDirectory: maps
       SupportedClouds: 'Public,Canary'
-      EnvVars:
-        AZURE_CLIENT_ID: $(MAPS_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(MAPS_CLIENT_SECRET)
-        AZURE_TENANT_ID: $(MAPS_TENANT_ID)
-        AZURE_SUBSCRIPTION_ID: $(MAPS_SUBSCRIPTION_ID)
+      UseFederatedAuth: true

--- a/sdk/maps/maps-render-rest/README.md
+++ b/sdk/maps/maps-render-rest/README.md
@@ -39,21 +39,21 @@ npm install @azure-rest/maps-render
 
 ### Create and authenticate a `MapsRenderClient`
 
-You'll need a `credential` instance for authentication when creating the `MapsRenderClient` instance used to access the Azure Maps render APIs. You can use either an Azure Active Directory (Azure AD) credential or an Azure subscription key to authenticate. For more information on authentication, see [Authentication with Azure Maps][az_map_auth].
+You'll need a `credential` instance for authentication when creating the `MapsRenderClient` instance used to access the Azure Maps render APIs. You can use either a Microsoft Entra ID credential or an Azure subscription key to authenticate. For more information on authentication, see [Authentication with Azure Maps][az_map_auth].
 
-#### Using an Azure AD credential
+#### Using an Microsoft Entra ID credential
 
-To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
+To use an [Microsoft Entra ID token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)
+To authenticate with Microsoft Entra ID, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
 can be used to authenticate the client.
 
-You'll need to register the new Azure AD application and grant access to Azure Maps by assigning the required role to your service principal. For more information, see [Host a daemon on non-Azure resources](https://learn.microsoft.com/azure/azure-maps/how-to-secure-daemon-app#host-a-daemon-on-non-azure-resources). Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
+You'll need to register the new Microsoft Entra ID application and grant access to Azure Maps by assigning the required role to your service principal. For more information, see [Host a daemon on non-Azure resources](https://learn.microsoft.com/azure/azure-maps/how-to-secure-daemon-app#host-a-daemon-on-non-azure-resources). Set the values of the client ID, tenant ID, and client secret of the Microsoft Entra ID application as environment variables:
 `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 
 You will also need to specify the Azure Maps resource you intend to use by specifying the `clientId` in the client options.
@@ -100,33 +100,33 @@ npm install @azure/core-auth
 Finally, you can use the SAS token to authenticate the client:
 
 ```javascript
-  const MapsRender = require("@azure-rest/maps-render").default;
-  const { AzureSASCredential } = require("@azure/core-auth");
-  const { DefaultAzureCredential } = require("@azure/identity");
-  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+const MapsRender = require("@azure-rest/maps-render").default;
+const { AzureSASCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
+const { AzureMapsManagementClient } = require("@azure/arm-maps");
 
-  const subscriptionId = "<subscription ID of the map account>"
-  const resourceGroupName = "<resource group name of the map account>";
-  const accountName = "<name of the map account>";
-  const mapsAccountSasParameters = {
-    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
-    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
-    maxRatePerSecond: 500,
-    principalId: "<principle ID (object ID) of the managed identity>",
-    signingKey: "primaryKey",
-  };
-  const credential = new DefaultAzureCredential();
-  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
-  const {accountSasToken} = await managementClient.accounts.listSas(
-    resourceGroupName,
-    accountName,
-    mapsAccountSasParameters
-  );
-  if (accountSasToken === undefined) {
-    throw new Error("No accountSasToken was found for the Maps Account.");
-  }
-  const sasCredential = new AzureSASCredential(accountSasToken);
-  const client = MapsRender(sasCredential);
+const subscriptionId = "<subscription ID of the map account>";
+const resourceGroupName = "<resource group name of the map account>";
+const accountName = "<name of the map account>";
+const mapsAccountSasParameters = {
+  start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+  expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+  maxRatePerSecond: 500,
+  principalId: "<principle ID (object ID) of the managed identity>",
+  signingKey: "primaryKey",
+};
+const credential = new DefaultAzureCredential();
+const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+const { accountSasToken } = await managementClient.accounts.listSas(
+  resourceGroupName,
+  accountName,
+  mapsAccountSasParameters,
+);
+if (accountSasToken === undefined) {
+  throw new Error("No accountSasToken was found for the Maps Account.");
+}
+const sasCredential = new AzureSASCredential(accountSasToken);
+const client = MapsRender(sasCredential);
 ```
 
 ## Key concepts
@@ -221,7 +221,7 @@ console.log("The metadata of Microsoft Base tileset: ");
 const { maxzoom, minzoom, bounds = [] } = response.body;
 console.log(`The zoom range started from ${minzoom} to ${maxzoom}`);
 console.log(
-  `The left bound is ${bounds[0]}, bottom bound is ${bounds[1]}, right bound is ${bounds[2]}, and top bound is ${bounds[3]}`
+  `The left bound is ${bounds[0]}, bottom bound is ${bounds[1]}, right bound is ${bounds[2]}, and top bound is ${bounds[3]}`,
 );
 ```
 

--- a/sdk/maps/maps-render-rest/assets.json
+++ b/sdk/maps/maps-render-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/maps/maps-render-rest",
-  "Tag": "js/maps/maps-render-rest_9358611c97"
+  "Tag": "js/maps/maps-render-rest_7aea6ec075"
 }

--- a/sdk/maps/maps-render-rest/karma.conf.js
+++ b/sdk/maps/maps-render-rest/karma.conf.js
@@ -51,11 +51,7 @@ module.exports = function (config) {
       // "dist-test/index.js": ["coverage"]
     },
 
-    envPreprocessor: [
-      "TEST_MODE",
-      "MAPS_RESOURCE_CLIENT_ID",
-      "RECORDINGS_RELATIVE_PATH",
-    ],
+    envPreprocessor: ["TEST_MODE", "MAPS_RESOURCE_CLIENT_ID", "RECORDINGS_RELATIVE_PATH"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/maps/maps-render-rest/karma.conf.js
+++ b/sdk/maps/maps-render-rest/karma.conf.js
@@ -53,11 +53,7 @@ module.exports = function (config) {
 
     envPreprocessor: [
       "TEST_MODE",
-      "MAPS_SUBSCRIPTION_KEY",
       "MAPS_RESOURCE_CLIENT_ID",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_CLIENT_ID",
-      "AZURE_TENANT_ID",
       "RECORDINGS_RELATIVE_PATH",
     ],
 

--- a/sdk/maps/maps-render-rest/sample.env
+++ b/sdk/maps/maps-render-rest/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightCaption.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightCaption.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightCaption.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightCaption.ts
@@ -1,33 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { isUnexpected } from "../src/generated";
 import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright caption.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/caption/{format}", "json").get();
 

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightCaption.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightCaption.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightForTile.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightForTile.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightForTile.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightForTile.ts
@@ -13,14 +13,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightForTile.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightForTile.ts
@@ -1,34 +1,34 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { positionToTileXY } from "@azure-rest/maps-render";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { isUnexpected } from "../src/generated";
 import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright of a certain tile.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 10;
   const tileSize = "512";

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightForWorld.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightForWorld.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightForWorld.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightForWorld.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightForWorld.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightForWorld.ts
@@ -1,33 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { isUnexpected } from "../src/generated";
 import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright all around the world.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/world/{format}", "json").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightFromBoundingBox.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightFromBoundingBox.ts
@@ -1,33 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { isUnexpected } from "../src/generated";
 import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright of tiles in a given bounding box.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/bounding/{format}", "json").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightFromBoundingBox.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightFromBoundingBox.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getCopyrightFromBoundingBox.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getCopyrightFromBoundingBox.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
@@ -1,33 +1,34 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { isUnexpected } from "../src/generated";
 import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright attribution of a certain tileset.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
+
 
   const baseResponse = await client.path("/map/attribution").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapAttribution.ts
@@ -29,7 +29,6 @@ async function main(): Promise<void> {
   // const credential = new AzureKeyCredential(subscriptionKey);
   // const client = MapsRender(credential);
 
-
   const baseResponse = await client.path("/map/attribution").get({
     queryParameters: {
       tilesetId: "microsoft.base",

--- a/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
@@ -13,14 +13,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { createWriteStream } from "fs";
 import MapsRender, { createPathQuery, createPinsQuery } from "@azure-rest/maps-render";
 import { LatLon } from "@azure/maps-common";
@@ -9,26 +9,26 @@ import { LatLon } from "@azure/maps-common";
 /**
  * @summary How to get the map static image with pins and paths specified.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   /** In this example, we handle the response stream in Node.js. For how to handle the browser stream, please refer to getMapTileInBrowser.ts */
   /** To get static image, one can assign bbox and zoom to the queryParameters */

--- a/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapStaticImage.ts
@@ -9,7 +9,7 @@ import { LatLon } from "@azure/maps-common";
 /**
  * @summary How to get the map static image with pins and paths specified.
  */
-async function main(): Promise<void>  {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
@@ -14,7 +14,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
@@ -1,32 +1,32 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRender, { positionToTileXY } from "@azure-rest/maps-render";
 
 /**
  * @summary How to get the map tile and render on the **browser**.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 6;
   const { x, y } = positionToTileXY([47.61559, -122.33817], 6, "256");

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
@@ -11,14 +11,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInBrowser.ts
@@ -7,7 +7,7 @@ import MapsRender, { positionToTileXY } from "@azure-rest/maps-render";
 /**
  * @summary How to get the map tile and render on the **browser**.
  */
-async function main(): Promise<void>  {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
@@ -1,33 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { createWriteStream } from "fs";
 import MapsRender, { positionToTileXY } from "@azure-rest/maps-render";
 
 /**
  * @summary How to get the map tile and store it as a file in **Node.js**.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 6;
   const { x, y } = positionToTileXY([47.61559, -122.33817], 6, "256");

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
@@ -8,7 +8,7 @@ import MapsRender, { positionToTileXY } from "@azure-rest/maps-render";
 /**
  * @summary How to get the map tile and store it as a file in **Node.js**.
  */
-async function main(): Promise<void>  {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileInNode.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
@@ -8,7 +8,7 @@ import MapsRender from "../src/mapsRender";
 /**
  * @summary How to get the metadata of a certain tileset.
  */
-async function main(): Promise<void>  {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
@@ -1,33 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { isUnexpected } from "../src/generated";
 import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the metadata of a certain tileset.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/tileset").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples-dev/getMapTileset.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/README.md
@@ -47,7 +47,7 @@ node getCopyrightCaption.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node getCopyrightCaption.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node getCopyrightCaption.js
 ```
 
 ## Next Steps
@@ -63,7 +63,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [getmaptileinbrowser]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
 [getmaptileinnode]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
 [getmaptileset]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
-[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-render
+[apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-render
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-render-rest/README.md

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/README.md
@@ -63,7 +63,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [getmaptileinbrowser]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
 [getmaptileinnode]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
 [getmaptileset]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
-[apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-render
+[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-render
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-render-rest/README.md

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightCaption.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightCaption.js
@@ -12,14 +12,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightCaption.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightCaption.js
@@ -15,7 +15,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightCaption.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightCaption.js
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-const { isUnexpected } = require("@azure-rest/maps-render");
-const MapsRender = require("@azure-rest/maps-render").default;
-require("dotenv").config();
+const { DefaultAzureCredential } = require("@azure/identity");
+const { isUnexpected } = require("../src/generated");
+const MapsRender = require("../src/mapsRender").default;
 
 /**
  * @summary How to get the copyright caption.
@@ -15,20 +14,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/caption/{format}", "json").get();
 

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForTile.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForTile.js
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 const { positionToTileXY } = require("@azure-rest/maps-render");
-const { AzureKeyCredential } = require("@azure/core-auth");
-const { isUnexpected } = require("@azure-rest/maps-render");
-const MapsRender = require("@azure-rest/maps-render").default;
-require("dotenv").config();
+const { DefaultAzureCredential } = require("@azure/identity");
+const { isUnexpected } = require("../src/generated");
+const MapsRender = require("../src/mapsRender").default;
 
 /**
  * @summary How to get the copyright of a certain tile.
@@ -16,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 10;
   const tileSize = "512";

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForTile.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForTile.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForTile.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForTile.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForWorld.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForWorld.js
@@ -12,14 +12,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForWorld.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForWorld.js
@@ -15,7 +15,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForWorld.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightForWorld.js
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-const { isUnexpected } = require("@azure-rest/maps-render");
-const MapsRender = require("@azure-rest/maps-render").default;
-require("dotenv").config();
+const { DefaultAzureCredential } = require("@azure/identity");
+const { isUnexpected } = require("../src/generated");
+const MapsRender = require("../src/mapsRender").default;
 
 /**
  * @summary How to get the copyright all around the world.
@@ -15,20 +14,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/world/{format}", "json").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightFromBoundingBox.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightFromBoundingBox.js
@@ -12,14 +12,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightFromBoundingBox.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightFromBoundingBox.js
@@ -15,7 +15,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightFromBoundingBox.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getCopyrightFromBoundingBox.js
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-const { isUnexpected } = require("@azure-rest/maps-render");
-const MapsRender = require("@azure-rest/maps-render").default;
-require("dotenv").config();
+const { DefaultAzureCredential } = require("@azure/identity");
+const { isUnexpected } = require("../src/generated");
+const MapsRender = require("../src/mapsRender").default;
 
 /**
  * @summary How to get the copyright of tiles in a given bounding box.
@@ -15,20 +14,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/bounding/{format}", "json").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapAttribution.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapAttribution.js
@@ -12,14 +12,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapAttribution.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapAttribution.js
@@ -15,7 +15,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapAttribution.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapAttribution.js
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-const { isUnexpected } = require("@azure-rest/maps-render");
-const MapsRender = require("@azure-rest/maps-render").default;
-require("dotenv").config();
+const { DefaultAzureCredential } = require("@azure/identity");
+const { isUnexpected } = require("../src/generated");
+const MapsRender = require("../src/mapsRender").default;
 
 /**
  * @summary How to get the copyright attribution of a certain tileset.
@@ -15,20 +14,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const baseResponse = await client.path("/map/attribution").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapStaticImage.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapStaticImage.js
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 const { createWriteStream } = require("fs");
 const MapsRender = require("@azure-rest/maps-render").default,
   { createPathQuery, createPinsQuery } = require("@azure-rest/maps-render");
-require("dotenv").config();
 
 /**
  * @summary How to get the map static image with pins and paths specified.
@@ -16,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   /** In this example, we handle the response stream in Node.js. For how to handle the browser stream, please refer to getMapTileInBrowser.ts */
   /** To get static image, one can assign bbox and zoom to the queryParameters */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapStaticImage.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapStaticImage.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapStaticImage.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapStaticImage.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
@@ -12,14 +12,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 const MapsRender = require("@azure-rest/maps-render").default,
   { positionToTileXY } = require("@azure-rest/maps-render");
-require("dotenv").config();
 
 /**
  * @summary How to get the map tile and render on the **browser**.
@@ -15,20 +14,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 6;
   const { x, y } = positionToTileXY([47.61559, -122.33817], 6, "256");

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInBrowser.js
@@ -15,7 +15,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 const { createWriteStream } = require("fs");
 const MapsRender = require("@azure-rest/maps-render").default,
   { positionToTileXY } = require("@azure-rest/maps-render");
-require("dotenv").config();
 
 /**
  * @summary How to get the map tile and store it as a file in **Node.js**.
@@ -16,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 6;
   const { x, y } = positionToTileXY([47.61559, -122.33817], 6, "256");

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileInNode.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
@@ -12,14 +12,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
@@ -15,7 +15,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/getMapTileset.js
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-const { isUnexpected } = require("@azure-rest/maps-render");
-const MapsRender = require("@azure-rest/maps-render").default;
-require("dotenv").config();
+const { DefaultAzureCredential } = require("@azure/identity");
+const { isUnexpected } = require("../src/generated");
+const MapsRender = require("../src/mapsRender").default;
 
 /**
  * @summary How to get the metadata of a certain tileset.
@@ -15,20 +14,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/tileset").get({
     queryParameters: {
@@ -44,7 +43,7 @@ async function main() {
   const { maxzoom, minzoom, bounds = [] } = response.body;
   console.log(`The zoom range started from ${minzoom} to ${maxzoom}`);
   console.log(
-    `The left bound is ${bounds[0]}, bottom bound is ${bounds[1]}, right bound is ${bounds[2]}, and top bound is ${bounds[3]}`
+    `The left bound is ${bounds[0]}, bottom bound is ${bounds[1]}, right bound is ${bounds[2]}, and top bound is ${bounds[3]}`,
   );
 }
 

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/package.json
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@azure-rest/maps-render": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0",
-    "@azure/maps-common": "^1.0.0-beta.2"
+    "@azure/identity": "^4.0.1",
+    "@azure/maps-common": "1.0.0-beta.2"
   }
 }

--- a/sdk/maps/maps-render-rest/samples/v1-beta/javascript/sample.env
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/javascript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/README.md
@@ -75,7 +75,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [getmaptileinbrowser]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
 [getmaptileinnode]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
 [getmaptileset]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
-[apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-render
+[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-render
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-render-rest/README.md

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/README.md
@@ -59,7 +59,7 @@ node dist/getCopyrightCaption.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node dist/getCopyrightCaption.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node dist/getCopyrightCaption.js
 ```
 
 ## Next Steps
@@ -75,7 +75,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [getmaptileinbrowser]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
 [getmaptileinnode]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
 [getmaptileset]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
-[apiref]: https://docs.microsoft.com/javascript/api/@azure-rest/maps-render
+[apiref]: https://docs.microsoft.com/javascript/api/@azure/maps-render
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azuremapsresource]: https://docs.microsoft.com/azure/azure-maps/how-to-create-template
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/maps/maps-render-rest/README.md

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@azure-rest/maps-render": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0",
-    "@azure/maps-common": "^1.0.0-beta.2"
+    "@azure/identity": "^4.0.1",
+    "@azure/maps-common": "1.0.0-beta.2"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/sample.env
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightCaption.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightCaption.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightCaption.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightCaption.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightCaption.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightCaption.ts
@@ -1,35 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
-import { isUnexpected } from "@azure-rest/maps-render";
-import MapsRender from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { DefaultAzureCredential } from "@azure/identity";
+import { isUnexpected } from "../src/generated";
+import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright caption.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/caption/{format}", "json").get();
 

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForTile.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForTile.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForTile.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForTile.ts
@@ -1,36 +1,34 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { positionToTileXY } from "@azure-rest/maps-render";
-import { AzureKeyCredential } from "@azure/core-auth";
-import { isUnexpected } from "@azure-rest/maps-render";
-import MapsRender from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { DefaultAzureCredential } from "@azure/identity";
+import { isUnexpected } from "../src/generated";
+import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright of a certain tile.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 10;
   const tileSize = "512";

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForTile.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForTile.ts
@@ -13,14 +13,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForWorld.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForWorld.ts
@@ -1,35 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
-import { isUnexpected } from "@azure-rest/maps-render";
-import MapsRender from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { DefaultAzureCredential } from "@azure/identity";
+import { isUnexpected } from "../src/generated";
+import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright all around the world.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/world/{format}", "json").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForWorld.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForWorld.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForWorld.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightForWorld.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightFromBoundingBox.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightFromBoundingBox.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightFromBoundingBox.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightFromBoundingBox.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightFromBoundingBox.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getCopyrightFromBoundingBox.ts
@@ -1,35 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
-import { isUnexpected } from "@azure-rest/maps-render";
-import MapsRender from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { DefaultAzureCredential } from "@azure/identity";
+import { isUnexpected } from "../src/generated";
+import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright of tiles in a given bounding box.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/copyright/bounding/{format}", "json").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapAttribution.ts
@@ -1,35 +1,34 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
-import { isUnexpected } from "@azure-rest/maps-render";
-import MapsRender from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { DefaultAzureCredential } from "@azure/identity";
+import { isUnexpected } from "../src/generated";
+import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the copyright attribution of a certain tileset.
  */
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
+
 
   const baseResponse = await client.path("/map/attribution").get({
     queryParameters: {

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapAttribution.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapAttribution.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapAttribution.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapStaticImage.ts
@@ -13,14 +13,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapStaticImage.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapStaticImage.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapStaticImage.ts
@@ -1,36 +1,34 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { createWriteStream } from "fs";
 import MapsRender, { createPathQuery, createPinsQuery } from "@azure-rest/maps-render";
 import { LatLon } from "@azure/maps-common";
-import * as dotenv from "dotenv";
-dotenv.config();
 
 /**
  * @summary How to get the map static image with pins and paths specified.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   /** In this example, we handle the response stream in Node.js. For how to handle the browser stream, please refer to getMapTileInBrowser.ts */
   /** To get static image, one can assign bbox and zoom to the queryParameters */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
@@ -14,7 +14,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
@@ -11,14 +11,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInBrowser.ts
@@ -1,34 +1,32 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRender, { positionToTileXY } from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
 
 /**
  * @summary How to get the map tile and render on the **browser**.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 6;
   const { x, y } = positionToTileXY([47.61559, -122.33817], 6, "256");

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileInNode.ts
@@ -1,35 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import { createWriteStream } from "fs";
 import MapsRender, { positionToTileXY } from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
 
 /**
  * @summary How to get the map tile and store it as a file in **Node.js**.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const zoom = 6;
   const { x, y } = positionToTileXY([47.61559, -122.33817], 6, "256");

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
@@ -12,14 +12,14 @@ async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRender(credential, mapsClientId);

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void>  {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/src/getMapTileset.ts
@@ -1,35 +1,33 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import { AzureKeyCredential } from "@azure/core-auth";
-import { isUnexpected } from "@azure-rest/maps-render";
-import MapsRender from "@azure-rest/maps-render";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { DefaultAzureCredential } from "@azure/identity";
+import { isUnexpected } from "../src/generated";
+import MapsRender from "../src/mapsRender";
 
 /**
  * @summary How to get the metadata of a certain tileset.
  */
-async function main() {
+async function main(): Promise<void>  {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRender(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRender(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRender(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRender(credential);
 
   const response = await client.path("/map/tileset").get({
     queryParameters: {
@@ -45,7 +43,7 @@ async function main() {
   const { maxzoom, minzoom, bounds = [] } = response.body;
   console.log(`The zoom range started from ${minzoom} to ${maxzoom}`);
   console.log(
-    `The left bound is ${bounds[0]}, bottom bound is ${bounds[1]}, right bound is ${bounds[2]}, and top bound is ${bounds[3]}`
+    `The left bound is ${bounds[0]}, bottom bound is ${bounds[1]}, right bound is ${bounds[2]}, and top bound is ${bounds[3]}`,
   );
 }
 

--- a/sdk/maps/maps-render-rest/samples/v1-beta/typescript/tsconfig.json
+++ b/sdk/maps/maps-render-rest/samples/v1-beta/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/sdk/maps/maps-render-rest/src/mapsRender.ts
+++ b/sdk/maps/maps-render-rest/src/mapsRender.ts
@@ -93,7 +93,7 @@ export default function MapsRender(
     client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
-        scopes: `${options.baseUrl || "https://atlas.microsoft.com"}/.default`,
+        scopes: "https://atlas.microsoft.com/.default",
       }),
     );
     client.pipeline.addPolicy(createMapsClientIdPolicy(clientId));

--- a/sdk/maps/maps-render-rest/src/mapsRender.ts
+++ b/sdk/maps/maps-render-rest/src/mapsRender.ts
@@ -80,7 +80,7 @@ export default function MapsRender(
   const options = typeof clientIdOrOptions === "string" ? maybeOptions : clientIdOrOptions;
 
   /**
-   * maps service requires a header "ms-x-client-id", which is different from the standard AAD.
+   * maps service requires a header "ms-x-client-id", which is different from the standard Microsoft Entra ID.
    * So we need to do our own implementation.
    * This customized authentication is following by this guide: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-customization.md#custom-authentication
    */

--- a/sdk/maps/maps-render-rest/swagger/README.md
+++ b/sdk/maps/maps-render-rest/swagger/README.md
@@ -24,7 +24,7 @@ source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/maps/data-plane/Render/stable/2022-08-01/render.json
 package-version: 1.0.0-beta.4
 rest-level-client: true
-# Although maps-render supports key-credentials and AAD, maps-route requires header "ms-x-client-id", which is different from the standard AAD, so we don't generate AAD code and implement ourselves.
+# Although maps-render supports key-credentials and Microsoft Entra ID, maps-route requires header "ms-x-client-id", which is different from the standard Microsoft Entra ID, so we don't generate Microsoft Entra ID code and implement ourselves.
 # For auth configuration, please refer to: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-quickstart.md#how-to-configure-authentication
 security: AzureKey
 security-header-name: subscription-key

--- a/sdk/maps/maps-render-rest/test/public/mapsRender.spec.ts
+++ b/sdk/maps/maps-render-rest/test/public/mapsRender.spec.ts
@@ -20,7 +20,7 @@ describe("Authentication", function () {
     await recorder.stop();
   });
 
-  it("should work with AAD authentication", async function () {
+  it("should work with Microsoft Entra ID authentication", async function () {
     /**
      * Skip this test in browser because we have to use InteractiveBrowserCredential in the browser.
      * But it requires user's interaction, which is not testable in karma.

--- a/sdk/maps/maps-render-rest/test/public/mapsRender.spec.ts
+++ b/sdk/maps/maps-render-rest/test/public/mapsRender.spec.ts
@@ -8,7 +8,6 @@ import { assert } from "chai";
 import { createClient, createRecorder } from "./utils/recordedClient";
 import { Context } from "mocha";
 import MapsRender, { isUnexpected, MapsRenderClient } from "../../src";
-import { AzureKeyCredential } from "@azure/core-auth";
 
 describe("Authentication", function () {
   let recorder: Recorder;
@@ -19,14 +18,6 @@ describe("Authentication", function () {
 
   afterEach(async function () {
     await recorder.stop();
-  });
-
-  it("should work with Shared Key authentication", async function () {
-    const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] as string);
-    const client = MapsRender(credential, recorder.configureClientOptions({}));
-
-    const response = await client.path("/map/copyright/caption/{format}", "json").get();
-    assert.isOk(!isUnexpected(response));
   });
 
   it("should work with AAD authentication", async function () {
@@ -197,7 +188,6 @@ describe("MapsRender", () => {
       assert.fail(response.body.error?.message || "Unexpected error.");
     }
 
-    assert.isNotEmpty(response.body.tilejson);
     assert.isNotEmpty(response.body.tiles);
   });
 });

--- a/sdk/maps/maps-render-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-render-rest/test/public/utils/recordedClient.ts
@@ -4,16 +4,12 @@
 import { Context } from "mocha";
 import { env, Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
 import "./env";
-import { AzureKeyCredential } from "@azure/core-auth";
 import MapsRender, { MapsRenderClient } from "../../../src";
 import { ClientOptions } from "@azure-rest/core-client";
+import { createTestCredential } from "@azure-tools/test-credential";
 
 const envSetupForPlayback: Record<string, string> = {
-  AZURE_CLIENT_ID: "azure_client_id",
-  AZURE_CLIENT_SECRET: "azure_client_secret",
-  AZURE_TENANT_ID: "88888888-8888-8888-8888-888888888888",
   MAPS_RESOURCE_CLIENT_ID: "azure_maps_client_id",
-  MAPS_SUBSCRIPTION_KEY: "azure_maps_subscription_key",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {
@@ -32,6 +28,11 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 }
 
 export function createClient(options?: ClientOptions): MapsRenderClient {
-  const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] ?? "");
-  return MapsRender(credential, options);
+    const credential = createTestCredential();
+  const client = MapsRender(
+    credential,
+    env["MAPS_RESOURCE_CLIENT_ID"] as string,
+    options,
+  );
+  return client;
 }

--- a/sdk/maps/maps-render-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-render-rest/test/public/utils/recordedClient.ts
@@ -28,11 +28,7 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 }
 
 export function createClient(options?: ClientOptions): MapsRenderClient {
-    const credential = createTestCredential();
-  const client = MapsRender(
-    credential,
-    env["MAPS_RESOURCE_CLIENT_ID"] as string,
-    options,
-  );
+  const credential = createTestCredential();
+  const client = MapsRender(credential, env["MAPS_RESOURCE_CLIENT_ID"] as string, options);
   return client;
 }

--- a/sdk/maps/maps-render-rest/tests.yml
+++ b/sdk/maps/maps-render-rest/tests.yml
@@ -6,8 +6,4 @@ extends:
       PackageName: "@azure-rest/maps-render"
       ServiceDirectory: maps
       SupportedClouds: 'Public,Canary'
-      EnvVars:
-        AZURE_CLIENT_ID: $(MAPS_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(MAPS_CLIENT_SECRET)
-        AZURE_TENANT_ID: $(MAPS_TENANT_ID)
-        AZURE_SUBSCRIPTION_ID: $(MAPS_SUBSCRIPTION_ID)
+      UseFederatedAuth: true

--- a/sdk/maps/maps-route-rest/README.md
+++ b/sdk/maps/maps-route-rest/README.md
@@ -35,19 +35,19 @@ npm install @azure-rest/maps-route
 
 ### Create and authenticate a `MapsRouteClient`
 
-To create a client object to access the Azure Maps Route APIs, you will need a `credential` object. The Azure Maps Route client can use an Azure Active Directory credential or an Azure Key credential to authenticate.
+To create a client object to access the Azure Maps Route APIs, you will need a `credential` object. The Azure Maps Route client can use a Microsoft Entra ID credential or an Azure Key credential to authenticate.
 
-#### Using an Azure Active Directory Credential
+#### Using a Microsoft Entra ID Credential
 
-You can authenticate with Azure Active Directory using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
+You can authenticate with Microsoft Entra ID using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 
 ```bash
 npm install @azure/identity
 ```
 
-You will also need to register a new AAD application and grant access to Azure Maps by assigning the suitable role to your service principal. Please refer to the [Manage authentication](https://docs.microsoft.com/azure/azure-maps/how-to-manage-authentication) page.
+You will also need to register a new Microsoft Entra ID application and grant access to Azure Maps by assigning the suitable role to your service principal. Please refer to the [Manage authentication](https://docs.microsoft.com/azure/azure-maps/how-to-manage-authentication) page.
 
-Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
+Set the values of the client ID, tenant ID, and client secret of the Microsoft Entra ID application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 
 You will also need to specify the Azure Maps resource you intend to use by specifying the `clientId` in the client options.
 The Azure Maps resource client id can be found in the Authentication sections in the Azure Maps resource. Please refer to the [documentation](https://docs.microsoft.com/azure/azure-maps/how-to-manage-authentication#view-authentication-details) on how to find it.
@@ -89,33 +89,33 @@ npm install @azure/core-auth
 Finally, you can use the SAS token to authenticate the client:
 
 ```javascript
-  const MapsRoute = require("@azure-rest/maps-route").default;
-  const { AzureSASCredential } = require("@azure/core-auth");
-  const { DefaultAzureCredential } = require("@azure/identity");
-  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+const MapsRoute = require("@azure-rest/maps-route").default;
+const { AzureSASCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
+const { AzureMapsManagementClient } = require("@azure/arm-maps");
 
-  const subscriptionId = "<subscription ID of the map account>"
-  const resourceGroupName = "<resource group name of the map account>";
-  const accountName = "<name of the map account>";
-  const mapsAccountSasParameters = {
-    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
-    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
-    maxRatePerSecond: 500,
-    principalId: "<principle ID (object ID) of the managed identity>",
-    signingKey: "primaryKey",
-  };
-  const credential = new DefaultAzureCredential();
-  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
-  const {accountSasToken} = await managementClient.accounts.listSas(
-    resourceGroupName,
-    accountName,
-    mapsAccountSasParameters
-  );
-  if (accountSasToken === undefined) {
-    throw new Error("No accountSasToken was found for the Maps Account.");
-  }
-  const sasCredential = new AzureSASCredential(accountSasToken);
-  const client = MapsRoute(sasCredential);
+const subscriptionId = "<subscription ID of the map account>";
+const resourceGroupName = "<resource group name of the map account>";
+const accountName = "<name of the map account>";
+const mapsAccountSasParameters = {
+  start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+  expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+  maxRatePerSecond: 500,
+  principalId: "<principle ID (object ID) of the managed identity>",
+  signingKey: "primaryKey",
+};
+const credential = new DefaultAzureCredential();
+const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+const { accountSasToken } = await managementClient.accounts.listSas(
+  resourceGroupName,
+  accountName,
+  mapsAccountSasParameters,
+);
+if (accountSasToken === undefined) {
+  throw new Error("No accountSasToken was found for the Maps Account.");
+}
+const sasCredential = new AzureSASCredential(accountSasToken);
+const client = MapsRoute(sasCredential);
 ```
 
 ## Examples
@@ -165,13 +165,13 @@ if (isUnexpected(routeDirectionsResult2)) {
 
 routeDirectionsResult2.body.routes.forEach(({ summary, legs }) => {
   console.log(
-    `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+    `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
   );
   legs.forEach(({ summary, points }, idx) => {
     console.log(
       `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
         summary.travelTimeInSeconds
-      } seconds. Followings are the first 10 points: `
+      } seconds. Followings are the first 10 points: `,
     );
     console.table(points.slice(0, 10));
   });
@@ -210,13 +210,13 @@ if (isUnexpected(routeDirectionsResult)) {
 
 routeDirectionsResult.body.routes.forEach(({ summary, legs }) => {
   console.log(
-    `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+    `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
   );
   legs.forEach(({ summary, points }, idx) => {
     console.log(
       `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
         summary.travelTimeInSeconds
-      } seconds. Followings are the first 10 points: `
+      } seconds. Followings are the first 10 points: `,
     );
     console.table(points.slice(0, 10));
   });
@@ -257,13 +257,13 @@ if (isUnexpected(routeDirectionsResult)) {
   throw routeDirectionsResult.body.error;
 }
 
-const { summary } = routeDirectionsResult.body.routes[0]; 
+const { summary } = routeDirectionsResult.body.routes[0];
 console.log(
-  `The optimized distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+  `The optimized distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
 );
 console.log("The route is optimized by: ");
 routeDirectionsResult.body.optimizedWaypoints.forEach(
-  ({ providedIndex, optimizedIndex }) => `Moving index ${providedIndex} to ${optimizedIndex}`
+  ({ providedIndex, optimizedIndex }) => `Moving index ${providedIndex} to ${optimizedIndex}`,
 );
 ```
 

--- a/sdk/maps/maps-route-rest/assets.json
+++ b/sdk/maps/maps-route-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/maps/maps-route-rest",
-  "Tag": "js/maps/maps-route-rest_473546f695"
+  "Tag": "js/maps/maps-route-rest_e57e383384"
 }

--- a/sdk/maps/maps-route-rest/karma.conf.js
+++ b/sdk/maps/maps-route-rest/karma.conf.js
@@ -51,11 +51,7 @@ module.exports = function (config) {
       // "dist-test/index.js": ["coverage"]
     },
 
-    envPreprocessor: [
-      "TEST_MODE",
-      "MAPS_RESOURCE_CLIENT_ID",
-      "RECORDINGS_RELATIVE_PATH",
-    ],
+    envPreprocessor: ["TEST_MODE", "MAPS_RESOURCE_CLIENT_ID", "RECORDINGS_RELATIVE_PATH"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/maps/maps-route-rest/karma.conf.js
+++ b/sdk/maps/maps-route-rest/karma.conf.js
@@ -53,11 +53,7 @@ module.exports = function (config) {
 
     envPreprocessor: [
       "TEST_MODE",
-      "MAPS_SUBSCRIPTION_KEY",
       "MAPS_RESOURCE_CLIENT_ID",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_CLIENT_ID",
-      "AZURE_TENANT_ID",
       "RECORDINGS_RELATIVE_PATH",
     ],
 

--- a/sdk/maps/maps-route-rest/sample.env
+++ b/sdk/maps/maps-route-rest/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-route-rest/samples-dev/directions.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/directions.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples-dev/directions.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/directions.ts
@@ -5,8 +5,7 @@
  * @summary Demonstrates the use of a MapsRoute to calculate routes.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, {
   createRouteDirectionsBatchRequest,
   isUnexpected,
@@ -18,26 +17,27 @@ import MapsRoute, {
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
+  
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   /**
    * Should provide at least two coordinates, origin and destination to the query.
@@ -75,10 +75,10 @@ async function main() {
     console.log(
       `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
     );
-    legs.forEach(({ summary, points }, idx) => {
+    legs.forEach(({ summary: legSummary, points }, idx) => {
       console.log(
-        `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
-          summary.travelTimeInSeconds
+        `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+          legSummary.travelTimeInSeconds
         } seconds. Followings are the first 10 points: `,
       );
       console.table(points.slice(0, 10));
@@ -133,10 +133,10 @@ async function main() {
     console.log(
       `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
     );
-    legs.forEach(({ summary, points }, idx) => {
+    legs.forEach(({ summary: letSummary, points }, idx) => {
       console.log(
-        `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
-          summary.travelTimeInSeconds
+        `The ${idx + 1}th leg's length is ${letSummary.lengthInMeters} meters, and it takes ${
+          letSummary.travelTimeInSeconds
         } seconds. Followings are the first 10 points: `,
       );
       console.table(points.slice(0, 10));
@@ -194,14 +194,14 @@ async function main() {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: routeSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
+          `The total distance is ${routeSummary.lengthInMeters} meters, and it takes ${routeSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
-              summary.travelTimeInSeconds
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+              legSummary.travelTimeInSeconds
             } seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));

--- a/sdk/maps/maps-route-rest/samples-dev/directions.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/directions.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  
+
   /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";

--- a/sdk/maps/maps-route-rest/samples-dev/directions.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/directions.ts
@@ -21,15 +21,15 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
   
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples-dev/lro.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/lro.ts
@@ -5,8 +5,7 @@
  * @summary Demonstrates how to manipulate a long running request.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, {
   createRouteDirectionsBatchRequest,
   getLongRunningPoller,
@@ -22,16 +21,16 @@ dotenv.config();
  * But the same approach can be used in:
  *  - "/route/matrix/"
  */
-async function main() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
+async function main(): Promise<void> {
+  /** Use Azure AD authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
 
-  /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsRoute(credential, mapsClientId);
+  /** Use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const request = createRouteDirectionsBatchRequest([
     {
@@ -74,7 +73,7 @@ async function main() {
   logBatchResponse(finalResult as RouteGetRouteDirectionsBatch200Response);
 }
 
-function logBatchResponse(result: RouteGetRouteDirectionsBatch200Response) {
+function logBatchResponse(result: RouteGetRouteDirectionsBatch200Response): void {
   const { summary, batchItems } = result.body;
   console.log(`${summary.successfulRequests}/${summary.totalRequests} requests succeeded.`);
   batchItems.forEach((item, index) => {
@@ -82,14 +81,14 @@ function logBatchResponse(result: RouteGetRouteDirectionsBatch200Response) {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: itemSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
+          `The total distance is ${itemSummary.lengthInMeters} meters, and it takes ${itemSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
-              summary.travelTimeInSeconds
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+              legSummary.travelTimeInSeconds
             } seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));

--- a/sdk/maps/maps-route-rest/samples-dev/lro.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/lro.ts
@@ -22,7 +22,7 @@ dotenv.config();
  *  - "/route/matrix/"
  */
 async function main(): Promise<void> {
-  /** Use Azure AD authentication (Recommended) */
+  /** Use Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples-dev/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/matrix.ts
@@ -19,7 +19,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples-dev/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/matrix.ts
@@ -16,14 +16,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples-dev/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/matrix.ts
@@ -1,38 +1,37 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates the use of a MapsRoute to retrieve a setting value.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, { RouteGetRouteMatrix200Response, isUnexpected } from "@azure-rest/maps-route";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   /**
    * Calculate route matrix in synchronous way.
@@ -74,7 +73,7 @@ async function main() {
   );
   matrix.forEach((row) => {
     row.forEach((cell) => {
-      cell.response && console.dir(cell.response.routeSummary);
+      if(cell.response) console.dir(cell.response.routeSummary);
     });
   });
 }

--- a/sdk/maps/maps-route-rest/samples-dev/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/matrix.ts
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
   );
   matrix.forEach((row) => {
     row.forEach((cell) => {
-      if(cell.response) console.dir(cell.response.routeSummary);
+      if (cell.response) console.dir(cell.response.routeSummary);
     });
   });
 }

--- a/sdk/maps/maps-route-rest/samples-dev/range.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/range.ts
@@ -16,14 +16,14 @@ async function main():Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples-dev/range.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/range.ts
@@ -12,7 +12,7 @@ import MapsRoute, { isUnexpected } from "@azure-rest/maps-route";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main():Promise<void> {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)

--- a/sdk/maps/maps-route-rest/samples-dev/range.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/range.ts
@@ -1,38 +1,37 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates the use of a MapsRoute to retrieve a route range.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, { isUnexpected } from "@azure-rest/maps-route";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main() {
+async function main():Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const routeRangeResult = await client
     .path("/route/range/{format}", "json")

--- a/sdk/maps/maps-route-rest/samples-dev/range.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/range.ts
@@ -19,7 +19,7 @@ async function main():Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples-dev/resumeLro.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/resumeLro.ts
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);
-  
+
   /** Use subscription key authentication */
   // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
   // const credential = new AzureKeyCredential(subscriptionKey);

--- a/sdk/maps/maps-route-rest/samples-dev/resumeLro.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/resumeLro.ts
@@ -25,7 +25,7 @@ dotenv.config();
  *  - "/route/matrix/"
  */
 async function main(): Promise<void> {
-  /** Or use Azure AD authentication */
+  /** Or use Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples-dev/resumeLro.ts
+++ b/sdk/maps/maps-route-rest/samples-dev/resumeLro.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates how to resume a long running request.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, {
   createRouteDirectionsBatchRequest,
   getLongRunningPoller,
@@ -25,16 +24,16 @@ dotenv.config();
  * But the same approach can be used in:
  *  - "/route/matrix/"
  */
-async function main() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
+async function main(): Promise<void> {
   /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+  
+  /** Use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const request = createRouteDirectionsBatchRequest([
     {
@@ -89,14 +88,14 @@ async function main() {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: routeSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
+          `The total distance is ${routeSummary.lengthInMeters} meters, and it takes ${routeSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${
-              summary.travelTimeInSeconds
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+              legSummary.travelTimeInSeconds
             } seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/README.md
@@ -43,7 +43,7 @@ node directions.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node directions.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node directions.js
 ```
 
 ## Next Steps

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/directions.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/directions.js
@@ -20,15 +20,15 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
 
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/directions.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/directions.js
@@ -23,7 +23,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/directions.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/directions.js
@@ -5,8 +5,7 @@
  * @summary Demonstrates the use of a MapsRoute to calculate routes.
  */
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-// import { DefaultAzureCredential } from "@azure/identity";
+const { DefaultAzureCredential } = require("@azure/identity");
 const MapsRoute = require("@azure-rest/maps-route").default,
   {
     createRouteDirectionsBatchRequest,
@@ -23,20 +22,21 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
 
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   /**
    * Should provide at least two coordinates, origin and destination to the query.
@@ -72,12 +72,11 @@ async function main() {
 
   getRouteDirectionsResult.body.routes.forEach(({ summary, legs }) => {
     console.log(
-      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
     );
-    legs.forEach(({ summary, points }, idx) => {
+    legs.forEach(({ summary: legSummary, points }, idx) => {
       console.log(
-        `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-        } seconds. Followings are the first 10 points: `
+        `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${legSummary.travelTimeInSeconds} seconds. Followings are the first 10 points: `,
       );
       console.table(points.slice(0, 10));
     });
@@ -129,12 +128,11 @@ async function main() {
 
   getRouteDirectionsResult.body.routes.forEach(({ summary, legs }) => {
     console.log(
-      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
     );
-    legs.forEach(({ summary, points }, idx) => {
+    legs.forEach(({ summary: letSummary, points }, idx) => {
       console.log(
-        `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-        } seconds. Followings are the first 10 points: `
+        `The ${idx + 1}th leg's length is ${letSummary.lengthInMeters} meters, and it takes ${letSummary.travelTimeInSeconds} seconds. Followings are the first 10 points: `,
       );
       console.table(points.slice(0, 10));
     });
@@ -189,14 +187,13 @@ async function main() {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: routeSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+          `The total distance is ${routeSummary.lengthInMeters} meters, and it takes ${routeSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-            } seconds. Followings are the first 10 points: `
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${legSummary.travelTimeInSeconds} seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));
         });

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/lro.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/lro.js
@@ -5,8 +5,7 @@
  * @summary Demonstrates how to manipulate a long running request.
  */
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-// import { DefaultAzureCredential } from "@azure/identity";
+const { DefaultAzureCredential } = require("@azure/identity");
 const MapsRoute = require("@azure-rest/maps-route").default,
   {
     createRouteDirectionsBatchRequest,
@@ -21,15 +20,15 @@ require("dotenv").config();
  *  - "/route/matrix/"
  */
 async function main() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
+  /** Use Azure AD authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
 
-  /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsRoute(credential, mapsClientId);
+  /** Use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const request = createRouteDirectionsBatchRequest([
     {
@@ -80,14 +79,13 @@ function logBatchResponse(result) {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: itemSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+          `The total distance is ${itemSummary.lengthInMeters} meters, and it takes ${itemSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-            } seconds. Followings are the first 10 points: `
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${legSummary.travelTimeInSeconds} seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));
         });

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/lro.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/lro.js
@@ -20,7 +20,7 @@ require("dotenv").config();
  *  - "/route/matrix/"
  */
 async function main() {
-  /** Use Azure AD authentication (Recommended) */
+  /** Use Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
@@ -16,14 +16,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates the use of a MapsRoute to retrieve a setting value.
  */
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-// import { DefaultAzureCredential } from "@azure/identity";
+const { DefaultAzureCredential } = require("@azure/identity");
 const MapsRoute = require("@azure-rest/maps-route").default,
   { isUnexpected } = require("@azure-rest/maps-route");
 
@@ -19,20 +18,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   /**
    * Calculate route matrix in synchronous way.
@@ -70,11 +69,11 @@ async function main() {
 
   const { summary, matrix } = routeMatrixResult.body;
   console.log(
-    `${summary.successfulRoutes}/${summary.totalRoutes} routes are successfully calculated. Following is the detailed info:`
+    `${summary.successfulRoutes}/${summary.totalRoutes} routes are successfully calculated. Following is the detailed info:`,
   );
   matrix.forEach((row) => {
     row.forEach((cell) => {
-      cell.response && console.dir(cell.response.routeSummary);
+      if (cell.response) console.dir(cell.response.routeSummary);
     });
   });
 }

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/matrix.js
@@ -19,7 +19,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/package.json
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "@azure-rest/maps-route": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0"
+    "@azure/identity": "^4.0.1"
   }
 }

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
@@ -16,14 +16,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates the use of a MapsRoute to retrieve a route range.
  */
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-// import { DefaultAzureCredential } from "@azure/identity";
+const { DefaultAzureCredential } = require("@azure/identity");
 const MapsRoute = require("@azure-rest/maps-route").default,
   { isUnexpected } = require("@azure-rest/maps-route");
 
@@ -19,20 +18,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const routeRangeResult = await client
     .path("/route/range/{format}", "json")

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/range.js
@@ -19,7 +19,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/resumeLro.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/resumeLro.js
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates how to resume a long running request.
  */
 
-const { AzureKeyCredential } = require("@azure/core-auth");
-// import { DefaultAzureCredential } from "@azure/identity";
+const { DefaultAzureCredential } = require("@azure/identity");
 const MapsRoute = require("@azure-rest/maps-route").default,
   {
     createRouteDirectionsBatchRequest,
@@ -24,15 +23,15 @@ require("dotenv").config();
  *  - "/route/matrix/"
  */
 async function main() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const request = createRouteDirectionsBatchRequest([
     {
@@ -87,14 +86,13 @@ async function main() {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: routeSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+          `The total distance is ${routeSummary.lengthInMeters} meters, and it takes ${routeSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-            } seconds. Followings are the first 10 points: `
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${legSummary.travelTimeInSeconds} seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));
         });

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/resumeLro.js
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/resumeLro.js
@@ -23,7 +23,7 @@ require("dotenv").config();
  *  - "/route/matrix/"
  */
 async function main() {
-  /** Or use Azure AD authentication */
+  /** Or use Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/javascript/sample.env
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/javascript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/README.md
@@ -55,7 +55,7 @@ node dist/directions.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node dist/directions.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node dist/directions.js
 ```
 
 ## Next Steps

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@azure-rest/maps-route": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0"
+    "@azure/identity": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/sample.env
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/directions.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/directions.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/directions.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/directions.ts
@@ -5,8 +5,7 @@
  * @summary Demonstrates the use of a MapsRoute to calculate routes.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, {
   createRouteDirectionsBatchRequest,
   isUnexpected,
@@ -18,26 +17,27 @@ import MapsRoute, {
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
+  
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   /**
    * Should provide at least two coordinates, origin and destination to the query.
@@ -73,12 +73,13 @@ async function main() {
 
   getRouteDirectionsResult.body.routes.forEach(({ summary, legs }) => {
     console.log(
-      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
     );
-    legs.forEach(({ summary, points }, idx) => {
+    legs.forEach(({ summary: legSummary, points }, idx) => {
       console.log(
-        `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-        } seconds. Followings are the first 10 points: `
+        `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+          legSummary.travelTimeInSeconds
+        } seconds. Followings are the first 10 points: `,
       );
       console.table(points.slice(0, 10));
     });
@@ -130,12 +131,13 @@ async function main() {
 
   getRouteDirectionsResult.body.routes.forEach(({ summary, legs }) => {
     console.log(
-      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+      `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`,
     );
-    legs.forEach(({ summary, points }, idx) => {
+    legs.forEach(({ summary: letSummary, points }, idx) => {
       console.log(
-        `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-        } seconds. Followings are the first 10 points: `
+        `The ${idx + 1}th leg's length is ${letSummary.lengthInMeters} meters, and it takes ${
+          letSummary.travelTimeInSeconds
+        } seconds. Followings are the first 10 points: `,
       );
       console.table(points.slice(0, 10));
     });
@@ -183,24 +185,24 @@ async function main() {
     throw routeDirectionBatchInitRes.body.error;
   }
 
-  const {
-    summary,
-    batchItems,
-  } = (routeDirectionBatchInitRes as RouteRequestRouteDirectionsBatchSync200Response).body;
+  const { summary, batchItems } = (
+    routeDirectionBatchInitRes as RouteRequestRouteDirectionsBatchSync200Response
+  ).body;
   console.log(`${summary.successfulRequests}/${summary.totalRequests} requests succeeded.`);
   batchItems.forEach((item, index) => {
     if (item.response.error) {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: routeSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+          `The total distance is ${routeSummary.lengthInMeters} meters, and it takes ${routeSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-            } seconds. Followings are the first 10 points: `
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+              legSummary.travelTimeInSeconds
+            } seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));
         });

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/directions.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/directions.ts
@@ -21,15 +21,15 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
   
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/lro.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/lro.ts
@@ -5,8 +5,7 @@
  * @summary Demonstrates how to manipulate a long running request.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, {
   createRouteDirectionsBatchRequest,
   getLongRunningPoller,
@@ -22,16 +21,16 @@ dotenv.config();
  * But the same approach can be used in:
  *  - "/route/matrix/"
  */
-async function main() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
+async function main(): Promise<void> {
+  /** Use Azure AD authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
 
-  /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsRoute(credential, mapsClientId);
+  /** Use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const request = createRouteDirectionsBatchRequest([
     {
@@ -74,7 +73,7 @@ async function main() {
   logBatchResponse(finalResult as RouteGetRouteDirectionsBatch200Response);
 }
 
-function logBatchResponse(result: RouteGetRouteDirectionsBatch200Response) {
+function logBatchResponse(result: RouteGetRouteDirectionsBatch200Response): void {
   const { summary, batchItems } = result.body;
   console.log(`${summary.successfulRequests}/${summary.totalRequests} requests succeeded.`);
   batchItems.forEach((item, index) => {
@@ -82,14 +81,15 @@ function logBatchResponse(result: RouteGetRouteDirectionsBatch200Response) {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: itemSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+          `The total distance is ${itemSummary.lengthInMeters} meters, and it takes ${itemSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-            } seconds. Followings are the first 10 points: `
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+              legSummary.travelTimeInSeconds
+            } seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));
         });

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/lro.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/lro.ts
@@ -22,7 +22,7 @@ dotenv.config();
  *  - "/route/matrix/"
  */
 async function main(): Promise<void> {
-  /** Use Azure AD authentication (Recommended) */
+  /** Use Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
@@ -19,7 +19,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
@@ -16,14 +16,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/matrix.ts
@@ -1,38 +1,37 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates the use of a MapsRoute to retrieve a setting value.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, { RouteGetRouteMatrix200Response, isUnexpected } from "@azure-rest/maps-route";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main() {
+async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   /**
    * Calculate route matrix in synchronous way.
@@ -70,11 +69,11 @@ async function main() {
 
   const { summary, matrix } = (routeMatrixResult as RouteGetRouteMatrix200Response).body;
   console.log(
-    `${summary.successfulRoutes}/${summary.totalRoutes} routes are successfully calculated. Following is the detailed info:`
+    `${summary.successfulRoutes}/${summary.totalRoutes} routes are successfully calculated. Following is the detailed info:`,
   );
   matrix.forEach((row) => {
     row.forEach((cell) => {
-      cell.response && console.dir(cell.response.routeSummary);
+      if(cell.response) console.dir(cell.response.routeSummary);
     });
   });
 }

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
@@ -16,14 +16,14 @@ async function main():Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
@@ -1,38 +1,37 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates the use of a MapsRoute to retrieve a route range.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, { isUnexpected } from "@azure-rest/maps-route";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
 
-async function main() {
+async function main():Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const routeRangeResult = await client
     .path("/route/range/{format}", "json")

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/range.ts
@@ -19,7 +19,7 @@ async function main():Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/resumeLro.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/resumeLro.ts
@@ -25,7 +25,7 @@ dotenv.config();
  *  - "/route/matrix/"
  */
 async function main(): Promise<void> {
-  /** Or use Azure AD authentication */
+  /** Or use Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsRoute(credential, mapsClientId);

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/resumeLro.ts
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/src/resumeLro.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * @summary Demonstrates how to resume a long running request.
  */
 
-import { AzureKeyCredential } from "@azure/core-auth";
-// import { DefaultAzureCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import MapsRoute, {
   createRouteDirectionsBatchRequest,
   getLongRunningPoller,
@@ -25,16 +24,16 @@ dotenv.config();
  * But the same approach can be used in:
  *  - "/route/matrix/"
  */
-async function main() {
-  /** Use subscription key authentication */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsRoute(credential);
-
+async function main(): Promise<void> {
   /** Or use Azure AD authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = new MapsRoute(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsRoute(credential, mapsClientId);
+  
+  /** Use subscription key authentication */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsRoute(credential);
 
   const request = createRouteDirectionsBatchRequest([
     {
@@ -89,14 +88,15 @@ async function main() {
       console.error(`Request ${index} failed with error: ${item.response.error.message}`);
     } else {
       console.log(`Request ${index} success!`);
-      item.response.routes.forEach(({ summary, legs }) => {
+      item.response.routes.forEach(({ summary: routeSummary, legs }) => {
         console.log(
-          `The total distance is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds} seconds.`
+          `The total distance is ${routeSummary.lengthInMeters} meters, and it takes ${routeSummary.travelTimeInSeconds} seconds.`,
         );
-        legs.forEach(({ summary, points }, idx) => {
+        legs.forEach(({ summary: legSummary, points }, idx) => {
           console.log(
-            `The ${idx + 1}th leg's length is ${summary.lengthInMeters} meters, and it takes ${summary.travelTimeInSeconds
-            } seconds. Followings are the first 10 points: `
+            `The ${idx + 1}th leg's length is ${legSummary.lengthInMeters} meters, and it takes ${
+              legSummary.travelTimeInSeconds
+            } seconds. Followings are the first 10 points: `,
           );
           console.table(points.slice(0, 10));
         });

--- a/sdk/maps/maps-route-rest/samples/v1-beta/typescript/tsconfig.json
+++ b/sdk/maps/maps-route-rest/samples/v1-beta/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/sdk/maps/maps-route-rest/src/mapsRoute.ts
+++ b/sdk/maps/maps-route-rest/src/mapsRoute.ts
@@ -94,7 +94,7 @@ export default function MapsRoute(
     client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
-        scopes: `${options.baseUrl || "https://atlas.microsoft.com"}/.default`,
+        scopes: "https://atlas.microsoft.com/.default",
       }),
     );
     client.pipeline.addPolicy(createMapsClientIdPolicy(clientId));

--- a/sdk/maps/maps-route-rest/src/mapsRoute.ts
+++ b/sdk/maps/maps-route-rest/src/mapsRoute.ts
@@ -81,7 +81,7 @@ export default function MapsRoute(
   const options = typeof clientIdOrOptions === "string" ? maybeOptions : clientIdOrOptions;
 
   /**
-   * maps service requires a header "ms-x-client-id", which is different from the standard AAD.
+   * maps service requires a header "ms-x-client-id", which is different from the standard Microsoft Entra ID.
    * So we need to do our own implementation.
    * This customized authentication is following by this guide: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-customization.md#custom-authentication
    */

--- a/sdk/maps/maps-route-rest/swagger/README.md
+++ b/sdk/maps/maps-route-rest/swagger/README.md
@@ -24,7 +24,7 @@ source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/maps/data-plane/Route/preview/1.0/route.json
 package-version: 1.0.0-beta.4
 rest-level-client: true
-# Although maps-route supports key-credentials and AAD, maps-route requires header "ms-x-client-id", which is different from the standard AAD, so we don't generate AAD code and implement ourselves.
+# Although maps-route supports key-credentials and Microsoft Entra ID, maps-route requires header "ms-x-client-id", which is different from the standard Microsoft Entra ID, so we don't generate Microsoft Entra ID code and implement ourselves.
 # For auth configuration, please refer to: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-quickstart.md#how-to-configure-authentication
 security: AzureKey
 security-header-name: subscription-key

--- a/sdk/maps/maps-route-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-route-rest/test/public/utils/recordedClient.ts
@@ -33,10 +33,6 @@ export const testLogger = createClientLogger("route-test");
 
 export function createClient(options?: ClientOptions): MapsRouteClient {
   const credential = createTestCredential();
-  const client = MapsRoute(
-    credential,
-    env["MAPS_RESOURCE_CLIENT_ID"] as string,
-    options,
-  );
+  const client = MapsRoute(credential, env["MAPS_RESOURCE_CLIENT_ID"] as string, options);
   return client;
 }

--- a/sdk/maps/maps-route-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-route-rest/test/public/utils/recordedClient.ts
@@ -5,17 +5,13 @@ import { Context } from "mocha";
 import { Recorder, RecorderStartOptions, env } from "@azure-tools/test-recorder";
 import "./env";
 import { createClientLogger } from "@azure/logger";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { createTestCredential } from "@azure-tools/test-credential";
 import MapsRoute from "../../../src/mapsRoute";
 import { ClientOptions } from "@azure-rest/core-client";
 import { MapsRouteClient } from "../../../src/generated";
 
 const envSetupForPlayback: Record<string, string> = {
-  AZURE_CLIENT_ID: "azure_client_id",
-  AZURE_CLIENT_SECRET: "azure_client_secret",
-  AZURE_TENANT_ID: "88888888-8888-8888-8888-888888888888",
   MAPS_RESOURCE_CLIENT_ID: "azure_maps_client_id",
-  MAPS_SUBSCRIPTION_KEY: "azure_maps_subscription_key",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {
@@ -36,6 +32,11 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 export const testLogger = createClientLogger("route-test");
 
 export function createClient(options?: ClientOptions): MapsRouteClient {
-  const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] ?? "");
-  return MapsRoute(credential, options);
+  const credential = createTestCredential();
+  const client = MapsRoute(
+    credential,
+    env["MAPS_RESOURCE_CLIENT_ID"] as string,
+    options,
+  );
+  return client;
 }

--- a/sdk/maps/maps-route-rest/tests.yml
+++ b/sdk/maps/maps-route-rest/tests.yml
@@ -6,8 +6,4 @@ extends:
       PackageName: "@azure-rest/maps-route"
       ServiceDirectory: maps
       SupportedClouds: 'Public,Canary'
-      EnvVars:
-        AZURE_CLIENT_ID: $(MAPS_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(MAPS_CLIENT_SECRET)
-        AZURE_TENANT_ID: $(MAPS_TENANT_ID)
-        AZURE_SUBSCRIPTION_ID: $(MAPS_SUBSCRIPTION_ID)
+      UseFederatedAuth: true

--- a/sdk/maps/maps-search-rest/README.md
+++ b/sdk/maps/maps-search-rest/README.md
@@ -45,19 +45,19 @@ npm install @azure-rest/maps-search
 
 ### Create and authenticate a `MapsSearchClient`
 
-To create a client object to access the Azure Maps Search APIs, you will need a `credential` object. The Azure Maps Search client can use an Azure Active Directory credential or an Azure Key credential to authenticate.
+To create a client object to access the Azure Maps Search APIs, you will need a `credential` object. The Azure Maps Search client can use a Microsoft Entra ID credential or an Azure Key credential to authenticate.
 
-#### Using an Azure Active Directory Credential
+#### Using a Microsoft Entra ID Credential
 
-You can authenticate with Azure Active Directory using the [Azure Identity library](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity). To use the [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential) provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
+You can authenticate with Microsoft Entra ID using the [Azure Identity library](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity). To use the [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential) provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 
 ```bash
 npm install @azure/identity
 ```
 
-You will also need to register a new AAD application and grant access to Azure Maps by assigning the suitable role to your service principal. Please refer to the [Manage authentication](https://docs.microsoft.com/azure/azure-maps/how-to-manage-authentication) page.
+You will also need to register a new Microsoft Entra ID application and grant access to Azure Maps by assigning the suitable role to your service principal. Please refer to the [Manage authentication](https://docs.microsoft.com/azure/azure-maps/how-to-manage-authentication) page.
 
-Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
+Set the values of the client ID, tenant ID, and client secret of the Microsoft Entra ID application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 
 You will also need to specify the Azure Maps resource you intend to use by specifying the `clientId` in the client options.
 The Azure Maps resource client id can be found in the Authentication sections in the Azure Maps resource. Please refer to the [documentation](https://docs.microsoft.com/azure/azure-maps/how-to-manage-authentication#view-authentication-details) on how to find it.
@@ -99,33 +99,33 @@ npm install @azure/core-auth
 Finally, you can use the SAS token to authenticate the client:
 
 ```javascript
-  const MapsSearch = require("@azure-rest/maps-search").default;
-  const { AzureSASCredential } = require("@azure/core-auth");
-  const { DefaultAzureCredential } = require("@azure/identity");
-  const { AzureMapsManagementClient } = require("@azure/arm-maps");
+const MapsSearch = require("@azure-rest/maps-search").default;
+const { AzureSASCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
+const { AzureMapsManagementClient } = require("@azure/arm-maps");
 
-  const subscriptionId = "<subscription ID of the map account>"
-  const resourceGroupName = "<resource group name of the map account>";
-  const accountName = "<name of the map account>";
-  const mapsAccountSasParameters = {
-    start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
-    expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
-    maxRatePerSecond: 500,
-    principalId: "<principle ID (object ID) of the managed identity>",
-    signingKey: "primaryKey",
-  };
-  const credential = new DefaultAzureCredential();
-  const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
-  const {accountSasToken} = await managementClient.accounts.listSas(
-    resourceGroupName,
-    accountName,
-    mapsAccountSasParameters
-  );
-  if (accountSasToken === undefined) {
-    throw new Error("No accountSasToken was found for the Maps Account.");
-  }
-  const sasCredential = new AzureSASCredential(accountSasToken);
-  const client = MapsSearch(sasCredential);
+const subscriptionId = "<subscription ID of the map account>";
+const resourceGroupName = "<resource group name of the map account>";
+const accountName = "<name of the map account>";
+const mapsAccountSasParameters = {
+  start: "<start time in ISO format>", // e.g. "2023-11-24T03:51:53.161Z"
+  expiry: "<expiry time in ISO format>", // maximum value to start + 1 day
+  maxRatePerSecond: 500,
+  principalId: "<principle ID (object ID) of the managed identity>",
+  signingKey: "primaryKey",
+};
+const credential = new DefaultAzureCredential();
+const managementClient = new AzureMapsManagementClient(credential, subscriptionId);
+const { accountSasToken } = await managementClient.accounts.listSas(
+  resourceGroupName,
+  accountName,
+  mapsAccountSasParameters,
+);
+if (accountSasToken === undefined) {
+  throw new Error("No accountSasToken was found for the Maps Account.");
+}
+const sasCredential = new AzureSASCredential(accountSasToken);
+const client = MapsSearch(sasCredential);
 ```
 
 ## Key concepts
@@ -153,7 +153,7 @@ const { isUnexpected } = require("@azure-rest/maps-search");
 /** Initialize the MapsSearchClient */
 const client = MapsSearch(new AzureKeyCredential("<subscription-key>"));
 
-async function main(){
+async function main() {
   /** Make a request to the geocoding API */
   const response = await client
     .path("/geocode")
@@ -167,10 +167,10 @@ async function main(){
     console.log(`No coordinates found for the address.`);
   } else {
     console.log(`The followings are the possible coordinates of the address:`);
-    for(const result of response.body.features) {
+    for (const result of response.body.features) {
       const [lon, lat] = result.geometry.coordinates;
       console.log(`Latitude: ${lat}, Longitude ${lon}`);
-      console.log("Postal code: ", result.properties?.address?.postalCode)
+      console.log("Postal code: ", result.properties?.address?.postalCode);
       console.log("Admin districts: ", result.properties?.address?.adminDistricts?.join(", "));
       console.log("Country region: ", result.properties?.address?.countryRegion);
     }
@@ -178,8 +178,8 @@ async function main(){
 }
 
 main().catch((err) => {
-    console.log(err);
-})
+  console.log(err);
+});
 ```
 
 ### Make a Reverse Address Search to translate coordinate location to street address
@@ -195,7 +195,7 @@ const { isUnexpected } = require("@azure-rest/maps-search");
 /** Initialize the MapsSearchClient */
 const client = MapsSearch(new AzureKeyCredential("<subscription-key>"));
 
-async function main(){
+async function main() {
   /** Make the request. */
   const response = await client.path("/reverseGeocode").get({
     queryParameters: { coordinates: [-121.89, 37.337] }, // [longitude, latitude],
@@ -208,7 +208,7 @@ async function main(){
     console.log("No results found.");
   } else {
     /** Log the response body. */
-    for(const feature of response.body.features) {
+    for (const feature of response.body.features) {
       if (feature.properties?.address?.formattedAddress) {
         console.log(feature.properties.address.formattedAddress);
       } else {
@@ -219,8 +219,8 @@ async function main(){
 }
 
 main().catch((err) => {
-    console.log(err);
-})
+  console.log(err);
+});
 ```
 
 ## Use V1 SDK
@@ -263,7 +263,7 @@ async function searchNearby(address) {
   }
 
   const [lon, lat] = geocodeResponse.body.features[0].geometry.coordinates;
-  
+
   /** Make a request to the search nearby API */
   const nearByResponse = await clientV1.path("/search/nearby/{format}", "json").get({
     queryParameters: { lat, lon },
@@ -273,22 +273,22 @@ async function searchNearby(address) {
     throw nearByResponse.body.error;
   }
   /** Log response body */
-  for(const results of nearByResponse.body.results) {
+  for (const results of nearByResponse.body.results) {
     console.log(
       `${result.poi ? result.poi.name + ":" : ""} ${result.address.freeformAddress}. (${
         result.position.lat
-      }, ${result.position.lon})\n`
+      }, ${result.position.lon})\n`,
     );
   }
 }
 
-async function main(){
+async function main() {
   searchNearBy("15127 NE 24th Street, Redmond, WA 98052");
 }
 
 main().catch((err) => {
-    console.log(err);
-})
+  console.log(err);
+});
 ```
 
 ## Troubleshooting

--- a/sdk/maps/maps-search-rest/assets.json
+++ b/sdk/maps/maps-search-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/maps/maps-search-rest",
-  "Tag": "js/maps/maps-search-rest_aa609e0b56"
+  "Tag": "js/maps/maps-search-rest_02b37595e1"
 }

--- a/sdk/maps/maps-search-rest/karma.conf.js
+++ b/sdk/maps/maps-search-rest/karma.conf.js
@@ -51,11 +51,7 @@ module.exports = function (config) {
       // "dist-test/index.js": ["coverage"]
     },
 
-    envPreprocessor: [
-      "TEST_MODE",
-      "MAPS_RESOURCE_CLIENT_ID",
-      "RECORDINGS_RELATIVE_PATH",
-    ],
+    envPreprocessor: ["TEST_MODE", "MAPS_RESOURCE_CLIENT_ID", "RECORDINGS_RELATIVE_PATH"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/maps/maps-search-rest/karma.conf.js
+++ b/sdk/maps/maps-search-rest/karma.conf.js
@@ -53,11 +53,7 @@ module.exports = function (config) {
 
     envPreprocessor: [
       "TEST_MODE",
-      "MAPS_SUBSCRIPTION_KEY",
       "MAPS_RESOURCE_CLIENT_ID",
-      "AZURE_CLIENT_SECRET",
-      "AZURE_CLIENT_ID",
-      "AZURE_TENANT_ID",
       "RECORDINGS_RELATIVE_PATH",
     ],
 

--- a/sdk/maps/maps-search-rest/sample.env
+++ b/sdk/maps/maps-search-rest/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,20 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
+  /** Azure Active Directory (Azure AD) authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
 
-  /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   /** Make the request. */
   const response = await client

--- a/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication (Recommended) */
+  /** Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocoding.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
@@ -14,15 +14,15 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    * 
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
 
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { GeocodingBatchResponseOutput, isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,21 +16,22 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
-   *
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * 
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
 
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
 
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
+  
   const response = await client.path("/geocode:batch").post({
     body: {
       batchItems: [

--- a/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    * 
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/geocodingBatch.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
-   * 
+   *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
 
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
   // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
   // const credential = new AzureKeyCredential(subscriptionKey);
   // const client = MapsSearch(credential);
-  
+
   const response = await client.path("/geocode:batch").post({
     body: {
       batchItems: [

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Microsoft Entra ID authentication
    *
-  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
@@ -30,7 +30,6 @@ async function main(): Promise<void> {
   // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
   // const credential = new AzureKeyCredential(subscriptionKey);
   // const client = MapsSearch(credential);
-
 
   /** Make the request. */
   const response = await client.path("/reverseGeocode").get({

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,21 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
+
 
   /** Make the request. */
   const response = await client.path("/reverseGeocode").get({

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocoding.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Microsoft Entra ID authentication
    *
-  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { GeocodingBatchResponseOutput, isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,20 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/reverseGeocode:batch").post({
     body: {

--- a/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/reverseGeocodingBatch.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);
-  
+
   /** Shared Key authentication (subscription-key) */
   // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
   // const credential = new AzureKeyCredential(subscriptionKey);

--- a/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,20 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+  
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/search/polygon").get({
     queryParameters: {

--- a/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples-dev/searchPolygons.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/README.md
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/README.md
@@ -43,7 +43,7 @@ node geocoding.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node geocoding.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node geocoding.js
 ```
 
 ## Next Steps

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocoding.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocoding.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication (Recommended) */
+  /** Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocoding.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocoding.js
@@ -3,7 +3,7 @@
 
 const MapsSearch = require("@azure-rest/maps-search").default,
   { isUnexpected } = require("@azure-rest/maps-search");
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
 /**
@@ -15,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
+  /** Azure Active Directory (Azure AD) authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
 
-  /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   /** Make the request. */
   const response = await client

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocoding.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocoding.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocodingBatch.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocodingBatch.js
@@ -3,7 +3,7 @@
 
 const MapsSearch = require("@azure-rest/maps-search").default,
   { isUnexpected } = require("@azure-rest/maps-search");
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
 /**
@@ -15,20 +15,21 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
 
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/geocode:batch").post({
     body: {

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocodingBatch.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocodingBatch.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocodingBatch.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/geocodingBatch.js
@@ -13,15 +13,15 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
 
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/package.json
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure-rest/maps-search": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0"
+    "@azure/identity": "^4.0.1"
   }
 }

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocoding.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocoding.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocoding.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocoding.js
@@ -3,7 +3,7 @@
 
 const MapsSearch = require("@azure-rest/maps-search").default,
   { isUnexpected } = require("@azure-rest/maps-search");
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
 /**
@@ -15,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   /** Make the request. */
   const response = await client.path("/reverseGeocode").get({

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocoding.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocoding.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocodingBatch.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocodingBatch.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocodingBatch.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocodingBatch.js
@@ -3,7 +3,7 @@
 
 const MapsSearch = require("@azure-rest/maps-search").default,
   { isUnexpected } = require("@azure-rest/maps-search");
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
 /**
@@ -15,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/reverseGeocode:batch").post({
     body: {

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocodingBatch.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/reverseGeocodingBatch.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/sample.env
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/searchPolygons.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/searchPolygons.js
@@ -3,7 +3,7 @@
 
 const MapsSearch = require("@azure-rest/maps-search").default,
   { isUnexpected } = require("@azure-rest/maps-search");
-const { AzureKeyCredential } = require("@azure/core-auth");
+const { DefaultAzureCredential } = require("@azure/identity");
 require("dotenv").config();
 
 /**
@@ -15,20 +15,20 @@ async function main() {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/search/polygon").get({
     queryParameters: {

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/searchPolygons.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/searchPolygons.js
@@ -13,14 +13,14 @@ async function main() {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/javascript/searchPolygons.js
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/javascript/searchPolygons.js
@@ -16,7 +16,7 @@ async function main() {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/README.md
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/README.md
@@ -55,7 +55,7 @@ node dist/geocoding.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env MAPS_SUBSCRIPTION_KEY="<maps subscription key>" node dist/geocoding.js
+npx cross-env MAPS_RESOURCE_CLIENT_ID="<maps resource client id>" node dist/geocoding.js
 ```
 
 ## Next Steps

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/package.json
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@azure-rest/maps-search": "next",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.3.0"
+    "@azure/identity": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/sample.env
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/sample.env
@@ -1,8 +1,1 @@
-# Maps subscription key when using AzureKey authentication
-MAPS_SUBSCRIPTION_KEY="<subscription-key>"
-
-# Maps Azure AD authentication
-AZURE_CLIENT_ID="<client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
-AZURE_TENANT_ID="<tenant-id>"
 MAPS_RESOURCE_CLIENT_ID="<maps-resource-client-id>"

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocoding.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,20 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
+  /** Azure Active Directory (Azure AD) authentication (Recommended) */
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
 
-  /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   /** Make the request. */
   const response = await client

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocoding.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication (Recommended) */
+  /** Microsoft Entra ID authentication (Recommended) */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocoding.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocoding.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication. 
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocodingBatch.ts
@@ -14,15 +14,15 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    * 
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
 
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocodingBatch.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { GeocodingBatchResponseOutput, isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,21 +16,22 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
-   *
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * 
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
 
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
 
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
+  
   const response = await client.path("/geocode:batch").post({
     body: {
       batchItems: [

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/geocodingBatch.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    * 
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocoding.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocoding.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,21 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
+
 
   /** Make the request. */
   const response = await client.path("/reverseGeocode").get({

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocoding.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocoding.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocodingBatch.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocodingBatch.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { GeocodingBatchResponseOutput, isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,20 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/reverseGeocode:batch").post({
     body: {

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocodingBatch.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/reverseGeocodingBatch.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+  * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/searchPolygons.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MapsSearch, { isUnexpected } from "@azure-rest/maps-search";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
 
 dotenv.config();
@@ -16,20 +16,20 @@ async function main(): Promise<void> {
    * - Shared Key authentication (subscription-key)
    * - Azure Active Directory (Azure AD) authentication
    *
-   * In this sample you can put MAPS_SUBSCRIPTION_KEY into .env file to use the first approach or populate
-   * the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for trying out AAD auth.
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Shared Key authentication (subscription-key) */
-  const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
-  const credential = new AzureKeyCredential(subscriptionKey);
-  const client = MapsSearch(credential);
-
   /** Azure Active Directory (Azure AD) authentication */
-  // const credential = new DefaultAzureCredential();
-  // const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
-  // const client = MapsSearch(credential, mapsClientId);
+  const credential = new DefaultAzureCredential();
+  const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
+  const client = MapsSearch(credential, mapsClientId);
+  
+  /** Shared Key authentication (subscription-key) */
+  // const subscriptionKey = process.env.MAPS_SUBSCRIPTION_KEY || "";
+  // const credential = new AzureKeyCredential(subscriptionKey);
+  // const client = MapsSearch(credential);
 
   const response = await client.path("/search/polygon").get({
     queryParameters: {

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/searchPolygons.ts
@@ -14,14 +14,14 @@ async function main(): Promise<void> {
   /**
    * Azure Maps supports two ways to authenticate requests:
    * - Shared Key authentication (subscription-key)
-   * - Azure Active Directory (Azure AD) authentication
+   * - Microsoft Entra ID authentication
    *
-   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for AAD auth,
+   * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
    * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */
-  /** Azure Active Directory (Azure AD) authentication */
+  /** Microsoft Entra ID authentication */
   const credential = new DefaultAzureCredential();
   const mapsClientId = process.env.MAPS_RESOURCE_CLIENT_ID || "";
   const client = MapsSearch(credential, mapsClientId);

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/searchPolygons.ts
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/src/searchPolygons.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
    * - Microsoft Entra ID authentication
    *
    * In this sample you can populate the three AZURE_CLIENT_ID, AZURE_CLIENT_SECRET & AZURE_TENANT_ID variables for Microsoft Entra ID auth,
-   * Or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
+   * or put MAPS_SUBSCRIPTION_KEY into .env file to use the shared key authentication.
    *
    * More info is available at https://docs.microsoft.com/en-us/azure/azure-maps/azure-maps-authentication.
    */

--- a/sdk/maps/maps-search-rest/samples/v2-beta/typescript/tsconfig.json
+++ b/sdk/maps/maps-search-rest/samples/v2-beta/typescript/tsconfig.json
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }

--- a/sdk/maps/maps-search-rest/src/MapsSearch.ts
+++ b/sdk/maps/maps-search-rest/src/MapsSearch.ts
@@ -94,7 +94,7 @@ export default function MapsSearch(
     client.pipeline.addPolicy(
       bearerTokenAuthenticationPolicy({
         credential,
-        scopes: `${options.baseUrl || "https://atlas.microsoft.com"}/.default`,
+        scopes: "https://atlas.microsoft.com/.default",
       }),
     );
     client.pipeline.addPolicy(createMapsClientIdPolicy(clientId));

--- a/sdk/maps/maps-search-rest/src/MapsSearch.ts
+++ b/sdk/maps/maps-search-rest/src/MapsSearch.ts
@@ -81,7 +81,7 @@ export default function MapsSearch(
   const options = typeof clientIdOrOptions === "string" ? maybeOptions : clientIdOrOptions;
 
   /**
-   * maps service requires a header "ms-x-client-id", which is different from the standard AAD.
+   * maps service requires a header "ms-x-client-id", which is different from the standard Microsoft Entra ID.
    * So we need to do our own implementation.
    * This customized authentication is following by this guide: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-customization.md#custom-authentication
    */

--- a/sdk/maps/maps-search-rest/swagger/README.md
+++ b/sdk/maps/maps-search-rest/swagger/README.md
@@ -27,7 +27,7 @@ source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/maps/data-plane/Search/stable/2023-06-01/search.json
 package-version: 2.0.0-beta.2
 rest-level-client: true
-# Although maps service supports key-credentials and AAD, maps service requires header "ms-x-client-id", which is different from the standard AAD, so we don't generate AAD code and implement ourselves.
+# Although maps service supports key-credentials and Microsoft Entra ID, maps service requires header "ms-x-client-id", which is different from the standard Microsoft Entra ID, so we don't generate Microsoft Entra ID code and implement ourselves.
 # For auth configuration, please refer to: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/RLC-quickstart.md#how-to-configure-authentication
 security: AzureKey
 security-header-name: subscription-key

--- a/sdk/maps/maps-search-rest/test/public/MapsSearch.spec.ts
+++ b/sdk/maps/maps-search-rest/test/public/MapsSearch.spec.ts
@@ -20,7 +20,7 @@ describe("Authentication", function () {
     await recorder.stop();
   });
 
-  it("should work with AAD authentication", async function () {
+  it("should work with Microsoft Entra ID authentication", async function () {
     /**
      * Skip this test in browser because we have to use InteractiveBrowserCredential in the browser.
      * But it requires user's interaction, which is not testable in karma.

--- a/sdk/maps/maps-search-rest/test/public/MapsSearch.spec.ts
+++ b/sdk/maps/maps-search-rest/test/public/MapsSearch.spec.ts
@@ -7,7 +7,6 @@ import { isNodeLike } from "@azure/core-util";
 import { createTestCredential } from "@azure-tools/test-credential";
 import { assert } from "chai";
 import { createClient, createRecorder } from "./utils/recordedClient";
-import { AzureKeyCredential } from "@azure/core-auth";
 import MapsSearch, { isUnexpected, MapsSearchClient } from "../../src";
 
 describe("Authentication", function () {
@@ -19,14 +18,6 @@ describe("Authentication", function () {
 
   afterEach(async function () {
     await recorder.stop();
-  });
-
-  it("should work with Shared Key authentication", async function () {
-    const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] as string);
-    const client = MapsSearch(credential, recorder.configureClientOptions({}));
-
-    const response = await client.path("/geocode").get({ queryParameters: { query: "Starbucks" } });
-    assert.isOk(!isUnexpected(response));
   });
 
   it("should work with AAD authentication", async function () {

--- a/sdk/maps/maps-search-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-search-rest/test/public/utils/recordedClient.ts
@@ -29,10 +29,6 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 
 export function createClient(options?: ClientOptions): MapsSearchClient {
   const credential = createTestCredential();
-  const client = MapsSearch(
-    credential,
-    env["MAPS_RESOURCE_CLIENT_ID"] as string,
-    options,
-  );
+  const client = MapsSearch(credential, env["MAPS_RESOURCE_CLIENT_ID"] as string, options);
   return client;
 }

--- a/sdk/maps/maps-search-rest/test/public/utils/recordedClient.ts
+++ b/sdk/maps/maps-search-rest/test/public/utils/recordedClient.ts
@@ -6,14 +6,10 @@ import { env, Recorder, RecorderStartOptions } from "@azure-tools/test-recorder"
 import "./env";
 import { ClientOptions } from "@azure-rest/core-client";
 import MapsSearch, { MapsSearchClient } from "../../../src/";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { createTestCredential } from "@azure-tools/test-credential";
 
 const envSetupForPlayback: Record<string, string> = {
-  AZURE_CLIENT_ID: "azure_client_id",
-  AZURE_CLIENT_SECRET: "azure_client_secret",
-  AZURE_TENANT_ID: "88888888-8888-8888-8888-888888888888",
   MAPS_RESOURCE_CLIENT_ID: "azure_maps_client_id",
-  MAPS_SUBSCRIPTION_KEY: "azure_maps_subscription_key",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {
@@ -32,6 +28,11 @@ export async function createRecorder(context: Context): Promise<Recorder> {
 }
 
 export function createClient(options?: ClientOptions): MapsSearchClient {
-  const credential = new AzureKeyCredential(env["MAPS_SUBSCRIPTION_KEY"] ?? "");
-  return MapsSearch(credential, options);
+  const credential = createTestCredential();
+  const client = MapsSearch(
+    credential,
+    env["MAPS_RESOURCE_CLIENT_ID"] as string,
+    options,
+  );
+  return client;
 }

--- a/sdk/maps/maps-search-rest/tests.yml
+++ b/sdk/maps/maps-search-rest/tests.yml
@@ -6,8 +6,4 @@ extends:
       PackageName: "@azure-rest/maps-search"
       ServiceDirectory: maps
       SupportedClouds: 'Public,Canary'
-      EnvVars:
-        AZURE_CLIENT_ID: $(MAPS_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(MAPS_CLIENT_SECRET)
-        AZURE_TENANT_ID: $(MAPS_TENANT_ID)
-        AZURE_SUBSCRIPTION_ID: $(MAPS_SUBSCRIPTION_ID)
+      UseFederatedAuth: true 


### PR DESCRIPTION
### Packages impacted by this PR
- @azure-rest/maps-search
- @azure-rest/maps-route
- @azure-rest/maps-render
- @azure-rest/maps-geolocation

### Issues associated with this PR
#29699 

### Describe the problem that is addressed by this PR
1. Migrate the test to federated authentication
2. In the samples, use AAD auth as default authentication method.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
NA


### Are there test cases added in this PR? _(If not, why?)_
Yes, changes are made in the `Maps<serviceName>.spec.ts`. Note that there are some failed pipelines:
1. LRO test in maps-route-rest: Known issue. Maps team has an exist work item under the internal backlog.
2. `CredentialUnavailableError` in macos environment under maps-geolocation: Know issue. #30356 

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
