### PR TITLE
Default to sub config file paths/svc connection for public + sovereign live tests

### DIFF
--- a/sdk/attestation/attestation/tests.yml
+++ b/sdk/attestation/attestation/tests.yml
@@ -7,10 +7,6 @@ extends:
       ServiceDirectory: attestation
       TimeoutInMinutes: 90
       Clouds: Preview
-      CloudConfig:
-        Preview:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ServiceConnection: azure-sdk-tests-preview      
       Location: westus
       MatrixFilters:
         - DependencyVersion=^$

--- a/sdk/communication/communication-common/tests.yml
+++ b/sdk/communication/communication-common/tests.yml
@@ -14,7 +14,7 @@ extends:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-js)
           MatrixFilters:
-            - DependencyVersion=^.+$  
+            - DependencyVersion=^.+$
       Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -10,12 +10,18 @@ extends:
       SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
         UsGov:
-          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          ServiceConnection: usgov_azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzureUsGovMsft.json
           Location: 'usgovarizona'
         China:
-          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          ServiceConnection: china_azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzureChinaMsft.json
           Location: 'chinaeast'
       EnvVars:
         AZURE_CLIENT_ID: $(EVENTHUB_CLIENT_ID)

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -9,19 +9,20 @@ extends:
       SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:
-          Location: 'eastus2'
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ServiceConnection: azure-sdk-tests
           SubscriptionConfigurationFilePaths:
             - eng/common/TestResources/sub-config/AzurePublicMsft.json
+          Location: 'eastus2'
         UsGov:
-          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          ServiceConnection: usgov_azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzureUsGovMsft.json
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
-          ServiceConnection: usgov_azure-sdk-tests
         China:
-          SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ServiceConnection: china_azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzureChinaMsft.json
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
       # KV HSM limitation prevents us from running live tests

--- a/sdk/search/search-documents/tests.yml
+++ b/sdk/search/search-documents/tests.yml
@@ -11,4 +11,15 @@ extends:
       SupportedClouds: "Preview,UsGov,China"
       CloudConfig:
         Preview:
+          ServiceConnection: azure-sdk-tests-preview
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePreviewMsft.json
           Location: "westcentralus"
+        UsGov:
+          ServiceConnection: usgov_azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzureUsGovMsft.json
+        China:
+          ServiceConnection: china_azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzureChinaMsft.json

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -10,12 +10,6 @@ extends:
       Location: canadacentral
       MatrixFilters:
         - DependencyVersion=^$
-      CloudConfig:
-        Preview:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ServiceConnection: azure-sdk-tests
-          SubscriptionConfigurationFilePaths: 
-            - eng/common/TestResources/sub-config/AzurePublicMsft.json
       MatrixConfigs:
         - Name: Storage_live_test_base
           Path: sdk/storage/storage-blob/platform-matrix.json

--- a/sdk/storage/storage-file-datalake/tests.yml
+++ b/sdk/storage/storage-file-datalake/tests.yml
@@ -9,10 +9,4 @@ extends:
       Location: canadacentral
       Clouds: 'Preview'
       MatrixFilters:
-        - DependencyVersion=^$        
-      CloudConfig:
-        Preview:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ServiceConnection: azure-sdk-tests
-          SubscriptionConfigurationFilePaths: 
-            - eng/common/TestResources/sub-config/AzurePublicMsft.json
+        - DependencyVersion=^$

--- a/sdk/storage/storage-file-share/tests.yml
+++ b/sdk/storage/storage-file-share/tests.yml
@@ -10,9 +10,3 @@ extends:
       Clouds: 'Preview'
       MatrixFilters:
         - DependencyVersion=^$
-      CloudConfig:
-        Preview:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ServiceConnection: azure-sdk-tests
-          SubscriptionConfigurationFilePaths: 
-            - eng/common/TestResources/sub-config/AzurePublicMsft.json

--- a/sdk/storage/storage-queue/tests.yml
+++ b/sdk/storage/storage-queue/tests.yml
@@ -9,9 +9,3 @@ extends:
       Clouds: 'Preview'
       MatrixFilters:
         - DependencyVersion=^$
-      CloudConfig:
-        Preview:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ServiceConnection: azure-sdk-tests
-          SubscriptionConfigurationFilePaths: 
-            - eng/common/TestResources/sub-config/AzurePublicMsft.json


### PR DESCRIPTION
This doesn't cover the many files still using secret sub configs with custom principals, those will be migrated separately. This changes the defaults to use file-based sub configs and service connections everywhere else. It is intended to be merged after/alongside federated auth mode becoming the default.

Relies on https://github.com/Azure/azure-sdk-tools/pull/8680