### PR TITLE
[monitor-opentelemetry-exporter] enable linting

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -58,6 +58,10 @@ steps:
     workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/analyze-deps
     displayName: "Analyze library dependencies"
 
+  - script: |
+      node common/scripts/install-run-rush.js install
+    displayName: "Install dependencies"
+
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -58,13 +58,17 @@ steps:
     workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/analyze-deps
     displayName: "Analyze library dependencies"
 
-  - template: /eng/pipelines/templates/steps/run-eslint.yml
-    parameters:
-      ServiceDirectory: ${{ parameters.ServiceDirectory }}
-
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
+
+  - script: |
+      node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
+    displayName: "Build libraries"
+
+  - template: /eng/pipelines/templates/steps/run-eslint.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - pwsh: |
       node eng/tools/rush-runner.js check-format "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose

--- a/sdk/monitor/monitor-opentelemetry-exporter/.eslintrc.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/.eslintrc.json
@@ -6,10 +6,16 @@
   },
   "plugins": ["@azure/azure-sdk"],
   "extends": [
-    "plugin:@azure/azure-sdk/azure-sdk-base",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:@azure/azure-sdk/azure-sdk-base"
   ],
   "rules": {
+    "@typescript-eslint/no-unsafe-member-access": "warn",
+    "@typescript-eslint/no-unsafe-assignment": "warn",
+    "@typescript-eslint/no-unsafe-call": "warn",
+    "@typescript-eslint/no-unsafe-argument": "warn",
+    "@typescript-eslint/restrict-template-expressions": "warn",
+    "@typescript-eslint/no-floating-promises": "warn",
     "no-underscore-dangle": [
       "error",
       {

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -20,7 +20,7 @@
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript ./swagger/README.md",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o telemetry-exporter-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts",
     "test": "npm run clean && npm run build:test && npm run unit-test",
     "test:node": "npm run clean && npm run build:test && npm run unit-test:node",
     "test:browser": "npm run unit-test:browser",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -169,7 +169,7 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
   }
 
   private setFeatures() {
-    let statsbeatFeatures = process.env.AZURE_MONITOR_STATSBEAT_FEATURES;
+    const statsbeatFeatures = process.env.AZURE_MONITOR_STATSBEAT_FEATURES;
     if (statsbeatFeatures) {
       try {
         this.feature = JSON.parse(statsbeatFeatures).feature;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -254,7 +254,7 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     counter.intervalRequestExecutionTime += duration;
   }
 
-  public countFailure(duration: number, statusCode: number) {
+  public countFailure(duration: number, statusCode: number): void {
     if (!this.isInitialized) {
       return;
     }
@@ -341,7 +341,7 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
   private getShortHost(originalHost: string): string {
     let shortHost = originalHost;
     try {
-      const hostRegex = new RegExp(/^https?:\/\/(?:www\.)?([^\/.-]+)/);
+      const hostRegex = new RegExp(/^https?:\/\/(?:www\.)?([^/.-]+)/);
       const res = hostRegex.exec(originalHost);
       if (res !== null && res.length > 1) {
         shortHost = res[1];

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatExporter.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatExporter.ts
@@ -40,6 +40,7 @@ export class AzureMonitorStatsbeatExporter
   /**
    * Export Statsbeat metrics.
    */
+  // eslint-disable-next-line @typescript-eslint/require-await
   async export(
     metrics: ResourceMetrics,
     resultCallback: (result: ExportResult) => void,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -18,6 +18,7 @@ import {
   VirtualMachineInfo,
 } from "./types";
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const os = require("os");
 
 export class StatsbeatMetrics {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/httpSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/httpSender.ts
@@ -79,11 +79,12 @@ export class HttpSender extends BaseSender {
    * Shutdown sender
    * @internal
    */
+  // eslint-disable-next-line @typescript-eslint/require-await
   async shutdown(): Promise<void> {
     diag.info("HttpSender shutting down");
   }
 
-  handlePermanentRedirect(location: string | undefined) {
+  handlePermanentRedirect(location: string | undefined): void {
     if (location) {
       const locUrl = new url.URL(location);
       if (locUrl && locUrl.host) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileAccessControl.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileAccessControl.ts
@@ -16,7 +16,7 @@ export class FileAccessControl {
   public static USE_ICACLS = os.type() === "Windows_NT";
 
   // Check if file access control could be enabled
-  public static checkFileProtection() {
+  public static checkFileProtection(): void {
     if (
       !FileAccessControl.OS_PROVIDES_FILE_PROTECTION &&
       !FileAccessControl.OS_FILE_PROTECTION_CHECKED
@@ -71,7 +71,7 @@ export class FileAccessControl {
     }
   }
 
-  public static applyACLRulesSync(directory: string) {
+  public static applyACLRulesSync(directory: string): void {
     if (FileAccessControl.USE_ICACLS) {
       // For performance, only run ACL rules if we haven't already during this session
       if (FileAccessControl.ACLED_DIRECTORIES[directory] === undefined) {
@@ -103,7 +103,7 @@ export class FileAccessControl {
     });
   }
 
-  private static _runICACLSSync(args: string[]) {
+  private static _runICACLSSync(args: string[]): void {
     // Some very old versions of Node (< 0.11) don't have this
     if (child_process.spawnSync) {
       const aclProc = child_process.spawnSync(FileAccessControl.ICACLS_PATH, args, <any>{
@@ -148,7 +148,7 @@ export class FileAccessControl {
     });
   }
 
-  private static _getACLIdentitySync() {
+  private static _getACLIdentitySync(): string {
     if (FileAccessControl.ACL_IDENTITY) {
       return FileAccessControl.ACL_IDENTITY;
     }
@@ -174,7 +174,7 @@ export class FileAccessControl {
     }
   }
 
-  private static _getACLArguments(directory: string, identity: string) {
+  private static _getACLArguments(directory: string, identity: string): string[] {
     return [
       directory,
       "/grant",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
@@ -99,6 +99,7 @@ export class FileSystemPersist implements PersistentStorage {
       try {
         const buffer = await this._getFirstFileOnDisk();
         if (buffer) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return JSON.parse(buffer.toString("utf8"));
         }
       } catch (e: any) {
@@ -191,6 +192,7 @@ export class FileSystemPersist implements PersistentStorage {
         if (files.length === 0) {
           return false;
         } else {
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           files.forEach(async (file) => {
             // Check expiration
             const fileCreationDate: Date = new Date(

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/sampling.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/sampling.ts
@@ -41,15 +41,15 @@ export class ApplicationInsightsSampler implements Sampler {
    * @returns a {@link SamplingResult}.
    */
   public shouldSample(
-    // @ts-ignore
+    // @ts-expect-error unused argument
     context: Context,
     traceId: string,
-    // @ts-ignore
+    // @ts-expect-error unused argument
     spanName: string,
-    // @ts-ignore
+    // @ts-expect-error unused argument
     spanKind: SpanKind,
     attributes: Attributes,
-    // @ts-ignore
+    // @ts-expect-error unused argument
     links: Link[],
   ): SamplingResult {
     let isSampledIn = false;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/breezeUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/breezeUtils.ts
@@ -45,14 +45,14 @@ export function msToTimeSpan(totalms: number): string {
   if (isNaN(totalms) || totalms < 0) {
     totalms = 0;
   }
-  var sec = ((totalms / 1000) % 60).toFixed(7).replace(/0{0,4}$/, "");
-  var min = "" + (Math.floor(totalms / (1000 * 60)) % 60);
-  var hour = "" + (Math.floor(totalms / (1000 * 60 * 60)) % 24);
-  var days = Math.floor(totalms / (1000 * 60 * 60 * 24));
+  let sec = ((totalms / 1000) % 60).toFixed(7).replace(/0{0,4}$/, "");
+  let min = "" + (Math.floor(totalms / (1000 * 60)) % 60);
+  let hour = "" + (Math.floor(totalms / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(totalms / (1000 * 60 * 60 * 24));
 
   sec = sec.indexOf(".") < 2 ? "0" + sec : sec;
   min = min.length < 2 ? "0" + min : min;
   hour = hour.length < 2 ? "0" + hour : hour;
-  var daysText = days > 0 ? days + "." : "";
+  const daysText = days > 0 ? days + "." : "";
   return daysText + hour + ":" + min + ":" + sec;
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -137,7 +137,7 @@ function getCloudRoleInstance(resource: Resource): string {
   return os && os.hostname();
 }
 
-export function isSqlDB(dbSystem: string) {
+export function isSqlDB(dbSystem: string): boolean {
   return (
     dbSystem === DBSYSTEMVALUES_DB2 ||
     dbSystem === DBSYSTEMVALUES_DERBY ||

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
@@ -61,7 +61,7 @@ export class ConnectionStringParser {
         : Constants.DEFAULT_LIVEMETRICS_ENDPOINT;
       if (result.authorization && result.authorization.toLowerCase() !== "ikey") {
         diag.warn(
-          `Connection String contains an unsupported 'Authorization' value: ${result.authorization!}. Defaulting to 'Authorization=ikey'. Instrumentation Key ${result.instrumentationkey!}`,
+          `Connection String contains an unsupported 'Authorization' value: ${result.authorization}. Defaulting to 'Authorization=ikey'. Instrumentation Key ${result.instrumentationkey!}`,
         );
       }
     } else {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
@@ -74,7 +74,7 @@ export class ConnectionStringParser {
     return result;
   }
 
-  public static sanitizeUrl(url: string) {
+  public static sanitizeUrl(url: string): string {
     let newUrl = url.trim();
     if (newUrl.indexOf("https://") < 0) {
       // Try to update http to https

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license
+// Licensed under the MIT license.
 
 /**
  * AI MS Links.

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -45,6 +45,7 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
   const sampleRate = 100;
   const instrumentationKey = ikey;
   const tags = createTagsFromLog(log);
+  // eslint-disable-next-line prefer-const
   let [properties, measurements] = createPropertiesFromLog(log);
   let name: string;
   let baseType: string;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -86,7 +86,7 @@ function createTagsFromSpan(span: ReadableSpan): Tags {
         try {
           const url = new URL(String(httpUrl));
           tags[KnownContextTagKeys.AiOperationName] = `${httpMethod} ${url.pathname}`;
-        } catch (ex: any) {}
+        } catch { /* no-op */ }
       }
       if (httpClientIp) {
         tags[KnownContextTagKeys.AiLocationIp] = String(httpClientIp);
@@ -183,7 +183,7 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
       try {
         const dependencyUrl = new URL(String(httpUrl));
         remoteDependencyData.name = `${httpMethod} ${dependencyUrl.pathname}`;
-      } catch (ex: any) {}
+      } catch { /* no-op */ }
     }
     remoteDependencyData.type = DependencyTypes.Http;
     remoteDependencyData.data = getUrl(span.attributes);
@@ -208,7 +208,7 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
             target = res[1] + res[2] + res[4];
           }
         }
-      } catch (ex: any) {}
+      } catch { /* no-op */ }
       remoteDependencyData.target = `${target}`;
     }
   }
@@ -245,7 +245,7 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
   }
   // grpc Dependency
   else if (rpcSystem) {
-    if (rpcSystem == DependencyTypes.Wcf) {
+    if (rpcSystem === DependencyTypes.Wcf) {
       remoteDependencyData.type = DependencyTypes.Wcf;
     } else {
       remoteDependencyData.type = DependencyTypes.Grpc;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -86,7 +86,9 @@ function createTagsFromSpan(span: ReadableSpan): Tags {
         try {
           const url = new URL(String(httpUrl));
           tags[KnownContextTagKeys.AiOperationName] = `${httpMethod} ${url.pathname}`;
-        } catch { /* no-op */ }
+        } catch {
+          /* no-op */
+        }
       }
       if (httpClientIp) {
         tags[KnownContextTagKeys.AiLocationIp] = String(httpClientIp);
@@ -183,7 +185,9 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
       try {
         const dependencyUrl = new URL(String(httpUrl));
         remoteDependencyData.name = `${httpMethod} ${dependencyUrl.pathname}`;
-      } catch { /* no-op */ }
+      } catch {
+        /* no-op */
+      }
     }
     remoteDependencyData.type = DependencyTypes.Http;
     remoteDependencyData.data = getUrl(span.attributes);
@@ -208,7 +212,9 @@ function createDependencyData(span: ReadableSpan): RemoteDependencyData {
             target = res[1] + res[2] + res[4];
           }
         }
-      } catch { /* no-op */ }
+      } catch {
+        /* no-op */
+      }
       remoteDependencyData.target = `${target}`;
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.test.ts
@@ -39,13 +39,13 @@ const deleteFolderRecursive = (dirPath: string): void => {
   }
 };
 
-const assertFirstFile = async (tempDir: string, expectation: unknown): Promise<void> => {
+const assertFirstFile = async (tempDirectory: string, expectation: unknown): Promise<void> => {
   // Assert that tempDir is a directory
-  const stats = await statAsync(tempDir);
+  const stats = await statAsync(tempDirectory);
   assert.strictEqual(stats.isDirectory(), true);
 
   // Read the first file in tempDir
-  const origFiles = await readdirAsync(tempDir);
+  const origFiles = await readdirAsync(tempDirectory);
   const files = origFiles.filter((f) =>
     path.basename(f).includes(FileSystemPersist.FILENAME_SUFFIX),
   );
@@ -53,7 +53,7 @@ const assertFirstFile = async (tempDir: string, expectation: unknown): Promise<v
 
   // Assert file matches expectation
   const firstFile = files[0];
-  const filePath = path.join(tempDir, firstFile);
+  const filePath = path.join(tempDirectory, firstFile);
   const payload = await readFileAsync(filePath);
   assert.deepStrictEqual(JSON.parse(payload.toString()), JSON.parse(JSON.stringify(expectation)));
 
@@ -96,13 +96,13 @@ describe("FileSystemPersist", () => {
 
     it("custom storageDirectory", async () => {
       const customPath = path.join(os.tmpdir(), "TestFolder");
-      const tempDir = path.join(
+      const tempDirectory = path.join(
         customPath,
         "Microsoft",
         "AzureMonitor",
         `${FileSystemPersist.TEMPDIR_PREFIX}${instrumentationKey}`,
       );
-      deleteFolderRecursive(tempDir);
+      deleteFolderRecursive(tempDirectory);
       const envelope: Envelope = {
         name: "name",
         time: new Date(),
@@ -111,7 +111,7 @@ describe("FileSystemPersist", () => {
       const persister = new FileSystemPersist(instrumentationKey, { storageDirectory: customPath });
       const success = await persister.push(envelopes);
       assert.strictEqual(success, true);
-      await assertFirstFile(tempDir, JSON.parse(JSON.stringify(envelopes)));
+      await assertFirstFile(tempDirectory, JSON.parse(JSON.stringify(envelopes)));
     });
 
     it("should disable the perister if OS_PROVIDES_FILE_PROTECTION is disabled", () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/log.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/log.test.ts
@@ -11,7 +11,7 @@ import { TelemetryItem as Envelope } from "../../../src/generated";
 describe("Log Exporter Scenarios", () => {
   describe(LogBasicScenario.prototype.constructor.name, () => {
     const scenario = new LogBasicScenario();
-    let ingest: Envelope[] = [];
+    const ingest: Envelope[] = [];
 
     before(() => {
       nock(DEFAULT_BREEZE_ENDPOINT)

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/log.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/log.test.ts
@@ -37,6 +37,7 @@ describe("Log Exporter Scenarios", () => {
         .run()
         .then(() => {
           // promisify doesn't work on this, so use callbacks/done for now
+          // eslint-disable-next-line promise/always-return
           return scenario.flush().then(() => {
             setTimeout(() => {
               assertLogExpectation(ingest, scenario.expectation);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/metric.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/metric.test.ts
@@ -35,6 +35,7 @@ describe("Metric Exporter Scenarios", () => {
         .run()
         .then(() => {
           // promisify doesn't work on this, so use callbacks/done for now
+          // eslint-disable-next-line promise/always-return
           return scenario.flush().then(() => {
             assertMetricExpectation(ingest, scenario.expectation);
             assertCount(ingest, scenario.expectation);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/trace.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/functional/trace.test.ts
@@ -38,6 +38,7 @@ describe("Trace Exporter Scenarios", () => {
         .run()
         .then(() => {
           // promisify doesn't work on this, so use callbacks/done for now
+          // eslint-disable-next-line promise/always-return
           return scenario.flush().then(() => {
             assertTraceExpectation(ingest, scenario.expectation);
             assertCount(ingest, scenario.expectation);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/httpSender.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/httpSender.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as assert from "assert";
-import { TokenCredential } from "@azure/core-auth";
+import { AccessToken, TokenCredential } from "@azure/core-auth";
 import { HttpSender } from "../../src/platform/nodejs/httpSender";
 import { DEFAULT_BREEZE_ENDPOINT } from "../../src/Declarations/Constants";
 import {
@@ -27,11 +27,12 @@ class TestTokenCredential implements TokenCredential {
     this.expiresOn = expiresOn || new Date();
   }
 
-  async getToken(): Promise<any> {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getToken(): Promise<AccessToken | null> {
     this.numberOfRefreshs++;
     return {
       token: "testToken" + this.numberOfRefreshs,
-      expiresOnTimestamp: this.expiresOn,
+      expiresOnTimestamp: this.expiresOn.getTime(),
     };
   }
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.test.ts
@@ -34,6 +34,7 @@ class TestExporter extends AzureMonitorMetricExporter {
   constructor(options: AzureMonitorExporterOptions = {}) {
     super(options);
   }
+  // eslint-disable-next-line @typescript-eslint/require-await
   async export(metrics: ResourceMetrics): Promise<void> {
     testMetrics = metrics;
     testMetrics.resource = new Resource({

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -126,7 +126,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         done();
       });
 
-      it("should add correct long interval properties to the custom metric",  () => {
+      it("should add correct long interval properties to the custom metric", () => {
         // const exporter = new TestExporter();
         // const statsbeatMetrics = exporter["sender"]["networkStatsbeatMetrics"];
         const longIntervalStatsbeatMetrics = getInstance(options);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -7,7 +7,7 @@ import { failedBreezeResponse, successfulBreezeResponse } from "../utils/breezeT
 import { DEFAULT_BREEZE_ENDPOINT, ENV_DISABLE_STATSBEAT } from "../../src/Declarations/Constants";
 import nock from "nock";
 import { NetworkStatsbeatMetrics } from "../../src/export/statsbeat/networkStatsbeatMetrics";
-// @ts-ignore Need to ignore this while we do not import types
+// @ts-expect-error Need to ignore this while we do not import types
 import sinon from "sinon";
 import { StatsbeatCounter } from "../../src/export/statsbeat/types";
 import { getInstance } from "../../src/export/statsbeat/longIntervalStatsbeatMetrics";
@@ -101,6 +101,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
       it("should add correct network properites to the custom metric", (done) => {
         const statsbeat = new NetworkStatsbeatMetrics(options);
+        // eslint-disable-next-line no-unused-expressions
         statsbeat["statsCollectionShortInterval"];
         statsbeat.countSuccess(100);
         const metric = statsbeat["networkStatsbeatCollection"][0];
@@ -125,7 +126,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         done();
       });
 
-      it("should add correct long interval properties to the custom metric", async () => {
+      it("should add correct long interval properties to the custom metric",  () => {
         // const exporter = new TestExporter();
         // const statsbeatMetrics = exporter["sender"]["networkStatsbeatMetrics"];
         const longIntervalStatsbeatMetrics = getInstance(options);
@@ -170,20 +171,21 @@ describe("#AzureMonitorStatsbeatExporter", () => {
     });
 
     describe("Resource provider function", () => {
-      let sandbox: any;
+      let sandboxInner: any;
 
       before(() => {
-        sandbox = sinon.createSandbox();
+        sandboxInner = sinon.createSandbox();
       });
 
       afterEach(() => {
-        sandbox.restore();
+        sandboxInner.restore();
       });
 
       const statsbeat = new NetworkStatsbeatMetrics(options);
 
       it("it should determine if the rp is unknown", (done) => {
         statsbeat["getResourceProvider"]()
+          // eslint-disable-next-line promise/always-return
           .then(() => {
             assert.strictEqual(statsbeat["resourceProvider"], "unknown");
             done();
@@ -200,6 +202,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const originalEnv = process.env;
         process.env = newEnv;
         statsbeat["getResourceProvider"]()
+          // eslint-disable-next-line promise/always-return
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
@@ -218,6 +221,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const originalEnv = process.env;
         process.env = newEnv;
         statsbeat["getResourceProvider"]()
+          // eslint-disable-next-line promise/always-return
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "functions");
@@ -230,7 +234,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       it("should determine if the rp is an Azure VM", (done) => {
-        const getAzureComputeStub = sandbox.stub(statsbeat, "getAzureComputeMetadata");
+        const getAzureComputeStub = sandboxInner.stub(statsbeat, "getAzureComputeMetadata");
         getAzureComputeStub.returns(Promise.resolve(true));
 
         const newEnv = <{ [id: string]: string }>{};
@@ -238,6 +242,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         process.env = newEnv;
 
         statsbeat["getResourceProvider"]()
+          // eslint-disable-next-line promise/always-return
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "vm");
@@ -256,6 +261,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         process.env = newEnv;
 
         statsbeat["getResourceProvider"]()
+          // eslint-disable-next-line promise/always-return
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "aks");
@@ -268,7 +274,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       it("should override OS and VM info", (done) => {
-        const getAzureComputeStub = sandbox.stub(statsbeat, "getAzureComputeMetadata");
+        const getAzureComputeStub = sandboxInner.stub(statsbeat, "getAzureComputeMetadata");
         getAzureComputeStub.returns(Promise.resolve(true));
         statsbeat["vmInfo"]["osType"] = "test";
 
@@ -277,6 +283,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         process.env = newEnv;
 
         statsbeat["getResourceProvider"]()
+          // eslint-disable-next-line promise/always-return
           .then(() => {
             process.env = originalEnv;
             assert.strictEqual(statsbeat["resourceProvider"], "vm");
@@ -290,11 +297,11 @@ describe("#AzureMonitorStatsbeatExporter", () => {
     });
 
     describe("Track data from statsbeats", () => {
-      let sandbox: sinon.SinonSandbox;
+      let sandboxInner: sinon.SinonSandbox;
       let statsbeat: NetworkStatsbeatMetrics;
 
       before(() => {
-        sandbox = sinon.createSandbox();
+        sandboxInner = sinon.createSandbox();
         process.env.WEBSITE_SITE_NAME = "test";
         statsbeat = new NetworkStatsbeatMetrics({
           ...options,
@@ -303,7 +310,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       afterEach(() => {
-        sandbox.restore();
+        sandboxInner.restore();
       });
 
       after(() => {
@@ -312,7 +319,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       it("should track duration", async () => {
-        const mockExport = sandbox.stub(statsbeat["networkAzureExporter"], "export");
+        const mockExport = sandboxInner.stub(statsbeat["networkAzureExporter"], "export");
         statsbeat.countSuccess(100);
         statsbeat.countRetry(206);
         statsbeat.countFailure(200, 500);
@@ -338,7 +345,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       it("should track statsbeat counts", async () => {
-        const mockExport = sandbox.stub(statsbeat["networkAzureExporter"], "export");
+        const mockExport = sandboxInner.stub(statsbeat["networkAzureExporter"], "export");
         statsbeat.countSuccess(100);
         statsbeat.countSuccess(100);
         statsbeat.countSuccess(100);
@@ -404,7 +411,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
       it("should track long interval statsbeats", async () => {
         const longIntervalStatsbeat = getInstance(options);
-        const mockExport = sandbox.stub(
+        const mockExport = sandboxInner.stub(
           longIntervalStatsbeat["longIntervalAzureExporter"],
           "export",
         );

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/utils/basic.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/utils/basic.ts
@@ -95,6 +95,7 @@ export class TraceBasicScenario implements Scenario {
   }
 
   flush(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return this._processor.forceFlush();
   }
 
@@ -406,6 +407,7 @@ export class LogBasicScenario implements Scenario {
     this._provider.addLogRecordProcessor(this._processor);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async run(): Promise<void> {
     const logger = this._provider.getLogger("basic");
 
@@ -433,6 +435,7 @@ export class LogBasicScenario implements Scenario {
   }
 
   flush(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return this._processor.forceFlush();
   }
 


### PR DESCRIPTION
This PR

- removes `-f html -o telemetry-exporter-lintReport.html || exit 0` from `lint` NPM script
- updates eslint config to report warn for some rules
- applies result of `lint:fix`
- fixes/suppresses linting errors
- in analyze pipeline, changes to build packages before linting so that linting with types works

### Packages impacted by this PR

monitor-opentelemetry-exporter

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/issues/17942