### PR TITLE
Add EntraID support to ImageAnalysis RLC

### DIFF
--- a/sdk/vision/ai-vision-image-analysis-rest/CHANGELOG.md
+++ b/sdk/vision/ai-vision-image-analysis-rest/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-beta.3 (Unreleased)
 
 ### Features Added
+Added EntraID support to client.
 
 ### Breaking Changes
 

--- a/sdk/vision/ai-vision-image-analysis-rest/README.md
+++ b/sdk/vision/ai-vision-image-analysis-rest/README.md
@@ -76,19 +76,40 @@ The `ImageAnalysisClient` is the primary interface for developers interacting wi
 
 ### Authenticate the client
 
-Here's an example of how to create an `ImageAnalysisClient` instance using a key-based authentication and an Azure Active Directory authentication.
+Here's an example of how to create an `ImageAnalysisClient` instance using a key-based authentication.
 
 
-```javascript Snippet:ImageAnalysisAuthKey
-const { ImageAnalysisClient, KeyCredential } = require("@azure-rest/ai-vision-image-analysis");
+```javascript Snippet:const endpoint = "<your_endpoint>";
+const key = "<your_key>";
+const credential = new AzureKeyCredential(key);
+
+const client = new ImageAnalysisClient(endpoint, credential);
+
+const { ImageAnalysisClient } = require("@azure-rest/ai-vision-image-analysis");
+const { AzureKeyCredential } = require('@azure/core-auth');
 
 const endpoint = "<your_endpoint>";
 const key = "<your_key>";
-const credential = new KeyCredential(key);
+const credential = new AzureKeyCredential(key);
 
 const client = new ImageAnalysisClient(endpoint, credential);
 ```
 
+#### Create ImageAnalysisClient with a Microsoft Entra ID Credential
+
+Client subscription key authentication is used in most of the examples in this getting started guide, but you can also authenticate with Microsoft Entra ID (formerly Azure Active Directory) using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][azure_identity_dac] provider shown below,
+or other credential providers provided with the Azure SDK, please install the Azure.Identity package:
+
+```
+npm install @azure/identity
+```
+
+```javascript Snippet:ImageAnalysisEntraIDAuth
+const endpoint = "<your_endpoint>";
+const credential = new DefaultAzureCredential();
+
+const client = new ImageAnalysisClient(endpoint, credential);
+```
 ### Analyze an image from URL
 
 The following example demonstrates how to analyze an image using the Image Analysis client library for JavaScript.

--- a/sdk/vision/ai-vision-image-analysis-rest/assets.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/vision/ai-vision-image-analysis-rest",
-  "Tag": "js/vision/ai-vision-image-analysis-rest_55f4635190"
+  "Tag": "js/vision/ai-vision-image-analysis-rest_fc08328d24"
 }

--- a/sdk/vision/ai-vision-image-analysis-rest/assets.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/vision/ai-vision-image-analysis-rest",
-  "Tag": "js/vision/ai-vision-image-analysis-rest_fc08328d24"
+  "Tag": "js/vision/ai-vision-image-analysis-rest_28e3d2c9d7"
 }

--- a/sdk/vision/ai-vision-image-analysis-rest/review/ai-vision-image-analysis.api.md
+++ b/sdk/vision/ai-vision-image-analysis-rest/review/ai-vision-image-analysis.api.md
@@ -12,6 +12,7 @@ import { KeyCredential } from '@azure/core-auth';
 import { RawHttpHeaders } from '@azure/core-rest-pipeline';
 import { RequestParameters } from '@azure-rest/core-client';
 import { StreamableMethod } from '@azure-rest/core-client';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public (undocumented)
 export interface AnalyzeFromImageData {
@@ -66,7 +67,7 @@ export interface AnalyzeFromImageDataQueryParamProperties {
     "gender-neutral-caption"?: boolean;
     "model-version"?: string;
     "smartcrops-aspect-ratios"?: number[];
-    features: string[];
+    features: VisualFeatures[];
     language?: string;
 }
 
@@ -117,7 +118,7 @@ export interface AnalyzeFromUrlQueryParamProperties {
     "gender-neutral-caption"?: boolean;
     "model-version"?: string;
     "smartcrops-aspect-ratios"?: number[];
-    features: string[];
+    features: VisualFeatures[];
     language?: string;
 }
 
@@ -128,7 +129,7 @@ export interface CaptionResultOutput {
 }
 
 // @public
-function createClient(endpoint: string, credentials: KeyCredential, options?: ClientOptions): ImageAnalysisClient;
+function createClient(endpointParam: string, credentials: TokenCredential | KeyCredential, { apiVersion, ...options }?: ImageAnalysisClientOptions): ImageAnalysisClient;
 export default createClient;
 
 // @public
@@ -192,6 +193,11 @@ export type ImageAnalysisClient = Client & {
 };
 
 // @public
+export interface ImageAnalysisClientOptions extends ClientOptions {
+    apiVersion?: string;
+}
+
+// @public
 export interface ImageAnalysisResultOutput {
     captionResult?: CaptionResultOutput;
     denseCaptionsResult?: DenseCaptionsResultOutput;
@@ -229,13 +235,11 @@ export interface ImageUrl {
     url: string;
 }
 
-// @public
-export interface ImageUrlOutput {
-    url: string;
-}
+// @public (undocumented)
+export function isUnexpected(response: AnalyzeFromImageData200Response | AnalyzeFromImageDataDefaultResponse): response is AnalyzeFromImageDataDefaultResponse;
 
 // @public (undocumented)
-export function isUnexpected(response: AnalyzeFromImageData200Response | AnalyzeFromUrl200Response | AnalyzeFromImageDataDefaultResponse): response is AnalyzeFromImageDataDefaultResponse;
+export function isUnexpected(response: AnalyzeFromUrl200Response | AnalyzeFromUrlDefaultResponse): response is AnalyzeFromUrlDefaultResponse;
 
 // @public
 export interface ObjectsResultOutput {
@@ -266,6 +270,9 @@ export interface SmartCropsResultOutput {
 export interface TagsResultOutput {
     values: Array<DetectedTagOutput>;
 }
+
+// @public
+export type VisualFeatures = string;
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/vision/ai-vision-image-analysis-rest/src/clientDefinitions.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/clientDefinitions.ts
@@ -1,24 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AnalyzeFromImageDataParameters, AnalyzeFromUrlParameters } from "./parameters";
+import {
+  AnalyzeFromImageDataParameters,
+  AnalyzeFromUrlParameters,
+} from "./parameters.js";
 import {
   AnalyzeFromImageData200Response,
   AnalyzeFromImageDataDefaultResponse,
   AnalyzeFromUrl200Response,
   AnalyzeFromUrlDefaultResponse,
-} from "./responses";
+} from "./responses.js";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
 export interface AnalyzeFromImageData {
   /** Performs a single Image Analysis operation */
   post(
     options: AnalyzeFromImageDataParameters,
-  ): StreamableMethod<AnalyzeFromImageData200Response | AnalyzeFromImageDataDefaultResponse>;
+  ): StreamableMethod<
+    AnalyzeFromImageData200Response | AnalyzeFromImageDataDefaultResponse
+  >;
   /** Performs a single Image Analysis operation */
   post(
     options: AnalyzeFromUrlParameters,
-  ): StreamableMethod<AnalyzeFromUrl200Response | AnalyzeFromUrlDefaultResponse>;
+  ): StreamableMethod<
+    AnalyzeFromUrl200Response | AnalyzeFromUrlDefaultResponse
+  >;
 }
 
 export interface Routes {

--- a/sdk/vision/ai-vision-image-analysis-rest/src/imageAnalysisClient.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/imageAnalysisClient.ts
@@ -3,24 +3,30 @@
 
 import { getClient, ClientOptions } from "@azure-rest/core-client";
 import { logger } from "./logger";
-import { KeyCredential } from "@azure/core-auth";
+import { TokenCredential, KeyCredential } from "@azure/core-auth";
 import { ImageAnalysisClient } from "./clientDefinitions";
+
+/** The optional parameters for the client */
+export interface ImageAnalysisClientOptions extends ClientOptions {
+  /** The api version option of the client */
+  apiVersion?: string;
+}
 
 /**
  * Initialize a new instance of `ImageAnalysisClient`
- * @param endpoint - Azure AI Computer Vision endpoint (protocol and hostname, for example:
+ * @param endpointParam - Azure AI Computer Vision endpoint (protocol and hostname, for example:
  * https://<resource-name>.cognitiveservices.azure.com).
  * @param credentials - uniquely identify client credential
  * @param options - the parameter for all optional parameters
  */
 export default function createClient(
-  endpoint: string,
-  credentials: KeyCredential,
-  options: ClientOptions = {},
+  endpointParam: string,
+  credentials: TokenCredential | KeyCredential,
+  { apiVersion = "2023-10-01", ...options }: ImageAnalysisClientOptions = {},
 ): ImageAnalysisClient {
-  const baseUrl = options.baseUrl ?? `${endpoint}/computervision`;
-  options.apiVersion = options.apiVersion ?? "2023-10-01";
-  const userAgentInfo = `azsdk-js-ai-vision-image-analysis-rest/1.0.0-beta.3`;
+  const endpointUrl =
+    options.endpoint ?? options.baseUrl ?? `${endpointParam}/computervision`;
+  const userAgentInfo = `azsdk-js-ai-vision-image-analysis-rest/1.0.0-beta.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
@@ -34,11 +40,35 @@ export default function createClient(
       logger: options.loggingOptions?.logger ?? logger.info,
     },
     credentials: {
-      apiKeyHeaderName: options.credentials?.apiKeyHeaderName ?? "Ocp-Apim-Subscription-Key",
+      scopes: options.credentials?.scopes ?? [
+        "https://cognitiveservices.azure.com/.default",
+      ],
+      apiKeyHeaderName:
+        options.credentials?.apiKeyHeaderName ?? "Ocp-Apim-Subscription-Key",
     },
   };
