### PR TITLE
[Docs] Clarifying that the URL for the schema registry needs the protocol part

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -69,7 +69,7 @@ const { SchemaRegistryClient } = require("@azure/schema-registry");
 const { AvroSerializer } = require("@azure/schema-registry-avro");
 
 const client = new SchemaRegistryClient(
-  "<fully qualified namespace>",
+  "<fully qualified namespace with protocol>",
   new DefaultAzureCredential()
 );
 const serializer = new AvroSerializer(client, {


### PR DESCRIPTION
### Packages impacted by this PR

schema-registry-avro

### Issues associated with this PR

None

### Describe the problem that is addressed by this PR

Clarifies that the URL for the schema registry must have the protocol part e.g. https://

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Just docs improvement.

### Are there test cases added in this PR? _(If not, why?)_

No, just docs.

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
