### PR TITLE
[kevault-certificates] Update timeout for nightly builds

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -43,7 +43,7 @@
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"samples-dev/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript swagger/README.md",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "dev-tool run test:vitest --no-test-proxy",
+    "integration-test:node": "dev-tool run test:vitest --no-test-proxy -- --test-timeout 350000",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json api-extractor.json src test",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/keyvault-certificates

### Issues associated with this PR

#30822 

### Describe the problem that is addressed by this PR

When migrating keyvault-certificates to ESM and vitest I forgot to port over the extended timeout needed for these tests
(see [this diff](https://github.com/Azure/azure-sdk-for-js/commit/58ac994ec5a58472d5887e94583007fe7c88cb82#diff-238f0a9c86d168f8a93aba09420e13a2cdc1bb6d157e76949a197eacd26774a3L54)) and noticed that the live tests started failing with a timeout.

This commit adds the timeout back in a command line argument. It also addresses an issue in our dependency-testing script where min/max tests were no longer carrying over the timeout from the package json's path in tests that have migrated to vitest. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
