### PR TITLE
[cosmos ]set default value of continueOnError in bulkRequestOptions to true

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 4.1.1 (2024-08-30)
 
 ### Bugs Fixed
+
 - Fixed a issue caused by accessing `process` without checking its existence in the global scope, it was leading to crashes in non-Node environments.
+- The default value of `continueOnError` of BulkRequestOptions is now set to true. Pass `{ continueOnError: false }` in `bulkOptions` to stop executing operations when one fails.
 
 ## 4.1.0 (2024-08-07)
 
@@ -150,7 +152,6 @@ await database.containers.createIfNotExists(containerDefinition);
 ### Bugs Fixed
 
 - Fix Bulk operations(Read, Delete, and Patch) failing due to wrong format of partition key in non-partitioned container.
-
 
 ## 4.0.0 (2023-09-12)
 

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -841,10 +841,11 @@ export class ClientContext {
       request.headers[HttpHeaders.IsBatchRequest] = true;
       request.headers[HttpHeaders.PartitionKeyRangeID] = partitionKeyRangeId;
       request.headers[HttpHeaders.IsBatchAtomic] = false;
-      request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError
-        ? bulkOptions.continueOnError
-        : true;
-
+      if (bulkOptions.continueOnError !== undefined) {
+        request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError;
+      } else {
+        request.headers[HttpHeaders.BatchContinueOnError] = true;
+      }
       this.applySessionToken(request);
 
       request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -841,11 +841,7 @@ export class ClientContext {
       request.headers[HttpHeaders.IsBatchRequest] = true;
       request.headers[HttpHeaders.PartitionKeyRangeID] = partitionKeyRangeId;
       request.headers[HttpHeaders.IsBatchAtomic] = false;
-      if (bulkOptions.continueOnError !== undefined) {
-        request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError;
-      } else {
-        request.headers[HttpHeaders.BatchContinueOnError] = true;
-      }
+      request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError ?? true;
       this.applySessionToken(request);
 
       request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -841,7 +841,9 @@ export class ClientContext {
       request.headers[HttpHeaders.IsBatchRequest] = true;
       request.headers[HttpHeaders.PartitionKeyRangeID] = partitionKeyRangeId;
       request.headers[HttpHeaders.IsBatchAtomic] = false;
-      request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError || true;
+      request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError
+        ? bulkOptions.continueOnError
+        : true;
 
       this.applySessionToken(request);
 

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -841,7 +841,7 @@ export class ClientContext {
       request.headers[HttpHeaders.IsBatchRequest] = true;
       request.headers[HttpHeaders.PartitionKeyRangeID] = partitionKeyRangeId;
       request.headers[HttpHeaders.IsBatchAtomic] = false;
-      request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError || false;
+      request.headers[HttpHeaders.BatchContinueOnError] = bulkOptions.continueOnError || true;
 
       this.applySessionToken(request);
 

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -460,7 +460,7 @@ export class Items {
    * ```
    *
    * @param operations - List of operations. Limit 100
-   * @param bulkOptions - Optional options object to modify bulk behavior. Pass \{ continueOnError: true \} to continue executing operations when one fails. (Defaults to false) ** NOTE: THIS WILL DEFAULT TO TRUE IN THE 4.0 RELEASE
+   * @param bulkOptions - Optional options object to modify bulk behavior. Pass \{ continueOnError: false \} to stop executing operations when one fails. (Defaults to true)
    * @param options - Used for modifying the request.
    */
   public async bulk(

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
@@ -937,11 +937,14 @@ describe("test bulk operations", async function () {
         };
         await runBulkTestDataSet(dataset);
       });
-      it("424 errors for operations after an error", async function () {
+      it.skip("424 errors for operations after an error when continueOnError is set to false", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
           dbName: addEntropy("424 errors"),
           documentToCreate: [],
+          bulkOperationOptions: {
+            continueOnError: false,
+          },
           operations: [
             {
               description: "Operation should fail with invalid ttl.",
@@ -961,14 +964,11 @@ describe("test bulk operations", async function () {
         };
         await runBulkTestDataSet(dataset);
       });
-      it("Continues after errors with continueOnError true", async function () {
+      it("Continues after errors with default value of continueOnError true", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
           dbName: addEntropy("continueOnError"),
           documentToCreate: [],
-          bulkOperationOptions: {
-            continueOnError: true,
-          },
           operations: [
             {
               description: "Operation should fail with invalid ttl.",

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
@@ -937,7 +937,7 @@ describe("test bulk operations", async function () {
         };
         await runBulkTestDataSet(dataset);
       });
-      it.skip("424 errors for operations after an error when continueOnError is set to false", async function () {
+      it("424 errors for operations after an error when continueOnError is set to false", async function () {
         const dataset: BulkTestDataSet = {
           ...defaultBulkTestDataSet,
           dbName: addEntropy("424 errors"),

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/bulk.item.spec.ts
@@ -432,9 +432,7 @@ describe("test bulk operations", async function () {
       };
       const defaultBulkTestDataSet: BulkTestDataSet = {
         dbName: "bulkTestDB",
-        bulkOperationOptions: {
-          continueOnError: false,
-        },
+        bulkOperationOptions: {},
         containerRequest: {
           id: "patchContainer",
           partitionKey: {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The default value of continueOnError in bulkRequestOptions has been set to true.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
