### PR TITLE
[engsys] use caret version for api-extractor

### DIFF
--- a/sdk/vision/ai-vision-image-analysis-rest/package.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/package.json
@@ -70,7 +70,7 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "~7.39.0",
+    "@microsoft/api-extractor": "^7.39.0",
     "autorest": "latest",
     "@types/node": "~20.10.3",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
to get the latest version and be consistent with the rest packages.