### PR TITLE
[identity] add support for AZURE_CLIENT_SEND_CERTIFICATE_CHAIN env var

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support in `EnvironmentCredential` and `DefaultAzureCredential` for `AZURE_CLIENT_SEND_CERTIFICATE_CHAIN` environment variable to configure subject name / issuer authentication. [#30570](https://github.com/Azure/azure-sdk-for-js/pull/30570)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity/test/internal/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/environmentCredential.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import Sinon from "sinon";
+import { assert } from "@azure-tools/test-utils";
+import { getSendCertificateChain } from "../../../src/credentials/environmentCredential";
+
+describe("EnvironmentCredential (internal)", function () {
+  afterEach(function () {
+    Sinon.restore();
+  });
+
+  describe("#getSendCertificateChain", () => {
+    it("should parse 'true' correctly", async () => {
+      Sinon.stub(process, "env").value({
+        AZURE_CLIENT_SEND_CERTIFICATE_CHAIN: "true",
+      });
+
+      const sendCertificateChain = getSendCertificateChain();
+      assert.isTrue(sendCertificateChain);
+    });
+
+    it("should parse '1' correctly", async () => {
+      Sinon.stub(process, "env").value({
+        AZURE_CLIENT_SEND_CERTIFICATE_CHAIN: "1",
+      });
+
+      const sendCertificateChain = getSendCertificateChain();
+      assert.isTrue(sendCertificateChain);
+    });
+
+    it("is case insensitive", async () => {
+      Sinon.stub(process, "env").value({
+        AZURE_CLIENT_SEND_CERTIFICATE_CHAIN: "TrUe",
+      });
+
+      const sendCertificateChain = getSendCertificateChain();
+      assert.isTrue(sendCertificateChain);
+    });
+
+    it("should parse undefined correctly", async () => {
+      Sinon.stub(process, "env").value({});
+
+      const sendCertificateChain = getSendCertificateChain();
+      assert.isFalse(sendCertificateChain);
+    });
+
+    it("should default other values to false", async () => {
+      Sinon.stub(process, "env").value({
+        AZURE_CLIENT_SEND_CERTIFICATE_CHAIN: "foobar",
+      });
+
+      const sendCertificateChain = getSendCertificateChain();
+      assert.isFalse(sendCertificateChain);
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #29592

### Describe the problem that is addressed by this PR

SNI authentication is a 1p certificate feature supported by
ClientCertificateCredential. In order to implement SNI based auth one has to use
ClientCertificateCredential directly instead of DefaultAzureCredential because
there's no way to configure sendCertificateChain from DAC.

For consistency with other languages, we're adding support for
AZURE_CLIENT_SEND_CERTIFICATE_CHAIN as an env var here

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-java/pull/41031

### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
