### PR TITLE
[Monitor OpenTelemetry] Update OTel Instrumentation Module Path to fix ESM/Webpack

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.7.1 (Unreleased)
+## 1.7.1 ()
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.7.1 (Unreleased)
+
+### Other Changes
+
+- Update the relative path used in the OTel instrumentation patcher to work with webpack.
+
 ## 1.7.0 (2024-08-14)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry/src/utils/opentelemetryInstrumentationPatcher.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/opentelemetryInstrumentationPatcher.ts
@@ -16,9 +16,9 @@ import { Logger } from "../shared/logging";
 export function patchOpenTelemetryInstrumentationEnable(): void {
   const emptyStatsbeatConfig: string = JSON.stringify({ instrumentation: 0, feature: 0 });
   try {
-    require.resolve("../../../@opentelemetry/instrumentation");
+    require.resolve("@opentelemetry/instrumentation");
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const autoLoaderUtils = require("../../../@opentelemetry/instrumentation/build/src/autoLoaderUtils");
+    const autoLoaderUtils = require("@opentelemetry/instrumentation/build/src/autoLoaderUtils");
 
     const originalModuleDefinition = autoLoaderUtils.enableInstrumentations;
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
#30900

### Describe the problem that is addressed by this PR
Removes the usage of a relative path such that changing the module location will not break imports.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
