### PR TITLE
[CODEOWNERS] update rush.json and ignore-links.txt owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1515,6 +1515,7 @@ sdk/ai/ai-inference-rest @glharper @dargilco
 /eng/                  @ckairen @mikeharder @weshaggard @benbp
 /eng/common/           @Azure/azure-sdk-eng
 /.github/workflows/    @Azure/azure-sdk-eng
+/eng/ignore-links.txt  @Azure/azure-sdk-js-dev
 
 ###########
 # Config
@@ -1540,10 +1541,9 @@ sdk/ai/ai-inference-rest @glharper @dargilco
 
 /eng/tools/dependency-testing @KarishmaGhiya @jeremymeng
 
-/rush.json @mikeharder @ckairen @jeremymeng @Azure/azure-sdk-for-js-core
+/rush.json @mikeharder @ckairen @jeremymeng @Azure/azure-sdk-for-js
 /tsconfig.json @mikeharder @ckairen @jeremymeng @deyaaeldeen
-/**/tsconfig.json @jeremymeng @deyaaeldeen
-/**/tsconfig.strict.json @deyaaeldeen
+/**/tsconfig.json @jeremymeng @deyaaeldeen @Azure/azure-sdk-for-js-core
 /.scripts/ @mikeharder @ckairen
 /vitest.shared.config.ts @jeremymeng @mpodwysocki @deyaaeldeen
 /vitest.browser.shared.config.ts @jeremymeng @mpodwysocki @deyaaeldeen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1541,7 +1541,7 @@ sdk/ai/ai-inference-rest @glharper @dargilco
 
 /eng/tools/dependency-testing @KarishmaGhiya @jeremymeng
 
-/rush.json @mikeharder @ckairen @jeremymeng @Azure/azure-sdk-for-js
+/rush.json @mikeharder @ckairen @jeremymeng @Azure/azure-sdk-js-dev
 /tsconfig.json @mikeharder @ckairen @jeremymeng @deyaaeldeen
 /**/tsconfig.json @jeremymeng @deyaaeldeen @Azure/azure-sdk-for-js-core
 /.scripts/ @mikeharder @ckairen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1515,7 +1515,7 @@ sdk/ai/ai-inference-rest @glharper @dargilco
 /eng/                  @ckairen @mikeharder @weshaggard @benbp
 /eng/common/           @Azure/azure-sdk-eng
 /.github/workflows/    @Azure/azure-sdk-eng
-/eng/ignore-links.txt  @Azure/azure-sdk-js-dev
+/eng/ignore-links.txt  @Azure/azure-sdk-eng @Azure/azure-sdk-js-dev
 
 ###########
 # Config


### PR DESCRIPTION
to js team because we need to add projects for management packages and ignore links to documents that are not ready yet.

also remove `/**/tsconfig.strict.json` entry. It was added for we did migration work for cosmos but we shouldn't own it any more. 