### PR TITLE
[EngSys] re-enable rush build cache

### DIFF
--- a/common/config/rush/build-cache.json
+++ b/common/config/rush/build-cache.json
@@ -5,7 +5,7 @@
   // to authenticate.
   "cacheProvider": "azure-blob-storage",
   "azureBlobStorageConfiguration": {
-    "storageAccountName": "azuresdkartifactstest",
+    "storageAccountName": "azuresdkartifacts",
     "storageContainerName": "azure-sdk-for-js-rush-cache",
     "isCacheWriteAllowed": false
   }

--- a/common/config/rush/build-cache.json
+++ b/common/config/rush/build-cache.json
@@ -1,12 +1,12 @@
 {
-  "buildCacheEnabled": false,
+  "buildCacheEnabled": true,
   // Follow instructions at
   //   https://rushjs.io/pages/maintainer/build_cache/#user-authentication
   // to authenticate.
   "cacheProvider": "azure-blob-storage",
   "azureBlobStorageConfiguration": {
-    "storageAccountName": "azsdkjsrush",
-    "storageContainerName": "rush-build-cache",
+    "storageAccountName": "azuresdkartifactstest",
+    "storageContainerName": "azure-sdk-for-js-rush-cache",
     "isCacheWriteAllowed": false
   }
 }

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -51,14 +51,13 @@ steps:
   - ${{if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
     - task: AzureCLI@2
       inputs:
-        azureSubscription: azure-sdk-tests
+        azureSubscription: 'Azure SDK Artifacts'
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          #az account set --name "Azure SDK Engineering System"
           az account show
           expiry=`date -u -d "45 minutes" '+%Y-%m-%dT%H:%MZ'`
-          sasToken=$(az storage container generate-sas --account-name azuresdkartifactstest --name azure-sdk-for-js-rush-cache --permissions dlrw --auth-mode login --as-user --expiry $expiry --https-only -o tsv)
+          sasToken=$(az storage container generate-sas --account-name azuresdkartifacts --name azure-sdk-for-js-rush-cache --permissions dlrw --auth-mode login --as-user --expiry $expiry --https-only -o tsv)
           echo "##vso[task.setvariable variable=rushBuildCacheCred;]$sasToken"
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -48,7 +48,7 @@ steps:
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
-  - ${{if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
     - task: AzureCLI@2
       inputs:
         azureSubscription: 'Azure SDK Artifacts'
@@ -66,7 +66,7 @@ steps:
       node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
     env:
-      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
+      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
         RUSH_BUILD_CACHE_CREDENTIAL: $(rushBuildCacheCred)
         RUSH_BUILD_CACHE_WRITE_ALLOWED: 1
 

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -48,7 +48,7 @@ steps:
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
-  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
     - task: AzureCLI@2
       inputs:
         azureSubscription: 'Azure SDK Artifacts'
@@ -66,7 +66,7 @@ steps:
       node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
     env:
-      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
+      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
         RUSH_BUILD_CACHE_CREDENTIAL: $(rushBuildCacheCred)
         RUSH_BUILD_CACHE_WRITE_ALLOWED: 1
 

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -58,7 +58,7 @@ steps:
           az account show
           expiry=`date -u -d "45 minutes" '+%Y-%m-%dT%H:%MZ'`
           sasToken=$(az storage container generate-sas --account-name azuresdkartifacts --name azure-sdk-for-js-rush-cache --permissions dlrw --auth-mode login --as-user --expiry $expiry --https-only -o tsv)
-          echo "##vso[task.setvariable variable=rushBuildCacheCred;]$sasToken"
+          echo "##vso[task.setvariable variable=rushBuildCacheCred;issecret=true;]$sasToken"
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -48,12 +48,29 @@ steps:
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
+  - ${{if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: azure-sdk-tests
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          #az account set --name "Azure SDK Engineering System"
+          az account show
+          expiry=`date -u -d "45 minutes" '+%Y-%m-%dT%H:%MZ'`
+          sasToken=$(az storage container generate-sas --account-name azuresdkartifactstest --name azure-sdk-for-js-rush-cache --permissions dlrw --auth-mode login --as-user --expiry $expiry --https-only -o tsv)
+          echo "##vso[task.setvariable variable=rushBuildCacheCred;]$sasToken"
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
       node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
+    env:
+      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
+        RUSH_BUILD_CACHE_CREDENTIAL: $(rushBuildCacheCred)
+        RUSH_BUILD_CACHE_WRITE_ALLOWED: 1
+
   - script: |
       node eng/tools/rush-runner.js build:samples "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose
     displayName: "Build samples"

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -48,7 +48,7 @@ steps:
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
       Artifacts: ${{ parameters.Artifacts }}
-  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
     - task: AzureCLI@2
       inputs:
         azureSubscription: 'Azure SDK Artifacts'
@@ -66,7 +66,7 @@ steps:
       node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
     env:
-      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+      ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
         RUSH_BUILD_CACHE_CREDENTIAL: $(rushBuildCacheCred)
         RUSH_BUILD_CACHE_WRITE_ALLOWED: 1
 


### PR DESCRIPTION
Use AzureCLI@2 task to generate a SAS for cache write credential so we don't need to store secrets anymore.