### PR TITLE
[Event Hubs] Revert GeoDR earliestPosition change

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 5.13.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Revert the change to the definition of the earliest event position.
+
+### Other Changes
+
 ## 5.13.0-beta.2 (2024-06-27)
 
 ### Bugs Fixed

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.13.0-beta.2",
+  "version": "5.13.0-beta.3",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -93,7 +93,7 @@ export function isLatestPosition(eventPosition: EventPosition): boolean {
  * first event in the partition which has not expired due to the retention policy.
  */
 export const earliestEventPosition: EventPosition = {
-  offset: "-1:-1",
+  offset: "-1",
 };
 
 /**

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.13.0-beta.1",
+  version: "5.13.0-beta.3",
 };
 
 /**

--- a/sdk/eventhub/event-hubs/test/internal/eventPosition.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventPosition.spec.ts
@@ -56,7 +56,7 @@ testWithServiceTypes(() => {
       // });
 
       it("should create from an offset from start", function (done: Mocha.Done): void {
-        const result = "amqp.annotation.x-opt-offset > '-1:-1'";
+        const result = "amqp.annotation.x-opt-offset > '-1'";
         const pos = earliestEventPosition;
         result.should.equal(getEventPositionFilter(pos));
         done();

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-paging": "^1.2.0",
-    "@azure/event-hubs": "5.13.0-beta.2",
+    "@azure/event-hubs": "5.13.0-beta.3",
     "@azure/logger": "^1.0.0",
     "@azure/storage-blob": "^12.9.0",
     "events": "^3.0.0",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/event-hubs

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The service doesn't recognize the GeoDR representation of earliest position causing tests to fail. This PR reverts this change for now until the service is updated.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A

### Are there test cases added in this PR? _(If not, why?)_

N/A

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-js/pull/30191/

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
