### PR TITLE
[identity] Use federated token in az cli

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -78,6 +78,9 @@ jobs:
       - template: ../steps/common.yml
 
       - ${{ if ne(parameters.ServiceDirectory, '') }}:
+
+        - ${{ parameters.PreSteps }}
+
         - template: /eng/common/TestResources/build-test-resource-config.yml
           parameters:
             SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
@@ -153,8 +156,6 @@ jobs:
         displayName: "Build test package"
         workingDirectory: $(PackageTestPath)
         condition: and(succeededOrFailed(),ne(variables['DependencyVersion'],''))
-
-      - ${{ parameters.PreSteps }}
 
       - pwsh: |
           npm install

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -77,10 +77,9 @@ jobs:
     steps:
       - template: ../steps/common.yml
 
+      - ${{ parameters.PreSteps }}
+
       - ${{ if ne(parameters.ServiceDirectory, '') }}:
-
-        - ${{ parameters.PreSteps }}
-
         - template: /eng/common/TestResources/build-test-resource-config.yml
           parameters:
             SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}

--- a/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
+++ b/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
@@ -18,12 +18,12 @@ describe("Azure Kubernetes Integration test", function () {
 
     if (process.env.IDENTITY_CLIENT_SECRET) {
       // Log in as service principal in CI
-      const clientId = requireEnvVar("IDENTITY_CLIENT_ID");
-      const clientSecret = requireEnvVar("IDENTITY_CLIENT_SECRET");
-      const tenantId = requireEnvVar("IDENTITY_TENANT_ID");
+      const clientId = requireEnvVar("ARM_CLIENT_ID");
+      const tenantId = requireEnvVar("ARM_TENANT_ID");
+      const oidc = requireEnvVar("ARM_OIDC_TOKEN");
       runCommand(
         "az",
-        `login --service-principal -u ${clientId} -p ${clientSecret} --tenant ${tenantId}`,
+        `login --service-principal -u ${clientId} --federated-token ${oidc} --tenant ${tenantId}`,
       );
     }
 

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -3,6 +3,13 @@ trigger: none
 extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
+      PreSteps:
+      - task: AzureCLI@2
+        displayName: Set OIDC variables
+        env:
+          ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
+          ARM_CLIENT_ID: $(ARM_CLIENT_ID)
+          ARM_TENANT_ID: $(ARM_TENANT_ID)
       PackageName: "@azure/identity"
       ServiceDirectory: identity
       TimeoutInMinutes: 120
@@ -27,3 +34,6 @@ extends:
         AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
         AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
         AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
+        ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
+        ARM_CLIENT_ID: $(ARM_CLIENT_ID)
+        ARM_TENANT_ID: $(ARM_TENANT_ID)

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -10,6 +10,15 @@ extends:
           ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
           ARM_CLIENT_ID: $(ARM_CLIENT_ID)
           ARM_TENANT_ID: $(ARM_TENANT_ID)
+        inputs:
+          azureSubscription: azure-sdk-tests
+          scriptType: pscore
+          scriptLocation: inlineScript
+          addSpnToEnvironment: true
+          inlineScript: |
+            Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
+            Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
+            Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
       PackageName: "@azure/identity"
       ServiceDirectory: identity
       TimeoutInMinutes: 120

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -11,6 +11,14 @@ param (
   [hashtable] $DeploymentOutputs,
 
   [Parameter()]
+  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+  [string] $TestApplicationId,
+
+  [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string] $TenantId,
+
+  [Parameter()]
   [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
 
   [Parameter()]
@@ -39,7 +47,7 @@ Write-Host "Working directory: $workingFolder"
 
 if ($CI) {
   Write-Host "Logging in to service principal"
-  az login --service-principal -u $DeploymentOutputs['IDENTITY_CLIENT_ID'] -p $DeploymentOutputs['IDENTITY_CLIENT_SECRET'] --tenant $DeploymentOutputs['IDENTITY_TENANT_ID']
+  az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
   az account set --subscription $DeploymentOutputs['IDENTITY_SUBSCRIPTION_ID']
 }
 

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -11,14 +11,6 @@ param (
   [hashtable] $DeploymentOutputs,
 
   [Parameter()]
-  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
-  [string] $TestApplicationId,
-
-  [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
-  [ValidateNotNullOrEmpty()]
-  [string] $TenantId,
-
-  [Parameter()]
   [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
 
   [Parameter()]
@@ -47,7 +39,7 @@ Write-Host "Working directory: $workingFolder"
 
 if ($CI) {
   Write-Host "Logging in to service principal"
-  az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
+  az login --service-principal -u $env:ARM_CLIENT_ID --tenant $env:ARM_TENANT_ID --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
   az account set --subscription $DeploymentOutputs['IDENTITY_SUBSCRIPTION_ID']
 }
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A - test fixes

### Describe the problem that is addressed by this PR

Identity client libraries need some extensive setup to test various credentials in different workloads. Some of the commands
require the az cli, and this enables us to login using az cli.

Eventually, my hope is to use this to provide federated credentials for keyvault managed HSMs resource creation where our credential expires by the time the HSM is deployed

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
