### PR TITLE
[Eng] Turn off federated auth for cosmos

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -46,6 +46,8 @@ extends:
             - template: /eng/pipelines/templates/steps/cosmos-integration-public.yml@self
           PostSteps:
             - template: /eng/pipelines/templates/steps/cosmos-additional-steps.yml@self
+          # Temporary fix for cosmos ci pipeline
+          UseFederatedAuth: false
           EnvVars:
             MOCHA_TIMEOUT: 100000
             NODE_TLS_REJECT_UNAUTHORIZED: 0


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR
More details about the issue [here]

### Describe the problem that is addressed by this PR
Cosmos ci pipeline is failing after turning on Federated Auth by default

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
