### PR TITLE
[core] Add react-native support at top level

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -32,6 +32,7 @@
   },
   "main": "./dist/commonjs/index.js",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "type": "module",
   "keywords": [

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -32,6 +32,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "files": [
     "dist/",
     "README.md",

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -38,6 +38,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "tags": [
     "isomorphic",
     "browser",

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -8,6 +8,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/commonjs/index.js",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
   "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
For back-compatibility.

This PR adds react-native top level field to package.json, similar to PR https://github.com/Azure/azure-sdk-for-js/pull/30493.

-------

### Packages impacted by this PR
core-util, core-rest-pipeline, core-amqp, logger