+  const client = getClient(
+    endpointUrl,
+    credentials,
+    options,
+  ) as ImageAnalysisClient;
 
-  const client = getClient(baseUrl, credentials, options) as ImageAnalysisClient;
+  client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
+  client.pipeline.addPolicy({
+    name: "ClientApiVersionPolicy",
+    sendRequest: (req, next) => {
+      // Use the apiVersion defined in request url directly
+      // Append one if there is no apiVersion and we have one at client options
+      const url = new URL(req.url);
+      if (!url.searchParams.get("api-version") && apiVersion) {
+        req.url = `${req.url}${
+          Array.from(url.searchParams.keys()).length > 0 ? "&" : "?"
+        }api-version=${apiVersion}`;
+      }
+
+      return next(req);
+    },
+  });
 
   return client;
 }

--- a/sdk/vision/ai-vision-image-analysis-rest/src/isUnexpected.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/isUnexpected.ts
@@ -3,8 +3,9 @@
 
 import {
   AnalyzeFromImageData200Response,
-  AnalyzeFromUrl200Response,
   AnalyzeFromImageDataDefaultResponse,
+  AnalyzeFromUrl200Response,
+  AnalyzeFromUrlDefaultResponse,
 } from "./responses";
 
 const responseMap: Record<string, string[]> = {
@@ -14,15 +15,20 @@ const responseMap: Record<string, string[]> = {
 export function isUnexpected(
   response:
     | AnalyzeFromImageData200Response
-    | AnalyzeFromUrl200Response
     | AnalyzeFromImageDataDefaultResponse,
 ): response is AnalyzeFromImageDataDefaultResponse;
 export function isUnexpected(
+  response: AnalyzeFromUrl200Response | AnalyzeFromUrlDefaultResponse,
+): response is AnalyzeFromUrlDefaultResponse;
+export function isUnexpected(
   response:
     | AnalyzeFromImageData200Response
+    | AnalyzeFromImageDataDefaultResponse
     | AnalyzeFromUrl200Response
-    | AnalyzeFromImageDataDefaultResponse,
-): response is AnalyzeFromImageDataDefaultResponse {
+    | AnalyzeFromUrlDefaultResponse,
+): response is
+  | AnalyzeFromImageDataDefaultResponse
+  | AnalyzeFromUrlDefaultResponse {
   const lroOriginal = response.headers["x-ms-original-url"];
   const url = new URL(lroOriginal ?? response.request.url);
   const method = response.request.method;
@@ -55,17 +61,24 @@ function getParametrizedPathSuccess(method: string, path: string): string[] {
 
     // track if we have found a match to return the values found.
     let found = true;
-    for (let i = candidateParts.length - 1, j = pathParts.length - 1; i >= 1 && j >= 1; i--, j--) {
-      if (candidateParts[i]?.startsWith("{") && candidateParts[i]?.indexOf("}") !== -1) {
+    for (
+      let i = candidateParts.length - 1, j = pathParts.length - 1;
+      i >= 1 && j >= 1;
+      i--, j--
+    ) {
+      if (
+        candidateParts[i]?.startsWith("{") &&
+        candidateParts[i]?.indexOf("}") !== -1
+      ) {
         const start = candidateParts[i]!.indexOf("}") + 1,
           end = candidateParts[i]?.length;
         // If the current part of the candidate is a "template" part
         // Try to use the suffix of pattern to match the path
         // {guid} ==> $
         // {guid}:export ==> :export$
-        const isMatched = new RegExp(`${candidateParts[i]?.slice(start, end)}`).test(
-          pathParts[j] || "",
-        );
+        const isMatched = new RegExp(
+          `${candidateParts[i]?.slice(start, end)}`,
+        ).test(pathParts[j] || "");
 
         if (!isMatched) {
           found = false;

--- a/sdk/vision/ai-vision-image-analysis-rest/src/models.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/models.ts
@@ -6,3 +6,6 @@ export interface ImageUrl {
   /** Publicly reachable URL of an image to analyze. */
   url: string;
 }
+
+/** Alias for VisualFeatures */
+export type VisualFeatures = string;

--- a/sdk/vision/ai-vision-image-analysis-rest/src/outputModels.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/outputModels.ts
@@ -203,9 +203,3 @@ export interface TagsResultOutput {
   /** A list of tags. */
   values: Array<DetectedTagOutput>;
 }
-
-/** An object holding the publicly reachable URL of an image to analyze. */
-export interface ImageUrlOutput {
-  /** Publicly reachable URL of an image to analyze. */
-  url: string;
-}

--- a/sdk/vision/ai-vision-image-analysis-rest/src/parameters.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/parameters.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { RequestParameters } from "@azure-rest/core-client";
-import { ImageUrl } from "./models";
+import { VisualFeatures, ImageUrl } from "./models.js";
 
 export interface AnalyzeFromImageDataBodyParam {
   /**
@@ -10,7 +10,11 @@ export interface AnalyzeFromImageDataBodyParam {
    *
    * Value may contain any sequence of octets
    */
-  body: string | Uint8Array | ReadableStream<Uint8Array> | NodeJS.ReadableStream;
+  body:
+    | string
+    | Uint8Array
+    | ReadableStream<Uint8Array>
+    | NodeJS.ReadableStream;
 }
 
 export interface AnalyzeFromImageDataQueryParamProperties {
@@ -19,7 +23,7 @@ export interface AnalyzeFromImageDataQueryParamProperties {
    * Seven visual features are supported: Caption, DenseCaptions, Read (OCR), Tags, Objects, SmartCrops, and People.
    * At least one visual feature must be specified.
    */
-  features: string[];
+  features: VisualFeatures[];
   /**
    * The desired language for result generation (a two-letter language code).
    * If this option is not specified, the default value 'en' is used (English).
@@ -74,7 +78,7 @@ export interface AnalyzeFromUrlQueryParamProperties {
    * Seven visual features are supported: Caption, DenseCaptions, Read (OCR), Tags, Objects, SmartCrops, and People.
    * At least one visual feature must be specified.
    */
-  features: string[];
+  features: VisualFeatures[];
   /**
    * The desired language for result generation (a two-letter language code).
    * If this option is not specified, the default value 'en' is used (English).

--- a/sdk/vision/ai-vision-image-analysis-rest/src/responses.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/src/responses.ts
@@ -3,7 +3,7 @@
 
 import { RawHttpHeaders } from "@azure/core-rest-pipeline";
 import { HttpResponse, ErrorResponse } from "@azure-rest/core-client";
-import { ImageAnalysisResultOutput } from "./outputModels";
+import { ImageAnalysisResultOutput } from "./outputModels.js";
 
 /** The request has succeeded. */
 export interface AnalyzeFromImageData200Response extends HttpResponse {

--- a/sdk/vision/ai-vision-image-analysis-rest/test/public/AnalysisTests.spec.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/test/public/AnalysisTests.spec.ts
@@ -33,6 +33,7 @@ describe("Analyze Tests", () => {
 
       beforeEach(async function (this: Context) {
         recorder = await createRecorder(this);
+        
         recorder.addSanitizers({
           headerSanitizers: [{ key: "Ocp-Apim-Subscription-Key", value: "***********" }],
           uriSanitizers: [{ target: "https://[a-zA-Z0-9-]*/", value: "https://endpoint/" }],
@@ -348,7 +349,6 @@ describe("Analyze Tests", () => {
           if (["person", "woman", "laptop", "cat", "canidae"].includes(oneTag.name.toLowerCase())) {
             found++;
           }
-console.log(oneTag.name);
           assert.isFalse(tagNames.has(oneTag.name));
           tagNames.add(oneTag.name);
         }

--- a/sdk/vision/ai-vision-image-analysis-rest/test/public/AnalysisTests.spec.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/test/public/AnalysisTests.spec.ts
@@ -11,368 +11,383 @@ import {
   ObjectsResultOutput,
   TagsResultOutput,
 } from "../../src/index.js";
-import { createClient, createRecorder } from "./utils/recordedClient";
-import { Recorder } from "@azure-tools/test-recorder";
+import { createRecorder } from "./utils/recordedClient";
+import { Recorder, assertEnvironmentVariable } from "@azure-tools/test-recorder";
+import { createClient } from "./utils/clientMethods";
+import { AzureKeyCredential } from "@azure/core-auth";
+import { createTestCredential } from "@azure-tools/test-credential";
+
+const key = assertEnvironmentVariable("VISION_KEY");
+const KeyCredential = new AzureKeyCredential(key);
+
+const credentials = [
+  { credential: KeyCredential, title: "AzureKeyCredential" },
+  { credential: createTestCredential(), title: "TokenCredential" }
+];
 
 describe("Analyze Tests", () => {
-  let recorder: Recorder;
-  let client: ImageAnalysisClient;
+  credentials.forEach((credential) => {
+    describe(`Using ${credential.title}`, () => {
+      let recorder: Recorder;
+      let client: ImageAnalysisClient;
 
-  beforeEach(async function (this: Context) {
-    recorder = await createRecorder(this);
-    recorder.addSanitizers({
-      headerSanitizers: [{ key: "Ocp-Apim-Subscription-Key", value: "***********" }],
-      uriSanitizers: [{ target: "https://[a-zA-Z0-9-]*/", value: "https://endpoint/" }],
+      beforeEach(async function (this: Context) {
+        recorder = await createRecorder(this);
+        recorder.addSanitizers({
+          headerSanitizers: [{ key: "Ocp-Apim-Subscription-Key", value: "***********" }],
+          uriSanitizers: [{ target: "https://[a-zA-Z0-9-]*/", value: "https://endpoint/" }],
+        });
+        client = await createClient(recorder, credential.credential);
+      });
+
+      afterEach(async function () {
+        await recorder?.stop();
+      });
+
+      async function downloadUrlToUint8Array(url: string): Promise<Uint8Array> {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to download content: ${response.status} ${response.statusText}`);
+        }
+        const buffer = await response.arrayBuffer();
+        return new Uint8Array(buffer);
+      }
+
+      it("Analyze from URL", async function () {
+        const allFeatures: string[] = [
+          "Caption",
+          "DenseCaptions",
+          "Objects",
+          "People",
+          "Read",
+          "SmartCrops",
+          "Tags",
+        ];
+
+        const someFeatures: string[] = ["Caption", "Read"];
+
+        const testFeaturesList: string[][] = [allFeatures, someFeatures];
+
+        for (const testFeatures of testFeaturesList) {
+          const result = await client.path("/imageanalysis:analyze").post({
+            body: {
+              url: "https://aka.ms/azsdk/image-analysis/sample.jpg",
+            },
+            queryParameters: {
+              features: testFeatures,
+              "smartCrops-aspect-ratios": [0.9, 1.33],
+            },
+            contentType: "application/json",
+          });
+
+          assert.isNotNull(result);
+          assert.equal(result.status, "200");
+
+          const iaResult: ImageAnalysisResultOutput = result.body as ImageAnalysisResultOutput;
+
+          validateResponse(iaResult, testFeatures, false);
+        }
+      });
+
+      it("Analyze from Stream", async function () {
+        const allFeatures: string[] = [
+          "Caption",
+          "DenseCaptions",
+          "Objects",
+          "People",
+          "Read",
+          "SmartCrops",
+          "Tags",
+        ];
+        const someFeatures: string[] = ["Caption", "Read"];
+        const url: string = "https://aka.ms/azsdk/image-analysis/sample.jpg";
+
+        const data: Uint8Array = await downloadUrlToUint8Array(url);
+
+        for (const testFeatures of [allFeatures, someFeatures]) {
+          const result = await client.path("/imageanalysis:analyze").post({
+            body: data,
+            queryParameters: {
+              features: testFeatures,
+              "smartCrops-aspect-ratios": [0.9, 1.33],
+            },
+            contentType: "application/octet-stream",
+          });
+
+          assert.isNotNull(result);
+
+          assert.equal(result.status, "200");
+
+          const iaResult: ImageAnalysisResultOutput = result.body as ImageAnalysisResultOutput;
+
+          validateResponse(iaResult, testFeatures, false);
+        }
+      });
+
+      function validateResponse(
+        iaResult: ImageAnalysisResultOutput,
+        testFeatures: string[],
+        genderNeutral: boolean,
+      ): void {
+        validateMetadata(iaResult);
+
+        const captionResult = iaResult.captionResult;
+        if (testFeatures.includes("Caption")) {
+          if (captionResult) {
+            validateCaption(captionResult, genderNeutral);
+          } else {
+            assert.fail("captionResult is null");
+          }
+        } else {
+          assert.isUndefined(captionResult);
+        }
+
+        if (testFeatures.includes("DenseCaptions")) {
+          validateDenseCaptions(iaResult);
+        } else {
+          assert.isUndefined(iaResult.denseCaptionsResult);
+        }
+
+        const objectsResult = iaResult.objectsResult;
+        if (testFeatures.includes("Objects")) {
+          if (objectsResult) {
+            validateObjectsResult(objectsResult);
+          } else {
+            assert.fail("objectsResult is null");
+          }
+        } else {
+          assert.isUndefined(objectsResult);
+        }
+
+        if (testFeatures.includes("Tags")) {
+          if (iaResult.tagsResult) {
+            validateTags(iaResult.tagsResult);
+          } else {
+            assert.fail("tagsResult is null");
+          }
+        } else {
+          assert.isUndefined(iaResult.tagsResult);
+        }
+
+        if (testFeatures.includes("People")) {
+          validatePeopleResult(iaResult);
+        } else {
+          assert.isUndefined(iaResult.peopleResult);
+        }
+
+        if (testFeatures.includes("SmartCrops")) {
+          validateSmartCrops(iaResult);
+        } else {
+          assert.isUndefined(iaResult.smartCropsResult);
+        }
+
+        const readResult = iaResult.readResult;
+        if (!testFeatures.includes("Read")) {
+          assert.isUndefined(readResult);
+        } else {
+          if (readResult) {
+            validateReadResult(iaResult);
+          } else {
+            assert.fail("readResult is null");
+          }
+        }
+      }
+
+      function validateReadResult(result: ImageAnalysisResultOutput): void {
+        const readResult = result.readResult;
+        if (!readResult) throw new Error("Read result is null");
+
+        const allText: string[] = [];
+        let words = 0;
+        let lines = 0;
+
+        const pagePolygon: ImagePointOutput[] = [
+          { x: 0, y: 0 },
+          { x: 0, y: result.metadata.height },
+          { x: result.metadata.width, y: result.metadata.height },
+          { x: result.metadata.width, y: 0 },
+        ];
+
+        for (const block of readResult.blocks) {
+          for (const oneLine of block.lines) {
+            if (!oneLine.boundingPolygon.every((p) => isInPolygon(p, pagePolygon))) {
+              throw new Error("Bounding polygon is not in the page polygon");
+            }
+
+            words += oneLine.words.length;
+            lines++;
+            allText.push(oneLine.text);
+            for (const word of oneLine.words) {
+              if (word.confidence <= 0 || word.confidence >= 1) {
+                throw new Error("Invalid word confidence value");
+              }
+              if (!oneLine.text.includes(word.text)) {
+                throw new Error("One line text does not contain word text");
+              }
+            }
+          }
+        }
+
+        if (words !== 6) throw new Error("Words count is not equal to 6");
+        if (lines !== 3) throw new Error("Lines count is not equal to 3");
+        if (allText.join("\n") !== "Sample text\nHand writing\n123 456") {
+          throw new Error("All text content is not equal to the expected value");
+        }
+      }
+
+      function isInPolygon(suspectPoint: ImagePointOutput, polygon: ImagePointOutput[]): boolean {
+        let intersectCount = 0;
+        const points = [...polygon, polygon[0]];
+
+        for (let i = 0; i < points.length - 1; i++) {
+          const p1 = points[i];
+          const p2 = points[i + 1];
+
+          if (
+            p1.y > suspectPoint.y !== p2.y > suspectPoint.y &&
+            suspectPoint.x < ((p2.x - p1.x) * (suspectPoint.y - p1.y)) / (p2.y - p1.y) + p1.x
+          ) {
+            intersectCount++;
+          }
+        }
+
+        const result = intersectCount % 2 !== 0;
+
+        if (!result) {
+          console.log(`Point ${suspectPoint} is not in polygon ${polygon}`);
+        }
+
+        return result;
+      }
+
+      function validateMetadata(iaResult: ImageAnalysisResultOutput): void {
+        assert.isAbove(iaResult.metadata.height, 0);
+        assert.isAbove(iaResult.metadata.width, 0);
+        assert.isFalse(iaResult.modelVersion.trim() === "");
+      }
+
+      function validateCaption(captionResult: CaptionResultOutput, genderNeutral: boolean): void {
+        assert.isNotNull(captionResult);
+        assert.isAbove(captionResult.confidence, 0);
+        assert.isBelow(captionResult.confidence, 1);
+        assert.isTrue(captionResult.text.toLowerCase().includes(genderNeutral ? "person" : "woman"));
+        assert.isTrue(captionResult.text.toLowerCase().includes("table"));
+        assert.isTrue(captionResult.text.toLowerCase().includes("laptop"));
+      }
+
+      function validateDenseCaptions(iaResult: ImageAnalysisResultOutput): void {
+        const denseCaptionsResult = iaResult.denseCaptionsResult;
+
+        assert.isNotNull(denseCaptionsResult);
+        assert.isAtLeast(denseCaptionsResult!.values.length, 1);
+
+        const firstCaption = denseCaptionsResult!.values[0];
+        assert.isNotNull(firstCaption);
+        assert.isNotNull(firstCaption.boundingBox);
+        assert.strictEqual(firstCaption.boundingBox.w, iaResult.metadata.width);
+        assert.strictEqual(firstCaption.boundingBox.h, iaResult.metadata.height);
+        assert.isNotNull(firstCaption.text);
+        if (iaResult.captionResult != null) {
+          assert.strictEqual(iaResult.captionResult.text, firstCaption.text);
+        }
+
+        const boundingBoxes = new Set<string>();
+
+        for (const oneDenseCaption of denseCaptionsResult!.values) {
+          assert.isNotNull(oneDenseCaption.boundingBox);
+          assert.isFalse(boundingBoxes.has(JSON.stringify(oneDenseCaption.boundingBox)));
+          boundingBoxes.add(JSON.stringify(oneDenseCaption.boundingBox));
+
+          assert.isNotNull(oneDenseCaption.text);
+
+          assert.isAbove(oneDenseCaption.confidence, 0);
+          assert.isBelow(oneDenseCaption.confidence, 1);
+        }
+      }
+
+      function validateObjectsResult(objectsResult: ObjectsResultOutput): void {
+        assert.isNotNull(objectsResult);
+        assert.isAtLeast(objectsResult.values.length, 0);
+
+        for (const oneObject of objectsResult.values) {
+          assert.isNotNull(oneObject.boundingBox);
+          assert.isTrue(
+            oneObject.boundingBox.x > 0 ||
+            oneObject.boundingBox.y > 0 ||
+            oneObject.boundingBox.h > 0 ||
+            oneObject.boundingBox.w > 0,
+          );
+          assert.isNotNull(oneObject.tags);
+          for (const oneTag of oneObject.tags) {
+            assert.isFalse(oneTag.name.trim() === "");
+            assert.isAbove(oneTag.confidence, 0);
+            assert.isBelow(oneTag.confidence, 1);
+          }
+        }
+
+        assert.isAtLeast(
+          objectsResult.values.filter((v) => v.tags.filter((t) => t.name.toLowerCase() === "person"))
+            .length,
+          0,
+        );
+      }
+
+      function validateTags(tagsResult: TagsResultOutput): void {
+        assert.isNotNull(tagsResult);
+        assert.isNotNull(tagsResult.values);
+        assert.isAtLeast(tagsResult.values.length, 0);
+
+        let found = 0;
+        const tagNames = new Set<string>();
+
+        for (const oneTag of tagsResult.values) {
+          assert.isAbove(oneTag.confidence, 0);
+          assert.isBelow(oneTag.confidence, 1);
+
+          assert.isFalse(oneTag.name.trim() === "");
+          if (["person", "woman", "laptop", "cat", "canidae"].includes(oneTag.name.toLowerCase())) {
+            found++;
+          }
+console.log(oneTag.name);
+          assert.isFalse(tagNames.has(oneTag.name));
+          tagNames.add(oneTag.name);
+        }
+
+        assert.isAtLeast(found, 2);
+      }
+
+      function validatePeopleResult(iaResult: ImageAnalysisResultOutput): void {
+        const peopleResult = iaResult.peopleResult;
+
+        assert.isNotNull(peopleResult);
+        assert.isAtLeast(peopleResult!.values.length, 0);
+
+        const boundingBoxes = new Set<string>();
+
+        for (const onePerson of peopleResult!.values) {
+          assert.isNotNull(onePerson.boundingBox);
+          assert.isFalse(boundingBoxes.has(JSON.stringify(onePerson.boundingBox)));
+          boundingBoxes.add(JSON.stringify(onePerson.boundingBox));
+
+          assert.isAbove(onePerson.confidence, 0);
+          assert.isBelow(onePerson.confidence, 1);
+        }
+      }
+
+      function validateSmartCrops(iaResult: ImageAnalysisResultOutput): void {
+        const smartCropsResult = iaResult.smartCropsResult;
+        assert.isNotNull(smartCropsResult);
+
+        assert.isNotNull(smartCropsResult!.values);
+        assert.strictEqual(smartCropsResult!.values.length, 2);
+
+        const boundingBoxes = new Set<string>();
+
+        for (const oneCrop of smartCropsResult!.values) {
+          assert.isFalse(boundingBoxes.has(JSON.stringify(oneCrop.boundingBox)));
+          boundingBoxes.add(JSON.stringify(oneCrop.boundingBox));
+        }
+      }
     });
-    client = await createClient(recorder);
   });
-
-  afterEach(async function () {
-    await recorder?.stop();
-  });
-
-  async function downloadUrlToUint8Array(url: string): Promise<Uint8Array> {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Failed to download content: ${response.status} ${response.statusText}`);
-    }
-    const buffer = await response.arrayBuffer();
-    return new Uint8Array(buffer);
-  }
-
-  it("Analyze from URL", async function () {
-    const allFeatures: string[] = [
-      "Caption",
-      "DenseCaptions",
-      "Objects",
-      "People",
-      "Read",
-      "SmartCrops",
-      "Tags",
-    ];
-
-    const someFeatures: string[] = ["Caption", "Read"];
-
-    const testFeaturesList: string[][] = [allFeatures, someFeatures];
-
-    for (const testFeatures of testFeaturesList) {
-      const result = await client.path("/imageanalysis:analyze").post({
-        body: {
-          url: "https://aka.ms/azsdk/image-analysis/sample.jpg",
-        },
-        queryParameters: {
-          features: testFeatures,
-          "smartCrops-aspect-ratios": [0.9, 1.33],
-        },
-        contentType: "application/json",
-      });
-
-      assert.isNotNull(result);
-      assert.equal(result.status, "200");
-
-      const iaResult: ImageAnalysisResultOutput = result.body as ImageAnalysisResultOutput;
-
-      validateResponse(iaResult, testFeatures, false);
-    }
-  });
-
-  it("Analyze from Stream", async function () {
-    const allFeatures: string[] = [
-      "Caption",
-      "DenseCaptions",
-      "Objects",
-      "People",
-      "Read",
-      "SmartCrops",
-      "Tags",
-    ];
-    const someFeatures: string[] = ["Caption", "Read"];
-    const url: string = "https://aka.ms/azsdk/image-analysis/sample.jpg";
-
-    const data: Uint8Array = await downloadUrlToUint8Array(url);
-
-    for (const testFeatures of [allFeatures, someFeatures]) {
-      const result = await client.path("/imageanalysis:analyze").post({
-        body: data,
-        queryParameters: {
-          features: testFeatures,
-          "smartCrops-aspect-ratios": [0.9, 1.33],
-        },
-        contentType: "application/octet-stream",
-      });
-
-      assert.isNotNull(result);
-
-      assert.equal(result.status, "200");
-
-      const iaResult: ImageAnalysisResultOutput = result.body as ImageAnalysisResultOutput;
-
-      validateResponse(iaResult, testFeatures, false);
-    }
-  });
-
-  function validateResponse(
-    iaResult: ImageAnalysisResultOutput,
-    testFeatures: string[],
-    genderNeutral: boolean,
-  ): void {
-    validateMetadata(iaResult);
-
-    const captionResult = iaResult.captionResult;
-    if (testFeatures.includes("Caption")) {
-      if (captionResult) {
-        validateCaption(captionResult, genderNeutral);
-      } else {
-        assert.fail("captionResult is null");
-      }
-    } else {
-      assert.isUndefined(captionResult);
-    }
-
-    if (testFeatures.includes("DenseCaptions")) {
-      validateDenseCaptions(iaResult);
-    } else {
-      assert.isUndefined(iaResult.denseCaptionsResult);
-    }
-
-    const objectsResult = iaResult.objectsResult;
-    if (testFeatures.includes("Objects")) {
-      if (objectsResult) {
-        validateObjectsResult(objectsResult);
-      } else {
-        assert.fail("objectsResult is null");
-      }
-    } else {
-      assert.isUndefined(objectsResult);
-    }
-
-    if (testFeatures.includes("Tags")) {
-      if (iaResult.tagsResult) {
-        validateTags(iaResult.tagsResult);
-      } else {
-        assert.fail("tagsResult is null");
-      }
-    } else {
-      assert.isUndefined(iaResult.tagsResult);
-    }
-
-    if (testFeatures.includes("People")) {
-      validatePeopleResult(iaResult);
-    } else {
-      assert.isUndefined(iaResult.peopleResult);
-    }
-
-    if (testFeatures.includes("SmartCrops")) {
-      validateSmartCrops(iaResult);
-    } else {
-      assert.isUndefined(iaResult.smartCropsResult);
-    }
-
-    const readResult = iaResult.readResult;
-    if (!testFeatures.includes("Read")) {
-      assert.isUndefined(readResult);
-    } else {
-      if (readResult) {
-        validateReadResult(iaResult);
-      } else {
-        assert.fail("readResult is null");
-      }
-    }
-  }
-
-  function validateReadResult(result: ImageAnalysisResultOutput): void {
-    const readResult = result.readResult;
-    if (!readResult) throw new Error("Read result is null");
-
-    const allText: string[] = [];
-    let words = 0;
-    let lines = 0;
-
-    const pagePolygon: ImagePointOutput[] = [
-      { x: 0, y: 0 },
-      { x: 0, y: result.metadata.height },
-      { x: result.metadata.width, y: result.metadata.height },
-      { x: result.metadata.width, y: 0 },
-    ];
-
-    for (const block of readResult.blocks) {
-      for (const oneLine of block.lines) {
-        if (!oneLine.boundingPolygon.every((p) => isInPolygon(p, pagePolygon))) {
-          throw new Error("Bounding polygon is not in the page polygon");
-        }
-
-        words += oneLine.words.length;
-        lines++;
-        allText.push(oneLine.text);
-        for (const word of oneLine.words) {
-          if (word.confidence <= 0 || word.confidence >= 1) {
-            throw new Error("Invalid word confidence value");
-          }
-          if (!oneLine.text.includes(word.text)) {
-            throw new Error("One line text does not contain word text");
-          }
-        }
-      }
-    }
-
-    if (words !== 6) throw new Error("Words count is not equal to 6");
-    if (lines !== 3) throw new Error("Lines count is not equal to 3");
-    if (allText.join("\n") !== "Sample text\nHand writing\n123 456") {
-      throw new Error("All text content is not equal to the expected value");
-    }
-  }
-
-  function isInPolygon(suspectPoint: ImagePointOutput, polygon: ImagePointOutput[]): boolean {
-    let intersectCount = 0;
-    const points = [...polygon, polygon[0]];
-
-    for (let i = 0; i < points.length - 1; i++) {
-      const p1 = points[i];
-      const p2 = points[i + 1];
-
-      if (
-        p1.y > suspectPoint.y !== p2.y > suspectPoint.y &&
-        suspectPoint.x < ((p2.x - p1.x) * (suspectPoint.y - p1.y)) / (p2.y - p1.y) + p1.x
-      ) {
-        intersectCount++;
-      }
-    }
-
-    const result = intersectCount % 2 !== 0;
-
-    if (!result) {
-      console.log(`Point ${suspectPoint} is not in polygon ${polygon}`);
-    }
-
-    return result;
-  }
-
-  function validateMetadata(iaResult: ImageAnalysisResultOutput): void {
-    assert.isAbove(iaResult.metadata.height, 0);
-    assert.isAbove(iaResult.metadata.width, 0);
-    assert.isFalse(iaResult.modelVersion.trim() === "");
-  }
-
-  function validateCaption(captionResult: CaptionResultOutput, genderNeutral: boolean): void {
-    assert.isNotNull(captionResult);
-    assert.isAbove(captionResult.confidence, 0);
-    assert.isBelow(captionResult.confidence, 1);
-    assert.isTrue(captionResult.text.toLowerCase().includes(genderNeutral ? "person" : "woman"));
-    assert.isTrue(captionResult.text.toLowerCase().includes("table"));
-    assert.isTrue(captionResult.text.toLowerCase().includes("laptop"));
-  }
-
-  function validateDenseCaptions(iaResult: ImageAnalysisResultOutput): void {
-    const denseCaptionsResult = iaResult.denseCaptionsResult;
-
-    assert.isNotNull(denseCaptionsResult);
-    assert.isAtLeast(denseCaptionsResult!.values.length, 1);
-
-    const firstCaption = denseCaptionsResult!.values[0];
-    assert.isNotNull(firstCaption);
-    assert.isNotNull(firstCaption.boundingBox);
-    assert.strictEqual(firstCaption.boundingBox.w, iaResult.metadata.width);
-    assert.strictEqual(firstCaption.boundingBox.h, iaResult.metadata.height);
-    assert.isNotNull(firstCaption.text);
-    if (iaResult.captionResult != null) {
-      assert.strictEqual(iaResult.captionResult.text, firstCaption.text);
-    }
-
-    const boundingBoxes = new Set<string>();
-
-    for (const oneDenseCaption of denseCaptionsResult!.values) {
-      assert.isNotNull(oneDenseCaption.boundingBox);
-      assert.isFalse(boundingBoxes.has(JSON.stringify(oneDenseCaption.boundingBox)));
-      boundingBoxes.add(JSON.stringify(oneDenseCaption.boundingBox));
-
-      assert.isNotNull(oneDenseCaption.text);
-
-      assert.isAbove(oneDenseCaption.confidence, 0);
-      assert.isBelow(oneDenseCaption.confidence, 1);
-    }
-  }
-
-  function validateObjectsResult(objectsResult: ObjectsResultOutput): void {
-    assert.isNotNull(objectsResult);
-    assert.isAtLeast(objectsResult.values.length, 0);
-
-    for (const oneObject of objectsResult.values) {
-      assert.isNotNull(oneObject.boundingBox);
-      assert.isTrue(
-        oneObject.boundingBox.x > 0 ||
-          oneObject.boundingBox.y > 0 ||
-          oneObject.boundingBox.h > 0 ||
-          oneObject.boundingBox.w > 0,
-      );
-      assert.isNotNull(oneObject.tags);
-      for (const oneTag of oneObject.tags) {
-        assert.isFalse(oneTag.name.trim() === "");
-        assert.isAbove(oneTag.confidence, 0);
-        assert.isBelow(oneTag.confidence, 1);
-      }
-    }
-
-    assert.isAtLeast(
-      objectsResult.values.filter((v) => v.tags.filter((t) => t.name.toLowerCase() === "person"))
-        .length,
-      0,
-    );
-  }
-
-  function validateTags(tagsResult: TagsResultOutput): void {
-    assert.isNotNull(tagsResult);
-    assert.isNotNull(tagsResult.values);
-    assert.isAtLeast(tagsResult.values.length, 0);
-
-    let found = 0;
-    const tagNames = new Set<string>();
-
-    for (const oneTag of tagsResult.values) {
-      assert.isAbove(oneTag.confidence, 0);
-      assert.isBelow(oneTag.confidence, 1);
-
-      assert.isFalse(oneTag.name.trim() === "");
-      if (["person", "woman", "laptop", "cat", "canidae"].includes(oneTag.name.toLowerCase())) {
-        found++;
-      }
-
-      assert.isFalse(tagNames.has(oneTag.name));
-      tagNames.add(oneTag.name);
-    }
-
-    assert.isAtLeast(found, 2);
-  }
-
-  function validatePeopleResult(iaResult: ImageAnalysisResultOutput): void {
-    const peopleResult = iaResult.peopleResult;
-
-    assert.isNotNull(peopleResult);
-    assert.isAtLeast(peopleResult!.values.length, 0);
-
-    const boundingBoxes = new Set<string>();
-
-    for (const onePerson of peopleResult!.values) {
-      assert.isNotNull(onePerson.boundingBox);
-      assert.isFalse(boundingBoxes.has(JSON.stringify(onePerson.boundingBox)));
-      boundingBoxes.add(JSON.stringify(onePerson.boundingBox));
-
-      assert.isAbove(onePerson.confidence, 0);
-      assert.isBelow(onePerson.confidence, 1);
-    }
-  }
-
-  function validateSmartCrops(iaResult: ImageAnalysisResultOutput): void {
-    const smartCropsResult = iaResult.smartCropsResult;
-    assert.isNotNull(smartCropsResult);
-
-    assert.isNotNull(smartCropsResult!.values);
-    assert.strictEqual(smartCropsResult!.values.length, 2);
-
-    const boundingBoxes = new Set<string>();
-
-    for (const oneCrop of smartCropsResult!.values) {
-      assert.isFalse(boundingBoxes.has(JSON.stringify(oneCrop.boundingBox)));
-      boundingBoxes.add(JSON.stringify(oneCrop.boundingBox));
-    }
-  }
 });

--- a/sdk/vision/ai-vision-image-analysis-rest/test/public/utils/clientMethods.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/test/public/utils/clientMethods.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Recorder, assertEnvironmentVariable } from "@azure-tools/test-recorder";
+import "./env";
+import { AzureKeyCredential, TokenCredential } from "@azure/core-auth";
+import importedCreateClient, { ImageAnalysisClient } from "../../../src/index";
+
+export async function createClient(recorder: Recorder, credential : AzureKeyCredential | TokenCredential): Promise<ImageAnalysisClient> {
+    const endpoint = assertEnvironmentVariable("VISION_ENDPOINT");
+    return importedCreateClient(endpoint, credential, recorder.configureClientOptions({}));
+  }
+  

--- a/sdk/vision/ai-vision-image-analysis-rest/test/public/utils/recordedClient.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/test/public/utils/recordedClient.ts
@@ -2,18 +2,14 @@
 // Licensed under the MIT license.
 
 import { Context } from "mocha";
-import {
-  Recorder,
-  RecorderStartOptions,
-  assertEnvironmentVariable,
-} from "@azure-tools/test-recorder";
-import "./env";
-import importedCreateClient, { ImageAnalysisClient } from "../../../src/index";
-import { AzureKeyCredential } from "@azure/core-auth";
+import { Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
 
 const envSetupForPlayback: Record<string, string> = {
-  VISION_ENDPOINT: "https://endpoint/",
-  VISION_KEY: "***********",
+  ENDPOINT: "https://endpoint",
+  AZURE_CLIENT_ID: "azure_client_id",
+  AZURE_CLIENT_SECRET: "azure_client_secret",
+  AZURE_TENANT_ID: "88888888-8888-8888-8888-888888888888",
+  SUBSCRIPTION_ID: "azure_subscription_id",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {
@@ -29,11 +25,4 @@ export async function createRecorder(context: Context): Promise<Recorder> {
   const recorder = new Recorder(context.currentTest);
   await recorder.start(recorderEnvSetup);
   return recorder;
-}
-
-export async function createClient(recorder: Recorder): Promise<ImageAnalysisClient> {
-  const endpoint = assertEnvironmentVariable("VISION_ENDPOINT");
-  const key = assertEnvironmentVariable("VISION_KEY");
-  const credential = new AzureKeyCredential(key);
-  return importedCreateClient(endpoint, credential, recorder.configureClientOptions({}));
 }

--- a/sdk/vision/ai-vision-image-analysis-rest/test/public/utils/recordedClient.ts
+++ b/sdk/vision/ai-vision-image-analysis-rest/test/public/utils/recordedClient.ts
@@ -14,6 +14,9 @@ const envSetupForPlayback: Record<string, string> = {
 
 const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback,
+  removeCentralSanitizers: [
+    "AZSDK3493",
+  ]
 };
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/ai-vision-image-analysis

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
Re-generated the client to pick up a TypeSpec change that added EntraID support.
Added test case for above.
Modified readme to show use of DefaultAzureCredential

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes.

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-rest-api-specs/pull/28482

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
