### PR TITLE
[eslint-plugin] exports ./prettier.json

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -30,7 +30,8 @@
       "types": "./dist-esm/src/index.d.ts",
       "default": "./dist-esm/src/index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./prettier.json": "./prettier.json"
   },
   "files": [
     "prettier.json",


### PR DESCRIPTION
so that VS Code prettier extension can import it via the "prettier" key in most of our packages' package.json:

```
"prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
```

### Packages impacted by this PR
eslint-plugin-azure-sdk
