### PR TITLE
[identity] Throw if user-assigned IDs are used for CloudShell MSI

### DIFF
--- a/sdk/identity/identity/BREAKING_CHANGES.md
+++ b/sdk/identity/identity/BREAKING_CHANGES.md
@@ -1,5 +1,9 @@
 # Breaking Changes
 
+## 4.5.0
+
+As of `@azure/identity` 4.5.0, providing a user-assigned managed identity ID as a constructor argument will throw an error, indicating to the user that this is an invalid scenario. Previously, the user-provided ID would be silently ignored as CloudShell does not support this.
+
 ## 4.1.0
 
 As of `@azure/identity` 4.1.0, the number of IMDS probing retries has been increased to 5 (from 3 initially) to match the [IMDS retry guidance](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#retry-guidance) in the `DefaultAzureCredential` and `ManagedIdentityCredential`. The users should be able to override the behavior, if required, by setting the `options.retryOptions.maxRetries` in the respective credential.

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Bugs Fixed
 
-- `ManagedIdentityCredential` now throws an error when attempting to pass a user-assigned Managed Identity in a CloudShell environment. []()
+- `ManagedIdentityCredential` now throws an error when attempting to pass a user-assigned Managed Identity in a CloudShell environment instead of silently ignoring it. [#30955](https://github.com/Azure/azure-sdk-for-js/pull/30955)
 
 ### Other Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugs Fixed
 
+- `ManagedIdentityCredential` now throws an error when attempting to pass a user-assigned Managed Identity in a CloudShell environment. []()
+
 ### Other Changes
 
 ## 4.5.0-beta.2 (2024-08-13)

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -62,6 +62,27 @@ describe("ManagedIdentityCredential (MSAL)", function () {
         );
       });
     });
+
+    describe("when using CloudShell Managed Identity", function () {
+      it("throws when user-assigned IDs are provided", function () {
+        Sinon.stub(ManagedIdentityApplication.prototype, "getManagedIdentitySource").returns(
+          "CloudShell",
+        );
+
+        assert.throws(
+          () => new MsalMsiProvider({ clientId: "id" }),
+          /Specifying a user-assigned managed identity is not supported for CloudShell at runtime/,
+        );
+        assert.throws(
+          () => new MsalMsiProvider({ resourceId: "id" }),
+          /Specifying a user-assigned managed identity is not supported for CloudShell at runtime/,
+        );
+        assert.throws(
+          () => new MsalMsiProvider({ objectId: "id" }),
+          /Specifying a user-assigned managed identity is not supported for CloudShell at runtime/,
+        );
+      });
+    });
   });
 
   describe("#getToken", function () {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

Resolves #30380

### Describe the problem that is addressed by this PR

If the Cloud Shell ManagedIdentitySource is detected via MSAL and a user-assigned managed identity clientID or resourceID is supplied, the ManagedIdentityCredential should throw.

The rationale for taking this minor breaking change is that CloudShell does not support specifying a clientID or ResourceID and the current behavior of silently falling back to attempting to use a system-assigned identity could be unexpected.

### Provide a list of related PRs _(if any)_

https://github.com/Azure/azure-sdk-for-cpp/pull/5837

