### PR TITLE
turn off federated auth for identity

### DIFF
--- a/sdk/identity/identity/test/public/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesCredential.spec.ts
@@ -22,7 +22,7 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       clientId,
       existingServiceConnectionId,
-      systemAccessToken,
+      systemAccessToken
     );
     const token = await credential.getToken(scope);
     assert.ok(token?.token);
@@ -30,7 +30,7 @@ describe("AzurePipelinesCredential", function () {
     if (token?.expiresOnTimestamp) assert.ok(token?.expiresOnTimestamp > Date.now());
   });
 
-  it("fails with with invalid service connection", async function () {
+  it.only("fails with with invalid service connection", async function () {
     if (!isLiveMode()) {
       this.skip();
     }
@@ -41,14 +41,19 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       clientId,
       "existingServiceConnectionId",
-      systemAccessToken,
+      systemAccessToken
     );
+    try {
+      await credential.getToken(scope);
+    } catch (e) {
+      console.error(e);
+    }
     const regExp: RegExp =
       /AzurePipelinesCredential: Authenticated Failed. Received null token from OIDC request. Response status- 404./;
     await assert.isRejected(
       credential.getToken(scope),
       regExp,
-      "error thrown doesn't match or promise not rejected",
+      "error thrown doesn't match or promise not rejected"
     );
   });
 
@@ -62,14 +67,14 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       "clientId",
       existingServiceConnectionId,
-      systemAccessToken,
+      systemAccessToken
     );
     const regExp: RegExp =
       /AADSTS700016: Application with identifier 'clientId' was not found in the directory 'Microsoft'/;
     await assert.isRejected(
       credential.getToken(scope),
       regExp,
-      "error thrown doesn't match or promise not rejected",
+      "error thrown doesn't match or promise not rejected"
     );
   });
 
@@ -83,7 +88,7 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       clientId,
       existingServiceConnectionId,
-      "systemAccessToken",
+      "systemAccessToken"
     );
     await assert.isRejected(credential.getToken(scope), /Status code: 302/);
   });

--- a/sdk/identity/identity/test/public/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesCredential.spec.ts
@@ -22,7 +22,7 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       clientId,
       existingServiceConnectionId,
-      systemAccessToken
+      systemAccessToken,
     );
     const token = await credential.getToken(scope);
     assert.ok(token?.token);
@@ -37,11 +37,12 @@ describe("AzurePipelinesCredential", function () {
     // clientId for above service connection
     const clientId = process.env.AZURE_SERVICE_CONNECTION_CLIENT_ID!;
     const systemAccessToken = process.env.SYSTEM_ACCESSTOKEN!;
+    console.log("clientId=", clientId);
     const credential = new AzurePipelinesCredential(
       tenantId,
       clientId,
       "existingServiceConnectionId",
-      systemAccessToken
+      systemAccessToken,
     );
     try {
       await credential.getToken(scope);
@@ -53,7 +54,7 @@ describe("AzurePipelinesCredential", function () {
     await assert.isRejected(
       credential.getToken(scope),
       regExp,
-      "error thrown doesn't match or promise not rejected"
+      "error thrown doesn't match or promise not rejected",
     );
   });
 
@@ -67,14 +68,14 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       "clientId",
       existingServiceConnectionId,
-      systemAccessToken
+      systemAccessToken,
     );
     const regExp: RegExp =
       /AADSTS700016: Application with identifier 'clientId' was not found in the directory 'Microsoft'/;
     await assert.isRejected(
       credential.getToken(scope),
       regExp,
-      "error thrown doesn't match or promise not rejected"
+      "error thrown doesn't match or promise not rejected",
     );
   });
 
@@ -88,7 +89,7 @@ describe("AzurePipelinesCredential", function () {
       tenantId,
       clientId,
       existingServiceConnectionId,
-      "systemAccessToken"
+      "systemAccessToken",
     );
     await assert.isRejected(credential.getToken(scope), /Status code: 302/);
   });

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -7,6 +7,7 @@ extends:
       ServiceDirectory: identity
       TimeoutInMinutes: 120
       SupportedClouds: 'Public,UsGov,China,Canary'
+      UseFederatedAuth: false
       CloudConfig:
         Public:
           ServiceConnection: azure-sdk-tests

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -1,31 +1,31 @@
 trigger: none
 
 extends:
