### PR TITLE
[apimanagement] remove console.log from bundling command output

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
@@ -32,7 +32,7 @@
   "type": "module",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "bundle:bin": "rollup -c rollup.config.bin.mjs",
+    "bundle:bin": "rollup -c rollup.config.bin.mjs 2>&1",
     "build:test": "echo skip",
     "build:samples": "echo skipped",
     "build": "npm run clean && tshy && npm run bundle:bin && dev-tool run extract-api",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/rollup.config.bin.mjs
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/rollup.config.bin.mjs
@@ -51,8 +51,7 @@ function copyTemplates() {
       const from = path.join("templates");
       const to = path.join("bin");
       fs.mkdirSync("bin", { recursive: true });
-      const log = (msg) => console.log("\x1b[36m%s\x1b[0m", msg);
-      log(`copy templates: ${from} → ${to}`);
+      this.info(`copy templates: ${from} → ${to}`);
       copyFolderRecursiveSync(from, to);
     },
   };


### PR DESCRIPTION
so that rush doesn't treat successful builds as completed with warnings

-------

### Packages impacted by this PR
@azure/api-management-custom-widgets-scaffolder