### PR TITLE
[Identity] Fix PowershellCredential token parsing logic

### DIFF
--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -239,7 +239,9 @@ export async function parseJsonToken(
           const jsonContent = JSON.parse(item);
           if (jsonContent?.Token) {
             resultWithoutToken = resultWithoutToken.replace(item, "");
-            logger.getToken.warning(resultWithoutToken);
+            if(resultWithoutToken){
+                logger.getToken.warning(resultWithoutToken);
+            }
             return jsonContent;
           }
         } catch (e) {

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -239,8 +239,8 @@ export async function parseJsonToken(
           const jsonContent = JSON.parse(item);
           if (jsonContent?.Token) {
             resultWithoutToken = resultWithoutToken.replace(item, "");
-            if(resultWithoutToken){
-                logger.getToken.warning(resultWithoutToken);
+            if (resultWithoutToken) {
+              logger.getToken.warning(resultWithoutToken);
             }
             return jsonContent;
           }

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -166,7 +166,7 @@ export class AzurePowerShellCredential implements TokenCredential {
       ]);
 
       const result = results[1];
-      return await parseJsonToken(result);
+      return parseJsonToken(result);
     }
     throw new Error(`Unable to execute PowerShell. Ensure that it is installed in your system`);
   }

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -166,7 +166,7 @@ export class AzurePowerShellCredential implements TokenCredential {
       ]);
 
       const result = results[1];
