### PR TITLE
[EngSys] rush update --full to fix inconsistent playwright versions

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1516,7 +1516,7 @@ packages:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.7.2
       '@azure/core-tracing': 1.1.2
-      '@azure/core-util': 1.9.1
+      '@azure/core-util': 1.9.2
       '@azure/logger': 1.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
@@ -1525,8 +1525,8 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/core-sse@2.1.2:
-    resolution: {integrity: sha512-yf+pFIu8yCzXu9RbH2+8kp9vITIKJLHgkLgFNA6hxiDHK3fxeP596cHUj4c8Cm8JlooaUnYdHmF84KCZt3jbmw==}
+  /@azure/core-sse@2.1.3:
+    resolution: {integrity: sha512-KSSdIKy8kvWCpYr8Hzpu22j3wcXsVTYE0IlgmI1T/aHvBDsLgV91y90UTfVWnuiuApRLCCVC4gS09ApBGOmYQA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       tslib: 2.6.3
@@ -1536,14 +1536,6 @@ packages:
     resolution: {integrity: sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      tslib: 2.6.3
-    dev: false
-
-  /@azure/core-util@1.9.1:
-    resolution: {integrity: sha512-OLsq0etbHO1MA7j6FouXFghuHrAFGk+5C1imcpQ2e+0oZhYF07WLA+NW2Vqs70R7d+zOAWiWM3tbE1sXcDN66g==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@azure/abort-controller': 2.1.2
       tslib: 2.6.3
     dev: false
 
@@ -1611,8 +1603,8 @@ packages:
       '@azure/core-tracing': 1.1.2
       '@azure/core-util': 1.9.2
       '@azure/logger': 1.1.4
-      '@azure/msal-browser': 3.20.0
-      '@azure/msal-node': 2.12.0
+      '@azure/msal-browser': 3.21.0
+      '@azure/msal-node': 2.13.0
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.2
@@ -1661,15 +1653,20 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/msal-browser@3.20.0:
-    resolution: {integrity: sha512-ErsxbfCGIwdqD8jipqdxpfAGiUEQS7MWUe39Rjhl0ZVPsb1JEe9bZCe2+0g23HDH6DGyCAtnTNN9scPtievrMQ==}
+  /@azure/msal-browser@3.21.0:
+    resolution: {integrity: sha512-BAwcFsVvOrYzKuUZHhFuvRykUmQGq6lDxst2qGnjxnpNZc3d/tnVPcmhgvUdeKl28VSE0ltgBzT3HkdpDtz9rg==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      '@azure/msal-common': 14.14.0
+      '@azure/msal-common': 14.14.1
     dev: false
 
   /@azure/msal-common@14.14.0:
     resolution: {integrity: sha512-OxcOk9H1/1fktHh6//VCORgSNJc2dCQObTm6JNmL824Z6iZSO6eFo/Bttxe0hETn9B+cr7gDouTQtsRq3YPuSQ==}
+    engines: {node: '>=0.8.0'}
+    dev: false
+
+  /@azure/msal-common@14.14.1:
+    resolution: {integrity: sha512-2Q3tqNz/PZLfSr8BvcHZVpRRfSn4MjGSqjj9J+HlBsmbf1Uu4P0WeXnemjTJwwx9KrmplsrN3UkZ/LPOR720rw==}
     engines: {node: '>=0.8.0'}
     dev: false
 
@@ -1688,11 +1685,11 @@ packages:
     requiresBuild: true
     dev: false
 
-  /@azure/msal-node@2.12.0:
-    resolution: {integrity: sha512-jmk5Im5KujRA2AcyCb0awA3buV8niSrwXZs+NBJWIvxOz76RvNlusGIqi43A0h45BPUy93Qb+CPdpJn82NFTIg==}
+  /@azure/msal-node@2.13.0:
+    resolution: {integrity: sha512-DhP97ycs7qlCVzzzWGzJiwAFyFj5okno74E4FUZ61oCLfKh4IxA1kxirqzrWuYZWpBe9HVPL6GA4NvmlEOBN5Q==}
     engines: {node: '>=16'}
     dependencies:
-      '@azure/msal-common': 14.14.0
+      '@azure/msal-common': 14.14.1
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
     dev: false
@@ -1704,7 +1701,7 @@ packages:
       '@azure-rest/core-client': 1.4.0
       '@azure/core-auth': 1.7.2
       '@azure/core-rest-pipeline': 1.16.3
-      '@azure/core-sse': 2.1.2
+      '@azure/core-sse': 2.1.3
       '@azure/core-util': 1.9.2
       '@azure/logger': 1.1.4
       tslib: 2.6.3
@@ -2587,7 +2584,7 @@ packages:
       '@inquirer/figures': 1.0.5
       '@inquirer/type': 1.5.2
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.2.0
+      '@types/node': 22.3.0
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-spinners: 2.9.2
@@ -2704,16 +2701,6 @@ packages:
       - '@types/node'
     dev: false
 
-  /@microsoft/api-extractor-model@7.29.4(@types/node@18.19.44):
-    resolution: {integrity: sha512-LHOMxmT8/tU1IiiiHOdHFF83Qsi+V8d0kLfscG4EvQE9cafiR8blOYr8SfkQKWB1wgEilQgXJX3MIA4vetDLZw==}
-    dependencies:
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.1(@types/node@18.19.44)
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: false
-
   /@microsoft/api-extractor-model@7.29.5(@types/node@18.19.44):
     resolution: {integrity: sha512-axMwj4pgtYH6/IclP9ly33laSwTym1kBwSUcoHElc2LYAE5NNlhGT78ucEpIZtqEZaGgA8yxGXIyS17XCC2Iuw==}
     dependencies:
@@ -2740,27 +2727,6 @@ packages:
       semver: 7.5.4
       source-map: 0.6.1
       typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: false
-
-  /@microsoft/api-extractor@7.47.5(@types/node@18.19.44):
-    resolution: {integrity: sha512-edKt4dFO2t25xmI2FX2rsP5liIgwKW1yuQImA0JM+5YGHCoo51GEQ7j+On17SvVpRJnuqLE/QVgtjIQ1Hpg98w==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor-model': 7.29.4(@types/node@18.19.44)
-      '@microsoft/tsdoc': 0.15.0
-      '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.1(@types/node@18.19.44)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.13.3(@types/node@18.19.44)
-      '@rushstack/ts-command-line': 4.22.4(@types/node@18.19.44)
-      lodash: 4.17.21
-      minimatch: 3.0.8
-      resolve: 1.22.8
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
     dev: false
@@ -3321,8 +3287,8 @@ packages:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
     dev: false
 
-  /@puppeteer/browsers@2.3.0:
-    resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
+  /@puppeteer/browsers@2.3.1:
+    resolution: {integrity: sha512-uK7o3hHkK+naEobMSJ+2ySYyXtQkBxIH8Gn4MK9ciePjNV+Pf+PgY/W7iPzn2MTjl3stcYB5AlcTmPYw7AXDwA==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
@@ -3589,25 +3555,6 @@ packages:
       z-schema: 5.0.5
     dev: false
 
-  /@rushstack/node-core-library@5.5.1(@types/node@18.19.44):
-    resolution: {integrity: sha512-ZutW56qIzH8xIOlfyaLQJFx+8IBqdbVCZdnj+XT1MorQ1JqqxHse8vbCpEM+2MjsrqcbxcgDIbfggB1ZSQ2A3g==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-    dependencies:
-      '@types/node': 18.19.44
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.8
-      semver: 7.5.4
-    dev: false
-
   /@rushstack/node-core-library@5.6.0(@types/node@18.19.44):
     resolution: {integrity: sha512-3ixIcEHseqU1sbnvoQkvxvfTYWbi1IIhnq/vexJcex7j6D8lnQCiYnd/E2oXbUH0Zv48CjtfslC/2MVFd71mpg==}
     peerDependencies:
@@ -3641,19 +3588,6 @@ packages:
       strip-json-comments: 3.1.1
     dev: false
 
-  /@rushstack/terminal@0.13.3(@types/node@18.19.44):
-    resolution: {integrity: sha512-fc3zjXOw8E0pXS5t9vTiIPx9gHA0fIdTXsu9mT4WbH+P3mYvnrX0iAQ5a6NvyK1+CqYWBTw/wVNx7SDJkI+WYQ==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-    dependencies:
-      '@rushstack/node-core-library': 5.5.1(@types/node@18.19.44)
-      '@types/node': 18.19.44
-      supports-color: 8.1.1
-    dev: false
-
   /@rushstack/terminal@0.13.4(@types/node@18.19.44):
     resolution: {integrity: sha512-h7g2RuffpqBCDKOijlUmvQ0b2O9kpIOK9TWCX9IR+2kvudp6MdtCYDu29zeqweWwCSWUnuAaUfB5HT88s0YCiw==}
     peerDependencies:
@@ -3674,17 +3608,6 @@ packages:
       argparse: 1.0.10
       colors: 1.2.5
       string-argv: 0.3.2
-    dev: false
-
-  /@rushstack/ts-command-line@4.22.4(@types/node@18.19.44):
-    resolution: {integrity: sha512-QoyhbWfyF9Ixg5DWdPzxO3h2RmJ7i5WH9b7qLzD5h5WFya/ZqicjdPrVwQiGtrFvAbBj8jhcC9DhbzU9xAk78g==}
-    dependencies:
-      '@rushstack/terminal': 0.13.3(@types/node@18.19.44)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
     dev: false
 
   /@rushstack/ts-command-line@4.22.5(@types/node@18.19.44):
@@ -3820,13 +3743,13 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/bunyan@1.8.9:
     resolution: {integrity: sha512-ZqS9JGpBxVOvsawzmVt30sP++gSQMTejCkIAQ3VdadOcRE8izTyW66hufvwLeH+YEGP6Js2AW7Gz+RMyvrEbmw==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/chai-as-promised@7.1.8:
@@ -3842,7 +3765,7 @@ packages:
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/cookie@0.4.1:
@@ -3856,7 +3779,7 @@ packages:
   /@types/cors@2.8.17:
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/debug@4.1.12:
@@ -3868,7 +3791,7 @@ packages:
   /@types/decompress@4.2.7:
     resolution: {integrity: sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/eslint-config-prettier@6.11.3:
@@ -3892,19 +3815,10 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: false
 
-  /@types/express-serve-static-core@4.19.0:
-    resolution: {integrity: sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==}
-    dependencies:
-      '@types/node': 22.2.0
-      '@types/qs': 6.9.15
-      '@types/range-parser': 1.2.7
-      '@types/send': 0.17.4
-    dev: false
-
   /@types/express-serve-static-core@4.19.5:
     resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -3923,13 +3837,7 @@ packages:
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.2.0
-    dev: false
-
-  /@types/fs-extra@8.1.5:
-    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
-    dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/http-errors@2.0.4:
@@ -3946,7 +3854,7 @@ packages:
   /@types/is-buffer@2.0.2:
     resolution: {integrity: sha512-G6OXy83Va+xEo8XgqAJYOuvOMxeey9xM5XKkvwJNmN8rVdcB+r15HvHsG86hl86JvU0y1aa7Z2ERkNFYWw9ySg==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/json-schema@7.0.15:
@@ -3960,19 +3868,19 @@ packages:
   /@types/jsonfile@6.1.4:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/jsonwebtoken@9.0.6:
     resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/jws@3.2.10:
     resolution: {integrity: sha512-cOevhttJmssERB88/+XvZXvsq5m9JLKZNUiGfgjUb5lcPRdV2ZQciU6dU76D/qXXFYpSqkP3PrSg4hMTiafTZw==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/linkify-it@5.0.0:
@@ -4019,19 +3927,19 @@ packages:
   /@types/mute-stream@0.0.4:
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 22.3.0
     dev: false
 
   /@types/mysql@2.15.22:
     resolution: {integrity: sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/node-fetch@2.6.11:
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
       form-data: 4.0.0
     dev: false
 
@@ -4047,10 +3955,10 @@ packages:
       undici-types: 5.26.5
     dev: false
 
-  /@types/node@22.2.0:
-    resolution: {integrity: sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==}
+  /@types/node@22.3.0:
+    resolution: {integrity: sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==}
     dependencies:
-      undici-types: 6.13.0
+      undici-types: 6.18.2
     dev: false
 
   /@types/pako@2.0.3:
@@ -4066,7 +3974,7 @@ packages:
   /@types/pg@8.6.1:
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
       pg-protocol: 1.6.1
       pg-types: 2.2.0
     dev: false
@@ -4086,7 +3994,7 @@ packages:
   /@types/readdir-glob@1.1.5:
     resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/resolve@1.20.2:
@@ -4105,14 +4013,14 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/serve-static@1.15.7:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
       '@types/send': 0.17.4
     dev: false
 
@@ -4137,13 +4045,13 @@ packages:
   /@types/stoppable@1.1.3:
     resolution: {integrity: sha512-7wGKIBJGE4ZxFjk9NkjAxZMLlIXroETqP1FJCdoSvKmEznwmBxQFmTB1dsCkAvVcNemuSZM5qkkd9HE/NL2JTw==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/through@0.0.33:
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/tough-cookie@4.0.5:
@@ -4177,13 +4085,13 @@ packages:
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/ws@8.5.12:
     resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
 
   /@types/yargs-parser@21.0.3:
@@ -4200,7 +4108,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
     dev: false
     optional: true
 
@@ -4375,36 +4283,6 @@ packages:
       playwright: 1.46.0
       sirv: 2.0.4
       vitest: 1.6.0(@types/node@18.19.44)(@vitest/browser@1.6.0)
-    dev: false
-
-  /@vitest/browser@2.0.5(playwright@1.45.3)(typescript@5.5.4)(vitest@2.0.5):
-    resolution: {integrity: sha512-VbOYtu/6R3d7ASZREcrJmRY/sQuRFO9wMVsEDqfYbWiJRh2fDNi8CL1Csn7Ux31pOcPmmM5QvzFCMpiojvVh8g==}
-    peerDependencies:
-      playwright: '*'
-      safaridriver: '*'
-      vitest: 2.0.5
-      webdriverio: '*'
-    peerDependenciesMeta:
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@testing-library/dom': 10.4.0
-      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/utils': 2.0.5
-      magic-string: 0.30.11
-      msw: 2.3.5(typescript@5.5.4)
-      playwright: 1.45.3
-      sirv: 2.0.4
-      vitest: 2.0.5(@types/node@18.19.44)(@vitest/browser@2.0.5)
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
     dev: false
 
   /@vitest/browser@2.0.5(playwright@1.46.0)(typescript@5.4.5)(vitest@2.0.5):
@@ -4672,7 +4550,7 @@ packages:
   /ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.13.0
     dev: false
 
   /ajv@6.12.6:
@@ -4953,8 +4831,8 @@ packages:
     engines: {node: '>=0.11'}
     dev: false
 
-  /axios@1.7.3(debug@4.3.6):
-    resolution: {integrity: sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==}
+  /axios@1.7.4(debug@4.3.6):
+    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.6)
       form-data: 4.0.0
@@ -5095,7 +4973,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001651
-      electron-to-chromium: 1.5.6
+      electron-to-chromium: 1.5.7
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
     dev: false
@@ -5965,8 +5843,8 @@ packages:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
-  /electron-to-chromium@1.5.6:
-    resolution: {integrity: sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==}
+  /electron-to-chromium@1.5.7:
+    resolution: {integrity: sha512-6FTNWIWMxMy/ZY6799nBlPtF1DFDQ6VQJ7yyDP27SJNt5lwtQ5ufqVvHylb3fdQefvRcgA3fKcFMJi9OLwBRNw==}
     dev: false
 
   /emoji-regex@8.0.0:
@@ -5999,7 +5877,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -9007,8 +8885,8 @@ packages:
       is-wsl: 2.2.0
     dev: false
 
-  /openai@4.55.4:
-    resolution: {integrity: sha512-TEC75Y6U/OKIJp9fHao3zkTYfKLYGqXdD2TI+xN2Zd5W8KNKvv6E4/OBTOW7jg7fySfrBrhy5fYzBbyBcdHEtQ==}
+  /openai@4.55.7:
+    resolution: {integrity: sha512-I2dpHTINt0Zk+Wlns6KzkKu77MmNW3VfIIQf5qYziEUI6t7WciG1zTobfKqdPzBmZi3TTM+3DtjPumxQdcvzwA==}
     hasBin: true
     peerDependencies:
       zod: ^3.23.8
@@ -9343,26 +9221,10 @@ packages:
       pathe: 1.1.2
     dev: false
 
-  /playwright-core@1.45.3:
-    resolution: {integrity: sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: false
-
   /playwright-core@1.46.0:
     resolution: {integrity: sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==}
     engines: {node: '>=18'}
     hasBin: true
-    dev: false
-
-  /playwright@1.45.3:
-    resolution: {integrity: sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dependencies:
-      playwright-core: 1.45.3
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /playwright@1.46.0:
@@ -9546,7 +9408,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.2.0
+      '@types/node': 18.19.44
       long: 5.2.3
     dev: false
 
@@ -9611,14 +9473,15 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /puppeteer-core@23.0.2:
-    resolution: {integrity: sha512-MvOHn+g1TYkAR2oVd/bf/YWXKqFTJmkhyyurYgxkrjh8rBOL1ZH5VyOsLJi0bLO7/yoipAmk1gFZEx9HUJnaoA==}
+  /puppeteer-core@23.1.0:
+    resolution: {integrity: sha512-SvAsu+xnLN2FMXE/59bp3s3WXp8ewqUGzVV4AQtml/2xmsciZnU/bXcCW+eETHPWQ6Agg2vTI7QzWXPpEARK2g==}
     engines: {node: '>=18'}
     dependencies:
-      '@puppeteer/browsers': 2.3.0
+      '@puppeteer/browsers': 2.3.1
       chromium-bidi: 0.6.4(devtools-protocol@0.0.1312386)
       debug: 4.3.6(supports-color@8.1.1)
       devtools-protocol: 0.0.1312386
+      typed-query-selector: 2.12.0
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -9626,17 +9489,18 @@ packages:
       - utf-8-validate
     dev: false
 
-  /puppeteer@23.0.2(typescript@5.5.4):
-    resolution: {integrity: sha512-I/l1P8s8brcLG+oW9AwF8hUaOSGGJcGKMflXRgULUH0S3ABptlLI9ZKjqWDo8ipY6v789ZKd+bNKtcCwpTh5Ww==}
+  /puppeteer@23.1.0(typescript@5.5.4):
+    resolution: {integrity: sha512-m+CyicDlGN1AVUeOsCa6/+KQydJzxfsPowL7fQy+VGNeaWafB0m8G5aGfXdfZztKMxzCsdz7KNNzbJPeG9wwFw==}
     engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@puppeteer/browsers': 2.3.0
+      '@puppeteer/browsers': 2.3.1
       chromium-bidi: 0.6.4(devtools-protocol@0.0.1312386)
       cosmiconfig: 9.0.0(typescript@5.5.4)
       devtools-protocol: 0.0.1312386
-      puppeteer-core: 23.0.2
+      puppeteer-core: 23.1.0
+      typed-query-selector: 2.12.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11036,6 +10900,10 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: false
 
+  /typed-query-selector@2.12.0:
+    resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
+    dev: false
+
   /typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
@@ -11133,8 +11001,8 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: false
 
-  /undici-types@6.13.0:
-    resolution: {integrity: sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==}
+  /undici-types@6.18.2:
+    resolution: {integrity: sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==}
     dev: false
 
   /undici@5.28.4:
@@ -11459,7 +11327,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      axios: 1.7.3(debug@4.3.6)
+      axios: 1.7.4(debug@4.3.6)
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8
@@ -11813,7 +11681,7 @@ packages:
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -11853,7 +11721,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -11900,7 +11768,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -11946,7 +11814,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -11993,7 +11861,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12038,7 +11906,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12083,7 +11951,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.20.0)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
@@ -12130,7 +11998,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -12173,7 +12041,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -12223,7 +12091,7 @@ packages:
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/decompress': 4.2.7
@@ -12270,7 +12138,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure/core-lro': 2.7.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       autorest: 3.7.1
@@ -12299,7 +12167,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12344,7 +12212,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -12392,7 +12260,7 @@ packages:
       '@azure/core-lro': 3.0.0-beta.1
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12438,7 +12306,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12482,7 +12350,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure/core-lro': 3.0.0-beta.1
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -12610,7 +12478,7 @@ packages:
       '@azure-rest/core-client': 1.4.0
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -12650,7 +12518,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12690,7 +12558,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12720,7 +12588,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12749,7 +12617,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12778,7 +12646,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12808,7 +12676,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12838,7 +12706,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12869,7 +12737,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12899,7 +12767,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12928,7 +12796,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12957,7 +12825,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -12987,7 +12855,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13018,7 +12886,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13048,7 +12916,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13094,7 +12962,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13122,7 +12990,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13149,7 +13017,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13179,7 +13047,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13207,7 +13075,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13237,7 +13105,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13267,7 +13135,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13298,7 +13166,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13325,7 +13193,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13354,7 +13222,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13384,7 +13252,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13414,7 +13282,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13444,7 +13312,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13473,7 +13341,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13502,7 +13370,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13532,7 +13400,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13560,7 +13428,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13587,7 +13455,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13617,7 +13485,7 @@ packages:
       '@azure/arm-cosmosdb': 16.0.0-beta.6
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13647,7 +13515,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13675,7 +13543,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13703,7 +13571,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13730,7 +13598,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13759,7 +13627,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13790,7 +13658,7 @@ packages:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13821,7 +13689,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13852,7 +13720,7 @@ packages:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13894,7 +13762,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -13937,7 +13805,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13968,7 +13836,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -13998,7 +13866,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14026,7 +13894,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14056,7 +13924,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14086,7 +13954,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14116,7 +13984,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14147,7 +14015,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14193,7 +14061,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14224,7 +14092,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14255,7 +14123,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14285,7 +14153,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14315,7 +14183,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14344,7 +14212,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14374,7 +14242,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14404,7 +14272,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14434,7 +14302,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14463,7 +14331,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14493,7 +14361,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14522,7 +14390,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14552,7 +14420,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14583,7 +14451,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14612,7 +14480,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14641,7 +14509,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14672,7 +14540,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14702,7 +14570,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14729,7 +14597,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14759,7 +14627,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14788,7 +14656,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14818,7 +14686,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14848,7 +14716,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14879,7 +14747,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14909,7 +14777,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14940,7 +14808,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14969,7 +14837,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -14998,7 +14866,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15028,7 +14896,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15058,7 +14926,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15087,7 +14955,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15117,7 +14985,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15146,7 +15014,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15172,7 +15040,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -15213,7 +15081,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15243,7 +15111,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15273,7 +15141,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15303,7 +15171,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15333,7 +15201,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15364,7 +15232,7 @@ packages:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15394,7 +15262,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15422,7 +15290,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15449,7 +15317,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15479,7 +15347,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15509,7 +15377,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15537,7 +15405,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15568,7 +15436,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15597,7 +15465,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15627,7 +15495,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15657,7 +15525,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15687,7 +15555,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15716,7 +15584,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15742,7 +15610,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -15785,7 +15653,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15814,7 +15682,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15844,7 +15712,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15874,7 +15742,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15903,7 +15771,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15934,7 +15802,7 @@ packages:
       '@azure/arm-compute': 21.6.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15965,7 +15833,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -15996,7 +15864,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16023,7 +15891,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16053,7 +15921,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16083,7 +15951,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16113,7 +15981,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16143,7 +16011,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16173,7 +16041,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16203,7 +16071,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16233,7 +16101,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16263,7 +16131,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16291,7 +16159,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16319,7 +16187,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16347,7 +16215,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16375,7 +16243,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16404,7 +16272,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16434,7 +16302,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16465,7 +16333,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16492,7 +16360,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16520,7 +16388,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16551,7 +16419,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16581,7 +16449,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16611,7 +16479,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16638,7 +16506,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16666,7 +16534,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16696,7 +16564,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16723,7 +16591,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16753,7 +16621,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16781,7 +16649,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16811,7 +16679,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16839,7 +16707,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16868,7 +16736,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16895,7 +16763,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -16936,7 +16804,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16966,7 +16834,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -16994,7 +16862,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17024,7 +16892,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17055,7 +16923,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17084,7 +16952,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17115,7 +16983,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17146,7 +17014,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17176,7 +17044,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17222,7 +17090,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17252,7 +17120,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17282,7 +17150,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17311,7 +17179,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17341,7 +17209,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17371,7 +17239,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17401,7 +17269,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17430,7 +17298,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17460,7 +17328,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17489,7 +17357,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17520,7 +17388,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17550,7 +17418,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17578,7 +17446,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17607,7 +17475,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17635,7 +17503,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17663,7 +17531,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17693,7 +17561,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17721,7 +17589,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17751,7 +17619,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17781,7 +17649,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17810,7 +17678,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17840,7 +17708,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17869,7 +17737,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17899,7 +17767,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17928,7 +17796,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17958,7 +17826,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -17989,7 +17857,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18019,7 +17887,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18049,7 +17917,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18081,7 +17949,7 @@ packages:
       '@azure/arm-recoveryservices': 5.4.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18112,7 +17980,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18142,7 +18010,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18174,7 +18042,7 @@ packages:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18205,7 +18073,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18236,7 +18104,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18266,7 +18134,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18296,7 +18164,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18324,7 +18192,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18351,7 +18219,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18381,7 +18249,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18411,7 +18279,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18439,7 +18307,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18469,7 +18337,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18499,7 +18367,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18530,7 +18398,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18561,7 +18429,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18592,7 +18460,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18623,7 +18491,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18653,7 +18521,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18683,7 +18551,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18712,7 +18580,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18741,7 +18609,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18771,7 +18639,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18801,7 +18669,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18847,7 +18715,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18876,7 +18744,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18906,7 +18774,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18934,7 +18802,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18964,7 +18832,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -18994,7 +18862,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19024,7 +18892,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19054,7 +18922,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19084,7 +18952,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19115,7 +18983,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19145,7 +19013,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19175,7 +19043,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19204,7 +19072,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19235,7 +19103,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19265,7 +19133,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19294,7 +19162,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19324,7 +19192,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19355,7 +19223,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19384,7 +19252,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19413,7 +19281,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19442,7 +19310,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19470,7 +19338,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19500,7 +19368,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19529,7 +19397,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19559,7 +19427,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19587,7 +19455,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19616,7 +19484,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19644,7 +19512,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19674,7 +19542,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19703,7 +19571,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19733,7 +19601,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19763,7 +19631,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19793,7 +19661,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19822,7 +19690,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19852,7 +19720,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19880,7 +19748,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -19907,7 +19775,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -19958,7 +19826,7 @@ packages:
       '@azure-rest/core-client': 1.4.0
       '@azure-tools/test-credential': 1.2.0
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 1.6.0(playwright@1.46.0)(vitest@1.6.0)
       '@vitest/coverage-istanbul': 1.6.0(vitest@1.6.0)
@@ -19999,7 +19867,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20042,7 +19910,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/communication-phone-numbers': 1.2.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20088,7 +19956,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/communication-signaling': 1.0.0-beta.28
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20134,7 +20002,7 @@ packages:
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -20181,7 +20049,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20224,8 +20092,8 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@azure/msal-node': 2.12.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@azure/msal-node': 2.13.0
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20268,7 +20136,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20318,7 +20186,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20363,7 +20231,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20408,7 +20276,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20452,7 +20320,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20497,7 +20365,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20533,7 +20401,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20579,7 +20447,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20624,7 +20492,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20670,7 +20538,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20714,7 +20582,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -20742,7 +20610,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -20783,7 +20651,7 @@ packages:
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@rollup/plugin-inject': 5.0.5(rollup@4.20.0)
       '@types/debug': 4.1.12
       '@types/node': 18.19.44
@@ -20829,7 +20697,7 @@ packages:
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -20864,7 +20732,7 @@ packages:
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -20899,7 +20767,7 @@ packages:
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -20934,7 +20802,7 @@ packages:
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -20968,7 +20836,7 @@ packages:
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21003,7 +20871,7 @@ packages:
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21038,7 +20906,7 @@ packages:
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21075,7 +20943,7 @@ packages:
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/express': 4.17.21
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
@@ -21114,7 +20982,7 @@ packages:
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21149,7 +21017,7 @@ packages:
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21184,7 +21052,7 @@ packages:
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@types/trusted-types': 2.0.7
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
@@ -21222,7 +21090,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@sinonjs/fake-timers': 11.2.2
       '@types/chai': 4.3.17
       '@types/debug': 4.1.12
@@ -21265,7 +21133,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -21311,7 +21179,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -21357,7 +21225,7 @@ packages:
       '@_ts/min': /typescript@4.2.4
       '@azure/identity': 4.4.1
       '@eslint/js': 9.2.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.20.0)
       '@rollup/plugin-inject': 5.0.5(rollup@4.20.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.20.0)
@@ -21366,7 +21234,7 @@ packages:
       '@types/archiver': 6.0.2
       '@types/decompress': 4.2.7
       '@types/express': 4.17.21
-      '@types/express-serve-static-core': 4.19.0
+      '@types/express-serve-static-core': 4.19.5
       '@types/fs-extra': 11.0.4
       '@types/minimist': 1.2.5
       '@types/node': 18.19.44
@@ -21425,7 +21293,7 @@ packages:
     dependencies:
       '@azure/core-lro': 3.0.0
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21465,7 +21333,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -21591,7 +21459,7 @@ packages:
     dependencies:
       '@azure/core-amqp': 4.4.0-beta.1
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@rollup/plugin-inject': 5.0.5(rollup@4.20.0)
       '@types/chai-as-promised': 7.1.8
       '@types/debug': 4.1.12
@@ -21650,7 +21518,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -21697,7 +21565,7 @@ packages:
       '@azure-rest/core-client': 1.4.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -21744,7 +21612,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -21787,16 +21655,14 @@ packages:
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
     dependencies:
-      '@azure/core-rest-pipeline': 1.16.3
-      '@azure/core-util': 1.9.1
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@rollup/plugin-inject': 5.0.5(rollup@4.20.0)
       '@types/chai-as-promised': 7.1.8
       '@types/debug': 4.1.12
       '@types/node': 18.19.44
-      '@vitest/browser': 2.0.5(playwright@1.45.3)(typescript@5.5.4)(vitest@2.0.5)
+      '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
       buffer: 6.0.3
       chai-as-promised: 8.0.0(chai@4.3.10)
@@ -21804,7 +21670,7 @@ packages:
       debug: 4.3.6(supports-color@8.1.1)
       dotenv: 16.4.5
       eslint: 8.57.0
-      playwright: 1.45.3
+      playwright: 1.46.0
       process: 0.11.10
       rimraf: 6.0.1
       stream: 0.0.3
@@ -21842,7 +21708,7 @@ packages:
     dependencies:
       '@azure/event-hubs': 5.12.0
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@rollup/plugin-inject': 5.0.5(rollup@4.20.0)
       '@types/chai-as-promised': 7.1.8
       '@types/debug': 4.1.12
@@ -21893,7 +21759,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/functions': 3.5.1
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -21935,7 +21801,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.4.5)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -21979,7 +21845,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22026,7 +21892,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22073,7 +21939,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22117,16 +21983,16 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/abort-controller': 1.1.0
       '@azure/identity': 4.4.1
-      '@azure/msal-node': 2.12.0
+      '@azure/msal-node': 2.13.0
       '@azure/msal-node-extensions': 1.1.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       '@types/sinon': 17.0.3
       cross-env: 7.0.3
       eslint: 8.57.0
       mocha: 10.7.3
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       tslib: 2.6.3
@@ -22144,9 +22010,9 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@azure/msal-node': 2.12.0
+      '@azure/msal-node': 2.13.0
       '@azure/msal-node-extensions': 1.1.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/jws': 3.2.10
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22158,7 +22024,7 @@ packages:
       inherits: 2.0.4
       keytar: 7.9.0
       mocha: 10.7.3
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       ts-node: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
@@ -22180,7 +22046,7 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/jws': 3.2.10
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22193,7 +22059,7 @@ packages:
       inherits: 2.0.4
       keytar: 7.9.0
       mocha: 10.7.3
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       ts-node: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
@@ -22215,9 +22081,9 @@ packages:
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/keyvault-keys': 4.8.0
-      '@azure/msal-browser': 3.20.0
-      '@azure/msal-node': 2.12.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@azure/msal-browser': 3.21.0
+      '@azure/msal-node': 2.13.0
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/jsonwebtoken': 9.0.6
       '@types/jws': 3.2.10
@@ -22247,7 +22113,7 @@ packages:
       ms: 2.1.3
       nyc: 17.0.0
       open: 8.4.2
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       stoppable: 1.1.0
@@ -22274,7 +22140,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22317,7 +22183,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22364,7 +22230,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       '@types/sinon': 17.0.3
@@ -22396,7 +22262,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       '@types/sinon': 17.0.3
@@ -22416,7 +22282,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -22437,14 +22303,14 @@ packages:
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       cross-env: 7.0.3
       eslint: 8.57.0
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -22468,7 +22334,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       '@types/sinon': 17.0.3
@@ -22489,7 +22355,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -22514,7 +22380,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       '@types/sinon': 17.0.3
@@ -22532,7 +22398,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -22558,7 +22424,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22601,7 +22467,7 @@ packages:
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -22638,7 +22504,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       eslint: 8.57.0
       rimraf: 5.0.10
@@ -22660,7 +22526,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22706,7 +22572,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22753,7 +22619,7 @@ packages:
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22800,7 +22666,7 @@ packages:
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
       '@azure/maps-common': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -22843,7 +22709,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -22887,7 +22753,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -22931,7 +22797,7 @@ packages:
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
       cross-env: 7.0.3
@@ -22968,7 +22834,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23013,7 +22879,7 @@ packages:
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
@@ -23049,7 +22915,7 @@ packages:
     dependencies:
       '@azure/functions': 4.5.0
       '@azure/functions-old': /@azure/functions@3.5.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@microsoft/applicationinsights-web-snippet': 1.2.1
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.52.1
@@ -23098,7 +22964,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.25.1(@opentelemetry/api@1.9.0)
@@ -23140,7 +23006,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -23178,12 +23044,12 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       cross-env: 7.0.3
       dotenv: 16.4.5
       eslint: 8.57.0
-      openai: 4.55.4
+      openai: 4.55.7
       rimraf: 3.0.2
       tshy: 2.0.1
       tslib: 2.6.3
@@ -23199,7 +23065,7 @@ packages:
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.52.1(@opentelemetry/api@1.9.0)
@@ -23715,7 +23581,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23760,7 +23626,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23804,7 +23670,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23849,7 +23715,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23895,7 +23761,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23940,7 +23806,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -23985,7 +23851,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24032,7 +23898,7 @@ packages:
       '@azure/event-hubs': 5.12.0
       '@azure/identity': 4.4.1
       '@azure/schema-registry': 1.2.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -24084,7 +23950,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/event-hubs': 5.12.0
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       ajv: 8.17.1
@@ -24126,7 +23992,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       cross-env: 7.0.3
@@ -24166,7 +24032,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
       '@azure/openai': 1.0.0-beta.12
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24212,7 +24078,7 @@ packages:
     dependencies:
       '@azure/core-amqp': 4.3.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/debug': 4.1.12
@@ -24249,7 +24115,7 @@ packages:
       nyc: 17.0.0
       process: 0.11.10
       promise: 8.3.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rhea-promise: 3.0.3
       rimraf: 5.0.10
       sinon: 17.0.1
@@ -24274,7 +24140,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24299,7 +24165,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -24325,7 +24191,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24347,7 +24213,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       source-map-support: 0.5.21
       ts-node: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
@@ -24371,7 +24237,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24396,7 +24262,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -24422,7 +24288,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24445,7 +24311,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -24467,7 +24333,7 @@ packages:
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24488,7 +24354,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       source-map-support: 0.5.21
       ts-node: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
@@ -24513,7 +24379,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
       '@azure/storage-blob': 12.24.0
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24534,7 +24400,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       source-map-support: 0.5.21
       ts-node: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
@@ -24557,7 +24423,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -24605,7 +24471,7 @@ packages:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -24654,7 +24520,7 @@ packages:
       '@azure-tools/test-recorder': 3.5.2
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -24702,7 +24568,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -24745,7 +24611,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
       cross-env: 7.0.3
@@ -24782,7 +24648,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.7
@@ -24826,7 +24692,7 @@ packages:
       '@azure-rest/core-client': 1.4.0
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/mocha': 10.0.7
       '@types/node': 18.19.44
@@ -24846,7 +24712,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       ts-node: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
       tslib: 2.6.3
@@ -24868,7 +24734,7 @@ packages:
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 1.6.0(playwright@1.46.0)(vitest@1.6.0)
       '@vitest/coverage-istanbul': 1.6.0(vitest@1.6.0)
@@ -24906,7 +24772,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/identity': 4.4.1
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       eslint: 8.57.0
       rimraf: 5.0.10
@@ -24952,8 +24818,7 @@ packages:
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
-      '@types/fs-extra': 8.1.5
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -25029,7 +24894,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@opentelemetry/api': 1.9.0
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
@@ -25065,7 +24930,7 @@ packages:
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/node': 18.19.44
       '@vitest/browser': 2.0.5(playwright@1.46.0)(typescript@5.5.4)(vitest@2.0.5)
       '@vitest/coverage-istanbul': 2.0.5(vitest@2.0.5)
@@ -25119,7 +24984,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure/web-pubsub-client': 1.0.0-beta.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/express': 4.17.21
@@ -25154,7 +25019,7 @@ packages:
       nyc: 17.0.0
       protobufjs: 7.3.2
       protobufjs-cli: 1.1.2(protobufjs@7.3.2)
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       rollup: 4.20.0
       sinon: 17.0.1
@@ -25177,7 +25042,7 @@ packages:
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/chai-as-promised': 7.1.8
       '@types/express': 4.17.21
@@ -25207,7 +25072,7 @@ packages:
       mocha: 10.7.3
       mock-socket: 9.3.1
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21
@@ -25230,7 +25095,7 @@ packages:
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/express': 4.17.21
       '@types/express-serve-static-core': 4.19.5
       '@types/jsonwebtoken': 9.0.6
@@ -25272,7 +25137,7 @@ packages:
     dependencies:
       '@azure-tools/test-credential': 1.2.0
       '@azure-tools/test-recorder': 3.5.2
-      '@microsoft/api-extractor': 7.47.5(@types/node@18.19.44)
+      '@microsoft/api-extractor': 7.47.6(@types/node@18.19.44)
       '@types/chai': 4.3.17
       '@types/jsonwebtoken': 9.0.6
       '@types/mocha': 10.0.7
@@ -25295,7 +25160,7 @@ packages:
       karma-sourcemap-loader: 0.3.8
       mocha: 10.7.3
       nyc: 17.0.0
-      puppeteer: 23.0.2(typescript@5.5.4)
+      puppeteer: 23.1.0(typescript@5.5.4)
       rimraf: 5.0.10
       sinon: 17.0.1
       source-map-support: 0.5.21


### PR DESCRIPTION
eventhubs-checkpointstore-blob still has playwright 1.45.3 in lockfile.  This PR updates the version to 1.46.0