### PR TITLE
[dev-tool] add command to type check files not being built by tshy

### DIFF
--- a/common/tools/dev-tool/src/commands/run/index.ts
+++ b/common/tools/dev-tool/src/commands/run/index.ts
@@ -15,6 +15,7 @@ export default subCommand(commandInfo, {
   "extract-api": () => import("./extract-api"),
   bundle: () => import("./bundle"),
   "build-test": () => import("./build-test"),
+  typecheck: () => import("./typecheck"),
   "start-browser-relay": () => import("./startBrowserRelay"),
 
   // "vendored" is a special command that passes through execution to dev-tool's own commands

--- a/common/tools/dev-tool/src/commands/run/typecheck.ts
+++ b/common/tools/dev-tool/src/commands/run/typecheck.ts
@@ -17,7 +17,7 @@ export const commandInfo = makeCommandInfo(
     paths: {
       kind: "string",
       description:
-        "relative path pattern of additional files (not included in tsconfig.json) to check for compilation errors. Examples: '--paths samples-dev/**/*.ts'.",
+        "comma-separated relative path patterns of additional files not included in tsconfig.json to check for compilation errors. Examples: '--paths samples-dev/**/*.ts,test/**/*.ts'.",
     },
   },
 );
@@ -31,9 +31,12 @@ export default leafCommand(commandInfo, async (options) => {
   });
 
   if (options.paths) {
-    const fullPaths = `${projPath}/${options.paths}`;
-    log.info(`  adding additional files at ${fullPaths}`);
-    project.addSourceFilesAtPaths(fullPaths);
+    const patterns = options.paths.split(",");
+    for (const pattern of patterns) {
+      const fullPaths = `${projPath}/${pattern}`;
+      log.info(`  adding additional files at ${fullPaths}`);
+      project.addSourceFilesAtPaths(fullPaths);
+    }
   }
 
   const diagnostics = project.getPreEmitDiagnostics();

--- a/common/tools/dev-tool/src/commands/run/typecheck.ts
+++ b/common/tools/dev-tool/src/commands/run/typecheck.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as path from "node:path";
+import { leafCommand, makeCommandInfo } from "../../framework/command";
+import { createPrinter } from "../../util/printer";
+import { resolveProject } from "../../util/resolveProject";
+import { Project } from "ts-morph";
+import { DiagnosticCategory } from "typescript";
+
+const log = createPrinter("typecheck");
+
+export const commandInfo = makeCommandInfo(
+  "typecheck",
+  "typecheck typescript code files that are not part of tshy build",
+  {
+    paths: {
+      kind: "string",
+      description:
+        "relative path pattern of additional files (not included in tsconfig.json) to check for compilation errors. Examples: '--paths samples-dev/**/*.ts'.",
+    },
+  },
+);
+
+export default leafCommand(commandInfo, async (options) => {
+  log.info(`type-checking...`);
+  const { path: projPath } = await resolveProject(process.cwd());
+
+  const project = new Project({
+    tsConfigFilePath: path.join(projPath, "tsconfig.json"),
+  });
+
+  if (options.paths) {
+    const fullPaths = `${projPath}/${options.paths}`;
+    log.info(`  adding additional files at ${fullPaths}`);
+    project.addSourceFilesAtPaths(fullPaths);
+  }
+
+  const diagnostics = project.getPreEmitDiagnostics();
+  const hasError = diagnostics.some((d) => d.getCategory() === DiagnosticCategory.Error);
+  if (hasError) {
+    log.error(
+      project.formatDiagnosticsWithColorAndContext(
+        diagnostics.filter((d) => d.getCategory() === DiagnosticCategory.Error),
+      ),
+    );
+  }
+  return !hasError;
+});


### PR DESCRIPTION
In our current setup, tshy won't build test and samples-dev folder even they are
included in tsconfig.json.  This PR adds a command that does the type-checking
for all files included in tsconfig.json, and allow additional files to be passed
in as well.