### PR TITLE
[Test][ServiceBus] work around Managed Identity credential issue

### DIFF
--- a/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/atomManagement.spec.ts
@@ -359,7 +359,11 @@ versionsToTest(serviceApiVersions, {}, (serviceVersion) => {
           const endpoint = `sb://${host}/`;
           const serviceBusAdministrationClient = new ServiceBusAdministrationClient(
             host,
-            new DefaultAzureCredential(),
+            new DefaultAzureCredential({
+              // Work around Msi credential issue in live test pipeline by failing
+              // its token retrieval
+              managedIdentityClientId: "fakeMsiClientId",
+            }),
           );
 
           should.equal(


### PR DESCRIPTION
In live test pipeline, our DefaultAzureCredential would succeed in getting a
token from MSI but that token doesn't work with our test resources.  This PR
works around the issue by passing a fake Msi client id to DefaultAzureCredential
constructor, thus cause token retrieval to fail, and DefaultAzureCredential can
continue to try the next credential type in the chain.