### PR TITLE
[eslint-plugin] add an override to turn off tsdoc/syntax for samples-dev

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
@@ -201,4 +201,10 @@ export default (parser: FlatConfig.Parser): FlatConfig.ConfigArray => [
   nOffForBrowser,
   noOnlyTestsCustomization as FlatConfig.Config,
   tsdocCustomization as FlatConfig.Config,
+  {
+    files: ["samples-dev/**/*.ts", "*/*/samples-dev/**/*.ts"],
+    rules: {
+      "tsdoc/syntax": "off",
+    },
+  },
 ];


### PR DESCRIPTION
because dev-tool is using @summary and @azsdk-weight when publishing samples.