### PR TITLE
[eslint-plugin] turn off `eslint-plugin-n` rules for browsers

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
@@ -108,9 +108,6 @@ const azsdkDefault: Record<string, SharedConfig.RuleEntry> = {
 
 const nCustomization = {
   name: "n-azsdk-customized",
-  plugins: {
-    n,
-  },
   rules: {
     "n/exports-style": ["error", "module.exports"],
     "n/no-missing-import": "off",
@@ -122,6 +119,19 @@ const nCustomization = {
     "n/no-unpublished-import": "off",
     "n/no-unpublished-require": "off",
   },
+};
+
+function turnoffN(): Record<string, SharedConfig.RuleEntry> {
+  const rules: Record<string, SharedConfig.RuleEntry> = {};
+  for (const rule of Object.keys(n.rules ?? {})) {
+    rules[`n/${rule}`] = "off";
+  }
+  return rules;
+}
+
+const nOffForBrowser = {
+  files: ["**/browser/**/*.{ts,cts,mts}", "**/*.browser.{ts,cts,mts}", "**/*-browser.{ts,cts,mts}"],
+  rules: turnoffN(),
 };
 
 const noOnlyTestsCustomization = {
@@ -197,6 +207,7 @@ export default (parser: FlatConfig.Parser): FlatConfig.ConfigArray => [
   },
   n.configs["flat/recommended"],
   nCustomization as unknown as FlatConfig.Config,
+  nOffForBrowser,
   noOnlyTestsCustomization as FlatConfig.Config,
   tsdocCustomization as FlatConfig.Config,
   importCustomization as FlatConfig.Config,


### PR DESCRIPTION
Add a configuration to turn off all `eslint-plugin-n` rules for browser code files.

Also remove the redundant `plugins` block in `nCustomization` because the
plugin's "flat/recommended" config already does that

https://github.com/eslint-community/eslint-plugin-n/blob/e5e758ea0cd238220127ae7bcbd967f1d8920f28/lib/index.js#L87

-------

### Packages impacted by this PR

eslint-plugin-azure-sdk