### PR TITLE
pin npm to 22.4.x

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -17,11 +17,7 @@
         "Pool": "env:MACPOOL"
       }
     },
-    "NodeTestVersion": [
-      "18.x",
-      "20.x",
-      "22.x"
-    ],
+    "NodeTestVersion": ["18.x", "20.x", "22.4.x"],
     "TestType": "node",
     "TestResultsFiles": "**/test-results.xml"
   },
@@ -59,10 +55,7 @@
       },
       "TestType": "node",
       "NodeTestVersion": "18.x",
-      "DependencyVersion": [
-        "max",
-        "min"
-      ],
+      "DependencyVersion": ["max", "min"],
       "TestResultsFiles": "**/test-results.xml"
     }
   ]


### PR DESCRIPTION
temporarily pinning npm 22 to 22.4.0 to adress issue #30445 