### PR TITLE
Add typechecking to vitest.shared.config.ts

### DIFF
--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 18000,
+    typecheck: {
+      enabled: true,
+    },
     reporters: ["basic", "junit"],
     outputFile: {
       junit: "test-results.xml",


### PR DESCRIPTION
To enable typechecking test suites, otherwise type errors will go silent. See https://vitest.dev/config/#typecheck