### PR TITLE
[core] Added calculateRetryDelay helper

### DIFF
--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `calculateExponentialDelayInterval` helper that can be used to calculate the next delay interval for exponential delay with jitter. []
+- Added `calculateExponentialDelayInterval` helper that can be used to calculate the next delay interval for exponential delay with jitter. [#30572](https://github.com/Azure/azure-sdk-for-js/pull/30572)
 
 ### Breaking Changes
 

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `calculateExponentialDelayInterval` helper that can be used to calculate the next delay interval for exponential delay with jitter. [#30572](https://github.com/Azure/azure-sdk-for-js/pull/30572)
+- Added `calculateRetryDelay` helper that can be used to calculate the next delay interval for exponential delay with jitter. [#30572](https://github.com/Azure/azure-sdk-for-js/pull/30572)
 
 ### Breaking Changes
 

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `calculateExponentialDelayInterval` helper that can be used to calculate the next delay interval for exponential delay with jitter. []
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-util/review/core-util.api.md
+++ b/sdk/core/core-util/review/core-util.api.md
@@ -18,7 +18,7 @@ export interface AbortOptions {
 }
 
 // @public
-export function calculateExponentialDelayInterval(retryAttempt: number, config: {
+export function calculateRetryDelay(retryAttempt: number, config: {
     retryDelayInMs: number;
     maxRetryDelayInMs: number;
 }): {

--- a/sdk/core/core-util/review/core-util.api.md
+++ b/sdk/core/core-util/review/core-util.api.md
@@ -18,6 +18,14 @@ export interface AbortOptions {
 }
 
 // @public
+export function calculateExponentialDelayInterval(retryAttempt: number, config: {
+    retryDelayInMs: number;
+    maxRetryDelayInMs: number;
+}): {
+    retryAfterInMs: number;
+};
+
+// @public
 export function cancelablePromiseRace<T extends unknown[]>(abortablePromiseBuilders: AbortablePromiseBuilder<T[number]>[], options?: {
     abortSignal?: AbortSignalLike;
 }): Promise<T[number]>;

--- a/sdk/core/core-util/src/delay.ts
+++ b/sdk/core/core-util/src/delay.ts
@@ -3,6 +3,7 @@
 
 import type { AbortOptions } from "./aborterUtils.js";
 import { createAbortablePromise } from "./createAbortablePromise.js";
+import { getRandomIntegerInclusive } from "./random.js";
 
 const StandardAbortMessage = "The delay was aborted.";
 
@@ -30,4 +31,30 @@ export function delay(timeInMs: number, options?: DelayOptions): Promise<void> {
       abortErrorMsg: abortErrorMsg ?? StandardAbortMessage,
     },
   );
+}
+
+/**
+ * Calculates the delay interval for retry attempts using exponential delay with jitter.
+ * @param retryAttempt - The current retry attempt number.
+ * @param config - The exponential retry configuration.
+ * @returns An object containing the calculated retry delay.
+ */
+export function calculateExponentialDelayInterval(
+  retryAttempt: number,
+  config: {
+    retryDelayInMs: number;
+    maxRetryDelayInMs: number;
+  },
+): { retryAfterInMs: number } {
+  // Exponentially increase the delay each time
+  const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
+
+  // Don't let the delay exceed the maximum
+  const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
+
+  // Allow the final value to have some "jitter" (within 50% of the delay size) so
+  // that retries across multiple clients don't occur simultaneously.
+  const retryAfterInMs = clampedDelay / 2 + getRandomIntegerInclusive(0, clampedDelay / 2);
+
+  return { retryAfterInMs };
 }

--- a/sdk/core/core-util/src/delay.ts
+++ b/sdk/core/core-util/src/delay.ts
@@ -39,7 +39,7 @@ export function delay(timeInMs: number, options?: DelayOptions): Promise<void> {
  * @param config - The exponential retry configuration.
  * @returns An object containing the calculated retry delay.
  */
-export function calculateExponentialDelayInterval(
+export function calculateRetryDelay(
   retryAttempt: number,
   config: {
     retryDelayInMs: number;

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { delay, type DelayOptions } from "./delay.js";
+export { delay, type DelayOptions, calculateExponentialDelayInterval } from "./delay.js";
 export {
   type AbortOptions,
   cancelablePromiseRace,

--- a/sdk/core/core-util/src/index.ts
+++ b/sdk/core/core-util/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { delay, type DelayOptions, calculateExponentialDelayInterval } from "./delay.js";
+export { delay, type DelayOptions, calculateRetryDelay } from "./delay.js";
 export {
   type AbortOptions,
   cancelablePromiseRace,

--- a/sdk/core/core-util/test/public/delay.spec.ts
+++ b/sdk/core/core-util/test/public/delay.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { afterEach, assert, describe, it, vi } from "vitest";
-import { calculateExponentialDelayInterval, delay } from "../../src/index.js";
+import { calculateRetryDelay, delay } from "../../src/index.js";
 
 describe("delay", function () {
   afterEach(function () {
@@ -38,14 +38,14 @@ describe("delay", function () {
     }
   });
 
-  describe("#calculateExponentialDelayInterval", function () {
+  describe("#calculateRetryDelay", function () {
     it("should calculate the correct delay for the first retry attempt", function () {
       const retryAttempt = 1;
       const config = {
         retryDelayInMs: 1000,
         maxRetryDelayInMs: 10000,
       };
-      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      const result = calculateRetryDelay(retryAttempt, config);
       assert.isAtLeast(result.retryAfterInMs, config.retryDelayInMs);
       assert.isAtMost(result.retryAfterInMs, config.retryDelayInMs * 2);
     });
@@ -56,7 +56,7 @@ describe("delay", function () {
         retryDelayInMs: 1000,
         maxRetryDelayInMs: 10000,
       };
-      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      const result = calculateRetryDelay(retryAttempt, config);
       const expectedMin = config.retryDelayInMs * Math.pow(2, retryAttempt - 1);
       const expectedMax = config.retryDelayInMs * Math.pow(2, retryAttempt);
       assert.isAtLeast(result.retryAfterInMs, expectedMin);
@@ -69,7 +69,7 @@ describe("delay", function () {
         retryDelayInMs: 1000,
         maxRetryDelayInMs: 5000,
       };
-      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      const result = calculateRetryDelay(retryAttempt, config);
       assert.isAtMost(result.retryAfterInMs, config.maxRetryDelayInMs);
     });
 
@@ -79,7 +79,7 @@ describe("delay", function () {
         retryDelayInMs: 0,
         maxRetryDelayInMs: 10000,
       };
-      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      const result = calculateRetryDelay(retryAttempt, config);
       assert.strictEqual(result.retryAfterInMs, 0);
     });
   });

--- a/sdk/core/core-util/test/public/delay.spec.ts
+++ b/sdk/core/core-util/test/public/delay.spec.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { describe, it, assert, afterEach, vi } from "vitest";
-import { delay } from "../../src/index.js";
+import { afterEach, assert, describe, it, vi } from "vitest";
+import { calculateExponentialDelayInterval, delay } from "../../src/index.js";
 
 describe("delay", function () {
   afterEach(function () {
@@ -36,5 +36,51 @@ describe("delay", function () {
       assert.strictEqual(err.name, "AbortError");
       assert.strictEqual(err.message, StandardAbortMessage);
     }
+  });
+
+  describe("#calculateExponentialDelayInterval", function () {
+    it("should calculate the correct delay for the first retry attempt", function () {
+      const retryAttempt = 1;
+      const config = {
+        retryDelayInMs: 1000,
+        maxRetryDelayInMs: 10000,
+      };
+      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      assert.isAtLeast(result.retryAfterInMs, config.retryDelayInMs);
+      assert.isAtMost(result.retryAfterInMs, config.retryDelayInMs * 2);
+    });
+
+    it("should calculate the correct delay for multiple retry attempts", function () {
+      const retryAttempt = 3;
+      const config = {
+        retryDelayInMs: 1000,
+        maxRetryDelayInMs: 10000,
+      };
+      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      const expectedMin = config.retryDelayInMs * Math.pow(2, retryAttempt - 1);
+      const expectedMax = config.retryDelayInMs * Math.pow(2, retryAttempt);
+      assert.isAtLeast(result.retryAfterInMs, expectedMin);
+      assert.isAtMost(result.retryAfterInMs, Math.min(expectedMax, config.maxRetryDelayInMs));
+    });
+
+    it("should not exceed the maximum retry delay", function () {
+      const retryAttempt = 10;
+      const config = {
+        retryDelayInMs: 1000,
+        maxRetryDelayInMs: 5000,
+      };
+      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      assert.isAtMost(result.retryAfterInMs, config.maxRetryDelayInMs);
+    });
+
+    it("should handle a retry delay of zero", function () {
+      const retryAttempt = 1;
+      const config = {
+        retryDelayInMs: 0,
+        maxRetryDelayInMs: 10000,
+      };
+      const result = calculateExponentialDelayInterval(retryAttempt, config);
+      assert.strictEqual(result.retryAfterInMs, 0);
+    });
   });
 });

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -103,6 +103,14 @@ export interface BodyPart {
 }
 
 // @public
+export function calculateRetryDelay(retryAttempt: number, config: {
+    retryDelayInMs: number;
+    maxRetryDelayInMs: number;
+}): {
+    retryAfterInMs: number;
+};
+
+// @public
 export function cancelablePromiseRace<T extends unknown[]>(abortablePromiseBuilders: AbortablePromiseBuilder<T[number]>[], options?: {
     abortSignal?: AbortSignalLike;
 }): Promise<T[number]>;

--- a/sdk/core/ts-http-runtime/src/index.ts
+++ b/sdk/core/ts-http-runtime/src/index.ts
@@ -107,7 +107,7 @@ export {
 export { useInstrumenter } from "./tracing/instrumenter.js";
 export { createTracingClient } from "./tracing/tracingClient.js";
 // from core-util
-export { delay, DelayOptions } from "./util/delay.js";
+export { delay, DelayOptions, calculateRetryDelay } from "./util/delay.js";
 export {
   AbortOptions,
   cancelablePromiseRace,

--- a/sdk/core/ts-http-runtime/src/util/delay.ts
+++ b/sdk/core/ts-http-runtime/src/util/delay.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortOptions } from "./aborterUtils.js";
+import type { AbortOptions } from "./aborterUtils.js";
 import { createAbortablePromise } from "./createAbortablePromise.js";
+import { getRandomIntegerInclusive } from "./random.js";
 
 const StandardAbortMessage = "The delay was aborted.";
 
@@ -30,4 +31,30 @@ export function delay(timeInMs: number, options?: DelayOptions): Promise<void> {
       abortErrorMsg: abortErrorMsg ?? StandardAbortMessage,
     },
   );
+}
+
+/**
+ * Calculates the delay interval for retry attempts using exponential delay with jitter.
+ * @param retryAttempt - The current retry attempt number.
+ * @param config - The exponential retry configuration.
+ * @returns An object containing the calculated retry delay.
+ */
+export function calculateRetryDelay(
+  retryAttempt: number,
+  config: {
+    retryDelayInMs: number;
+    maxRetryDelayInMs: number;
+  },
+): { retryAfterInMs: number } {
+  // Exponentially increase the delay each time
+  const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
+
+  // Don't let the delay exceed the maximum
+  const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
+
+  // Allow the final value to have some "jitter" (within 50% of the delay size) so
+  // that retries across multiple clients don't occur simultaneously.
+  const retryAfterInMs = clampedDelay / 2 + getRandomIntegerInclusive(0, clampedDelay / 2);
+
+  return { retryAfterInMs };
 }

--- a/sdk/core/ts-http-runtime/test/util/delay.spec.ts
+++ b/sdk/core/ts-http-runtime/test/util/delay.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { describe, it, assert, vi, afterEach } from "vitest";
-import { delay } from "../../src/index.js";
+import { calculateRetryDelay, delay } from "../../src/index.js";
 
 describe("delay", function () {
   afterEach(function () {
@@ -36,5 +36,51 @@ describe("delay", function () {
       assert.strictEqual(err.name, "AbortError");
       assert.strictEqual(err.message, StandardAbortMessage);
     }
+  });
+
+  describe("#calculateRetryDelay", function () {
+    it("should calculate the correct delay for the first retry attempt", function () {
+      const retryAttempt = 1;
+      const config = {
+        retryDelayInMs: 1000,
+        maxRetryDelayInMs: 10000,
+      };
+      const result = calculateRetryDelay(retryAttempt, config);
+      assert.isAtLeast(result.retryAfterInMs, config.retryDelayInMs);
+      assert.isAtMost(result.retryAfterInMs, config.retryDelayInMs * 2);
+    });
+
+    it("should calculate the correct delay for multiple retry attempts", function () {
+      const retryAttempt = 3;
+      const config = {
+        retryDelayInMs: 1000,
+        maxRetryDelayInMs: 10000,
+      };
+      const result = calculateRetryDelay(retryAttempt, config);
+      const expectedMin = config.retryDelayInMs * Math.pow(2, retryAttempt - 1);
+      const expectedMax = config.retryDelayInMs * Math.pow(2, retryAttempt);
+      assert.isAtLeast(result.retryAfterInMs, expectedMin);
+      assert.isAtMost(result.retryAfterInMs, Math.min(expectedMax, config.maxRetryDelayInMs));
+    });
+
+    it("should not exceed the maximum retry delay", function () {
+      const retryAttempt = 10;
+      const config = {
+        retryDelayInMs: 1000,
+        maxRetryDelayInMs: 5000,
+      };
+      const result = calculateRetryDelay(retryAttempt, config);
+      assert.isAtMost(result.retryAfterInMs, config.maxRetryDelayInMs);
+    });
+
+    it("should handle a retry delay of zero", function () {
+      const retryAttempt = 1;
+      const config = {
+        retryDelayInMs: 0,
+        maxRetryDelayInMs: 10000,
+      };
+      const result = calculateRetryDelay(retryAttempt, config);
+      assert.strictEqual(result.retryAfterInMs, 0);
+    });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-util

### Issues associated with this PR

Contributes to #30187

### Describe the problem that is addressed by this PR

Ports over the logic from @azure/core-rest-pipeline's exponentialRetryStrategy
to a helper function that can be used by client libraries.

This code was duplicated in @azure/identity and a partner team attempted to add
exponential-backoff as a dependency to add support for this logic.

A helper function can be used to calculate the next interval, leaving the
business logic / deciding what to do next to the specific usecase

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-js/pull/30172#discussion_r1655215478

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
