### PR TITLE
[identity] Use MCR for as docker registry

### DIFF
--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-ARG NODE_VERSION=20
+ARG NODE_VERSION=18
 
 # docker can't tell when the repo has changed and will therefore cache this layer
 # internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -67,7 +67,7 @@ Write-Host "Deploying Identity Docker image to ACR"
 az acr login -n $DeploymentOutputs['IDENTITY_ACR_NAME']
 $loginServer = az acr show -n $DeploymentOutputs['IDENTITY_ACR_NAME'] --query loginServer -o tsv
 $image = "$loginServer/identity-aks-test-image"
-docker build --no-cache -t $image "$workingFolder/AzureKubernetes"
+docker build --no-cache --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/" -t $image "$workingFolder/AzureKubernetes"
 docker push $image
 Write-Host "Deployed image to ACR"
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity 


We're getting rate-limited by dockerhub - this PR switches to use mcr's mirror for our CI pipeline.