### PR TITLE
[@azure/monitor-query] Fixed the audience values for MetricsQueryClient and MetricsClient

### DIFF
--- a/sdk/monitor/monitor-query/CHANGELOG.md
+++ b/sdk/monitor/monitor-query/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.3.1 (2024-07-31)
+
+### Bugs Fixed
+
+- Fixed the `audience` values for `MetricsQueryClient` and `MetricsClient`.
+
 ## 1.3.0 (2024-06-11)
 
 ### Features Added

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-query",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An isomorphic client library for querying Azure Monitor's Logs and Metrics data sources.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -30,9 +30,23 @@ export const Durations: {
 
 // @public
 export enum KnownMonitorAudience {
-    AzureChina = "https://monitor.azure.cn",
-    AzureGovernment = "https://monitor.azure.us",
-    AzurePublicCloud = "https://monitor.azure.com"
+    AzureChina = "https://metrics.monitor.azure.cn",
+    AzureGovernment = "https://metrics.monitor.azure.us",
+    AzurePublicCloud = "https://metrics.monitor.azure.com"
+}
+
+// @public
+export enum KnownMonitorLogAudience {
+    AzureChina = "https://api.loganalytics.cn",
+    AzureGovernment = "https://api.loganalytics.us",
+    AzurePublicCloud = "https://api.loganalytics.io"
+}
+
+// @public
+export enum KnownMonitorMetricsQueryAudience {
+    AzureChina = "https://management.azure.cn/",
+    AzureGovernment = "https://management.azure.us/",
+    AzurePublicCloud = "https://management.azure.com/"
 }
 
 // @public

--- a/sdk/monitor/monitor-query/review/monitor-query.api.md
+++ b/sdk/monitor/monitor-query/review/monitor-query.api.md
@@ -36,16 +36,16 @@ export enum KnownMonitorAudience {
 }
 
 // @public
