### PR TITLE
[Monitor OpenTelemetry Exporter] Fix Property Truncation

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Other Changes
 
-- Updated OTel dependencies
+- Enforce property length limits on telemetry using truncation.
+- Updated OTel dependencies.
 
 ## 1.0.0-beta.25 (2024-08-14)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
@@ -99,7 +99,6 @@ export class FileSystemPersist implements PersistentStorage {
       try {
         const buffer = await this._getFirstFileOnDisk();
         if (buffer) {
-           
           return JSON.parse(buffer.toString("utf8"));
         }
       } catch (e: any) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
@@ -99,7 +99,7 @@ export class FileSystemPersist implements PersistentStorage {
       try {
         const buffer = await this._getFirstFileOnDisk();
         if (buffer) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+           
           return JSON.parse(buffer.toString("utf8"));
         }
       } catch (e: any) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
@@ -71,3 +71,14 @@ export enum BreezePerformanceCounterNames {
   REQUEST_RATE = "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Requests/Sec",
   REQUEST_DURATION = "\\ASP.NET Applications(??APP_W3SVC_PROC??)\\Request Execution Time",
 }
+
+/**
+ * Property Max Lengths
+ * @internal
+ */
+export enum MaxPropertyLengths {
+  NINE_BIT = 512,
+  TEN_BIT = 1024,
+  THIRTEEN_BIT = 8192,
+  FIFTEEN_BIT = 32768,
+}

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -20,7 +20,7 @@ import {
   SEMATTRS_EXCEPTION_STACKTRACE,
   SEMATTRS_EXCEPTION_TYPE,
 } from "@opentelemetry/semantic-conventions";
-import { Measurements, Properties, Tags } from "../types";
+import { MaxPropertyLengths, Measurements, Properties, Tags } from "../types";
 import { diag } from "@opentelemetry/api";
 import {
   ApplicationInsightsAvailabilityBaseType,
@@ -90,6 +90,15 @@ export function logToEnvelope(log: ReadableLogRecord, ikey: string): Envelope | 
     if (!baseData) {
       // Failed to parse log
       return;
+    }
+  }
+  // Truncate properties
+  if (baseData.message) {
+    baseData.message = String(baseData.message).substring(0, MaxPropertyLengths.FIFTEEN_BIT);
+  }
+  if (properties) {
+    for (const key of Object.keys(properties)) {
+      properties[key] = String(properties[key]).substring(0, MaxPropertyLengths.THIRTEEN_BIT);
     }
   }
   return {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -366,7 +366,10 @@ export function readableSpanToEnvelope(span: ReadableSpan, ikey: string): Envelo
   }
   if (baseData.properties) {
     for (const key of Object.keys(baseData.properties)) {
-      baseData.properties[key] = baseData.properties[key].substring(0, MaxPropertyLengths.THIRTEEN_BIT);
+      baseData.properties[key] = baseData.properties[key].substring(
+        0,
+        MaxPropertyLengths.THIRTEEN_BIT,
+      );
     }
   }
 
@@ -469,7 +472,10 @@ export function spanEventsToEnvelopes(span: ReadableSpan, ikey: string): Envelop
       }
       if (baseData.properties) {
         for (const key of Object.keys(baseData.properties)) {
-          baseData.properties[key] = baseData.properties[key].substring(0, MaxPropertyLengths.THIRTEEN_BIT);
+          baseData.properties[key] = baseData.properties[key].substring(
+            0,
+            MaxPropertyLengths.THIRTEEN_BIT,
+          );
         }
       }
       const env: Envelope = {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.test.ts
@@ -69,7 +69,6 @@ describe("FileSystemPersist", () => {
   afterEach((done) => {
     fs.readdir(tempDir, (err, files) => {
       if (err) {
-         
         console.error(err);
         done();
       } else {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.test.ts
@@ -69,7 +69,7 @@ describe("FileSystemPersist", () => {
   afterEach((done) => {
     fs.readdir(tempDir, (err, files) => {
       if (err) {
-        // eslint-disable-next-line no-console
+         
         console.error(err);
         done();
       } else {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -101,7 +101,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
       it("should add correct network properites to the custom metric", (done) => {
         const statsbeat = new NetworkStatsbeatMetrics(options);
-        // eslint-disable-next-line no-unused-expressions, @typescript-eslint/no-unused-expressions
+        // eslint-disable-next-line no-unused-expressions
         statsbeat["statsCollectionShortInterval"];
         statsbeat.countSuccess(100);
         const metric = statsbeat["networkStatsbeatCollection"][0];


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/30969

### Describe the problem that is addressed by this PR
Enforces truncation on properties parsed from user telemetry.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
