### PR TITLE
[appconf, etc.] upgrade dependency `@azure/abort-controller` version to v2

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -83,7 +83,7 @@
     ]
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^2.0.0",
     "@azure/core-client": "^1.5.0",
     "@azure/core-http-compat": "^2.0.0",
     "@azure/core-lro": "^2.5.1",

--- a/sdk/appconfiguration/app-configuration/test/internal/node/throttlingRetryPolicy.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/node/throttlingRetryPolicy.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortController } from "@azure/abort-controller";
 import { AppConfigurationClient } from "../../../src";
 import { RestError } from "@azure/core-rest-pipeline";
 import chai from "chai";
@@ -53,7 +52,7 @@ describe("Should not retry forever", () => {
               value: "added",
             },
             {
-              abortSignal: AbortController.timeout(1000),
+              abortSignal: AbortSignal.timeout(1000),
             },
           ),
         );

--- a/sdk/cognitivelanguage/ai-language-conversations/package.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^2.0.0",
     "@azure/core-client": "^1.5.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -77,7 +77,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/abort-controller": "^1.1.0",
+    "@azure/abort-controller": "^2.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -58,7 +58,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^2.0.0",
     "@azure/core-paging": "^1.2.0",
     "@azure/event-hubs": "5.13.0-beta.3",
     "@azure/logger": "^1.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
@@ -16,7 +16,6 @@ import { PartitionOwnership, Checkpoint, EventHubConsumerClient } from "@azure/e
 import { Guid } from "guid-typescript";
 import { parseIntOrThrow } from "../src/blobCheckpointStore";
 import { fail } from "assert";
-import { AbortController } from "@azure/abort-controller";
 const env = getEnvVars();
 
 describe("Blob Checkpoint Store", function (): void {

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -58,7 +58,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^2.0.0",
     "@azure/event-hubs": "^5.6.0",
     "@azure/data-tables": "^13.2.2",
     "@azure/logger": "^1.0.0",

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -59,7 +59,7 @@
     "ts-node": "^10.0.0"
   },
   "dependencies": {
-    "@azure/abort-controller": "^1.0.0",
+    "@azure/abort-controller": "^2.0.0",
     "rhea": "^3.0.0",
     "tslib": "^2.2.0"
   },

--- a/sdk/eventhub/mock-hub/src/sender/streamingPartitionSender.ts
+++ b/sdk/eventhub/mock-hub/src/sender/streamingPartitionSender.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AbortController, AbortError, AbortSignalLike } from "@azure/abort-controller";
+import { AbortError, AbortSignalLike } from "@azure/abort-controller";
 import { DeliveryAnnotations, Sender, SenderEvents, types } from "rhea";
 import { MessageRecord, MessageStore } from "../storage/messageStore";
 import { EventPosition } from "../utils/eventPosition";


### PR DESCRIPTION
- upgrade for app-configuration

- upgrade for ai-language-conversations

- upgrade for container-registry

- upgrade for event hubs checkpoint stores

- upgrade for mock-hub