### PR TITLE
[identity] Update parameter validation errors

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 
 - Fixed an issue where an incorrect error message was returned when the service responds with a 400 status code. [#30532](https://github.com/Azure/azure-sdk-for-js/pull/30532)
+- Improved error messages for credential parameter validation. [#30610](https://github.com/Azure/azure-sdk-for-js/pull/30610)
 
 ### Other Changes
 
@@ -886,7 +887,7 @@ This release doesn't have the changes from `1.2.4-beta.1`.
 
 ## 1.0.0-preview.1 (2019-06-27)
 
-For release notes and more information please visit https://aka.ms/azsdk/releases/july2019preview
+For release notes and more information please visit <https://aka.ms/azsdk/releases/july2019preview>
 
 - Introduced the following credential types:
   - `DefaultAzureCredential`.

--- a/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePipelinesCredential.ts
@@ -2,14 +2,15 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
-import { ClientAssertionCredential } from "./clientAssertionCredential";
 import { AuthenticationError, CredentialUnavailableError } from "../errors";
-import { credentialLogger } from "../util/logging";
-import { checkTenantId } from "../util/tenantIdUtils";
 import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+
 import { AzurePipelinesCredentialOptions } from "./azurePipelinesCredentialOptions";
+import { ClientAssertionCredential } from "./clientAssertionCredential";
 import { IdentityClient } from "../client/identityClient";
 import { PipelineResponse } from "@azure/core-rest-pipeline";
+import { checkTenantId } from "../util/tenantIdUtils";
+import { credentialLogger } from "../util/logging";
 
 const credentialName = "AzurePipelinesCredential";
 const logger = credentialLogger(credentialName);
@@ -38,11 +39,27 @@ export class AzurePipelinesCredential implements TokenCredential {
     systemAccessToken: string,
     options?: AzurePipelinesCredentialOptions,
   ) {
-    if (!clientId || !tenantId || !serviceConnectionId || !systemAccessToken) {
+    if (!clientId) {
       throw new CredentialUnavailableError(
-        `${credentialName}: is unavailable. tenantId, clientId, serviceConnectionId, and systemAccessToken are required parameters.`,
+        `${credentialName}: is unavailable. clientId is a required parameter.`,
       );
     }
+    if (!tenantId) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: is unavailable. tenantId is a required parameter.`,
+      );
+    }
+    if (!serviceConnectionId) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: is unavailable. serviceConnectionId is a required parameter.`,
+      );
+    }
+    if (!systemAccessToken) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: is unavailable. systemAccessToken is a required parameter.`,
+      );
+    }
+
     this.identityClient = new IdentityClient(options);
     checkTenantId(logger, tenantId);
     logger.info(

--- a/sdk/identity/identity/src/credentials/clientAssertionCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientAssertionCredential.ts
@@ -9,6 +9,7 @@ import {
 } from "../util/tenantIdUtils";
 
 import { ClientAssertionCredentialOptions } from "./clientAssertionCredentialOptions";
+import { CredentialUnavailableError } from "../errors";
 import { credentialLogger } from "../util/logging";
 import { tracingClient } from "../util/tracing";
 
@@ -40,9 +41,21 @@ export class ClientAssertionCredential implements TokenCredential {
     getAssertion: () => Promise<string>,
     options: ClientAssertionCredentialOptions = {},
   ) {
-    if (!tenantId || !clientId || !getAssertion) {
-      throw new Error(
-        "ClientAssertionCredential: tenantId, clientId, and clientAssertion are required parameters.",
+    if (!tenantId) {
+      throw new CredentialUnavailableError(
+        "ClientAssertionCredential: tenantId is a required parameter.",
+      );
+    }
+
+    if (!clientId) {
+      throw new CredentialUnavailableError(
+        "ClientAssertionCredential: clientId is a required parameter.",
+      );
+    }
+
+    if (!getAssertion) {
+      throw new CredentialUnavailableError(
+        "ClientAssertionCredential: clientAssertion is a required parameter.",
       );
     }
     this.tenantId = tenantId;

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.ts
@@ -9,7 +9,7 @@ import {
 } from "../util/tenantIdUtils";
 
 import { ClientSecretCredentialOptions } from "./clientSecretCredentialOptions";
-import { CredentialUnavailableError } from "@azure/identity";
+import { CredentialUnavailableError } from "../errors";
 import { credentialLogger } from "../util/logging";
 import { ensureScopes } from "../util/scopeUtils";
 import { tracingClient } from "../util/tracing";

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.ts
@@ -9,6 +9,7 @@ import {
 } from "../util/tenantIdUtils";
 
 import { ClientSecretCredentialOptions } from "./clientSecretCredentialOptions";
+import { CredentialUnavailableError } from "@azure/identity";
 import { credentialLogger } from "../util/logging";
 import { ensureScopes } from "../util/scopeUtils";
 import { tracingClient } from "../util/tracing";
@@ -45,9 +46,21 @@ export class ClientSecretCredential implements TokenCredential {
     clientSecret: string,
     options: ClientSecretCredentialOptions = {},
   ) {
-    if (!tenantId || !clientId || !clientSecret) {
-      throw new Error(
-        "ClientSecretCredential: tenantId, clientId, and clientSecret are required parameters. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.",
+    if (!tenantId) {
+      throw new CredentialUnavailableError(
+        "ClientSecretCredential: tenantId is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.",
+      );
+    }
+
+    if (!clientId) {
+      throw new CredentialUnavailableError(
+        "ClientSecretCredential: clientId is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.",
+      );
+    }
+
+    if (!clientSecret) {
+      throw new CredentialUnavailableError(
+        "ClientSecretCredential: clientSecret is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.",
       );
     }
 

--- a/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
+++ b/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
@@ -2,26 +2,28 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 import {
   OnBehalfOfCredentialAssertionOptions,
   OnBehalfOfCredentialCertificateOptions,
   OnBehalfOfCredentialOptions,
   OnBehalfOfCredentialSecretOptions,
 } from "./onBehalfOfCredentialOptions";
+import { credentialLogger, formatError } from "../util/logging";
 import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
 } from "../util/tenantIdUtils";
-import { CredentialPersistenceOptions } from "./credentialPersistenceOptions";
-import { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialOptions";
-import { credentialLogger, formatError } from "../util/logging";
-import { ensureScopes } from "../util/scopeUtils";
-import { tracingClient } from "../util/tracing";
-import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
+
 import { CertificateParts } from "../msal/types";
 import { ClientCertificatePEMCertificatePath } from "./clientCertificateCredential";
-import { readFile } from "node:fs/promises";
+import { CredentialPersistenceOptions } from "./credentialPersistenceOptions";
+import { CredentialUnavailableError } from "../errors";
+import { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialOptions";
 import { createHash } from "node:crypto";
+import { ensureScopes } from "../util/scopeUtils";
+import { readFile } from "node:fs/promises";
+import { tracingClient } from "../util/tracing";
 
 const credentialName = "OnBehalfOfCredential";
 const logger = credentialLogger(credentialName);
@@ -130,14 +132,27 @@ export class OnBehalfOfCredential implements TokenCredential {
       userAssertionToken,
       additionallyAllowedTenants: additionallyAllowedTenantIds,
     } = options;
-    if (
-      !tenantId ||
-      !clientId ||
-      !(clientSecret || certificatePath || getAssertion) ||
-      !userAssertionToken
-    ) {
-      throw new Error(
-        `${credentialName}: tenantId, clientId, clientSecret (or certificatePath or getAssertion) and userAssertionToken are required parameters.`,
+    if (!tenantId) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: tenantId is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.`,
+      );
+    }
+
+    if (!clientId) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: clientId is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.`,
+      );
+    }
+
+    if (!clientSecret && !certificatePath && !getAssertion) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: You must provide one of clientSecret, certificatePath, or a getAssertion callback but none were provided. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.`,
+      );
+    }
+
+    if (!userAssertionToken) {
+      throw new CredentialUnavailableError(
+        `${credentialName}: userAssertionToken is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.`,
       );
     }
     this.certificatePath = certificatePath;

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -2,15 +2,17 @@
 // Licensed under the MIT license.
 
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 import {
   processMultiTenantRequest,
   resolveAdditionallyAllowedTenantIds,
 } from "../util/tenantIdUtils";
