### PR TITLE
[CODEOWNERS] add an entry for ./github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,12 @@
 /** @xirzec @jeremymeng @Azure/azure-sdk-eng
 
 ################
+# CODEOWNERS
+################
+
+/.github/CODEOWNERS @xirzec @jeremymeng @qiaozha @MaryGao @Azure/azure-sdk-eng
+
+################
 # Misc.
 ################
 


### PR DESCRIPTION
as we often need to update the file to add entries for Management plane packages