### PR TITLE
[eslint] fix ci failures

### DIFF
--- a/eng/pipelines/run-for-all-packages.yml
+++ b/eng/pipelines/run-for-all-packages.yml
@@ -25,22 +25,22 @@ stages:
             displayName: "Install library dependencies"
 
           - script: |
-              node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk
-              node eng/tools/rush-runner.js lint -p max
+              node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk -t @azure/monitor-opentelemetry-exporter
+              node common/scripts/install-run-rush.js lint -p max
             displayName: "Build ESLint Plugin and Lint All Packages"
 
           - script: |
-              node eng/tools/rush-runner.js build -p max
+              node common/scripts/install-run-rush.js build -p max
             displayName: "Build All Packages"
 
           - script: |
-              node eng/tools/rush-runner.js build:test -t @azure/identity -t @azure/app-configuration -t @azure/event-hubs -t @azure-rest/synapse-access-control -t @azure/storage-blob
+              node common/scripts/install-run-rush.js build:test -t @azure/identity -t @azure/app-configuration -t @azure/event-hubs -t @azure-rest/synapse-access-control -t @azure/storage-blob
             displayName: "Build Tests for Selected Packages"
 
           - script: |
-              node eng/tools/rush-runner.js unit-test -t @azure/identity -t @azure/app-configuration -t @azure/event-hubs -p 1
+              node common/scripts/install-run-rush.js unit-test -t @azure/identity -t @azure/app-configuration -t @azure/event-hubs -p 1
             displayName: "Run Unit Tests for Selected Packages"
 
           - script: |
-              node eng/tools/rush-runner.js integration-test --only @azure/app-configuration --only @azure/storage-blob --only @azure-rest/synapse-access-control -p 1
+              node common/scripts/install-run-rush.js integration-test --only @azure/app-configuration --only @azure/storage-blob --only @azure-rest/synapse-access-control -p 1
             displayName: "Run Integration Tests for Selected Packages"

--- a/eng/pipelines/templates/steps/run-eslint.yml
+++ b/eng/pipelines/templates/steps/run-eslint.yml
@@ -7,6 +7,6 @@ steps:
     displayName: "Install library dependencies"
 
   - pwsh: |
-      node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk
+      node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk -t @azure/monitor-opentelemetry-exporter
       node eng/tools/rush-runner.js lint "${{parameters.ServiceDirectory}}" -p max
     displayName: "Build ESLint Plugin and Lint Libraries"

--- a/eng/pipelines/templates/steps/test-eslint.yml
+++ b/eng/pipelines/templates/steps/test-eslint.yml
@@ -7,7 +7,7 @@ steps:
     displayName: "Install library dependencies"
 
   - pwsh: |
-      node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk
+      node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk -t @azure/monitor-opentelemetry-exporter
       node eng/tools/rush-runner.js lint "${{parameters.ServiceDirectory}}" -p max
     displayName: "Build ESLint Plugin and Lint Libraries"
 


### PR DESCRIPTION
Recently linting was enabled for `monitor-opentelemetry-exporter`.  Its eslint
config enables typed linting which requires its dependencies to be build in
order to have proper types.

This PR passes `-t @azure/monitor-opentelemetry-exporter` to `rush build`
before linting so that its dependencies are built.

While at it, also change the `run-for-all-packages` pipeline to use `install-run-rush.js` for consistency.