### PR TITLE
[Event Hubs] [Bicep] Factor out KV definition

### DIFF
--- a/sdk/eventhub/kv.bicep
+++ b/sdk/eventhub/kv.bicep
@@ -1,0 +1,29 @@
+param location string = resourceGroup().location
+param kvName string = 'kv-${resourceGroup().name}'
+param objectId string = 'testApplicationOid'
+param tenantId string = subscription().tenantId
+
+resource keyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
+  name: kvName
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: tenantId
+    accessPolicies: [
+      {
+        tenantId: tenantId
+        objectId: objectId
+        permissions: {
+          secrets: [
+            'get'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+output keyVaultUri string = keyVault.properties.vaultUri

--- a/sdk/eventhub/test-resources.bicep
+++ b/sdk/eventhub/test-resources.bicep
@@ -1,28 +1,27 @@
 param baseName string = resourceGroup().name
-param storageEndpointSuffix string = environment().suffixes.storage
+param location string = resourceGroup().location
 param testApplicationOid string
 
-var apiVersion = '2024-01-01'
+var eventHubApiVersion = '2024-01-01'
 var storageApiVersion = '2023-05-01'
-var iotApiVersion = '2023-06-30'
-var namespaceName = baseName
+var iotHubApiVersion = '2023-06-30'
 var storageAccountName = 'storage${baseName}'
 var containerName = 'container'
-var iotName = 'iot${baseName}'
-var authorizationName = '${baseName}/RootManageSharedAccessKey'
+var iotHubName = 'iot${baseName}'
 var eventHubName = 'eventhub'
-var eventHubNameFull = '${baseName}/eventhub'
 var eventHubConsumerGroupName = '$Default'
+var eventHubConnectionStringSecretName = 'eventhub-connection-string'
+var iotHubConnectionStringSecretName = 'iothub-connection-string'
+var kvName = 'kv-${baseName}'
 var retentionTimeInDays = 1
 var partitionCount = 4
-var location = resourceGroup().location
 var eventHubsDataOwnerRoleId = 'f526a384-b230-433a-b45c-95f59c4a2dec'
 var blobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 var tablesDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 var iotHubDataContributorRoleId = '4fc6c259-987e-4a07-842e-c321cc9d413f'
 
 resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
-  name: namespaceName
+  name: baseName
   location: location
   sku: {
     name: 'Standard'
@@ -36,11 +35,9 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
   }
 }
 
-resource eventHubAuthorizationRule 'Microsoft.EventHub/namespaces/AuthorizationRules@2024-01-01' = {
-  name: authorizationName
-  dependsOn: [
-    eventHubNamespace
-  ]
+resource eventHubAuthorizationRule 'Microsoft.EventHub/namespaces/authorizationRules@2024-01-01' = {
+  name: 'RootManageSharedAccessKey'
+  parent: eventHubNamespace
   properties: {
     rights: [
       'Listen'
@@ -51,10 +48,8 @@ resource eventHubAuthorizationRule 'Microsoft.EventHub/namespaces/AuthorizationR
 }
 
 resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
-  name: eventHubNameFull
-  dependsOn: [
-    eventHubNamespace
-  ]
+  name: eventHubName
+  parent: eventHubNamespace
   properties: {
     messageRetentionInDays: retentionTimeInDays
     partitionCount: partitionCount
@@ -63,10 +58,6 @@ resource eventHub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
 
 resource eventHubConsumerGroup 'Microsoft.EventHub/namespaces/eventhubs/consumergroups@2024-01-01' = {
   name: eventHubConsumerGroupName
-  dependsOn: [
-    eventHubNamespace
-  ]
-  properties: {}
   parent: eventHub
 }
 
@@ -108,7 +99,7 @@ resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/container
 }
 
 resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
-  name: iotName
+  name: iotHubName
   location: location
   sku: {
     name: 'S1'
@@ -143,7 +134,7 @@ resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
     storageEndpoints: {
       '$default': {
         sasTtlAsIso8601: 'PT1H'
-        connectionString: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};AccountKey=${listKeys(storageAccount.id, storageApiVersion).keys[0].value};EndpointSuffix=${storageEndpointSuffix}'
+        connectionString: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};AccountKey=${listKeys(storageAccount.id, storageApiVersion).keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
         containerName: containerName
       }
     }
@@ -168,57 +159,42 @@ resource iotHub 'Microsoft.Devices/IotHubs@2023-06-30' = {
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
-  name: '${baseName}-kv'
-  location: location
-  properties: {
-    sku: {
-      family: 'A'
-      name: 'standard'
-    }
+module keyVault 'kv.bicep' = {
+  name: 'deployKeyVault'
+  params: {
+    location: location
+    kvName: kvName
+    objectId: testApplicationOid
     tenantId: subscription().tenantId
-    accessPolicies: [
-      {
-        tenantId: subscription().tenantId
-        objectId: testApplicationOid
-        permissions: {
-          secrets: [
-            'get'
-            'list'
-            'set'
-          ]
-        }
-      }
-    ]
   }
   dependsOn: [
     eventHubAuthorizationRule
-    storageAccount
     iotHub
   ]
 }
 
-resource eventHubConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'eventhub-connection-string'
+resource eventHubConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: '${kvName}/${eventHubConnectionStringSecretName}'
   properties: {
-    value: listKeys(eventHubAuthorizationRule.id, apiVersion).primaryConnectionString
+    value: listKeys(eventHubAuthorizationRule.id, eventHubApiVersion).primaryConnectionString
   }
-  parent: keyVault
+  dependsOn: [
+    keyVault
+  ]
 }
 
-resource iotHubConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  name: 'iothub-connection-string'
+resource iotHubConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+  name: '${kvName}/${iotHubConnectionStringSecretName}'
   properties: {
-    value: 'HostName=${iotHub.properties.hostName};SharedAccessKeyName=iothubowner;SharedAccessKey=${listKeys(iotHub.id, iotApiVersion).value[0].primaryKey}'
+    value: 'HostName=${iotHub.properties.hostName};SharedAccessKeyName=iothubowner;SharedAccessKey=${listKeys(iotHub.id, iotHubApiVersion).value[0].primaryKey}'
   }
-  parent: keyVault
+  dependsOn: [
+    keyVault
+  ]
 }
 
 resource eventHubsDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid('dataOwnerRoleId', baseName)
-  dependsOn: [
-    eventHubNamespace
-  ]
+  name: guid('dataOwnerRoleId', eventHubNamespace.id)
   properties: {
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', eventHubsDataOwnerRoleId)
     principalId: testApplicationOid
@@ -226,10 +202,7 @@ resource eventHubsDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignmen
 }
 
 resource blobDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid('blobDataContributorRoleId', storageAccountName)
-  dependsOn: [
-    storageAccount
-  ]
+  name: guid('blobDataContributorRoleId', storageAccount.id)
   properties: {
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', blobDataContributorRoleId)
     principalId: testApplicationOid
@@ -237,10 +210,7 @@ resource blobDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignme
 }
 
 resource tablesDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid('tablesDataContributorRoleId', storageAccountName)
-  dependsOn: [
-    storageAccount
-  ]
+  name: guid('tablesDataContributorRoleId', storageAccount.id)
   properties: {
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', tablesDataContributorRoleId)
     principalId: testApplicationOid
@@ -248,10 +218,7 @@ resource tablesDataContributorRoleAssignment 'Microsoft.Authorization/roleAssign
 }
 
 resource iotHubDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid('iotHubDataContributorRoleId', iotName)
-  dependsOn: [
-    iotHub
-  ]
+  name: guid('iotHubDataContributorRoleId', iotHub.id)
   properties: {
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', iotHubDataContributorRoleId)
     principalId: testApplicationOid
@@ -259,14 +226,14 @@ resource iotHubDataContributorRoleAssignment 'Microsoft.Authorization/roleAssign
 }
 
 output EVENTHUB_FQDN string = replace(replace(eventHubNamespace.properties.serviceBusEndpoint, ':443/', ''), 'https://', '')
-output EVENTHUB_NAME string = eventHubName
-output EVENTHUB_CONSUMER_GROUP_NAME string = eventHubConsumerGroupName
+output EVENTHUB_NAME string = eventHub.name
+output EVENTHUB_CONSUMER_GROUP_NAME string = eventHubConsumerGroup.name
 output IOTHUB_EVENTHUB_FQDN string = iotHub.properties.eventHubEndpoints.events.endpoint
 output IOTHUB_EVENTHUB_NAME string = iotHub.properties.eventHubEndpoints.events.path
-output STORAGE_ACCOUNT_NAME string = storageAccountName
+output STORAGE_ACCOUNT_NAME string = storageAccount.name
 output STORAGE_ENDPOINT string = storageAccount.properties.primaryEndpoints.blob
 output STORAGE_CONTAINER_NAME string = containerName
 output STORAGE_CONTAINER_URL string = '${storageAccount.properties.primaryEndpoints.blob}${containerName}'
-output KEYVAULT_URI string = keyVault.properties.vaultUri
-output EVENTHUB_CONNECTION_STRING_SECRET_NAME string = eventHubConnectionStringSecret.name
-output IOTHUB_CONNECTION_STRING_SECRET_NAME string = iotHubConnectionStringSecret.name
+output KEYVAULT_URI string = keyVault.outputs.keyVaultUri
+output EVENTHUB_CONNECTION_STRING_SECRET_NAME string = eventHubConnectionStringSecretName
+output IOTHUB_CONNECTION_STRING_SECRET_NAME string = iotHubConnectionStringSecretName


### PR DESCRIPTION
Moving to a modular bicep definition so that we can share bits and pieces between all of them. This PR factors out the key vault definition so other bicep scripts can import it too. For now, it lives next to the event hub's test-resources.bicep script but I'll consider moving it to a central place once other libraries move to import it.

The PR also edits the script to make it more compact.

Live tests run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4079360&view=results