### PR TITLE
[core] Sanitize RestError request and response properties

### DIFF
--- a/sdk/core/core-rest-pipeline/src/restError.ts
+++ b/sdk/core/core-rest-pipeline/src/restError.ts
@@ -72,8 +72,8 @@ export class RestError extends Error {
     this.name = "RestError";
     this.code = options.code;
     this.statusCode = options.statusCode;
-    this.request = options.request;
-    this.response = options.response;
+    this.request = options.request && errorSanitizer.sanitizePipelineRequest(options.request);
+    this.response = options.response && errorSanitizer.sanitizePipelineResponse(options.response);
 
     Object.setPrototypeOf(this, RestError.prototype);
   }

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 import { type UnknownObject, isObject } from "@azure/core-util";
+import { PipelineRequest, PipelineResponse, RawHttpHeaders } from "../interfaces.js";
+import { createHttpHeaders } from "../httpHeaders.js";
 
 /**
  * @internal
@@ -150,6 +152,37 @@ export class Sanitizer {
     }
 
     return url.toString();
+  }
+
+  /**
+   * Returns a version of the given pipeline request where the headers and request URL have been sanitized.
+   */
+  public sanitizePipelineRequest(request: PipelineRequest): PipelineRequest {
+    const sanitizedHeaders = createHttpHeaders(
+      this.sanitizeHeaders(request.headers.toJSON({ preserveCase: true })) as RawHttpHeaders,
+    );
+
+    return {
+      ...request,
+      url: this.sanitizeUrl(request.url),
+      headers: sanitizedHeaders,
+    };
+  }
+
+  /**
+   * Returns a version of the given pipeline response where the response headers, request headers, and request URL have been sanitized.
+   */
+  public sanitizePipelineResponse(response: PipelineResponse): PipelineResponse {
+    const sanitizedRequest = this.sanitizePipelineRequest(response.request);
+    const sanitizedHeaders = createHttpHeaders(
+      this.sanitizeHeaders(response.headers.toJSON({ preserveCase: true })) as RawHttpHeaders,
+    );
+
+    return {
+      ...response,
+      headers: sanitizedHeaders,
+      request: sanitizedRequest,
+    };
   }
 
   private sanitizeHeaders(obj: UnknownObject): UnknownObject {

--- a/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
+++ b/sdk/core/core-rest-pipeline/src/util/sanitizer.ts
@@ -158,13 +158,13 @@ export class Sanitizer {
    * Returns a version of the given pipeline request where the headers and request URL have been sanitized.
    */
   public sanitizePipelineRequest(request: PipelineRequest): PipelineRequest {
-    const sanitizedHeaders = createHttpHeaders(
+    const sanitizedHeaders = request.headers && createHttpHeaders(
       this.sanitizeHeaders(request.headers.toJSON({ preserveCase: true })) as RawHttpHeaders,
     );
 
     return {
       ...request,
-      url: this.sanitizeUrl(request.url),
+      url: request.url && this.sanitizeUrl(request.url),
       headers: sanitizedHeaders,
     };
   }
@@ -174,7 +174,7 @@ export class Sanitizer {
    */
   public sanitizePipelineResponse(response: PipelineResponse): PipelineResponse {
     const sanitizedRequest = this.sanitizePipelineRequest(response.request);
-    const sanitizedHeaders = createHttpHeaders(
+    const sanitizedHeaders = response.headers && createHttpHeaders(
       this.sanitizeHeaders(response.headers.toJSON({ preserveCase: true })) as RawHttpHeaders,
     );
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-rest-pipeline`
- (todo) `@typespec/ts-http-runtime`

### Issues associated with this PR

- See e.g. https://github.com/Azure/azure-sdk-for-js/issues/30247
- Also https://github.com/Azure/azure-sdk-for-js/issues/29910
- And #29630 

### Describe the problem that is addressed by this PR

`PipelineRequest` and `PipelineResponse` objects may contain secrets in the request URL or headers. This is problematic since `RestError` objects are often logged. While we override `util.inspect.custom` to sanitize log output in Node, this does not work in all situations and environments. For example:
- `console.log` in browser does not respect `util.inspect.custom`, meaning secrets could be logged to the browser console. Other non-Node environments also may not respect this Node-specific functionality.
- JSON serialization of `RestError` objects. Calling `JSON.stringify` on the `RestError` currently results in an object that contains unsanitized secrets. We have encountered scenarios where the JSON serialization is logged, for example with vitest.

This PR changes the `RestError` constructor so that it sanitizes the request headers, request URL, and response headers. This means that `RestError` objects are much safer to log (although it is possible that secrets are present in the request or response body).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could do a more targeted fix where we implement `toJSON` so that the JSON serialization is sanitized, but the actual `request` and `response` properties on `RestError` remain unsanitized. Doing this would be lower risk from a breaking change perspective, but would still leave the door open for secrets to be leaked. I think we should try this more thorough approach first, reverting to a more targeted fix if it results in significant issues. But I don't feel too strongly about this if others think differently.

### Are there test cases added in this PR? _(If not, why?)_

Yes, added test cases of the new sanitizer logic.