+
+import { CredentialUnavailableError } from "..";
 import { UsernamePasswordCredentialOptions } from "./usernamePasswordCredentialOptions";
 import { credentialLogger } from "../util/logging";
 import { ensureScopes } from "../util/scopeUtils";
 import { tracingClient } from "../util/tracing";
-import { MsalClient, createMsalClient } from "../msal/nodeFlows/msalClient";
 
 const logger = credentialLogger("UsernamePasswordCredential");
 
@@ -45,9 +47,27 @@ export class UsernamePasswordCredential implements TokenCredential {
     password: string,
     options: UsernamePasswordCredentialOptions = {},
   ) {
-    if (!tenantId || !clientId || !username || !password) {
-      throw new Error(
-        "UsernamePasswordCredential: tenantId, clientId, username and password are required parameters. To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.",
+    if (!tenantId) {
+      throw new CredentialUnavailableError(
+        "UsernamePasswordCredential: tenantId is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.",
+      );
+    }
+
+    if (!clientId) {
+      throw new CredentialUnavailableError(
+        "UsernamePasswordCredential: clientId is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.",
+      );
+    }
+
+    if (!username) {
+      throw new CredentialUnavailableError(
+        "UsernamePasswordCredential: username is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.",
+      );
+    }
+
+    if (!password) {
+      throw new CredentialUnavailableError(
+        "UsernamePasswordCredential: password is a required parameter. To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.",
       );
     }
 

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -8,7 +8,7 @@ import {
   resolveAdditionallyAllowedTenantIds,
 } from "../util/tenantIdUtils";
 
-import { CredentialUnavailableError } from "..";
+import { CredentialUnavailableError } from "../errors";
 import { UsernamePasswordCredentialOptions } from "./usernamePasswordCredentialOptions";
 import { credentialLogger } from "../util/logging";
 import { ensureScopes } from "../util/scopeUtils";

--- a/sdk/identity/identity/test/internal/node/clientAssertionCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientAssertionCredential.spec.ts
@@ -34,8 +34,6 @@ describe("ClientAssertionCredential (internal)", function () {
   });
 
   it("Should throw if the parameteres are not correctly specified", async function () {
-    const expectedMessage =
-      "ClientAssertionCredential: tenantId, clientId, and clientAssertion are required parameters.";
     assert.throws(
       () =>
         new ClientAssertionCredential(
@@ -43,7 +41,7 @@ describe("ClientAssertionCredential (internal)", function () {
           env.AZURE_CLIENT_ID ?? "client",
           async () => "assertion",
         ),
-      expectedMessage,
+      "ClientAssertionCredential: tenantId is a required parameter.",
     );
     assert.throws(
       () =>
@@ -52,12 +50,12 @@ describe("ClientAssertionCredential (internal)", function () {
           undefined as any,
           async () => "assertion",
         ),
-      expectedMessage,
+      "ClientAssertionCredential: clientId is a required parameter.",
     );
 
     assert.throws(
       () => new ClientAssertionCredential(undefined as any, undefined as any, undefined as any),
-      expectedMessage,
+      "ClientAssertionCredential: tenantId is a required parameter.",
     );
   });
 

--- a/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/clientSecretCredential.spec.ts
@@ -37,34 +37,18 @@ describe("ClientSecretCredential (internal)", function () {
   const scope = "https://vault.azure.net/.default";
 
   it("Should throw if the parameteres are not correctly specified", async function () {
-    const errors: Error[] = [];
-    try {
-      new ClientSecretCredential(undefined as any, env.AZURE_CLIENT_ID!, env.AZURE_CLIENT_SECRET!);
-    } catch (e: any) {
-      errors.push(e);
-    }
-    try {
-      new ClientSecretCredential(env.AZURE_TENANT_ID!, undefined as any, env.AZURE_CLIENT_SECRET!);
-    } catch (e: any) {
-      errors.push(e);
-    }
-    try {
-      new ClientSecretCredential(env.AZURE_TENANT_ID!, env.AZURE_CLIENT_ID!, undefined as any);
-    } catch (e: any) {
-      errors.push(e);
-    }
-    try {
-      new ClientSecretCredential(undefined as any, undefined as any, undefined as any);
-    } catch (e: any) {
-      errors.push(e);
-    }
-    assert.equal(errors.length, 4);
-    errors.forEach((e) => {
-      assert.equal(
-        e.message,
-        "ClientSecretCredential: tenantId, clientId, and clientSecret are required parameters. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.",
-      );
-    });
+    assert.throws(
+      () => new ClientSecretCredential("", "clientId", "clientSecret"),
+      /tenantId is a required parameter/,
+    );
+    assert.throws(
+      () => new ClientSecretCredential("tenantId", "", "clientSecret"),
+      /clientId is a required parameter/,
+    );
+    assert.throws(
+      () => new ClientSecretCredential("tenantId", "clientId", ""),
+      /clientSecret is a required parameter/,
+    );
   });
 
   it("Authenticates with tenantId on getToken", async function (this: Context) {

--- a/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/usernamePasswordCredential.spec.ts
@@ -6,6 +6,7 @@
 import { AzureLogger, setLogLevel } from "@azure/logger";
 import { MsalTestCleanup, msalNodeTestSetup } from "../../node/msalNodeTestSetup";
 import { Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
+
 import { Context } from "mocha";
 import { PublicClientApplication } from "@azure/msal-node";
 import Sinon from "sinon";
@@ -41,65 +42,22 @@ describe("UsernamePasswordCredential (internal)", function () {
   const scope = "https://vault.azure.net/.default";
 
   it("Should throw if the parameteres are not correctly specified", async function () {
-    const errors: Error[] = [];
-    try {
-      new UsernamePasswordCredential(
-        undefined as any,
-        "azure_client_id",
-        "azure_username",
-        "azure_password",
-      );
-    } catch (e: any) {
-      errors.push(e);
-    }
-    try {
-      new UsernamePasswordCredential(
-        "azure_tenant_id",
-        undefined as any,
-        "azure_username",
-        "azure_password",
-      );
-    } catch (e: any) {
-      errors.push(e);
-    }
-    try {
-      new UsernamePasswordCredential(
-        "azure_tenant_id",
-        "azure_client_id",
-        undefined as any,
-        "azure_password",
-      );
-    } catch (e: any) {
-      errors.push(e);
-    }
-    try {
-      new UsernamePasswordCredential(
-        "azure_tenant_id",
-        "azure_client_id",
-        "azure_username",
-        undefined as any,
-      );
-    } catch (e: any) {
-      errors.push(e);
-    }
-
-    try {
-      new UsernamePasswordCredential(
-        undefined as any,
-        undefined as any,
-        undefined as any,
-        undefined as any,
-      );
-    } catch (e: any) {
-      errors.push(e);
-    }
-    assert.equal(errors.length, 5);
-    errors.forEach((e) => {
-      assert.equal(
-        e.message,
-        "UsernamePasswordCredential: tenantId, clientId, username and password are required parameters. To troubleshoot, visit https://aka.ms/azsdk/js/identity/usernamepasswordcredential/troubleshoot.",
-      );
-    });
+    assert.throws(
+      () => new UsernamePasswordCredential("", "clientId", "username", "password"),
+      /tenantId is a required parameter/,
+    );
+    assert.throws(
+      () => new UsernamePasswordCredential("tenantId", "", "username", "password"),
+      /clientId is a required parameter/,
+    );
+    assert.throws(
+      () => new UsernamePasswordCredential("tenantId", "clientId", "", "password"),
+      /username is a required parameter/,
+    );
+    assert.throws(
+      () => new UsernamePasswordCredential("tenantId", "clientId", "username", ""),
+      /password is a required parameter/,
+    );
   });
 
   it("Authenticates silently after the initial request", async function (this: Context) {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Improve client error messages

### Describe the problem that is addressed by this PR

Noticed in passing in the AzurePipelinesCredential - the error message lists all
required parameters but does not specify _which_ parameter was not provided.

Now that I am paying attention to errors, I did a sweep of our credentials
updating each credential with better / more specific error messages

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Alternatively we can add some method to collect all required parameters and
which were not provided to avoid getting errors one at a time for each
parameter, but I decided not to go that route here - keeping things simple and
straightforward


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
