### PR TITLE
[identity] Only set error.cause if it exists

### DIFF
--- a/sdk/identity/identity/src/errors.ts
+++ b/sdk/identity/identity/src/errors.ts
@@ -236,9 +236,7 @@ export class AuthenticationRequiredError extends Error {
     super(
       options.message,
       // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
-      {
-        cause: options.cause,
-      },
+      options.cause ? { cause: options.cause } : undefined,
     );
     this.scopes = options.scopes;
     this.getTokenOptions = options.getTokenOptions;


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity 

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

A minor cosmetic fix where we only set `cause` if it exists in the options.
Before this change, node would print `[cause]: undefined` which can be
misleading. 

Now, we'll omit `cause` entirely if its not set.

### Are there test cases added in this PR? _(If not, why?)_

Testing error presentation is challenging

