### PR TITLE
[identity] Add support for Managed Identity ObjectID

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for providing an object ID to `ManagedIdentityCredential`. [#30771](https://github.com/Azure/azure-sdk-for-js/pull/30771)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -361,12 +361,18 @@ export class ManagedIdentityCredential implements TokenCredential {
     constructor(clientId: string, options?: TokenCredentialOptions);
     constructor(options?: ManagedIdentityCredentialClientIdOptions);
     constructor(options?: ManagedIdentityCredentialResourceIdOptions);
+    constructor(options?: ManagedIdentityCredentialObjectIdOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
 }
 
 // @public
 export interface ManagedIdentityCredentialClientIdOptions extends TokenCredentialOptions {
     clientId?: string;
+}
+
+// @public
+export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
+    objectId: string;
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -34,6 +34,17 @@ export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredent
 }
 
 /**
+ * Options to send on the {@link ManagedIdentityCredential} constructor.
+ * This variation supports `objectId` as a constructor argument.
+ */
+export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
+  /**
+   * TODO
+   */
+  objectId: string;
+}
+
+/**
  * Attempts authentication using a managed identity available at the deployment environment.
  * This authentication type works in Azure VMs, App Service instances, Azure Functions applications,
  * Azure Kubernetes Services, Azure Service Fabric instances and inside of the Azure Cloud Shell.
@@ -65,6 +76,12 @@ export class ManagedIdentityCredential implements TokenCredential {
    */
   constructor(options?: ManagedIdentityCredentialResourceIdOptions);
   /**
+   * Creates an instance of ManagedIdentityCredential with Object Id
+   *
+   * @param options - Options for configuring the resource which makes the access token request.
+   */
+  constructor(options?: ManagedIdentityCredentialObjectIdOptions);
+  /**
    * @internal
    * @hidden
    */
@@ -72,7 +89,8 @@ export class ManagedIdentityCredential implements TokenCredential {
     clientIdOrOptions?:
       | string
       | ManagedIdentityCredentialClientIdOptions
-      | ManagedIdentityCredentialResourceIdOptions,
+      | ManagedIdentityCredentialResourceIdOptions
+      | ManagedIdentityCredentialObjectIdOptions,
     options?: TokenCredentialOptions,
   ) {
     // https://github.com/Azure/azure-sdk-for-js/issues/30189

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -39,7 +39,8 @@ export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredent
  */
 export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
   /**
-   * TODO
+   * Allows specifying the object ID of the service principal used to authenticate a user-assigned managed identity.
+   * This is an alternative for providing a client ID and is not required for system-assigned managed identities.
    */
   objectId: string;
 }