-  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
-  parameters:
-    PackageName: "@azure/identity"
-    ServiceDirectory: identity
-    TimeoutInMinutes: 120
-    SupportedClouds: "Public,UsGov,China,Canary"
-    UseFederatedAuth: false
-    CloudConfig:
-      Public:
-        ServiceConnection: azure-sdk-tests
-        SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
-          # Contains alternate tenant, AAD app and cert info for testing
-          - $(sub-config-identity-test-resources)
-          - $(sub-config-identity-test-resources-js)
-    AdditionalMatrixConfigs:
-      - Name: Identity_msi_live_test_base
-        Path: sdk/identity/identity/managed-identity-matrix.json
-        Selection: sparse
-        GenerateVMJobs: true
-    MatrixReplace:
-      - Pool=.*LINUXNEXTPOOL.*/azsdk-pool-mms-ubuntu-2204-identitymsi
-      - OSVmImage=.*LINUXNEXTVMIMAGE.*/azsdk-pool-mms-ubuntu-2204-1espt
-    EnvVars:
-      AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
-      AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
-      AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+    parameters:
+      PackageName: "@azure/identity"
+      ServiceDirectory: identity
+      TimeoutInMinutes: 120
+      SupportedClouds: 'Public,UsGov,China,Canary'
+      UseFederatedAuth: false
+      CloudConfig:
+        Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            # Contains alternate tenant, AAD app and cert info for testing
+            - $(sub-config-identity-test-resources)
+            - $(sub-config-identity-test-resources-js)
+      AdditionalMatrixConfigs:
+        - Name: Identity_msi_live_test_base
+          Path: sdk/identity/identity/managed-identity-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true
+      MatrixReplace:
+        - Pool=.*LINUXNEXTPOOL.*/azsdk-pool-mms-ubuntu-2204-identitymsi
+        - OSVmImage=.*LINUXNEXTVMIMAGE.*/azsdk-pool-mms-ubuntu-2204-1espt
+      EnvVars:
+        AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
+        AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
+        AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -1,30 +1,31 @@
 trigger: none
 
 extends:
-    template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
-    parameters:
-      PackageName: "@azure/identity"
-      ServiceDirectory: identity
-      TimeoutInMinutes: 120
-      SupportedClouds: 'Public,UsGov,China,Canary'
-      UseFederatedAuth: false
-      CloudConfig:
-        Public:
-          ServiceConnection: azure-sdk-tests
-          SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
-            # Contains alternate tenant, AAD app and cert info for testing
-            - $(sub-config-identity-test-resources)
-            - $(sub-config-identity-test-resources-js)
-      AdditionalMatrixConfigs:
-        - Name: Identity_msi_live_test_base
-          Path: sdk/identity/identity/managed-identity-matrix.json
-          Selection: sparse
-          GenerateVMJobs: true
-      MatrixReplace:
-        - Pool=.*LINUXNEXTPOOL.*/azsdk-pool-mms-ubuntu-2204-identitymsi
-        - OSVmImage=.*LINUXNEXTVMIMAGE.*/azsdk-pool-mms-ubuntu-2204-1espt
-      EnvVars:
-        AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
-        AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
+  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    PackageName: "@azure/identity"
+    ServiceDirectory: identity
+    TimeoutInMinutes: 120
+    SupportedClouds: "Public,UsGov,China,Canary"
+    UseFederatedAuth: false
+    CloudConfig:
+      Public:
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurations:
+          - $(sub-config-azure-cloud-test-resources)
+          # Contains alternate tenant, AAD app and cert info for testing
+          - $(sub-config-identity-test-resources)
+          - $(sub-config-identity-test-resources-js)
+    AdditionalMatrixConfigs:
+      - Name: Identity_msi_live_test_base
+        Path: sdk/identity/identity/managed-identity-matrix.json
+        Selection: sparse
+        GenerateVMJobs: true
+    MatrixReplace:
+      - Pool=.*LINUXNEXTPOOL.*/azsdk-pool-mms-ubuntu-2204-identitymsi
+      - OSVmImage=.*LINUXNEXTVMIMAGE.*/azsdk-pool-mms-ubuntu-2204-1espt
+    EnvVars:
+      AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
+      AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
+      AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
To get the live tests working again, we'll need to make the client id and tenant id env vars available for our pipelines, for that we need to turn off the federal auth.
Build pipeline - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4017250&view=results

New run - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4017875&view=results