### PR TITLE
[vitest] Use verbose reporter

### DIFF
--- a/sdk/eventhub/event-hubs/vitest.browser.config.ts
+++ b/sdk/eventhub/event-hubs/vitest.browser.config.ts
@@ -23,7 +23,6 @@ export default mergeConfig(
       testTimeout: 600000,
       hookTimeout: 60000,
       fileParallelism: false,
-      reporters: ["verbose", "junit"],
       include: ["dist-test/browser/**/*.spec.js"],
       setupFiles: !process.env["AZURE_LOG_LEVEL"] ? [] : ['./test/activate-browser-logging.ts'],
       fakeTimers: {

--- a/sdk/eventhub/event-hubs/vitest.config.ts
+++ b/sdk/eventhub/event-hubs/vitest.config.ts
@@ -8,7 +8,6 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      reporters: ["verbose", "junit"],
       testTimeout: 600000,
       hookTimeout: 60000,
       fileParallelism: false,

--- a/vitest.browser.shared.config.ts
+++ b/vitest.browser.shared.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   test: {
     testTimeout: 18000,
-    reporters: ["basic", "junit"],
+    reporters: ["verbose", "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     typecheck: {
       enabled: true,
     },
-    reporters: ["basic", "junit"],
+    reporters: ["verbose", "junit"],
     outputFile: {
       junit: "test-results.xml",
     },


### PR DESCRIPTION
The verbose reporter writes out the status of each unit test after it gets executed. This is inline with our experience with mocha before and it helps us track progress better in real time.