@@ -64,19 +65,19 @@ export class ManagedIdentityCredential implements TokenCredential {
    */
   constructor(clientId: string, options?: TokenCredentialOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential with clientId
+   * Creates an instance of ManagedIdentityCredential with a Client Id
    *
    * @param options - Options for configuring the client which makes the access token request.
    */
   constructor(options?: ManagedIdentityCredentialClientIdOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential with Resource Id
+   * Creates an instance of ManagedIdentityCredential with a Resource Id
    *
    * @param options - Options for configuring the resource which makes the access token request.
    */
   constructor(options?: ManagedIdentityCredentialResourceIdOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential with Object Id
+   * Creates an instance of ManagedIdentityCredential with an Object Id
    *
    * @param options - Options for configuring the resource which makes the access token request.
    */

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -39,7 +39,7 @@ export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredent
  */
 export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
   /**
-   * Allows specifying the object ID of the service principal used to authenticate a user-assigned managed identity.
+   * Allows specifying the object ID of the underlying service principal used to authenticate a user-assigned managed identity.
    * This is an alternative to providing a client ID and is not required for system-assigned managed identities.
    */
   objectId: string;

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -71,7 +71,7 @@ export class ManagedIdentityCredential implements TokenCredential {
    */
   constructor(options?: ManagedIdentityCredentialClientIdOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential with a Resource Id
+   * Creates an instance of ManagedIdentityCredential with a resource ID
    *
    * @param options - Options for configuring the resource which makes the access token request.
    */

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -40,7 +40,7 @@ export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredent
 export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
   /**
    * Allows specifying the object ID of the service principal used to authenticate a user-assigned managed identity.
-   * This is an alternative for providing a client ID and is not required for system-assigned managed identities.
+   * This is an alternative to providing a client ID and is not required for system-assigned managed identities.
    */
   objectId: string;
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -65,7 +65,7 @@ export class ManagedIdentityCredential implements TokenCredential {
    */
   constructor(clientId: string, options?: TokenCredentialOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential with a Client Id
+   * Creates an instance of ManagedIdentityCredential with a client ID
    *
    * @param options - Options for configuring the client which makes the access token request.
    */

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -40,7 +40,7 @@ export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredent
 export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
   /**
    * Allows specifying the object ID of the underlying service principal used to authenticate a user-assigned managed identity.
-   * This is an alternative to providing a client ID and is not required for system-assigned managed identities.
+   * This is an alternative to providing a client ID or resource ID and is not required for system-assigned managed identities.
    */
   objectId: string;
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -77,7 +77,7 @@ export class ManagedIdentityCredential implements TokenCredential {
    */
   constructor(options?: ManagedIdentityCredentialResourceIdOptions);
   /**
-   * Creates an instance of ManagedIdentityCredential with an Object Id
+   * Creates an instance of ManagedIdentityCredential with an object ID
    *
    * @param options - Options for configuring the resource which makes the access token request.
    */

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -40,7 +40,8 @@ interface ManagedIdentityCredentialOptions extends TokenCredentialOptions {
   resourceId?: string;
 
   /**
-   * The objectID of the user-assigned managed identity.
+   * Allows specifying the object ID of the service principal used to authenticate a user-assigned managed identity.
+   * This is an alternative for providing a client ID and is not required for system-assigned managed identities.
    */
   objectId?: string;
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -40,8 +40,8 @@ interface ManagedIdentityCredentialOptions extends TokenCredentialOptions {
   resourceId?: string;
 
   /**
-   * Allows specifying the object ID of the service principal used to authenticate a user-assigned managed identity.
-   * This is an alternative for providing a client ID and is not required for system-assigned managed identities.
+   * Allows specifying the object ID of the underlying service principal used to authenticate a user-assigned managed identity.
+   * This is an alternative to providing a client ID and is not required for system-assigned managed identities.
    */
   objectId?: string;
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -38,6 +38,11 @@ interface ManagedIdentityCredentialOptions extends TokenCredentialOptions {
    * without having to first determine the client Id of the created identity.
    */
   resourceId?: string;
+
+  /**
+   * The objectID of the user-assigned managed identity.
+   */
+  objectId?: string;
 }
 
 export class MsalMsiProvider {
@@ -45,6 +50,7 @@ export class MsalMsiProvider {
   private identityClient: IdentityClient;
   private clientId?: string;
   private resourceId?: string;
+  private objectId?: string;
   private msiRetryConfig: MSIConfiguration["retryConfig"] = {
     maxRetries: 5,
     startDelayInMs: 800,
@@ -65,11 +71,13 @@ export class MsalMsiProvider {
       _options = clientIdOrOptions ?? {};
     }
     this.resourceId = _options?.resourceId;
+    this.objectId = _options?.objectId;
 
     // For JavaScript users.
-    if (this.clientId && this.resourceId) {
+    const providedIds = [this.clientId, this.resourceId, this.objectId].filter(Boolean);
+    if (providedIds.length > 1) {
       throw new Error(
-        `ManagedIdentityCredential - Client Id and Resource Id can't be provided at the same time.`,
+        `ManagedIdentityCredential - Only one of 'clientId', 'resourceId', or 'objectId' may be provided. Received values: ${providedIds.join(", ")}`,
       );
     }
 
@@ -89,6 +97,7 @@ export class MsalMsiProvider {
       managedIdentityIdParams: {
         userAssignedClientId: this.clientId,
         userAssignedResourceId: this.resourceId,
+        userAssignedObjectId: this.objectId,
       },
       system: {
         // todo: proxyUrl?

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -78,7 +78,9 @@ export class MsalMsiProvider {
     const providedIds = [this.clientId, this.resourceId, this.objectId].filter(Boolean);
     if (providedIds.length > 1) {
       throw new Error(
-        `ManagedIdentityCredential - Only one of 'clientId', 'resourceId', or 'objectId' may be provided. Received values: ${providedIds.join(", ")}`,
+        `ManagedIdentityCredential - At most one of 'clientId', 'resourceId', or 'objectId' may be provided. Received values: ${JSON.stringify(
+          { clientId: this.clientId, resourceId: this.resourceId, objectId: this.objectId },
+        )}`,
       );
     }
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -78,7 +78,7 @@ export class MsalMsiProvider {
     const providedIds = [this.clientId, this.resourceId, this.objectId].filter(Boolean);
     if (providedIds.length > 1) {
       throw new Error(
-        `ManagedIdentityCredential - At most one of 'clientId', 'resourceId', or 'objectId' may be provided. Received values: ${JSON.stringify(
+        `ManagedIdentityCredential - At most, one of 'clientId', 'resourceId', or 'objectId' may be provided. Received values: ${JSON.stringify(
           { clientId: this.clientId, resourceId: this.resourceId, objectId: this.objectId },
         )}`,
       );

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/msalMsiProvider.ts
@@ -78,7 +78,7 @@ export class MsalMsiProvider {
     const providedIds = [this.clientId, this.resourceId, this.objectId].filter(Boolean);
     if (providedIds.length > 1) {
       throw new Error(
-        `ManagedIdentityCredential - At most, one of 'clientId', 'resourceId', or 'objectId' may be provided. Received values: ${JSON.stringify(
+        `ManagedIdentityCredential - only one of 'clientId', 'resourceId', or 'objectId' can be provided. Received values: ${JSON.stringify(
           { clientId: this.clientId, resourceId: this.resourceId, objectId: this.objectId },
         )}`,
       );

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -75,6 +75,7 @@ export {
   ManagedIdentityCredential,
   ManagedIdentityCredentialClientIdOptions,
   ManagedIdentityCredentialResourceIdOptions,
+  ManagedIdentityCredentialObjectIdOptions,
 } from "./credentials/managedIdentityCredential";
 export { DeviceCodeCredential } from "./credentials/deviceCodeCredential";
 export {

--- a/sdk/identity/identity/test/integration/azureVMUserAssignedTest.spec.ts
+++ b/sdk/identity/identity/test/integration/azureVMUserAssignedTest.spec.ts
@@ -18,7 +18,7 @@ describe("AzureVM UserAssigned Integration test", function () {
       throw new Error("IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID is not set");
     }
     const credential = new ManagedIdentityCredential({ clientId: userAssignedClientId });
-    const accessToken = await credential.getToken("https://management.azure.com//.default");
+    const accessToken = await credential.getToken("https://management.azure.com/.default");
     assert.exists(accessToken.token);
   });
 
@@ -33,21 +33,7 @@ describe("AzureVM UserAssigned Integration test", function () {
       throw new Error("IDENTITY_VM_USER_ASSIGNED_MI_OBJECT_ID is not set");
     }
     const credential = new ManagedIdentityCredential({ objectId: userAssignedObjectId });
-    const accessToken = await credential.getToken("https://management.azure.com//.default");
-    assert.exists(accessToken.token);
-  });
-
-  it("test the Azure VM IMDS endpoint where the MI credential is used.", async function (this: Context) {
-    if (!isLiveMode()) {
-      this.skip();
-    }
-    const userAssignedVM = process.env.IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID;
-    if (!userAssignedVM) {
-      console.log("IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID is not set");
-      throw new Error("IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID is not set");
-    }
-    const credential = new ManagedIdentityCredential({ clientId: userAssignedVM });
-    const accessToken = await credential.getToken("https://management.azure.com//.default");
+    const accessToken = await credential.getToken("https://management.azure.com/.default");
     assert.exists(accessToken.token);
   });
 });

--- a/sdk/identity/identity/test/integration/azureVMUserAssignedTest.spec.ts
+++ b/sdk/identity/identity/test/integration/azureVMUserAssignedTest.spec.ts
@@ -7,6 +7,36 @@ import { isLiveMode } from "@azure-tools/test-recorder";
 import { ManagedIdentityCredential } from "../../src";
 
 describe("AzureVM UserAssigned Integration test", function () {
+  it("works with a user assigned clientId", async function (this: Context) {
+    if (!isLiveMode()) {
+      this.skip();
+    }
+
+    const userAssignedClientId = process.env.IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID;
+    if (!userAssignedClientId) {
+      console.log("IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID is not set");
+      throw new Error("IDENTITY_VM_USER_ASSIGNED_MI_CLIENT_ID is not set");
+    }
+    const credential = new ManagedIdentityCredential({ clientId: userAssignedClientId });
+    const accessToken = await credential.getToken("https://management.azure.com//.default");
+    assert.exists(accessToken.token);
+  });
+
+  it("works with a user assigned objectId", async function (this: Context) {
+    if (!isLiveMode()) {
+      this.skip();
+    }
+
+    const userAssignedObjectId = process.env.IDENTITY_VM_USER_ASSIGNED_MI_OBJECT_ID;
+    if (!userAssignedObjectId) {
+      console.log("IDENTITY_VM_USER_ASSIGNED_MI_OBJECT_ID is not set");
+      throw new Error("IDENTITY_VM_USER_ASSIGNED_MI_OBJECT_ID is not set");
+    }
+    const credential = new ManagedIdentityCredential({ objectId: userAssignedObjectId });
+    const accessToken = await credential.getToken("https://management.azure.com//.default");
+    assert.exists(accessToken.token);
+  });
+
   it("test the Azure VM IMDS endpoint where the MI credential is used.", async function (this: Context) {
     if (!isLiveMode()) {
       this.skip();

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -37,28 +37,28 @@ describe("ManagedIdentityCredential (MSAL)", function () {
       it("throws when both clientId and resourceId are provided", function () {
         assert.throws(
           () => new MsalMsiProvider("id", { resourceId: "id" }),
-          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /only one of 'clientId', 'resourceId', or 'objectId' can be provided/,
         );
       });
 
       it("throws when both clientId and resourceId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ clientId: "id", resourceId: "id" }),
-          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /only one of 'clientId', 'resourceId', or 'objectId' can be provided/,
         );
       });
 
       it("throws when both clientId and objectId are provided", function () {
         assert.throws(
           () => new MsalMsiProvider("id", { objectId: "id" }),
-          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /only one of 'clientId', 'resourceId', or 'objectId' can be provided/,
         );
       });
 
       it("throws when both resourceId and objectId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ resourceId: "id", objectId: "id" }),
-          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /only one of 'clientId', 'resourceId', or 'objectId' can be provided/,
         );
       });
     });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -35,15 +35,21 @@ describe("ManagedIdentityCredential (MSAL)", function () {
       // 2. MsalMsiProvider(clientId: string, options: MsalMsiOptions)
       // by relying on the error handling of the constructor
       it("throws when both clientId and resourceId are provided", function () {
-        assert.throws(
-          () => new MsalMsiProvider("id", { resourceId: "id" }),
-          /provided at the same time./,
-        );
+        assert.throws(() => new MsalMsiProvider("id", { resourceId: "id" }), /may be provided./);
       });
       it("throws when both clientId and resourceId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ clientId: "id", resourceId: "id" }),
-          /provided at the same time./,
+          /may be provided./,
+        );
+      });
+      it("throws when both clientId and objectId are provided", function () {
+        assert.throws(() => new MsalMsiProvider("id", { objectId: "id" }), /may be provided./);
+      });
+      it("throws when both resourceId and objectId are provided via options", function () {
+        assert.throws(
+          () => new MsalMsiProvider({ resourceId: "id", objectId: "id" }),
+          /may be provided./,
         );
       });
     });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -51,14 +51,14 @@ describe("ManagedIdentityCredential (MSAL)", function () {
       it("throws when both clientId and objectId are provided", function () {
         assert.throws(
           () => new MsalMsiProvider("id", { objectId: "id" }),
-          /At most one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
         );
       });
 
       it("throws when both resourceId and objectId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ resourceId: "id", objectId: "id" }),
-          /At most one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
         );
       });
     });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -37,14 +37,14 @@ describe("ManagedIdentityCredential (MSAL)", function () {
       it("throws when both clientId and resourceId are provided", function () {
         assert.throws(
           () => new MsalMsiProvider("id", { resourceId: "id" }),
-          /At most one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
         );
       });
 
       it("throws when both clientId and resourceId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ clientId: "id", resourceId: "id" }),
-          /may be provided./,
+          /At most, one of 'clientId', 'resourceId', or 'objectId' may be provided/,
         );
       });
 

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -35,21 +35,30 @@ describe("ManagedIdentityCredential (MSAL)", function () {
       // 2. MsalMsiProvider(clientId: string, options: MsalMsiOptions)
       // by relying on the error handling of the constructor
       it("throws when both clientId and resourceId are provided", function () {
-        assert.throws(() => new MsalMsiProvider("id", { resourceId: "id" }), /may be provided./);
+        assert.throws(
+          () => new MsalMsiProvider("id", { resourceId: "id" }),
+          /At most one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+        );
       });
+
       it("throws when both clientId and resourceId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ clientId: "id", resourceId: "id" }),
           /may be provided./,
         );
       });
+
       it("throws when both clientId and objectId are provided", function () {
-        assert.throws(() => new MsalMsiProvider("id", { objectId: "id" }), /may be provided./);
+        assert.throws(
+          () => new MsalMsiProvider("id", { objectId: "id" }),
+          /At most one of 'clientId', 'resourceId', or 'objectId' may be provided/,
+        );
       });
+
       it("throws when both resourceId and objectId are provided via options", function () {
         assert.throws(
           () => new MsalMsiProvider({ resourceId: "id", objectId: "id" }),
-          /may be provided./,
+          /At most one of 'clientId', 'resourceId', or 'objectId' may be provided/,
         );
       });
     });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves https://github.com/Azure/azure-sdk-for-js-pr/issues/262

### Describe the problem that is addressed by this PR

Adds support for providing an objectID to be used in managed Identity.

### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
