### PR TITLE
Fix Bulk split error substatus

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Computed Properties: Support for adding Computed Properties in items is added. [docs](https://learn.microsoft.com/azure/cosmos-db/nosql/query/computed-properties?tabs=dotnet#creating-computed-properties)
 - Composite Indexing: The JS SDK now supports including composite indexes in the indexing policy, improving query performance on multiple fields. [docs](https://learn.microsoft.com/azure/cosmos-db/index-overview#composite-indexes)
 - Correlated Activity Id: Correlated Activity Id is added in header of every query request on Items. This helps in troubleshooting by linking all requests for a query that involves multiple server interactions and partitions. Correlated Activity Id can be accessed through query response headers or `response.correlatedActivityId`.
-- Split/Merge proof for Bulk API: Earlier, whenever Bulk API encountered a partition merge or split during processing, it would return an error message. Now, JS SDK ensures that the Bulk API is resistant to partition splitting and merging. [#18682](https://github.com/Azure/azure-sdk-for-js/issues/18682)
+- Split proof Bulk API: Earlier, whenever Bulk API encountered a partition split during processing, it would return an error message. Now, JS SDK ensures that the Bulk API is resistant to partition split. [#18682](https://github.com/Azure/azure-sdk-for-js/issues/18682)
 - Improved samples: The samples have been updated in this release, now organized into two folders: `v3` for features up to the v3 release, and `v4` for features up to the v4 release.
 - Added support for MakeList and MakeSet query aggregators
 

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -551,8 +551,8 @@ export class Items {
         // partition key types as well since we don't support them, so for now we throw
         if (err.code === StatusCodes.Gone) {
           const isPartitionSplit =
-            err.subStatusCode === SubStatusCodes.PartitionKeyRangeGone ||
-            err.subStatusCode === SubStatusCodes.CompletingSplit;
+            err.substatus === SubStatusCodes.PartitionKeyRangeGone ||
+            err.substatus === SubStatusCodes.CompletingSplit;
 
           if (isPartitionSplit) {
             const queryRange = new QueryRange(batch.min, batch.max, true, false);

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
@@ -376,7 +376,7 @@ describe("test bulk operations", async function () {
               if (context.operationType === "batch" && responseIndex < 1) {
                 const error = new ErrorResponse();
                 error.code = StatusCodes.Gone;
-                error.subStatusCode = SubStatusCodes.PartitionKeyRangeGone;
+                error.substatus = SubStatusCodes.PartitionKeyRangeGone;
                 responseIndex++;
                 throw error;
               }
@@ -1108,7 +1108,7 @@ describe("test bulk operations", async function () {
               if (context.operationType === "batch" && responseIndex % 50 === 0) {
                 const error = new ErrorResponse();
                 error.code = StatusCodes.Gone;
-                error.subStatusCode = SubStatusCodes.PartitionKeyRangeGone;
+                error.substatus = SubStatusCodes.PartitionKeyRangeGone;
                 responseIndex++;
                 throw error;
               }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR

- On a partition error gone error in bulk calls, `substatus` in the error needs to be checked instead of `subStatusCode`.
- Update ChangeLog with just the split proof support in bulk API. Currently our SDK as a whole does not support merge.



### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
