### PR TITLE
[AI] [Inference] add non-happy path tests

### DIFF
--- a/sdk/ai/ai-inference-rest/assets.json
+++ b/sdk/ai/ai-inference-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/ai/ai-inference-rest",
-  "Tag": "js/ai/ai-inference-rest_3635abd7cf"
+  "Tag": "js/ai/ai-inference-rest_e1a1e4356f"
 }

--- a/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
@@ -268,6 +268,16 @@ describe("chat test suite", () => {
     });
 
   it("chat auth error test", async function () {
+    client = await createModelClient("dummy", recorder);
+    const response = await client.path("/chat/completions").post({
+      body: {
+        messages: [
+          { role: "user", content: "How many feet are in a mile?" },
+        ]
+      }
+    });
+
+    assert.isTrue(isUnexpected(response));
   },
     {
       timeout: 50000

--- a/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
@@ -226,4 +226,51 @@ describe("chat test suite", () => {
       timeout: 50000
     });
 
+  it("multi-turn chat test", async function () {
+    const messages = [
+      { role: "system", content: "You are a helpful assistant" },
+      { role: "user", content: "How many feet are in a mile?" },
+    ];
+    let response = await client.path("/chat/completions").post({
+      body: { messages }
+    });
+
+    assert.isFalse(isUnexpected(response));
+
+    const completion = response.body as ChatCompletionsOutput;
+    assert.isDefined(completion);
+    assert.isNotEmpty(completion.choices);
+    assert.isDefined(completion.choices[0].message);
+    assert.isDefined(completion.choices[0].message.content);
+    
+    const assistantMessage = completion.choices[0].message.content as string;
+    assert.isTrue(assistantMessage.includes("280"));
+    messages.push({ role: "assistant", content: assistantMessage});
+    messages.push({ role: "user", content: "and how many yards?"});
+
+    response = await client.path("/chat/completions").post({
+      body: { messages }
+    });
+
+    assert.isFalse(isUnexpected(response));
+
+    const secondCompletion = response.body as ChatCompletionsOutput;
+    assert.isDefined(secondCompletion);
+    assert.isNotEmpty(secondCompletion.choices);
+    assert.isDefined(secondCompletion.choices[0].message);
+    assert.isDefined(secondCompletion.choices[0].message.content);
+
+    const yardsMessage = completion.choices[0].message.content as string;
+    assert.isTrue(yardsMessage.includes("760"));
+  },
+    {
+      timeout: 80000
+    });
+
+  it("chat auth error test", async function () {
+  },
+    {
+      timeout: 50000
+    });
+
 });

--- a/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
@@ -118,10 +118,7 @@ describe("chat test suite", () => {
       assert.isTrue(json["tools"][0].function.name == body.tools[0].function.name);
       assert.isTrue(json["tools"][0].function.description == body.tools[0].function.description);
     }
-  },
-    {
-      timeout: 50000
-    });
+  });
 
 
   it("simple chat test", async function () {
@@ -140,10 +137,7 @@ describe("chat test suite", () => {
     assert.isNotEmpty(completion.choices);
     assert.isDefined(completion.choices[0].message);
     assert.isDefined(completion.choices[0].message.content);
-  },
-    {
-      timeout: 50000
-    });
+  });
 
   it("function calling test", async function () {
     const getCurrentWeather = {
@@ -192,10 +186,7 @@ describe("chat test suite", () => {
     assert.isDefined(toolCall.function);
     assert.isNotEmpty(toolCall.function.name);
     assert.isTrue(toolCall.function.arguments.includes("location"));
-  },
-    {
-      timeout: 50000
-    });
+  });
 
   it("image url test", async function () {
     const url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
@@ -221,10 +212,7 @@ describe("chat test suite", () => {
     assert.isNotEmpty(completion.choices);
     assert.isDefined(completion.choices[0].message);
     assert.isDefined(completion.choices[0].message.content);
-  },
-    {
-      timeout: 50000
-    });
+  });
 
   it("multi-turn chat test", async function () {
     const messages = [
@@ -263,10 +251,7 @@ describe("chat test suite", () => {
 
     const yardsMessage = secondCompletion.choices[0].message.content as string;
     assert.isTrue(yardsMessage.includes("760"));
-  },
-    {
-      timeout: 80000
-    });
+  });
 
   it("chat auth error test", async function () {
     client = await createModelClient("dummy", recorder);
@@ -279,9 +264,6 @@ describe("chat test suite", () => {
     });
 
     assert.isTrue(isUnexpected(response));
-  },
-    {
-      timeout: 50000
-    });
+  });
 
 });

