### PR TITLE
[identity] Add ServiceConnection to tests.yml

### DIFF
--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -9,6 +9,7 @@ extends:
       SupportedClouds: 'Public,UsGov,China,Canary'
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
             # Contains alternate tenant, AAD app and cert info for testing


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A build failures

### Describe the problem that is addressed by this PR

Looks like this was missed as part of the recent changes, but we need the ServiceConnection property to be set at the tests.yml level. This PR fixes that.

[teams chat (MICROSOFT INTERNAL)](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1721920991966?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1721920991966&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1721920991966)
