### PR TITLE
Removing VM size check from Azure Remote Rendering sdk tests

### DIFF
--- a/sdk/remoterendering/mixed-reality-remote-rendering/test/public/remoteRenderingClient.spec.ts
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/test/public/remoteRenderingClient.spec.ts
@@ -288,7 +288,6 @@ describe("RemoteRendering functional tests", () => {
     );
 
     assert.equal(sessionPoller.getOperationState().latestResponse.sessionId, sessionId);
-    assert.equal(sessionPoller.getOperationState().latestResponse.size, sessionSettings.size);
     assert.equal(
       sessionPoller.getOperationState().latestResponse.maxLeaseTimeInMinutes,
       sessionSettings.maxLeaseTimeInMinutes,


### PR DESCRIPTION
### Packages impacted by this PR

mixed-reality-remote-rendering

### Issues associated with this PR

Test pipeline failures in the mixed-reality-remote-rendering sdk tests.

### Describe the problem that is addressed by this PR

Test failures are fixed by removing the respectively failing check.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The specific checks are ill formed currently, as the testing account is internally load balanced. Azure Remote Rendering introduced this recently as the tests created negative customer impact with regards to session availability. Hence, the tests will not necessarily be served the exact requested session type. Consequently the check is now pointless.

### Are there test cases added in this PR? _(If not, why?)_

There isn't any functional change to the SDK in this PR.

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x ] Added impacted package name to the issue description
- [x ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x ] Added a changelog (if necessary)
