### PR TITLE
Do not publish to the nightly MSDocs branch if nightly PublishPackages fails

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -266,7 +266,7 @@ stages:
                       Tag: "dev"
 
       - job: PublishDocsToNightlyBranch
-        condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),  ne(variables['Skip.PublishDocs'], 'true')))
+        condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),  ne(variables['Skip.PublishDocs'], 'true'))))
         dependsOn: PublishPackages
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general


### PR DESCRIPTION
There was an issue with the nightly MSDocs build where it was trying to install a preview version of a library whose nightly publish to the dev feed had failed. As expected, this caused the nightly MSDocs build to fail. The nightly MSDocs publish step depends on nightly PublishPackages step but, for whatever reason, never checked if it succeeded. The MSDocs publish for an official release correctly checks if the publish succeeded.

NET, Java, JS and Python are all getting this same fix.

Testing was done by running [js - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4029274&view=results) with SetDevVersion set to True to produce a nightly release which succeeded