### PR TITLE
[EngSys] remove AzurePowerShell credential workaround

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -212,11 +212,6 @@ jobs:
 
       # ===== BEGIN LIVE TEST RUNS =====
 
-      - pwsh: |
-          eng/common/scripts/Import-AzModules.ps1
-          Update-AzConfig -DisplayBreakingChangeWarning $false
-        displayName: "Workaround https://github.com/Azure/azure-sdk-for-js/issues/30356"
-
       - ${{ if eq('true', parameters.UseFederatedAuth) }}:
         - task: AzurePowerShell@5
           inputs:


### PR DESCRIPTION
Now that the product issue is fixed and released in identity, we no longer needs
this workaround. This PR removes it.