### PR TITLE
docs(): uncomment broken links for microsoft-playwright-testing

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/README.md
@@ -11,7 +11,7 @@ description: Samples for the @azure/microsoft-playwright-testing client library
 
 # @azure/microsoft-playwright-testing samples for javascript
 
-- [Using connect options]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/using-connect-options/README.md)-->
-- [Manually connecting to browsers]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/manually-connecting-to-browsers/README.md)-->
-- [Customising service parameters]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/customising-service-parameters/README.md)-->
-- [Set default authentication mechanism]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/README.md)-->
+- [Using connect options](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/using-connect-options/README.md)
+- [Manually connecting to browsers](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/manually-connecting-to-browsers/README.md)
+- [Customising service parameters](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/customising-service-parameters/README.md)
+- [Set default authentication mechanism](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/README.md)

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/customising-service-parameters/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/customising-service-parameters/README.md
@@ -1,6 +1,6 @@
 ## Learn about different available service parameters and how to use them
 
-Follow the steps listed in this [README]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md)--> to integrate your existing Playwright test suite with the Microsoft Playwright Testing service.
+Follow the steps listed in this [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md) to integrate your existing Playwright test suite with the Microsoft Playwright Testing service.
 
 This guide explains the different options available to you in the `playwright.service.config.ts` file and how to use them.
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/manually-connecting-to-browsers/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/manually-connecting-to-browsers/README.md
@@ -13,7 +13,7 @@ This guide will walk you through the steps to integrate your Playwright project,
 
 Make sure you have set up your Playwright Testing workspace by following these steps:
 
-- [Create a workspace]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)-->
+- [Create a workspace](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)
 
 ### Install Microsoft Playwright Testing package
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/README.md
@@ -13,7 +13,7 @@ This guide will walk you through the steps to integrate your Playwright project 
 
 Make sure you have set up your Playwright Testing workspace by following these steps
 
-- [Create a workspace]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)-->
+- [Create a workspace](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)
 
 ### Install Microsoft Playwright Testing package
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/using-connect-options/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/using-connect-options/README.md
@@ -1,1 +1,1 @@
-Refer to the [README]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md)--> for the package to learn how to use the connect options function provided by Playwright OSS to connect to the cloud-hosted browsers.
+Refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md) for the package to learn how to use the connect options function provided by Playwright OSS to connect to the cloud-hosted browsers.

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/README.md
@@ -11,7 +11,7 @@ description: Samples for the @azure/microsoft-playwright-testing client library
 
 # @azure/microsoft-playwright-testing samples for typescript
 
-- [Using connect options]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/using-connect-options/README.md)-->
-- [Manually connecting to browsers]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/manually-connecting-to-browsers/README.md)-->
-- [Customising service parameters]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/customising-service-parameters/README.md)-->
-- [Set default authentication mechanism]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/README.md)-->
+- [Using connect options](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/using-connect-options/README.md)
+- [Manually connecting to browsers](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/manually-connecting-to-browsers/README.md)
+- [Customising service parameters](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/customising-service-parameters/README.md)
+- [Set default authentication mechanism](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/README.md)

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/customising-service-parameters/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/customising-service-parameters/README.md
@@ -1,6 +1,6 @@
 ## Learn about different available service parameters and how to use them
 
-Follow the steps listed in this [README]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md)--> to integrate your existing Playwright test suite with the Microsoft Playwright Testing service.
+Follow the steps listed in this [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md) to integrate your existing Playwright test suite with the Microsoft Playwright Testing service.
 
 This guide explains the different options available to you in the `playwright.service.config.ts` file and how to use them.
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/manually-connecting-to-browsers/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/manually-connecting-to-browsers/README.md
@@ -13,7 +13,7 @@ This guide will walk you through the steps to integrate your Playwright project,
 
 Make sure you have set up your Playwright Testing workspace by following these steps:
 
-- [Create a workspace]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)-->
+- [Create a workspace](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)
 
 ### Install Microsoft Playwright Testing package
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/README.md
@@ -13,7 +13,7 @@ This guide will walk you through the steps to integrate your Playwright project 
 
 Make sure you have set up your Playwright Testing workspace by following these steps
 
-- [Create a workspace]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)-->
+- [Create a workspace](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md#create-a-workspace)
 
 ### Install Microsoft Playwright Testing package
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/using-connect-options/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/using-connect-options/README.md
@@ -1,1 +1,1 @@
-Refer to the [README]<!--(https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md)--> for the package to learn how to use the connect options function provided by Playwright OSS to connect to the cloud-hosted browsers.
+Refer to the [README](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/playwrighttesting/microsoft-playwright-testing/README.md) for the package to learn how to use the connect options function provided by Playwright OSS to connect to the cloud-hosted browsers.


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

Uncomment links to other README files in the microsoft-playwright-testing SDK.

### Describe the problem that is addressed by this PR

As per https://github.com/Azure/azure-sdk/blob/main/docs/policies/README-TEMPLATE.md#link-guidelines, any relative link to a file which does not exist in main, will require the initial PR to go in with link commented out, followed by a PR to uncomment those links.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A

### Are there test cases added in this PR? _(If not, why?)_

Not pplicable

### Provide a list of related PRs _(if any)_

Initial PR - https://github.com/Azure/azure-sdk-for-js/pull/30433

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