-export enum KnownMonitorLogAudience {
-    AzureChina = "https://api.loganalytics.cn",
+export enum KnownMonitorLogsQueryAudience {
+    AzureChina = "https://api.loganalytics.azure.cn",
     AzureGovernment = "https://api.loganalytics.us",
     AzurePublicCloud = "https://api.loganalytics.io"
 }
 
 // @public
 export enum KnownMonitorMetricsQueryAudience {
-    AzureChina = "https://management.azure.cn/",
-    AzureGovernment = "https://management.azure.us/",
+    AzureChina = "https://management.chinacloudapi.cn",
+    AzureGovernment = "https://management.usgovcloudapi.net",
     AzurePublicCloud = "https://management.azure.com/"
 }
 

--- a/sdk/monitor/monitor-query/src/constants.ts
+++ b/sdk/monitor/monitor-query/src/constants.ts
@@ -27,11 +27,11 @@ export enum KnownMonitorAudience {
 /**
  * Known values for Monitor Audience
  */
-export enum KnownMonitorLogAudience {
+export enum KnownMonitorLogsQueryAudience {
   /**
    * Audience for Azure China
    */
-  AzureChina = "https://api.loganalytics.cn",
+  AzureChina = "https://api.loganalytics.azure.cn",
   /**
    * Audience for Azure Government
    */
@@ -49,11 +49,11 @@ export enum KnownMonitorMetricsQueryAudience {
   /**
    * Audience for Azure China
    */
-  AzureChina = "https://management.azure.cn/",
+  AzureChina = "https://management.chinacloudapi.cn",
   /**
    * Audience for Azure Government
    */
-  AzureGovernment = "https://management.azure.us/",
+  AzureGovernment = "https://management.usgovcloudapi.net",
   /**
    * Audience for Azure Public
    */

--- a/sdk/monitor/monitor-query/src/constants.ts
+++ b/sdk/monitor/monitor-query/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * @internal
  */
-export const SDK_VERSION: string = "1.3.0";
+export const SDK_VERSION: string = "1.3.1";
 
 /**
  * Known values for Monitor Audience
@@ -13,13 +13,49 @@ export enum KnownMonitorAudience {
   /**
    * Audience for Azure China
    */
-  AzureChina = "https://monitor.azure.cn",
+  AzureChina = "https://metrics.monitor.azure.cn",
   /**
    * Audience for Azure Government
    */
-  AzureGovernment = "https://monitor.azure.us",
+  AzureGovernment = "https://metrics.monitor.azure.us",
   /**
    * Audience for Azure Public
    */
-  AzurePublicCloud = "https://monitor.azure.com",
+  AzurePublicCloud = "https://metrics.monitor.azure.com",
+}
+
+/**
+ * Known values for Monitor Audience
+ */
+export enum KnownMonitorLogAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://api.loganalytics.cn",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://api.loganalytics.us",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://api.loganalytics.io",
+}
+
+/**
+ * Known values for Monitor Audience
+ */
+export enum KnownMonitorMetricsQueryAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://management.azure.cn/",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://management.azure.us/",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://management.azure.com/",
 }

--- a/sdk/monitor/monitor-query/src/constants.ts
+++ b/sdk/monitor/monitor-query/src/constants.ts
@@ -8,6 +8,9 @@ export const SDK_VERSION: string = "1.3.1";
 
 /**
  * Known values for Monitor Audience
+ *
+ * **NOTE**: This is applicable only to `MetricsClient` in the `@azure/monitor-query` data plane package.
+ * The name `KnownMonitorAudience` is added for backward compatibilty.
  */
 export enum KnownMonitorAudience {
   /**

--- a/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/logquery/src/azureLogAnalyticsContext.ts
@@ -26,7 +26,7 @@ export class AzureLogAnalyticsContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-log-query/1.3.0`;
+    const packageDetails = `azsdk-js-monitor-log-query/1.3.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metrics/src/monitorManagementClientContext.ts
@@ -38,7 +38,7 @@ export class MonitorManagementClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-metrics/1.3.0`;
+    const packageDetails = `azsdk-js-monitor-metrics/1.3.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsdefinitions/src/monitorManagementClientContext.ts
@@ -38,7 +38,7 @@ export class MonitorManagementClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-metrics-definitions/1.3.0`;
+    const packageDetails = `azsdk-js-monitor-metrics-definitions/1.3.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClientContext.ts
+++ b/sdk/monitor/monitor-query/src/generated/metricsnamespaces/src/monitorManagementClientContext.ts
@@ -38,7 +38,7 @@ export class MonitorManagementClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-monitor-metrics-namespaces/1.3.0`;
+    const packageDetails = `azsdk-js-monitor-metrics-namespaces/1.3.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -64,4 +64,8 @@ export { NamespaceClassification } from "./generated/metricsnamespaces/src";
 
 export { MetricsQueryResourcesOptions } from "./models/publicBatchModels";
 export { MetricsClient } from "./metricsClient";
-export { KnownMonitorAudience, KnownMonitorLogAudience, KnownMonitorMetricsQueryAudience } from "./constants";
+export {
+  KnownMonitorAudience,
+  KnownMonitorLogAudience,
+  KnownMonitorMetricsQueryAudience,
+} from "./constants";

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -66,6 +66,6 @@ export { MetricsQueryResourcesOptions } from "./models/publicBatchModels";
 export { MetricsClient } from "./metricsClient";
 export {
   KnownMonitorAudience,
-  KnownMonitorLogAudience,
+  KnownMonitorLogsQueryAudience,
   KnownMonitorMetricsQueryAudience,
 } from "./constants";

--- a/sdk/monitor/monitor-query/src/index.ts
+++ b/sdk/monitor/monitor-query/src/index.ts
@@ -64,4 +64,4 @@ export { NamespaceClassification } from "./generated/metricsnamespaces/src";
 
 export { MetricsQueryResourcesOptions } from "./models/publicBatchModels";
 export { MetricsClient } from "./metricsClient";
-export { KnownMonitorAudience } from "./constants";
+export { KnownMonitorAudience, KnownMonitorLogAudience, KnownMonitorMetricsQueryAudience } from "./constants";

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -25,7 +25,7 @@ import { formatPreferHeader } from "./internal/util";
 import { CommonClientOptions, FullOperationResponse, OperationOptions } from "@azure/core-client";
 import { QueryTimeInterval } from "./models/timeInterval";
 import { convertTimespanToInterval } from "./timespanConversion";
-import { KnownMonitorLogAudience, SDK_VERSION } from "./constants";
+import { KnownMonitorLogsQueryAudience, SDK_VERSION } from "./constants";
 import { tracingClient } from "./tracing";
 import { getLogQueryEndpoint } from "./internal/logQueryOptionUtils";
 
@@ -60,7 +60,7 @@ export class LogsQueryClient {
   constructor(tokenCredential: TokenCredential, options?: LogsQueryClientOptions) {
     const scope: string = options?.audience
       ? `${options.audience}/.default`
-      : `${KnownMonitorLogAudience.AzurePublicCloud}/.default`;
+      : `${KnownMonitorLogsQueryAudience.AzurePublicCloud}/.default`;
 
     let endpoint = options?.endpoint;
     if (options?.endpoint) {

--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -25,11 +25,9 @@ import { formatPreferHeader } from "./internal/util";
 import { CommonClientOptions, FullOperationResponse, OperationOptions } from "@azure/core-client";
 import { QueryTimeInterval } from "./models/timeInterval";
 import { convertTimespanToInterval } from "./timespanConversion";
-import { SDK_VERSION } from "./constants";
+import { KnownMonitorLogAudience, SDK_VERSION } from "./constants";
 import { tracingClient } from "./tracing";
 import { getLogQueryEndpoint } from "./internal/logQueryOptionUtils";
-
-const defaultMonitorScope = "https://api.loganalytics.io/";
 
 /**
  * Options for the LogsQueryClient.
@@ -62,7 +60,7 @@ export class LogsQueryClient {
   constructor(tokenCredential: TokenCredential, options?: LogsQueryClientOptions) {
     const scope: string = options?.audience
       ? `${options.audience}/.default`
-      : `${defaultMonitorScope}/.default`;
+      : `${KnownMonitorLogAudience.AzurePublicCloud}/.default`;
 
     let endpoint = options?.endpoint;
     if (options?.endpoint) {

--- a/sdk/monitor/monitor-query/src/metricsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsQueryClient.ts
@@ -34,7 +34,7 @@ import {
   convertResponseForMetrics,
   convertResponseForMetricsDefinitions,
 } from "./internal/modelConverters";
-import { SDK_VERSION, KnownMonitorAudience } from "./constants";
+import { SDK_VERSION, KnownMonitorAudience, KnownMonitorMetricsQueryAudience } from "./constants";
 
 /**
  * Options for the MetricsQueryClient.
@@ -67,7 +67,7 @@ export class MetricsQueryClient {
   constructor(tokenCredential: TokenCredential, options?: MetricsQueryClientOptions) {
     const scope: string = options?.audience
       ? `${options.audience}/.default`
-      : `${KnownMonitorAudience.AzurePublicCloud}/.default`;
+      : `${KnownMonitorMetricsQueryAudience.AzurePublicCloud}/.default`;
 
     const packageDetails = `azsdk-js-monitor-query/${SDK_VERSION}`;
     const userAgentPrefix =

--- a/sdk/monitor/monitor-query/src/metricsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/metricsQueryClient.ts
@@ -34,7 +34,7 @@ import {
   convertResponseForMetrics,
   convertResponseForMetricsDefinitions,
 } from "./internal/modelConverters";
-import { SDK_VERSION, KnownMonitorAudience, KnownMonitorMetricsQueryAudience } from "./constants";
+import { SDK_VERSION, KnownMonitorMetricsQueryAudience } from "./constants";
 
 /**
  * Options for the MetricsQueryClient.
@@ -46,7 +46,7 @@ export interface MetricsQueryClientOptions extends CommonClientOptions {
   /**
    * The Audience to use for authentication with Microsoft Entra ID. The
    * audience is not considered when using a shared key.
-   * {@link KnownMonitorAudience} can be used interchangeably with audience
+   * {@link KnownMonitorMetricsQueryAudience} can be used interchangeably with audience
    */
   audience?: string;
 }

--- a/sdk/monitor/perf-tests/monitor-query/package.json
+++ b/sdk/monitor/perf-tests/monitor-query/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@azure/monitor-query": "1.3.0",
+    "@azure/monitor-query": "1.3.1",
     "@azure-tools/test-perf": "^1.0.0",
     "dotenv": "^16.0.0",
     "@azure/identity": "^4.0.1"


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-query

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
The audience values set for MetricsQueryClient is incorrect and has to be fixed. Also, new Audience values are introduced for LogsQueryClient and MetricsClient. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
No specific design considerations or big API changes.

### Are there test cases added in this PR? _(If not, why?)_
No. They are just changes to enum values.

### Provide a list of related PRs _(if any)_
NA

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
NA

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)


@srnagar @xirzec Please review and approve the PR.