### PR TITLE
[eslint-plugin] upgrade `eslint-plugin-no-only-tests` to `^3.3.0`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6244,8 +6244,8 @@ packages:
       semver: 7.6.3
     dev: false
 
-  /eslint-plugin-no-only-tests@3.1.0:
-    resolution: {integrity: sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==}
+  /eslint-plugin-no-only-tests@3.3.0:
+    resolution: {integrity: sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==}
     engines: {node: '>=5.0.0'}
     dev: false
 
@@ -21372,7 +21372,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk-helper.tgz:
-    resolution: {integrity: sha512-xHpH9pq2/ySvOp5t8KNaBzNF4pcAysfUMzfOf2o+7xWwVgHaunwEpXKw6fg1zJoaJM06sjh8TpL2rTcka9yzRg==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
+    resolution: {integrity: sha512-BNAjKfF+QfoGeAHl3ED/z/aDIJTM5ylb7gO2V6q5bwvhJHnCFWTNm0lRd0jK9c3JVyIxD+LWPJO0P2i0hGXNiA==, tarball: file:projects/eslint-plugin-azure-sdk-helper.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk-helper'
     version: 0.0.0
     dependencies:
@@ -21389,7 +21389,7 @@ packages:
       eslint-plugin-import: 2.29.1(eslint@8.57.0)
       eslint-plugin-markdown: 5.1.0(eslint@8.57.0)
       eslint-plugin-n: 17.10.2(eslint@8.57.0)
-      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-promise: 6.6.0(eslint@8.57.0)
       eslint-plugin-tsdoc: 0.2.17
       glob: 10.4.5
@@ -21401,7 +21401,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-A0owIVA9YqDG8X7LQ+phP23yxojh7pQ/JoIX2xNdF1ItiZFy+5IIyAUN5QmqC7uShmAPQqL80G+J438xMuF0Ig==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-PmDtKMlzVHnqzw+ALXhDOvsHlS6tzEfC0NCMpeNeidFcxzG2PKpen3KYfea4aCIzqJuFMePAdg5fwf1wqdQ16w==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -21425,7 +21425,7 @@ packages:
       eslint-plugin-import: 2.29.1(eslint@8.57.0)
       eslint-plugin-markdown: 5.1.0(eslint@8.57.0)
       eslint-plugin-n: 17.10.2(eslint@8.57.0)
-      eslint-plugin-no-only-tests: 3.1.0
+      eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-promise: 6.6.0(eslint@8.57.0)
       eslint-plugin-tsdoc: 0.2.17
       glob: 10.4.5

--- a/common/tools/eslint-plugin-azure-sdk-helper/package.json
+++ b/common/tools/eslint-plugin-azure-sdk-helper/package.json
@@ -10,7 +10,7 @@
     "eslint": "^8.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-n": "^17.10.1",
-    "eslint-plugin-no-only-tests": "^3.0.0",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-tsdoc": "^0.2.10",
     "eslint-plugin-markdown": "^5.0.0"

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -67,7 +67,7 @@
     "eslint": "^8.50.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-n": "^17.10.1",
-    "eslint-plugin-no-only-tests": "^3.0.0",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-tsdoc": "^0.2.10",
     "eslint-plugin-markdown": "^5.0.0"

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
@@ -127,7 +127,7 @@ const nCustomization = {
 const noOnlyTestsCustomization = {
   name: "no-only-tests-azsdk-customized",
   plugins: {
-    "no-only-tests": fixupPluginRules(noOnlyTests),
+    "no-only-tests": noOnlyTests,
   },
   files: ["**/test/**/*.ts"],
   rules: {


### PR DESCRIPTION
which allows up to remove the fixup as the new version supports flat config.

-------

### Packages impacted by this PR
eslint-plugin-azure-sdk