### PR TITLE
[dev-tool] Allow samples to use createTestCredential

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10523,6 +10523,12 @@ packages:
     hasBin: true
     dev: false
 
+  /typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
   /ua-parser-js@0.7.38:
     resolution: {integrity: sha512-fYmIy7fKTSFAhG3fuPlubeGaMoAd6r0rSnfEsO5nEY55i26KSLt9EH7PLQiiqPUhNqYIJvSkTy1oArIcXAbPbA==}
     dev: false
@@ -20445,12 +20451,13 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-zyu8AiqGLwZWuEpTuodQDLMu+auXoDcDC2rLYtEysykv5r2j1ORxUZofNqNOlwQxfOzrMHBNYj5Vv9GrLNNAKA==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-1kwzdBVoElCTK0/NpA/sa1ZVfGg2PSSJi2EtoIE3D4U37LdRyDGQmU+Sn7k/ajQIF7dzThCHJ1cmKmFslQlgSg==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
-      '@_ts/max': /typescript@5.5.3
+      '@_ts/max': /typescript@5.5.4
       '@_ts/min': /typescript@4.2.4
+      '@azure-tools/test-credential': 1.2.0
       '@azure/identity': 4.4.0
       '@microsoft/api-extractor': 7.47.1(@types/node@18.19.40)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.18.1)

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -45,6 +45,7 @@
     "@_ts/min": "npm:typescript@~4.2.4",
     "@_ts/max": "npm:typescript@latest",
     "@azure/identity": "^4.2.0",
