### PR TITLE
[identity] Add support for AsSecureString in PowerShellCredential

### DIFF
--- a/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
+++ b/sdk/identity/identity/src/credentials/azurePowerShellCredential.ts
@@ -46,6 +46,7 @@ async function runCommands(commands: string[][], timeout?: number): Promise<stri
       encoding: "utf8",
       timeout,
     })) as string;
+
     results.push(result);
   }
 
@@ -143,29 +144,45 @@ export class AzurePowerShellCredential implements TokenCredential {
         continue;
       }
 
-      let tenantSection = "";
-      if (tenantId) {
-        tenantSection = `-TenantId "${tenantId}"`;
-      }
-
       const results = await runCommands([
         [
           powerShellCommand,
           "-NoProfile",
           "-NonInteractive",
           "-Command",
-          "Import-Module Az.Accounts -MinimumVersion 2.2.0 -PassThru",
-        ],
-        [
-          powerShellCommand,
-          "-NoProfile",
-          "-NonInteractive",
-          "-Command",
-          `Get-AzAccessToken ${tenantSection} -ResourceUrl "${resource}" | ConvertTo-Json`,
+          `
+          $tenantId = "${tenantId ?? ""}"
+          $m = Import-Module Az.Accounts -MinimumVersion 2.2.0 -PassThru
+          $useSecureString = $m.Version -ge [version]'2.17.0'
+
+          $params = @{
+            ResourceUrl = "${resource}"
+          }
+
+          if ($tenantId.Length -gt 0) {
+            $params["TenantId"] = $tenantId
+          }
+
+          if ($useSecureString) {
+            $params["AsSecureString"] = $true
+          }
+
+          $token = Get-AzAccessToken @params
+
+          $result = New-Object -TypeName PSObject
+          $result | Add-Member -MemberType NoteProperty -Name ExpiresOn -Value $token.ExpiresOn
+          if ($useSecureString) {
+            $result | Add-Member -MemberType NoteProperty -Name Token -Value (ConvertFrom-SecureString -AsPlainText $token.Token)
+          } else {
+            $result | Add-Member -MemberType NoteProperty -Name Token -Value $token.Token
+          }
+
+          Write-Output (ConvertTo-Json $result)
+          `,
         ],
       ]);
 
-      const result = results[1];
+      const result = results[0];
       return parseJsonToken(result);
     }
     throw new Error(`Unable to execute PowerShell. Ensure that it is installed in your system`);

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -47,6 +47,7 @@ describe("AzurePowerShellCredential", function () {
 
   it("throws an expected error if the user hasn't logged in through PowerShell", async function () {
     const stub = sandbox.stub(processUtils, "execFile");
+    stub.onCall(0).returns(Promise.resolve("")); // The first call checks that the command is available.
     stub.onCall(1).throws(new Error(`Get-AzAccessToken: ${powerShellErrors.login}`));
 
     const credential = new AzurePowerShellCredential();

--- a/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azurePowerShellCredential.spec.ts
@@ -47,7 +47,6 @@ describe("AzurePowerShellCredential", function () {
 
   it("throws an expected error if the user hasn't logged in through PowerShell", async function () {
     const stub = sandbox.stub(processUtils, "execFile");
-    stub.onCall(0).returns(Promise.resolve("")); // The first call checks that the command is available.
     stub.onCall(1).throws(new Error(`Get-AzAccessToken: ${powerShellErrors.login}`));
 
     const credential = new AzurePowerShellCredential();
@@ -113,7 +112,6 @@ describe("AzurePowerShellCredential", function () {
     const stub = sandbox.stub(processUtils, "execFile");
     let idx = 0;
     stub.onCall(idx++).returns(Promise.resolve("")); // The first call checks that the command is available.
-    stub.onCall(idx++).returns(Promise.resolve("This one we ignore."));
     stub.onCall(idx++).returns(Promise.resolve("Not valid JSON"));
 
     const credential = new AzurePowerShellCredential();
@@ -139,7 +137,6 @@ describe("AzurePowerShellCredential", function () {
       let idx = 0;
       stub.onCall(idx++).throws(new Error());
       stub.onCall(idx++).returns(Promise.resolve("")); // The first call checks that the command is available.
-      stub.onCall(idx++).returns(Promise.resolve("This one we ignore."));
       stub.onCall(idx++).returns(Promise.resolve("Not valid JSON"));
 
       const credential = new AzurePowerShellCredential();
@@ -170,8 +167,7 @@ describe("AzurePowerShellCredential", function () {
 
     const stub = sandbox.stub(processUtils, "execFile");
     stub.onCall(0).returns(Promise.resolve("")); // The first call checks that the command is available.
-    stub.onCall(1).returns(Promise.resolve("This one we ignore."));
-    stub.onCall(2).returns(Promise.resolve(JSON.stringify(tokenResponse)));
+    stub.onCall(1).returns(Promise.resolve(JSON.stringify(tokenResponse)));
 
     const credential = new AzurePowerShellCredential();
 
@@ -190,8 +186,7 @@ describe("AzurePowerShellCredential", function () {
 
     const stub = sandbox.stub(processUtils, "execFile");
     stub.onCall(0).returns(Promise.resolve("")); // The first call checks that the command is available.
-    stub.onCall(1).returns(Promise.resolve("This one we ignore."));
-    stub.onCall(2).returns(Promise.resolve(JSON.stringify(tokenResponse)));
+    stub.onCall(1).returns(Promise.resolve(JSON.stringify(tokenResponse)));
 
     const credential = new AzurePowerShellCredential();
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity 

### Issues associated with this PR

Resolves #30356

### Describe the problem that is addressed by this PR

Adds support for the `-AsSecureString` flag for `AzurePowerShellCredential` in order to support upcoming breaking
changes from Az Pwsh modules in a backwards compat way


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
