### PR TITLE
fix: default for AZURE_LOG_LEVEL

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
@@ -76,7 +76,7 @@ export class Logger {
         setLogLevel("error");
         break;
       default:
-        setLogLevel((process.env.AZURE_LOG_LEVEL as AzureLogLevel) || "warning");
+        setLogLevel(process.env.AZURE_LOG_LEVEL || "warning");
         break;
     }
     // Override Azure logger

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
@@ -61,8 +61,8 @@ export class Logger {
     });
 
     let azureLogLevelEnv =
-      process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL || process.env.AZURE_LOG_LEVEL;
-    let azureLogLevel: AzureLogLevel = "warning"; // default
+      process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
+    let azureLogLevel: AzureLogLevel = process.env.AZURE_LOG_LEVEL || "warning"; // default
     switch (azureLogLevelEnv) {
       // Application Insights levels
       case "VERBOSE":

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
@@ -76,7 +76,7 @@ export class Logger {
         setLogLevel("error");
         break;
       default:
-        setLogLevel(process.env.AZURE_LOG_LEVEL as AzureLogLevel || "warning");
+        setLogLevel((process.env.AZURE_LOG_LEVEL as AzureLogLevel) || "warning");
         break;
     }
     // Override Azure logger

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
@@ -76,7 +76,7 @@ export class Logger {
         setLogLevel("error");
         break;
       default:
-        setLogLevel(process.env.AZURE_LOG_LEVEL || "warning");
+        setLogLevel(process.env.AZURE_LOG_LEVEL as AzureLogLevel || "warning");
         break;
     }
     // Override Azure logger

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/logger.ts
@@ -60,26 +60,24 @@ export class Logger {
       suppressOverrideMessage: true,
     });
 
-    let azureLogLevelEnv =
-      process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
-    let azureLogLevel: AzureLogLevel = process.env.AZURE_LOG_LEVEL || "warning"; // default
+    const azureLogLevelEnv = process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
     switch (azureLogLevelEnv) {
       // Application Insights levels
       case "VERBOSE":
-        azureLogLevel = "verbose";
+        setLogLevel("verbose");
         break;
       case "INFO":
-        azureLogLevel = "info";
+        setLogLevel("info");
         break;
       case "WARN":
-        azureLogLevel = "warning";
+        setLogLevel("warning");
         break;
       case "ERROR":
-        azureLogLevel = "error";
+        setLogLevel("error");
         break;
-    }
-    if (azureLogLevel) {
-      setLogLevel(azureLogLevel);
+      default:
+        setLogLevel((process.env.AZURE_LOG_LEVEL as AzureLogLevel) || "warning");
+        break;
     }
     // Override Azure logger
     AzureLogger.log = (...args) => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/30660

### Describe the problem that is addressed by this PR
The default set by AZURE_LOG_LEVEL is ignored

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Change the value in the line above to conform to upper. I felt it is better to overwrite the default, as in essence AZURE_LOG_LEVEL is the default for this.


### Are there test cases added in this PR? _(If not, why?)_
No, haven't been any before as well :-P

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