+    "@azure-tools/test-credential": "^1.0.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.0.1",
     "@rollup/plugin-multi-entry": "^6.0.1",

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -357,8 +357,8 @@ export async function makeSamplesFactory(
               copy("sample.env", path.join(projectInfo.path, "sample.env")),
               // We copy the samples sources in to the `src` folder on the typescript side
               dir("src", [
-                ...info.moduleInfos.map(({ relativeSourcePath, filePath }) =>
-                  file(relativeSourcePath, () => postProcess(fs.readFileSync(filePath))),
+                ...info.moduleInfos.map(({ relativeSourcePath, tsModuleText }) =>
+                  file(relativeSourcePath, () => postProcess(tsModuleText)),
                 ),
                 ...dtsFiles.map(([relative, absolute]) =>
                   file(relative, fs.readFileSync(absolute)),

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -325,6 +325,8 @@ export async function makeSamplesFactory(
    * Helper to remove azsdk- directives from the resulting module code.
    */
   function postProcess(moduleText: string | Buffer): string {
+    console.log("Post-processing module text");
+    console.log(moduleText);
     const content = Buffer.isBuffer(moduleText) ? moduleText.toString("utf8") : moduleText;
     return (
       content

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -325,8 +325,6 @@ export async function makeSamplesFactory(
    * Helper to remove azsdk- directives from the resulting module code.
    */
   function postProcess(moduleText: string | Buffer): string {
-    console.log("Post-processing module text");
-    console.log(moduleText);
     const content = Buffer.isBuffer(moduleText) ? moduleText.toString("utf8") : moduleText;
     return (
       content

--- a/common/tools/dev-tool/src/util/samples/info.ts
+++ b/common/tools/dev-tool/src/util/samples/info.ts
@@ -124,6 +124,10 @@ export interface ModuleInfo {
    */
   jsModuleText: string;
   /**
+   * The processed TypeScript Module
+   */
+  tsModuleText: string;
+  /**
    * The description provided by the first doc comment.
    */
   summary?: string;

--- a/common/tools/dev-tool/src/util/samples/processor.ts
+++ b/common/tools/dev-tool/src/util/samples/processor.ts
@@ -121,6 +121,7 @@ export async function processSources(
       },
     });
 
+    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
     const sourceFile = ts.createSourceFile(source, sourceText, ts.ScriptTarget.Latest, true);
     const tsModuleText = credentialTransformer(undefined)(sourceFile).getText();
 
@@ -413,7 +414,8 @@ const credentialTransformer: (
   const visitor: ts.Visitor = (node) => {
     if (ts.isImportDeclaration(node)) {
       if (node.moduleSpecifier.getText() === '"@azure-tools/test-credential"') {
-        return ts.factory.createImportDeclaration(
+        return ts.factory.updateImportDeclaration(
+          node,
           node.modifiers,
           ts.factory.createImportClause(
             false,
@@ -421,12 +423,12 @@ const credentialTransformer: (
             ts.factory.createNamedImports([
               ts.factory.createImportSpecifier(
                 false,
+
                 undefined,
                 ts.factory.createIdentifier("DefaultAzureCredential"),
               ),
             ]),
           ),
-
           ts.factory.createStringLiteral("@azure/identity"),
           node.attributes,
         );

--- a/common/tools/dev-tool/src/util/samples/processor.ts
+++ b/common/tools/dev-tool/src/util/samples/processor.ts
@@ -414,6 +414,7 @@ async function replaceTestCredential(sourceText: string) {
   sourceFile.forEachDescendant((node) => {
     if (Node.isImportDeclaration(node)) {
       if (node.getModuleSpecifierValue() === "@azure-tools/test-credential") {
+        log.debug("Replacing import of test credential with DefaultAzureCredential");
         node.replaceWithText(`import { DefaultAzureCredential } from "@azure/identity";`);
       }
     }
@@ -422,6 +423,7 @@ async function replaceTestCredential(sourceText: string) {
         Node.isIdentifier(node.getExpression()) &&
         node.getExpression().getText() === "createTestCredential"
       ) {
+        log.debug("Replacing call to createTestCredential with new DefaultAzureCredential");
         node.replaceWithText("new DefaultAzureCredential()");
       }
     }

--- a/common/tools/dev-tool/test/samples/files.spec.ts
+++ b/common/tools/dev-tool/test/samples/files.spec.ts
@@ -96,13 +96,13 @@ describe("File content tests", { timeout: 50000 }, async function () {
             const actual = await fs.readFile(actualFileName);
             const expected = await fs.readFile(expectedFileName);
 
-            // console.log(expectedFileName);
-            // if (expectedFileName.includes("credential")) {
-            //   console.log("=====EXPECTED=====");
-            //   console.log(expected.toString("utf8"));
-            //   console.log("=====ACTUAL=====");
-            //   console.log(actual.toString("utf8"));
-            // }
+            console.log(expectedFileName);
+            if (expectedFileName.includes("credential")) {
+              console.log("=====EXPECTED=====");
+              console.log(expected.toString("utf8"));
+              console.log("=====ACTUAL=====");
+              console.log(actual.toString("utf8"));
+            }
             assert.equal(actual.toString("utf8"), expected.toString("utf8"));
           }
 

--- a/common/tools/dev-tool/test/samples/files.spec.ts
+++ b/common/tools/dev-tool/test/samples/files.spec.ts
@@ -96,6 +96,13 @@ describe("File content tests", { timeout: 50000 }, async function () {
             const actual = await fs.readFile(actualFileName);
             const expected = await fs.readFile(expectedFileName);
 
+            // console.log(expectedFileName);
+            // if (expectedFileName.includes("credential")) {
+            //   console.log("=====EXPECTED=====");
+            //   console.log(expected.toString("utf8"));
+            //   console.log("=====ACTUAL=====");
+            //   console.log(actual.toString("utf8"));
+            // }
             assert.equal(actual.toString("utf8"), expected.toString("utf8"));
           }
 

--- a/common/tools/dev-tool/test/samples/files.spec.ts
+++ b/common/tools/dev-tool/test/samples/files.spec.ts
@@ -96,13 +96,6 @@ describe("File content tests", { timeout: 50000 }, async function () {
             const actual = await fs.readFile(actualFileName);
             const expected = await fs.readFile(expectedFileName);
 
-            console.log(expectedFileName);
-            if (expectedFileName.includes("credential")) {
-              console.log("=====EXPECTED=====");
-              console.log(expected.toString("utf8"));
-              console.log("=====ACTUAL=====");
-              console.log(actual.toString("utf8"));
-            }
             assert.equal(actual.toString("utf8"), expected.toString("utf8"));
           }
 

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/README.md
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/README.md
@@ -1,0 +1,53 @@
+# Azure Template client library samples for JavaScript
+
+These sample programs show how to use the JavaScript client libraries for Azure Template in some common scenarios.
+
+| **File Name**                                         | **Description**                      |
+| ----------------------------------------------------- | ------------------------------------ |
+| [getConfigurationSetting.js][getconfigurationsetting] | a succinct and simple sample example |
+
+## Prerequisites
+
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
+
+You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
+
+- [Azure App Configuration][createinstance_azureappconfiguration]
+
+Samples retrieve credentials to access the service endpoint from environment variables. Alternatively, edit the source code to include the appropriate credentials. See each individual sample for details on which environment variables/credentials it requires to function.
+
+Adapting the samples to run in the browser may require some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the dependencies using `npm`:
+
+```bash
+npm install
+```
+
+2. Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.
+
+3. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node getConfigurationSetting.js
+```
+
+Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
+
+```bash
+npx cross-env MY_VARIABLE="<my variable>" node getConfigurationSetting.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[getconfigurationsetting]: https://github.com/Azure/azure-sdk-for-js/blob/main/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/getConfigurationSetting.js
+[apiref]: https://docs.microsoft.com/javascript/api/
+[freesub]: https://azure.microsoft.com/free/
+[createinstance_azureappconfiguration]: https://docs.microsoft.com/azure/azure-app-configuration/
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/README.md

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/getConfigurationSetting.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/getConfigurationSetting.js
@@ -5,10 +5,10 @@
  * @summary a succinct and simple sample example
  */
 
-const { DefaultAzureCredential } = require("@azure/identity");
-
 // Load the .env file if it exists
 require("dotenv").config();
+
+const { DefaultAzureCredential } = require("@azure/identity");
 
 async function main() {
   const credential = new DefaultAzureCredential();

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/getConfigurationSetting.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/getConfigurationSetting.js
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @summary a succinct and simple sample example
+ */
+
+const { DefaultAzureCredential } = require("@azure/identity");
+
+// Load the .env file if it exists
+require("dotenv").config();
+
+async function main() {
+  const credential = new DefaultAzureCredential();
+  await credential.getToken("https://vault.azure.net/.default");
+
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
+
+  // Let's test some new Node 14 syntax
+  const n = 1_999_999;
+
+  const f = (n) => n;
+
+  console.log(f?.(n)?.toString());
+
+  console.log("Here's what we found:", envValue);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/credential",
   "dependencies": {
-    "simple": "latest",
-    "dotenv": "latest"
+    "credential": "latest",
+    "dotenv": "latest",
+    "@azure/identity": "^4.2.0"
   }
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@azure-samples/credential-js",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Azure Template client library samples for JavaScript",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
+    "directory": "common/tools/dev-tool/test/samples/files/expectations/credential"
+  },
+  "keywords": [
+    "credential"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/credential",
+  "dependencies": {
+    "simple": "latest",
+    "dotenv": "latest"
+  }
+}

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/sample.env
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/javascript/sample.env
@@ -1,0 +1,7 @@
+# Used in most samples. Retrieve these values from an instance in the Azure
+# Portal. The APPCONFIG_TEST_SETTING_KEY value indicates which key to use
+# when retrieving an example setting.
+
+APPCONFIG_ENDPOINT="https://<resource name>.azconfig.io",
+APPCONFIG_TEST_SETTING_KEY="<key>"
+

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/README.md
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/README.md
@@ -1,0 +1,66 @@
+# Azure Template client library samples for TypeScript
+
+These sample programs show how to use the TypeScript client libraries for Azure Template in some common scenarios.
+
+| **File Name**                                         | **Description**                      |
+| ----------------------------------------------------- | ------------------------------------ |
+| [getConfigurationSetting.ts][getconfigurationsetting] | a succinct and simple sample example |
+
+## Prerequisites
+
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
+
+Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:
+
+```bash
+npm install -g typescript
+```
+
+You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
+
+- [Azure App Configuration][createinstance_azureappconfiguration]
+
+Samples retrieve credentials to access the service endpoint from environment variables. Alternatively, edit the source code to include the appropriate credentials. See each individual sample for details on which environment variables/credentials it requires to function.
+
+Adapting the samples to run in the browser may require some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the dependencies using `npm`:
+
+```bash
+npm install
+```
+
+2. Compile the samples:
+
+```bash
+npm run build
+```
+
+3. Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.
+
+4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node dist/getConfigurationSetting.js
+```
+
+Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
+
+```bash
+npx cross-env MY_VARIABLE="<my variable>" node dist/getConfigurationSetting.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[getconfigurationsetting]: https://github.com/Azure/azure-sdk-for-js/blob/main/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/src/getConfigurationSetting.ts
+[apiref]: https://docs.microsoft.com/javascript/api/
+[freesub]: https://azure.microsoft.com/free/
+[createinstance_azureappconfiguration]: https://docs.microsoft.com/azure/azure-app-configuration/
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/README.md
+[typescript]: https://www.typescriptlang.org/docs/home.html

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@azure-samples/credential-ts",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Azure Template client library samples for TypeScript",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rimraf dist/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
+    "directory": "common/tools/dev-tool/test/samples/files/expectations/credential"
+  },
+  "keywords": [
+    "credential"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/credential",
+  "dependencies": {
+    "simple": "latest",
+    "dotenv": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "~5.5.3",
+    "rimraf": "latest"
+  }
+}

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/package.json
@@ -25,8 +25,9 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/credential",
   "dependencies": {
-    "simple": "latest",
-    "dotenv": "latest"
+    "credential": "latest",
+    "dotenv": "latest",
+    "@azure/identity": "^4.2.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/sample.env
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/sample.env
@@ -1,0 +1,7 @@
+# Used in most samples. Retrieve these values from an instance in the Azure
+# Portal. The APPCONFIG_TEST_SETTING_KEY value indicates which key to use
+# when retrieving an example setting.
+
+APPCONFIG_ENDPOINT="https://<resource name>.azconfig.io",
+APPCONFIG_TEST_SETTING_KEY="<key>"
+

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/src/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/src/getConfigurationSetting.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @summary a succinct and simple sample example
+ */
+
+import { DefaultAzureCredential } from "@azure/identity";
+
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+async function main() {
+  const credential = new DefaultAzureCredential();
+  await credential.getToken("https://vault.azure.net/.default");
+
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
+
+  // Let's test some new Node 14 syntax
+  const n = 1_999_999;
+
+  const f: ((n: number) => number) | undefined = (n) => n;
+
+  console.log(f?.(n)?.toString());
+
+  console.log("Here's what we found:", envValue);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/src/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/src/getConfigurationSetting.ts
@@ -5,11 +5,11 @@
  * @summary a succinct and simple sample example
  */
 
-import { DefaultAzureCredential } from "@azure/identity";
-
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
+
+import { DefaultAzureCredential } from "@azure/identity";
 
 async function main() {
   const credential = new DefaultAzureCredential();

--- a/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/credential/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "alwaysStrict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/common/tools/dev-tool/test/samples/files/inputs/credential/config.json
+++ b/common/tools/dev-tool/test/samples/files/inputs/credential/config.json
@@ -1,0 +1,10 @@
+{
+  "skipFolder": false,
+  "disableDocsMs": true,
+  "productName": "Azure Template",
+  "productSlugs": [],
+  "apiRefLink": "https://docs.microsoft.com/javascript/api/",
+  "requiredResources": {
+    "Azure App Configuration": "https://docs.microsoft.com/azure/azure-app-configuration/"
+  }
+}

--- a/common/tools/dev-tool/test/samples/files/inputs/credential/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/credential/getConfigurationSetting.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @summary a succinct and simple sample example
+ */
+
+import { createTestCredential } from "@azure-tools/test-credential";
+
+// Load the .env file if it exists
+import * as dotenv from "dotenv";
+dotenv.config();
+
+async function main() {
+  const credential = createTestCredential();
+  await credential.getToken("https://vault.azure.net/.default");
+
+  const envValue = process.env.MY_VARIABLE ?? "<my variable>";
+
+  // Let's test some new Node 14 syntax
+  const n = 1_999_999;
+
+  const f: ((n: number) => number) | undefined = (n) => n;
+
+  console.log(f?.(n)?.toString());
+
+  console.log("Here's what we found:", envValue);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/common/tools/dev-tool/test/samples/files/inputs/credential/getConfigurationSetting.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/credential/getConfigurationSetting.ts
@@ -5,11 +5,11 @@
  * @summary a succinct and simple sample example
  */
 
-import { createTestCredential } from "@azure-tools/test-credential";
-
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
+
+import { createTestCredential } from "@azure-tools/test-credential";
 
 async function main() {
   const credential = createTestCredential();

--- a/common/tools/dev-tool/test/samples/files/inputs/credential/sample.env
+++ b/common/tools/dev-tool/test/samples/files/inputs/credential/sample.env
@@ -1,0 +1,7 @@
+# Used in most samples. Retrieve these values from an instance in the Azure
+# Portal. The APPCONFIG_TEST_SETTING_KEY value indicates which key to use
+# when retrieving an example setting.
+
+APPCONFIG_ENDPOINT="https://<resource name>.azconfig.io",
+APPCONFIG_TEST_SETTING_KEY="<key>"
+

--- a/sdk/keyvault/keyvault-keys/samples-dev/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples-dev/cryptography.ts
@@ -8,7 +8,7 @@
 import { createHash } from "crypto";
 
 import { CryptographyClient, KeyClient } from "@azure/keyvault-keys";
-import { DefaultAzureCredential } from "@azure/identity";
+import { createTestCredential } from "@azure-tools/test-credential";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -18,7 +18,7 @@ export async function main(): Promise<void> {
   // This sample uses DefaultAzureCredential, which supports a number of authentication mechanisms.
   // See https://docs.microsoft.com/javascript/api/overview/azure/identity-readme?view=azure-node-latest for more information
   // about DefaultAzureCredential and the other credentials that are available for use.
-  const credential = new DefaultAzureCredential();
+  const credential = createTestCredential();
 
   const url = process.env["KEYVAULT_URI"] || "<keyvault-url>";
 

--- a/sdk/keyvault/keyvault-keys/samples-dev/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples-dev/helloWorld.ts
@@ -6,7 +6,7 @@
  */
 
 import { KeyClient } from "@azure/keyvault-keys";
-import { DefaultAzureCredential } from "@azure/identity";
+import { createTestCredential } from "@azure-tools/test-credential";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -16,7 +16,7 @@ export async function main(): Promise<void> {
   // This sample uses DefaultAzureCredential, which supports a number of authentication mechanisms.
   // See https://docs.microsoft.com/javascript/api/overview/azure/identity-readme?view=azure-node-latest for more information
   // about DefaultAzureCredential and the other credentials that are available for use.
-  const credential = new DefaultAzureCredential();
+  const credential = createTestCredential();
 
   const url = process.env["KEYVAULT_URI"] || "<keyvault-url>";
   const client = new KeyClient(url, credential);

--- a/sdk/keyvault/keyvault-keys/samples-dev/keyRotation.ts
+++ b/sdk/keyvault/keyvault-keys/samples-dev/keyRotation.ts
@@ -6,7 +6,7 @@
  */
 
 import { KeyClient } from "@azure/keyvault-keys";
-import { DefaultAzureCredential } from "@azure/identity";
+import { createTestCredential } from "@azure-tools/test-credential";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
 dayjs.extend(duration);
@@ -19,7 +19,7 @@ export async function main(): Promise<void> {
   // This sample uses DefaultAzureCredential, which supports a number of authentication mechanisms.
   // See https://docs.microsoft.com/javascript/api/overview/azure/identity-readme?view=azure-node-latest for more information
   // about DefaultAzureCredential and the other credentials that are available for use.
-  const credential = new DefaultAzureCredential();
+  const credential = createTestCredential();
 
   const url = process.env["KEYVAULT_URI"] || "<keyvault-url>";
   const client = new KeyClient(url, credential);

--- a/sdk/keyvault/keyvault-keys/samples/v4/javascript/cryptography.js
+++ b/sdk/keyvault/keyvault-keys/samples/v4/javascript/cryptography.js
@@ -31,7 +31,7 @@ async function main() {
 
   const cryptoClient = new CryptographyClient(
     myWorkKey.id, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
-    credential
+    credential,
   );
 
   // Sign and Verify

--- a/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/keyvault-keys": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^4.2.1",
+    "@azure/identity": "^4.0.1",
     "dayjs": "^1.10.7"
   }
 }

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azure/keyvault-keys": "latest",
     "dotenv": "latest",
-    "@azure/identity": "^4.2.1",
+    "@azure/identity": "^4.0.1",
     "dayjs": "^1.10.7"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/src/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/src/cryptography.ts
@@ -32,7 +32,7 @@ export async function main(): Promise<void> {
 
   const cryptoClient = new CryptographyClient(
     myWorkKey.id!, // You can use either the key or the key Id i.e. its url to create a CryptographyClient.
-    credential
+    credential,
   );
 
   // Sign and Verify

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -12,6 +12,6 @@
     "rootDir": "src"
   },
   "include": [
-    "src/**.ts"
+    "src/**/*.ts"
   ]
 }


### PR DESCRIPTION
### Packages impacted by this PR

@azure-tools/dev-tool

### Issues associated with this PR

Contributes to #30447 

### Describe the problem that is addressed by this PR

Using [AZURE_POD_IDENTITY_AUTHORITY_HOST](https://github.com/Azure/azure-sdk-for-js/blob/1e789d828a31e7947369a934778ef47fc381d81f/eng/pipelines/templates/jobs/live.tests.yml#L284) as a workaround was necessary because we wanted to continue using DefaultAzureCredential in samples but skip Managed Identity when
running samples. 

In tests, we use `createTestCredential` which works well but is not the credential we want to showcase
in sample code.

This PR allows us to use `createTestCredential` in samples-dev (which will be run by CI) while still promoting DAC
as the credential to use in sample code.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