-      await parseJsonToken(result);
+      return await parseJsonToken(result);
     }
     throw new Error(`Unable to execute PowerShell. Ensure that it is installed in your system`);
   }

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -230,11 +230,11 @@ export async function parseJsonToken(
   result: string,
 ): Promise<{ Token: string; ExpiresOn: string }> {
   const jsonRegex = /{[^{}]*}/g;
-  let matches = result.match(jsonRegex);
+  const matches = result.match(jsonRegex);
   let resultWithoutToken = result;
   if (matches) {
     try {
-      for (let item of matches) {
+      for (const item of matches) {
         const jsonContent = JSON.parse(item);
         if (jsonContent?.Token) {
           resultWithoutToken = resultWithoutToken.replace(item, "");

--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -235,11 +235,15 @@ export async function parseJsonToken(
   if (matches) {
     try {
       for (const item of matches) {
-        const jsonContent = JSON.parse(item);
-        if (jsonContent?.Token) {
-          resultWithoutToken = resultWithoutToken.replace(item, "");
-          logger.getToken.warning(resultWithoutToken);
-          return jsonContent;
+        try {
+          const jsonContent = JSON.parse(item);
+          if (jsonContent?.Token) {
+            resultWithoutToken = resultWithoutToken.replace(item, "");
+            logger.getToken.warning(resultWithoutToken);
+            return jsonContent;
+          }
+        } catch (e) {
+          continue;
         }
       }
     } catch (e: any) {

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -132,16 +132,15 @@ describe("AzurePowerShellCredential", function () {
       await credential.getToken(scope);
     } catch (e: any) {
       error = e;
+      sandbox.restore();
     }
 
     assert.ok(error);
     assert.equal(error?.name, "CredentialUnavailableError");
     assert.equal(
       error?.message,
-      `Error: Unable to parse the output of PowerShell. Received output: Not valid JSON. To troubleshoot, visit https://aka.ms/azsdk/js/identity/powershellcredential/troubleshoot.`,
+      `Error: No access token found in the output. Received output: Not valid JSON. To troubleshoot, visit https://aka.ms/azsdk/js/identity/powershellcredential/troubleshoot.`,
     );
-
-    sandbox.restore();
   });
 
   if (process.platform === "win32") {
@@ -162,16 +161,15 @@ describe("AzurePowerShellCredential", function () {
         await credential.getToken(scope);
       } catch (e: any) {
         error = e;
+        sandbox.restore();
       }
 
       assert.ok(error);
       assert.equal(error?.name, "CredentialUnavailableError");
       assert.equal(
         error?.message,
-        `Error: Unable to parse the output of PowerShell. Received output: Not valid JSON. To troubleshoot, visit https://aka.ms/azsdk/js/identity/powershellcredential/troubleshoot.`,
+        `Error: No access token found in the output. Received output: Not valid JSON. To troubleshoot, visit https://aka.ms/azsdk/js/identity/powershellcredential/troubleshoot.`,
       );
-
-      sandbox.restore();
     });
   }
 
@@ -193,10 +191,9 @@ describe("AzurePowerShellCredential", function () {
     const credential = new AzurePowerShellCredential();
 
     const token = await credential.getToken(scope);
+    sandbox.restore();
     assert.equal(token?.token, tokenResponse.Token);
     assert.equal(token?.expiresOnTimestamp!, new Date(tokenResponse.ExpiresOn).getTime());
-
-    sandbox.restore();
   });
 
   it("authenticates with tenantId on getToken", async function () {
@@ -217,10 +214,9 @@ describe("AzurePowerShellCredential", function () {
     const credential = new AzurePowerShellCredential();
 
     const token = await credential.getToken(scope, { tenantId: "TENANT-ID" } as GetTokenOptions);
+    sandbox.restore();
     assert.equal(token?.token, tokenResponse.Token);
     assert.equal(token?.expiresOnTimestamp!, new Date(tokenResponse.ExpiresOn).getTime());
-
-    sandbox.restore();
   });
 
   /**

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -29,10 +29,10 @@ describe("AzurePowerShellCredential", function () {
   const scope = "https://vault.azure.net/.default";
   const tenantIdErrorMessage =
     "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://learn.microsoft.com/partner-center/find-ids-and-domain-names.";
-  let sandbox:Sinon.SinonSandbox;
-  beforeEach(()=>{
-    sandbox = Sinon.createSandbox();    
-  })
+  let sandbox: Sinon.SinonSandbox;
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox();
+  });
   afterEach(() => {
     sandbox.restore();
     resetCommandStack();

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -280,40 +280,37 @@ describe("AzurePowerShellCredential", function () {
     });
   }
 
-  it.only("parses JSON correctly from an output of multiple JSON objects from AzurePowerShell",async function(){
-
+  it("parses JSON correctly from an output of multiple JSON objects from AzurePowerShell", async function () {
     const tokenResponse = {
-      "Token": "token",
-      "ExpiresOn": "2024-07-19T05:35:37+00:00",
-      "TenantId": "***",
-      "UserId": "***",
-      "Type": "Bearer"
+      Token: "token",
+      ExpiresOn: "2024-07-19T05:35:37+00:00",
+      TenantId: "***",
+      UserId: "***",
+      Type: "Bearer",
     };
-    const completeResponse = `
- Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
-  {},
+    const completeResponse = `Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
+{}
+{
+"fsdf
 {
   "Token": "token",
   "ExpiresOn": "2024-07-19T05:35:37+00:00",
   "TenantId": "***",
   "UserId": "***",
   "Type": "Bearer"
-}
-  `
-  console.log("wat characters are these = ")
-  console.log(completeResponse.substring(406,410))
-    const token = await parseJsonToken(completeResponse)
+},
+  }`;
+    const token = await parseJsonToken(completeResponse);
     assert.equal(token?.Token, tokenResponse.Token);
-  })
+  });
 
-  it("parses JSON correctly from an output of errors from AzurePowerShell",async function(){
-
+  it("parses JSON correctly from an output of errors from AzurePowerShell", async function () {
     const tokenResponse = {
-      "Token": "token",
-      "ExpiresOn": "2024-07-19T05:35:37+00:00",
-      "TenantId": "***",
-      "UserId": "***",
-      "Type": "Bearer"
+      Token: "token",
+      ExpiresOn: "2024-07-19T05:35:37+00:00",
+      TenantId: "***",
+      UserId: "***",
+      Type: "Bearer",
     };
     const completeResponse = `AggregateAuthenticationError: ChainedTokenCredential authentication failed.
 CredentialUnavailableError: Error: Unable to parse the output of PowerShell. Received output: WARNING: Upcoming breaking changes in the cmdlet 'Get-AzAccessToken' :
@@ -342,8 +339,8 @@ CredentialUnavailableError: EnvironmentCredential is unavailable. No underlying 
       at Object.defaultAuthorizeRequest [as authorizeRequest] (/Users/runner/work/1/s/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts:114:23)
       at Object.sendRequest (/Users/runner/work/1/s/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts:179:7)
       at sendRequest (/Users/runner/work/1/s/common/temp/node_modules/.pnpm/@azure-rest+core-client@1.4.0/node_modules/@azure-rest/core-client/src/sendRequest.ts:40:20)
-     at Context.<anonymous> (/Users/runner/work/1/s/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts:2:35)`
-    const token = await parseJsonToken(completeResponse)
+     at Context.<anonymous> (/Users/runner/work/1/s/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts:2:35)`;
+    const token = await parseJsonToken(completeResponse);
     assert.equal(token?.Token, tokenResponse.Token);
-  })
+  });
 });

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -5,6 +5,7 @@
 
 import {
   formatCommand,
+  parseJsonToken,
   powerShellErrors,
   powerShellPublicErrorMessages,
 } from "../../../src/credentials/azurePowerShellCredential";
@@ -278,4 +279,71 @@ describe("AzurePowerShellCredential", function () {
       );
     });
   }
+
+  it.only("parses JSON correctly from an output of multiple JSON objects from AzurePowerShell",async function(){
+
+    const tokenResponse = {
+      "Token": "token",
+      "ExpiresOn": "2024-07-19T05:35:37+00:00",
+      "TenantId": "***",
+      "UserId": "***",
+      "Type": "Bearer"
+    };
+    const completeResponse = `
+ Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
+  {},
+{
+  "Token": "token",
+  "ExpiresOn": "2024-07-19T05:35:37+00:00",
+  "TenantId": "***",
+  "UserId": "***",
+  "Type": "Bearer"
+}
+  `
+  console.log("wat characters are these = ")
+  console.log(completeResponse.substring(406,410))
+    const token = await parseJsonToken(completeResponse)
+    assert.equal(token?.Token, tokenResponse.Token);
+  })
+
+  it("parses JSON correctly from an output of errors from AzurePowerShell",async function(){
+
+    const tokenResponse = {
+      "Token": "token",
+      "ExpiresOn": "2024-07-19T05:35:37+00:00",
+      "TenantId": "***",
+      "UserId": "***",
+      "Type": "Bearer"
+    };
+    const completeResponse = `AggregateAuthenticationError: ChainedTokenCredential authentication failed.
+CredentialUnavailableError: Error: Unable to parse the output of PowerShell. Received output: WARNING: Upcoming breaking changes in the cmdlet 'Get-AzAccessToken' :
+The Token property of the output type will be changed from String to SecureString. Add the [-AsSecureString] switch to avoid the impact of this upcoming breaking change.
+- The change is expected to take effect in Az version : '13.0.0'
+- The change is expected to take effect in Az.Accounts version : '4.0.0'
+Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
+{
+  "Token": "token",
+  "ExpiresOn": "2024-07-19T05:35:37+00:00",
+  "TenantId": "***",
+  "UserId": "***",
+  "Type": "Bearer"
+}
+
+. To troubleshoot, visit https://aka.ms/azsdk/js/identity/powershellcredential/troubleshoot.
+CredentialUnavailableError: Please run 'az login' from a command prompt to authenticate before using this credential.
+CredentialUnavailableError: Azure Developer CLI couldn't be found. To mitigate this issue, see the troubleshooting guidelines at https://aka.ms/azsdk/js/identity/azdevclicredential/troubleshoot.
+CredentialUnavailableError: EnvironmentCredential is unavailable. No underlying credential could be used. To troubleshoot, visit https://aka.ms/azsdk/js/identity/environmentcredential/troubleshoot.
+      at /Users/runner/work/1/s/common/temp/node_modules/.pnpm/@azure+identity@4.4.0/node_modules/@azure/identity/src/credentials/chainedTokenCredential.ts:85:23
+      at processTicksAndRejections (node:internal/process/task_queues:95:5)
+      at Object.withSpan (/Users/runner/work/1/s/common/temp/node_modules/.pnpm/@azure+core-tracing@1.1.2/node_modules/@azure/core-tracing/src/tracingClient.ts:70:22)
+      at ChainedTokenCredential.getToken (/Users/runner/work/1/s/common/temp/node_modules/.pnpm/@azure+identity@4.4.0/node_modules/@azure/identity/src/credentials/chainedTokenCredential.ts:51:23)
+      at tryGetAccessToken (/Users/runner/work/1/s/sdk/core/core-rest-pipeline/src/util/tokenCycler.ts:71:26)
+      at beginRefresh (/Users/runner/work/1/s/sdk/core/core-rest-pipeline/src/util/tokenCycler.ts:82:35)
+      at Object.defaultAuthorizeRequest [as authorizeRequest] (/Users/runner/work/1/s/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts:114:23)
+      at Object.sendRequest (/Users/runner/work/1/s/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts:179:7)
+      at sendRequest (/Users/runner/work/1/s/common/temp/node_modules/.pnpm/@azure-rest+core-client@1.4.0/node_modules/@azure-rest/core-client/src/sendRequest.ts:40:20)
+     at Context.<anonymous> (/Users/runner/work/1/s/sdk/maps/maps-geolocation-rest/test/public/MapsGeolocation.spec.ts:2:35)`
+    const token = await parseJsonToken(completeResponse)
+    assert.equal(token?.Token, tokenResponse.Token);
+  })
 });

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -285,9 +285,9 @@ describe("AzurePowerShellCredential", function () {
       Type: "Bearer",
     };
     const completeResponse = `Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
-{}
+{"afasf"}
 {
-"fsdf
+"fsdf": 
 {
   "Token": "token",
   "ExpiresOn": "2024-07-19T05:35:37+00:00",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
- Customer reported issue - https://github.com/Azure/azure-sdk-for-js/issues/30356

### Describe the problem that is addressed by this PR
- The token parsing logic in AzurePowershellCredential currently does not account for warmings being emitted by az-powershell, due to which the json token parsing when attempted on the warning string will definitely fail. 
- One option is to suppress the warnings, 
- the other is to make the token parsing logic more robust

We will do both in case we don't want to suppress few warnings (future-proofing solutions)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
In this PR, I am essentially making the  token parsing logic more robust to account for all strings and multiple json objects, carefully pick the correct json for the access token and log the rest of the output as warning with the logger.

### Are there test cases added in this PR? _(If not, why?)_
- Yes two test cases

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Added a changelog (if necessary)
