### PR TITLE
[Event Hubs] Abstract event receiver and processor in tests

### DIFF
--- a/sdk/eventhub/event-hubs/scripts/mockService.mts
+++ b/sdk/eventhub/event-hubs/scripts/mockService.mts
@@ -4,11 +4,12 @@
 import { MockEventHub, MockServerOptions } from "@azure/mock-hub";
 import { readFileSync } from "fs";
 import { resolve as resolvePath } from "path";
-import { EVENTHUB_NAME } from "../test/utils/constants.js";
+import { EVENTHUB_CONSUMER_GROUP_NAME, EVENTHUB_NAME } from "../test/utils/constants.js";
 
 export function createMockServer(options: MockServerOptions = {}): MockEventHub {
   return new MockEventHub({
     name: EVENTHUB_NAME,
+    consumerGroups: [EVENTHUB_CONSUMER_GROUP_NAME],
     partitionCount: 4,
     connectionInactivityTimeoutInMs: 300000, // 5 minutes
     port: 5671,

--- a/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/node/disconnect.spec.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { EventHubConsumerClient, latestEventPosition } from "../../../src/index.js";
-import { createReceiver, WritableReceiver } from "../../../src/partitionReceiver.js";
+import { latestEventPosition } from "../../../src/index.js";
+import { WritableReceiver } from "../../../src/partitionReceiver.js";
 import { EventHubSender } from "../../../src/eventHubSender.js";
 import { MessagingError } from "@azure/core-amqp";
 import { should } from "../../utils/chai.js";
 import { describe, it, beforeAll, vi } from "vitest";
-import { createConsumer, createContext } from "../../utils/clients.js";
+import { createConsumer, createContext, createReceiver } from "../../utils/clients.js";
 
 describe("disconnected", function () {
   let partitionIds: string[] = [];
@@ -60,20 +60,18 @@ describe("disconnected", function () {
         const context = createContext().context;
 
         // Add 2 receivers.
-        const receiver1 = createReceiver(
-          context,
-          EventHubConsumerClient.defaultConsumerGroupName,
-          "Consumer1",
-          partitionIds[0],
-          latestEventPosition,
-        );
-        const receiver2 = createReceiver(
-          context,
-          EventHubConsumerClient.defaultConsumerGroupName,
-          "Consumer2",
-          partitionIds[1],
-          latestEventPosition,
-        );
+        const receiver1 = createReceiver({
+          ctx: context,
+          consumerId: "Consumer1",
+          partitionId: partitionIds[0],
+          eventPosition: latestEventPosition,
+        }).receiver;
+        const receiver2 = createReceiver({
+          ctx: context,
+          consumerId: "Consumer2",
+          partitionId: partitionIds[1],
+          eventPosition: latestEventPosition,
+        }).receiver;
 
         // Add 2 senders.
         const sender1 = new EventHubSender(context, "Sender1", {
@@ -126,20 +124,18 @@ describe("disconnected", function () {
         const context = createContext().context;
 
         // Add 2 receivers.
-        const receiver1 = createReceiver(
-          context,
-          EventHubConsumerClient.defaultConsumerGroupName,
-          "Consumer1",
-          partitionIds[0],
-          latestEventPosition,
-        );
-        const receiver2 = createReceiver(
-          context,
-          EventHubConsumerClient.defaultConsumerGroupName,
-          "Consumer2",
-          partitionIds[1],
-          latestEventPosition,
-        );
+        const receiver1 = createReceiver({
+          ctx: context,
+          consumerId: "Consumer1",
+          partitionId: partitionIds[0],
+          eventPosition: latestEventPosition,
+        }).receiver;
+        const receiver2 = createReceiver({
+          ctx: context,
+          consumerId: "Consumer2",
+          partitionId: partitionIds[1],
+          eventPosition: latestEventPosition,
+        }).receiver;
 
         // Add 2 senders.
         const sender1 = new EventHubSender(context, "Sender1", {

--- a/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/receiveBatch.spec.ts
@@ -8,11 +8,10 @@ import {
   EventPosition,
   MessagingError,
 } from "../../src/index.js";
-import { createReceiver } from "../../src/partitionReceiver.js";
 import { translate } from "@azure/core-amqp";
 import "../utils/chai.js";
 import { describe, it, beforeEach, afterEach } from "vitest";
-import { createConsumer, createProducer } from "../utils/clients.js";
+import { createConsumer, createProducer, createReceiver } from "../utils/clients.js";
 
 describe("EventHubConsumerClient", function () {
   let producerClient: EventHubProducerClient;
@@ -47,18 +46,17 @@ describe("EventHubConsumerClient", function () {
       await producerClient.sendBatch([message], { partitionId });
 
       // Disable retries to make it easier to test scenario.
-      const receiver = createReceiver(
-        consumerClient["_context"],
-        EventHubConsumerClient.defaultConsumerGroupName,
-        "Consumer",
+      const { receiver } = createReceiver({
+        ctx: consumerClient["_context"],
+        consumerId: "Consumer",
         partitionId,
-        startPosition,
-        {
+        eventPosition: startPosition,
+        options: {
           retryOptions: {
             maxRetries: 0,
           },
         },
-      );
+      });
 
       // Periodically check that the receiver's checkpoint has been updated.
       const checkpointInterval = setInterval(() => {
@@ -102,18 +100,17 @@ describe("EventHubConsumerClient", function () {
       await producerClient.sendBatch([message], { partitionId });
 
       // Disable retries to make it easier to test scenario.
-      const receiver = createReceiver(
-        consumerClient["_context"],
-        EventHubConsumerClient.defaultConsumerGroupName,
-        "Consumer",
+      const { receiver } = createReceiver({
+        ctx: consumerClient["_context"],
+        consumerId: "Consumer",
         partitionId,
-        startPosition,
-        {
+        eventPosition: startPosition,
+        options: {
           retryOptions: {
             maxRetries: 1,
           },
         },
-      );
+      });
 
       // Periodically check that the receiver's checkpoint has been updated.
       const checkpointInterval = setInterval(() => {

--- a/sdk/eventhub/event-hubs/test/utils/constants.ts
+++ b/sdk/eventhub/event-hubs/test/utils/constants.ts
@@ -4,6 +4,7 @@
 export enum EnvVarKeys {
   EVENTHUB_FQDN = "EVENTHUB_FQDN",
   EVENTHUB_NAME = "EVENTHUB_NAME",
+  EVENTHUB_CONSUMER_GROUP_NAME = "EVENTHUB_CONSUMER_GROUP_NAME",
   EVENTHUB_CONNECTION_STRING = "EVENTHUB_CONNECTION_STRING",
   TEST_MODE = "TEST_MODE",
 }
@@ -11,6 +12,7 @@ export enum EnvVarKeys {
 // Mocked values
 export const EVENTHUB_FQDN = "localhost";
 export const EVENTHUB_NAME = "mock-hub";
+export const EVENTHUB_CONSUMER_GROUP_NAME = "mock-consumer-group";
 export const sharedAccessKeyName = "Foo";
 export const sharedAccessKey = "Bar";
 export const EVENTHUB_CONNECTION_STRING_WITH_KEY = `Endpoint=sb://${EVENTHUB_FQDN}/;SharedAccessKeyName=${sharedAccessKeyName};SharedAccessKey=${sharedAccessKey}`;

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -85,7 +85,7 @@
     {
       "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
       "apiVersion": "[variables('apiVersion')]",
-      "name": "[concat(variables('eventHubNameFull'), variables('eventHubConsumerGroupName'))]",
+      "name": "[concat(variables('eventHubNameFull'), '/', variables('eventHubConsumerGroupName'))]",
       "location": "[variables('location')]",
       "dependsOn": [
         "[resourceId('Microsoft.EventHub/namespaces/eventhubs', variables('namespaceName'), variables('eventHubName'))]",


### PR DESCRIPTION
So consumer group name can be loaded from the environment variable.

Live tests run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4039773&view=results