### PR TITLE
Turn off warnings from sdl disablement

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -37,6 +37,8 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
     sdl:
+      # Turn off the build warnings caused by disabling some sdl checks
+      createAdoIssuesForJustificationsForDisablement: false
       codeql:
         compiled:
           enabled: false


### PR DESCRIPTION
See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/disablingtools for info on this new flag.
