### PR TITLE
bump core versions

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.7.3 (Unreleased)
+## 1.8.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- `AccessToken` now has an optional `refreshAfterTimestamp` attribute that can be used to specify when the token should be refreshed. #30402
 
 ## 1.7.2 (2024-04-09)
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.16.4 (Unreleased)
+## 1.17.0 (Unreleased)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- The token cycler of `BearerTokenCredentialPolicy` now checks the `refreshAfterTimestamp` attribute in the `AccessToken` when determining if a token request should be made in the `shouldRefresh` method. #30402
 
 ## 1.16.3 (2024-08-01)
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.16.4",
+  "version": "1.17.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "type": "module",
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.4.0",
+    "@azure/core-auth": "^1.8.0",
     "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.9.0",
     "@azure/logger": "^1.0.0",

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 
+- Added support for the field `refreshAfterTimestamp` in `AccessToken` [#30402](https://github.com/Azure/azure-sdk-for-js/pull/30402)
 - Added support for providing an object ID to `ManagedIdentityCredential`. [#30771](https://github.com/Azure/azure-sdk-for-js/pull/30771)
 
 ### Breaking Changes

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -109,9 +109,9 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.5.0",
+    "@azure/core-auth": "^1.8.0",
     "@azure/core-client": "^1.9.2",
-    "@azure/core-rest-pipeline": "^1.1.0",
+    "@azure/core-rest-pipeline": "^1.17.0",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.3.0",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
Bump core package versions to next minor and dependency versions after the refreshAfterTimestamp addition to AccessToken https://github.com/Azure/azure-sdk-for-js/pull/30402