### PR TITLE
Support operation-location final-state-via for LRO

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-Add the `operation-location` support in resourceLocationConfig option for POST and PATCH LRO.
+Add the `operation-location` support in resourceLocationConfig option.
 
 ### Breaking Changes
 

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+Add the `operation-location` support in resourceLocationConfig option for POST and PATCH LRO.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -85,7 +85,7 @@ export interface RawResponse<TRequest extends RawRequest = RawRequest> {
 }
 
 // @public
-export type ResourceLocationConfig = "azure-async-operation" | "location" | "original-uri";
+export type ResourceLocationConfig = "azure-async-operation" | "location" | "original-uri" | "operation-location";
 
 // @public
 export type RestorableOperationState<TResult, T extends OperationState<TResult>> = T & {

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -7,7 +7,7 @@ import { LroError } from "../poller/models.js";
 /**
  * The potential location of the result of the LRO if specified by the LRO extension in the swagger.
  */
-export type ResourceLocationConfig = "azure-async-operation" | "location" | "original-uri";
+export type ResourceLocationConfig = "azure-async-operation" | "location" | "original-uri" | "operation-location";
 
 /**
  * The type of a LRO response body. This is just a convenience type for checking the status of the operation.

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -7,7 +7,11 @@ import { LroError } from "../poller/models.js";
 /**
  * The potential location of the result of the LRO if specified by the LRO extension in the swagger.
  */
-export type ResourceLocationConfig = "azure-async-operation" | "location" | "original-uri" | "operation-location";
+export type ResourceLocationConfig =
+  | "azure-async-operation"
+  | "location"
+  | "original-uri"
+  | "operation-location";
 
 /**
  * The type of a LRO response body. This is just a convenience type for checking the status of the operation.

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -64,6 +64,7 @@ function findResourceLocation(inputs: {
 
   function getDefault() {
     switch (resourceLocationConfig) {
+      case "operation-location":
       case "azure-async-operation": {
         return undefined;
       }

--- a/sdk/core/core-lro/test/lro.spec.ts
+++ b/sdk/core/core-lro/test/lro.spec.ts
@@ -732,6 +732,75 @@ matrix(
               assert.equal(result.id, "100");
             });
 
+            it("should handle POST with final-state-via: operation-location", async () => {
+              const path = "/post/final-state-via";
+              const locationPath = `/LROPostFinalStateViaOperationLocation/location`;
+              const operationLocationPath = `/LROPostFinalStateViaOperationLocation/asyncOperationUrl`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    path,
+                    body: "",
+                    headers: {
+                      Location: locationPath,
+                      [headerName]: operationLocationPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "succeeded", "id": "100"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: locationPath,
+                    status: 400,
+                  },
+                ],
+                resourceLocationConfig: "operation-location",
+              });
+              assert.equal(result.statusCode, 200);
+              assert.equal(result.id, "100");
+            });
+
+            it("should handle POST with final-state-via: location", async () => {
+              const path = "/post/final-state-via";
+              const locationPath = `/LROPostFinalStateViaOperationLocation/location`;
+              const operationLocationPath = `/LROPostFinalStateViaOperationLocation/asyncOperationUrl`;
+              const result = await runLro({
+                routes: [
+                  {
+                    method: "POST",
+                    status: 202,
+                    path,
+                    body: "",
+                    headers: {
+                      Location: locationPath,
+                      [headerName]: operationLocationPath,
+                    },
+                  },
+                  {
+                    method: "GET",
+                    path: operationLocationPath,
+                    status: 200,
+                    body: `{ "status": "succeeded"}`,
+                  },
+                  {
+                    method: "GET",
+                    path: locationPath,
+                    status: 200,
+                    body: `{ "id": "100" }`,
+                  },
+                ],
+                resourceLocationConfig: "location",
+              });
+              assert.equal(result.statusCode, 200);
+              assert.equal(result.id, "100");
+            });
+
             it("should handle postDoubleHeadersFinalAzureHeaderGetDefault", async () => {
               const resourceLocationPath =
                 "/LROPostDoubleHeadersFinalAzureHeaderGetDefault/location";


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-js/issues/30949

We should skip the final GET when the final-state-via is set as `operation-location` and see [definition](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md#x-ms-long-running-operation-options).
```
operation-location - poll until terminal state, skip any final GET on Location or Origin-URI and use the final response at the uri pointed to by the header Operation-Location
```

