### PR TITLE
[identity] Errors can include a cause field

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Breaking Changes
 
+### Bugs Fixed
+
+- Fixed an issue where an incorrect error message was returned when the service responds with a 400 status code. [#30532](https://github.com/Azure/azure-sdk-for-js/pull/30532)
+
+### Other Changes
+
+- ManagedIdentityCredential errors will now include the underlying error cause under the `cause` property. [#30532](https://github.com/Azure/azure-sdk-for-js/pull/30532)
+
 ## 4.4.1 (2024-07-30)
 
 ### Bugs Fixed

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -25,7 +25,9 @@ export const AggregateAuthenticationErrorName = "AggregateAuthenticationError";
 
 // @public
 export class AuthenticationError extends Error {
-    constructor(statusCode: number, errorBody: object | string | undefined | null);
+    constructor(statusCode: number, errorBody: object | string | undefined | null, options?: {
+        cause?: unknown;
+    });
     readonly errorResponse: ErrorResponse;
     readonly statusCode: number;
 }
@@ -52,6 +54,7 @@ export class AuthenticationRequiredError extends Error {
 
 // @public
 export interface AuthenticationRequiredErrorOptions {
+    cause?: unknown;
     getTokenOptions?: GetTokenOptions;
     message?: string;
     scopes: string[];
@@ -222,7 +225,9 @@ export interface CredentialPersistenceOptions {
 
 // @public
 export class CredentialUnavailableError extends Error {
-    constructor(message?: string);
+    constructor(message?: string, options?: {
+        cause?: unknown;
+    });
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -244,7 +244,7 @@ export class MsalMsiProvider {
       });
     };
     if (!msalToken) {
-      throw createError("No response");
+      throw createError("No response.");
     }
     if (!msalToken.expiresOn) {
       throw createError(`Response had no "expiresOn" property.`);

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -150,6 +150,8 @@ export class MsalMsiProvider {
         const identitySource = this.managedIdentityApp.getManagedIdentitySource();
         const isImdsMsi = identitySource === "DefaultToImds" || identitySource === "Imds"; // Neither actually checks that IMDS endpoint is available, just that it's the source the MSAL _would_ try to use.
 
+        logger.getToken.info(`MSAL Identity source: ${identitySource}`);
+
         if (isTokenExchangeMsi) {
           // In the AKS scenario we will use the existing tokenExchangeMsi indefinitely.
           logger.getToken.info("Using the token exchange managed identity.");
@@ -163,7 +165,7 @@ export class MsalMsiProvider {
 
           if (result === null) {
             throw new CredentialUnavailableError(
-              "The managed identity endpoint was reached, yet no tokens were received.",
+              "Attempted to use the token exchange managed identity, but received a null token.",
             );
           }
 
@@ -182,7 +184,7 @@ export class MsalMsiProvider {
 
           if (!isAvailable) {
             throw new CredentialUnavailableError(
-              `ManagedIdentityCredential: The managed identity endpoint is not available.`,
+              `ManagedIdentityCredential: MSAL indicated that the IMDS endpoint is the source for managed identity, but the IMDS endpoint is not available.`,
             );
           }
         }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -215,11 +215,13 @@ export class MsalMsiProvider {
         if (isNetworkError(err)) {
           throw new CredentialUnavailableError(
             `ManagedIdentityCredential: Network unreachable. Message: ${err.message}`,
+            { cause: err },
           );
         }
 
         throw new CredentialUnavailableError(
           `ManagedIdentityCredential: Authentication failed. Message ${err.message}`,
+          { cause: err },
         );
       }
     });

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -165,7 +165,7 @@ export class MsalMsiProvider {
 
           if (result === null) {
             throw new CredentialUnavailableError(
-              "Attempted to use the token exchange managed identity, but received a null token.",
+              "Attempted to use the token exchange managed identity, but received a null response.",
             );
           }
 
@@ -184,7 +184,7 @@ export class MsalMsiProvider {
 
           if (!isAvailable) {
             throw new CredentialUnavailableError(
-              `ManagedIdentityCredential: MSAL indicated that the IMDS endpoint is the source for managed identity, but the IMDS endpoint is not available.`,
+              `ManagedIdentityCredential: Attempted to use the IMDS endpoint, but it is not available.`,
             );
           }
         }

--- a/sdk/identity/identity/src/errors.ts
+++ b/sdk/identity/identity/src/errors.ts
@@ -125,8 +125,8 @@ export class AuthenticationError extends Error {
       } catch (e: any) {
         if (statusCode === 400) {
           errorResponse = {
-            error: "authority_not_found",
-            errorDescription: "The specified authority URL was not found.",
+            error: "invalid_request",
+            errorDescription: `The service indicated that the request was invalid.\n\n${errorBody}`,
           };
         } else {
           errorResponse = {
@@ -143,7 +143,7 @@ export class AuthenticationError extends Error {
     }
 
     super(
-      `${errorResponse.error} Status code: ${statusCode}\nMore details:\n${errorResponse.errorDescription}`,
+      `${errorResponse.error} Status code: ${statusCode}\nMore details:\n${errorResponse.errorDescription},`,
       // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
       options,
     );

--- a/sdk/identity/identity/src/errors.ts
+++ b/sdk/identity/identity/src/errors.ts
@@ -75,10 +75,19 @@ export const CredentialUnavailableErrorName = "CredentialUnavailableError";
  * an error that should halt the chain, it's caught and the chain continues
  */
 export class CredentialUnavailableError extends Error {
-  constructor(message?: string) {
-    super(message);
+  constructor(message?: string, options?: ErrorOptions) {
+    // TypeScript does not recognize this until we use ES2022 as the target
+    // However all our major runtimes do support the `cause` property
+    // see https://medium.com/ovrsea/power-up-your-node-js-debugging-and-error-handling-with-the-new-error-cause-feature-4136c563126a
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    super(message, options);
     this.name = CredentialUnavailableErrorName;
   }
+}
+
+export interface ErrorOptions {
+  cause?: unknown;
 }
 
 /**
@@ -103,7 +112,11 @@ export class AuthenticationError extends Error {
   public readonly errorResponse: ErrorResponse;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  constructor(statusCode: number, errorBody: object | string | undefined | null) {
+  constructor(
+    statusCode: number,
+    errorBody: object | string | undefined | null,
+    options?: ErrorOptions,
+  ) {
     let errorResponse: ErrorResponse = {
       error: "unknown",
       errorDescription: "An unknown error occurred and no additional details are available.",
@@ -139,6 +152,12 @@ export class AuthenticationError extends Error {
 
     super(
       `${errorResponse.error} Status code: ${statusCode}\nMore details:\n${errorResponse.errorDescription}`,
+      // TypeScript does not recognize this until we use ES2022 as the target
+      // However all our major runtimes do support the `cause` property
+      // see https://medium.com/ovrsea/power-up-your-node-js-debugging-and-error-handling-with-the-new-error-cause-feature-4136c563126a
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      options,
     );
     this.statusCode = statusCode;
     this.errorResponse = errorResponse;

--- a/sdk/identity/identity/src/errors.ts
+++ b/sdk/identity/identity/src/errors.ts
@@ -75,19 +75,11 @@ export const CredentialUnavailableErrorName = "CredentialUnavailableError";
  * an error that should halt the chain, it's caught and the chain continues
  */
 export class CredentialUnavailableError extends Error {
-  constructor(message?: string, options?: ErrorOptions) {
-    // TypeScript does not recognize this until we use ES2022 as the target
-    // However all our major runtimes do support the `cause` property
-    // see https://medium.com/ovrsea/power-up-your-node-js-debugging-and-error-handling-with-the-new-error-cause-feature-4136c563126a
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+  constructor(message?: string, options?: { cause?: unknown }) {
+    // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
     super(message, options);
     this.name = CredentialUnavailableErrorName;
   }
-}
-
-export interface ErrorOptions {
-  cause?: unknown;
 }
 
 /**
@@ -115,7 +107,7 @@ export class AuthenticationError extends Error {
   constructor(
     statusCode: number,
     errorBody: object | string | undefined | null,
-    options?: ErrorOptions,
+    options?: { cause?: unknown },
   ) {
     let errorResponse: ErrorResponse = {
       error: "unknown",
@@ -152,11 +144,7 @@ export class AuthenticationError extends Error {
 
     super(
       `${errorResponse.error} Status code: ${statusCode}\nMore details:\n${errorResponse.errorDescription}`,
-      // TypeScript does not recognize this until we use ES2022 as the target
-      // However all our major runtimes do support the `cause` property
-      // see https://medium.com/ovrsea/power-up-your-node-js-debugging-and-error-handling-with-the-new-error-cause-feature-4136c563126a
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
       options,
     );
     this.statusCode = statusCode;
@@ -220,6 +208,10 @@ export interface AuthenticationRequiredErrorOptions {
    * The message of the error.
    */
   message?: string;
+  /**
+   * The underlying cause, if any, that caused the authentication to fail.
+   */
+  cause?: unknown;
 }
 
 /**
@@ -241,7 +233,13 @@ export class AuthenticationRequiredError extends Error {
      */
     options: AuthenticationRequiredErrorOptions,
   ) {
-    super(options.message);
+    super(
+      options.message,
+      // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
+      {
+        cause: options.cause,
+      },
+    );
     this.scopes = options.scopes;
     this.getTokenOptions = options.getTokenOptions;
     this.name = "AuthenticationRequiredError";

--- a/sdk/identity/identity/test/public/errors.spec.ts
+++ b/sdk/identity/identity/test/public/errors.spec.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AggregateAuthenticationError, CredentialUnavailableError } from "../../src";
-
+import { AggregateAuthenticationError } from "../../src";
 import { assert } from "chai";
 
 describe("AggregateAuthenticationError", function () {
@@ -13,12 +12,5 @@ describe("AggregateAuthenticationError", function () {
     ]);
 
     assert(aggregateError.message.includes("Error: Boom.\nError: Boom again."));
-  });
-});
-
-describe.only("CredentialUnavailableError", function () {
-  it("produces a message containing details of the errors it contains", async () => {
-    const err = new CredentialUnavailableError("outer error", { cause: new Error("inner error") });
-    throw err;
   });
 });

--- a/sdk/identity/identity/test/public/errors.spec.ts
+++ b/sdk/identity/identity/test/public/errors.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AggregateAuthenticationError } from "../../src";
+import { AggregateAuthenticationError, CredentialUnavailableError } from "../../src";
+
 import { assert } from "chai";
 
 describe("AggregateAuthenticationError", function () {
@@ -12,5 +13,12 @@ describe("AggregateAuthenticationError", function () {
     ]);
 
     assert(aggregateError.message.includes("Error: Boom.\nError: Boom again."));
+  });
+});
+
+describe.only("CredentialUnavailableError", function () {
+  it("produces a message containing details of the errors it contains", async () => {
+    const err = new CredentialUnavailableError("outer error", { cause: new Error("inner error") });
+    throw err;
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

In order to improve the error experience for Managed Identity we want to do a few things:

1. Remove misleading error messages like authority_not_found for any 400
2. Display the error's cause / InnerException / etc. 
3. Provide helpful debugging information in the exception message

(1) and (2) are done here, (3) is still in flux as I need to think about what information will be helpful without
being overwhelming.

### Are there test cases added in this PR? _(If not, why?)_

Printing out the error's cause is an implementation detail of the runtime and _not_ something that gets stringified

### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
