### PR TITLE
[eslint-plugin] fix `ts-modules-only-named` invalid test cases

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
+++ b/common/tools/eslint-plugin-azure-sdk/tests/rules/ts-modules-only-named.ts
@@ -13,7 +13,7 @@ import rule from "../../src/rules/ts-modules-only-named";
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = createRuleTester({ settings: { main: "src/test.ts" } });
+const ruleTester = createRuleTester({ settings: { main: "tests/fixture/src/test.ts" } });
 
 ruleTester.run("ts-modules-only-named", rule, {
   valid: [
@@ -37,23 +37,23 @@ ruleTester.run("ts-modules-only-named", rule, {
     },
   ],
   invalid: [
-    // {
-    //   code: 'export default {test: "test"}',
-    //   filename: "src/test.ts",
-    //   errors: [
-    //     {
-    //       message: "Exports at top level should be named",
-    //     },
-    //   ],
-    // },
-    // {
-    //   code: 'const foo = {test: "test"}; export default foo',
-    //   filename: "src/test.ts",
-    //   errors: [
-    //     {
-    //       message: "Exports at top level should be named",
-    //     },
-    //   ],
-    // },
+    {
+      code: 'export default {test: "test"}',
+      filename: "src/test.ts",
+      errors: [
+        {
+          message: "Exports at top level should be named",
+        },
+      ],
+    },
+    {
+      code: 'const foo = {test: "test"}; export default foo',
+      filename: "src/test.ts",
+      errors: [
+        {
+          message: "Exports at top level should be named",
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
There's some change in `typescript-eslint` that breaks some eslint test cases.
Previously when running tests, in a rule's `create()` method, we get a relative
path for `context.filename`, and when we pass a setting of `{ main:
"src/test.ts" }` in rule tester option, the two were considered the same file,
therefore the following condition check failed, and we continue to report error
for default exports.

https://github.com/Azure/azure-sdk-for-js/blob/6dd8b582e2f5a3257befab368bab0e64499f4d57/common/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts#L31

After the upgrade, `context.filename` now contains the full path, the file
`src/test.ts` in our test fixture has a full path of
`/.../common/tools/eslint-plugin-azure-sdk/tests/fixture/src/test.ts`. It is not
considered the same file as the passed settings implies
`/.../common/tools/eslint-plugin-azure-sdk/src/test.ts` when we run the tests.
So we return earlier instead of going to check for default exports.

This is not an issue in real scenario where we have settings of `{ main:
"src/index.ts" }`, which would match the full path of the file we are linting
when we run `eslint` from a package directory.

This PR fixes the test by passing `tests/fixture/src/test.ts` in the settings so
that it matches the full path of `context.filename` we get in `create()`.