--- a/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/chatCompletions.spec.ts
@@ -39,7 +39,7 @@ describe("chat test suite", () => {
       messages: [
         { role: "system", content: "You are a helpful assistant." },
         { role: "user", content: "How many feet are in a mile?" },
-        { role: "user", content: [{ type: "image_url", image_url: { url, detail: "auto" } } ]},
+        { role: "user", content: [{ type: "image_url", image_url: { url, detail: "auto" } }] },
       ],
       frequency_penalty: 1,
       stream: false,
@@ -52,7 +52,7 @@ describe("chat test suite", () => {
       model: "foo",
       response_format: "foo",
       tool_choice: "auto",
-      tools: [ { type: "function", function: { name: "foo", description: "bar" } } ]
+      tools: [{ type: "function", function: { name: "foo", description: "bar" } }]
     }
     const response = await client.path("/chat/completions").post({
       headers,
@@ -228,10 +228,10 @@ describe("chat test suite", () => {
 
   it("multi-turn chat test", async function () {
     const messages = [
-      { role: "system", content: "You are a helpful assistant" },
+      { role: "system", content: "You are a helpful assistant answering questions regarding length units." },
       { role: "user", content: "How many feet are in a mile?" },
     ];
-    let response = await client.path("/chat/completions").post({
+    const response = await client.path("/chat/completions").post({
       body: { messages }
     });
 
@@ -242,25 +242,26 @@ describe("chat test suite", () => {
     assert.isNotEmpty(completion.choices);
     assert.isDefined(completion.choices[0].message);
     assert.isDefined(completion.choices[0].message.content);
-    
+
     const assistantMessage = completion.choices[0].message.content as string;
     assert.isTrue(assistantMessage.includes("280"));
-    messages.push({ role: "assistant", content: assistantMessage});
-    messages.push({ role: "user", content: "and how many yards?"});
+    messages.push({ role: "assistant", content: assistantMessage });
+    messages.push({ role: "user", content: "and how many yards?" });
 
-    response = await client.path("/chat/completions").post({
+    const secondResponse = await client.path("/chat/completions").post({
       body: { messages }
     });
 
-    assert.isFalse(isUnexpected(response));
+    assert.isFalse(isUnexpected(secondResponse));
 
-    const secondCompletion = response.body as ChatCompletionsOutput;
+    const secondCompletion = secondResponse.body as ChatCompletionsOutput;
     assert.isDefined(secondCompletion);
     assert.isNotEmpty(secondCompletion.choices);
+
     assert.isDefined(secondCompletion.choices[0].message);
     assert.isDefined(secondCompletion.choices[0].message.content);
 
-    const yardsMessage = completion.choices[0].message.content as string;
+    const yardsMessage = secondCompletion.choices[0].message.content as string;
     assert.isTrue(yardsMessage.includes("760"));
   },
     {

--- a/sdk/ai/ai-inference-rest/test/public/embeddings.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/embeddings.spec.ts
@@ -60,10 +60,7 @@ describe("embeddings test suite", () => {
     assert.isTrue(json["model"] == embeddingParams.body?.model);
     assert.isTrue(json["encoding_format"] == embeddingParams.body?.encoding_format);
     assert.isTrue(json["input_type"] == embeddingParams.body?.input_type);
-  },
-    {
-      timeout: 50000
-    });
+  });
 
   it("simple embeddings test", async function () {
     const response = await client.path("/embeddings").post({
@@ -87,9 +84,6 @@ describe("embeddings test suite", () => {
     assert.isDefined(result.usage);
     assert.isTrue(result.usage.prompt_tokens > 0);
     assert.isTrue(result.usage.prompt_tokens == result.usage.total_tokens);
-  },
-    {
-      timeout: 50000
-    });
+  });
 
 });

--- a/sdk/ai/ai-inference-rest/test/public/node/imageChat.spec.ts
+++ b/sdk/ai/ai-inference-rest/test/public/node/imageChat.spec.ts
@@ -56,8 +56,5 @@ describe("image file test suite", () => {
     assert.isNotEmpty(completion.choices);
     assert.isDefined(completion.choices[0].message);
     assert.isDefined(completion.choices[0].message.content);
-  },
-    {
-      timeout: 50000
-    });
+  });
 });

--- a/sdk/ai/ai-inference-rest/test/public/types.ts
+++ b/sdk/ai/ai-inference-rest/test/public/types.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export type DeploymentType = "embeddings" | "completions";
+export type DeploymentType = "embeddings" | "completions" | "dummy";

--- a/sdk/ai/ai-inference-rest/vitest.browser.config.ts
+++ b/sdk/ai/ai-inference-rest/vitest.browser.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "process.env": process.env,
   },
   test: {
+    testTimeout: 50000,
     reporters: ["basic", "junit"],
     outputFile: {
       junit: "test-results.browser.xml",

--- a/sdk/ai/ai-inference-rest/vitest.config.ts
+++ b/sdk/ai/ai-inference-rest/vitest.config.ts
@@ -8,6 +8,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
+      testTimeout: 50000,
       include: ["test/internal/**/*.spec.ts", "test/public/**/*.spec.ts"],
     },
   }),


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/ai-inference

### Issues associated with this PR


### Describe the problem that is addressed by this PR
adds chat multi-turn and auth error test

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
