### PR TITLE
chore(playwrighttesting): remove fallback authentication logic

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
@@ -30,7 +30,7 @@ export type EndpointOptions = {
 };
 
 // @public
-export const getConnectOptions: (options?: Omit<PlaywrightServiceAdditionalOptions, "defaultAuthenticationMechanism">) => Promise<BrowserConnectOptions>;
+export const getConnectOptions: (options?: Omit<PlaywrightServiceAdditionalOptions, "serviceAuthType">) => Promise<BrowserConnectOptions>;
 
 // @public
 export const getServiceConfig: (config: PlaywrightConfigInput, options?: PlaywrightServiceAdditionalOptions) => PlaywrightConfig;
@@ -61,7 +61,7 @@ export type PlaywrightConfigInput = {
 
 // @public
 export type PlaywrightServiceAdditionalOptions = {
-    defaultAuth?: AuthenticationType;
+    serviceAuthType?: AuthenticationType;
     os?: OsType;
     runId?: string;
     timeout?: number;
@@ -73,8 +73,8 @@ export type PlaywrightServiceAdditionalOptions = {
 
 // @public
 export const ServiceAuth: {
-    readonly ENTRA: "ENTRA";
-    readonly TOKEN: "TOKEN";
+    readonly ENTRA_ID: "ENTRA_ID";
+    readonly ACCESS_TOKEN: "ACCESS_TOKEN";
 };
 
 // @public

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/README.md
@@ -43,7 +43,7 @@ The service configuration serves to:
     ```javascript
     const {
         getServiceConfig,
-        Auth,
+        ServiceAuth,
     } = require("@azure/microsoft-playwright-testing");
     const { defineConfig } = require("@playwright/test");
     const config = require("./playwright.config");
@@ -51,7 +51,7 @@ The service configuration serves to:
     export default defineConfig(
         config,
         getServiceConfig(config, {
-            defaultAuth: ServiceAuth.TOKEN,
+            serviceAuthType: ServiceAuth.ACCESS_TOKEN,
         }),
         {
             reporter: [["list"], ["@azure/microsoft-playwright-testing/reporter"]],

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/playwright.service.config.js
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/javascript/set-default-authentication-mechanism/playwright.service.config.js
@@ -1,9 +1,9 @@
-const { getServiceConfig, Auth } = require("@azure/microsoft-playwright-testing");
+const { getServiceConfig, ServiceAuth } = require("@azure/microsoft-playwright-testing");
 const { defineConfig } = require('@playwright/test');
 const config = require("./playwright.config");
 
 export default defineConfig(config, getServiceConfig(config, {
-  defaultAuth: ServiceAuth.TOKEN
+  serviceAuthType: ServiceAuth.ACCESS_TOKEN
 }), {
   reporter: [["list"], ["@azure/microsoft-playwright-testing/reporter"]],
 });

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/README.md
@@ -43,7 +43,7 @@ The service configuration serves to:
     ```typescript
     import {
         getServiceConfig,
-        Auth,
+        ServiceAuth,
     } from "@azure/microsoft-playwright-testing";
     import { defineConfig } from "@playwright/test";
     import config from "./playwright.config";
@@ -51,7 +51,7 @@ The service configuration serves to:
     export default defineConfig(
         config,
         getServiceConfig(config, {
-            defaultAuth: ServiceAuth.TOKEN,
+            serviceAuthType: ServiceAuth.ACCESS_TOKEN,
         }),
         {
             reporter: [["list"], ["@azure/microsoft-playwright-testing/reporter"]],

--- a/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/playwright.service.config.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/samples/v1/typescript/set-default-authentication-mechanism/playwright.service.config.ts
@@ -1,11 +1,11 @@
-import { getServiceConfig, Auth } from "@azure/microsoft-playwright-testing";
+import { getServiceConfig, ServiceAuth } from "@azure/microsoft-playwright-testing";
 import { defineConfig } from "@playwright/test";
 import config from "./playwright.config";
 
 export default defineConfig(
   config,
   getServiceConfig(config, {
-    defaultAuth: ServiceAuth.TOKEN,
+    serviceAuthType: ServiceAuth.ACCESS_TOKEN,
   }),
   {
     reporter: [["list"], ["@azure/microsoft-playwright-testing/reporter"]],

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/constants.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/constants.ts
@@ -22,8 +22,8 @@ export const ServiceOS = {
  * Authentication types supported on Microsoft Playwright Testing
  */
 export const ServiceAuth = {
-  ENTRA: "ENTRA",
-  TOKEN: "TOKEN",
+  ENTRA_ID: "ENTRA_ID",
+  ACCESS_TOKEN: "ACCESS_TOKEN",
 } as const;
 
 /** @public
@@ -37,10 +37,6 @@ export const ServiceEnvironmentVariable = {
   PLAYWRIGHT_SERVICE_ACCESS_TOKEN: "PLAYWRIGHT_SERVICE_ACCESS_TOKEN",
   PLAYWRIGHT_SERVICE_URL: "PLAYWRIGHT_SERVICE_URL",
   PLAYWRIGHT_SERVICE_REPORTING_URL: "PLAYWRIGHT_SERVICE_REPORTING_URL",
-};
-
-export const InternalServiceEnvironmentVariable = {
-  PLAYWRIGHT_SERVICE_CLOUD_HOSTED_BROWSER_USED: "_PLAYWRIGHT_SERVICE_CLOUD_HOSTED_BROWSER_USED",
 };
 
 export const DefaultConnectOptionsConstants = {
@@ -222,6 +218,8 @@ export const TestResultErrorConstants = [
 
 export const InternalEnvironmentVariables = {
   MPT_PLAYWRIGHT_VERSION: "_MPT_PLAYWRIGHT_VERSION",
+  MPT_SETUP_FATAL_ERROR: "_MPT_SETUP_FATAL_ERROR",
+  MPT_CLOUD_HOSTED_BROWSER_USED: "_MPT_CLOUD_HOSTED_BROWSER_USED",
 };
 
 export const MINIMUM_SUPPORTED_PLAYWRIGHT_VERSION = "1.47.0";

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
@@ -147,9 +147,9 @@ export type PlaywrightServiceAdditionalOptions = {
    *
    * Authentication types supported by Microsoft Playwright Testing.
    *
-   * @defaultValue  `ENTRA`
+   * @defaultValue  `ENTRA_ID`
    */
-  defaultAuth?: AuthenticationType;
+  serviceAuthType?: AuthenticationType;
 
   /**
    * @public

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { InternalServiceEnvironmentVariable, ServiceAuth } from "../common/constants";
+import { InternalEnvironmentVariables, ServiceAuth } from "../common/constants";
 import customerConfig from "../common/customerConfig";
 import { PlaywrightServiceConfig } from "../common/playwrightServiceConfig";
 import playwrightServiceEntra from "./playwrightServiceEntra";
@@ -72,7 +72,7 @@ const getServiceConfig = (
   emitReportingUrl();
 
   const globalFunctions: any = {};
-  if (options?.defaultAuth === ServiceAuth.TOKEN && getAccessToken()) {
+  if (options?.serviceAuthType === ServiceAuth.ACCESS_TOKEN) {
     // mpt PAT requested and set by the customer, no need to setup entra lifecycle handlers
     validateMptPAT();
   } else {
@@ -85,11 +85,8 @@ const getServiceConfig = (
       ...globalFunctions,
     };
   }
-  if (
-    !process.env[InternalServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_CLOUD_HOSTED_BROWSER_USED]
-  ) {
-    process.env[InternalServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_CLOUD_HOSTED_BROWSER_USED] =
-      "true";
+  if (!process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED]) {
+    process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED] = "true";
   }
 
   return {
@@ -141,7 +138,7 @@ const getServiceConfig = (
  * ```
  */
 const getConnectOptions = async (
-  options?: Omit<PlaywrightServiceAdditionalOptions, "defaultAuthenticationMechanism">,
+  options?: Omit<PlaywrightServiceAdditionalOptions, "serviceAuthType">,
 ): Promise<BrowserConnectOptions> => {
   const playwrightServiceConfig = new PlaywrightServiceConfig();
   playwrightServiceConfig.setOptions(options);

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/reporter/mptReporter.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/reporter/mptReporter.ts
@@ -12,7 +12,7 @@ import type {
 import { reporterLogger } from "../common/logger";
 import {
   Constants,
-  InternalServiceEnvironmentVariable,
+  InternalEnvironmentVariables,
   TestResultErrorConstants,
 } from "../common/constants";
 import { EnvironmentVariables } from "../common/environmentVariables";
@@ -333,6 +333,10 @@ class MPTReporter implements Reporter {
 
   private initializeMPTReporter(): void {
     this.envVariables = new EnvironmentVariables();
+    if (process.env[InternalEnvironmentVariables.MPT_SETUP_FATAL_ERROR] === "true") {
+      this.isTokenValid = false;
+      return;
+    }
     if (!process.env["PLAYWRIGHT_SERVICE_REPORTING_URL"]) {
       process.stdout.write("\nReporting service url not found.");
       this.isTokenValid = false;
@@ -389,9 +393,7 @@ class MPTReporter implements Reporter {
 
   private processTestResult(result: TestResult): void {
     if (
-      process.env[
-        InternalServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_CLOUD_HOSTED_BROWSER_USED
-      ] &&
+      process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED] &&
       result.status !== "passed"
     ) {
       result.errors.forEach((error) => {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
@@ -87,15 +87,16 @@ describe("getServiceConfig", () => {
     );
   });
 
-  it("should set service global setup and teardown for mpt PAT authentication if pat is not set", () => {
+  it("should not set service global setup and teardown for mpt PAT authentication even if pat is not set", () => {
     const { getServiceConfig } = require("../../src/core/playwrightService");
+    sandbox.stub(utils, "validateMptPAT").returns();
     const config = getServiceConfig(samplePlaywrightConfigInput, {
-      defaultAuth: ServiceAuth.TOKEN,
+      serviceAuthType: ServiceAuth.ACCESS_TOKEN,
     });
-    expect(config.globalSetup).to.equal(
+    expect(config.globalSetup).not.to.equal(
       require.resolve("../../src/core/global/playwright-service-global-setup"),
     );
-    expect(config.globalTeardown).to.equal(
+    expect(config.globalTeardown).not.to.equal(
       require.resolve("../../src/core/global/playwright-service-global-teardown"),
     );
   });
@@ -117,7 +118,7 @@ describe("getServiceConfig", () => {
     const { getServiceConfig } = require("../../src/core/playwrightService");
     process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = "token";
     const config = getServiceConfig(samplePlaywrightConfigInput, {
-      defaultAuth: ServiceAuth.TOKEN,
+      serviceAuthType: ServiceAuth.ACCESS_TOKEN,
     });
     expect(config.globalSetup).to.be.undefined;
     expect(config.globalTeardown).to.be.undefined;
@@ -223,7 +224,9 @@ describe("getConnectOptions", () => {
     process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = accessToken;
     sandbox.stub(utils, "parseJwt").returns({ exp: Date.now() / 1000 });
     const credential = {
-      getToken: sandbox.stub().resolves(accessToken),
+      getToken: sandbox
+        .stub()
+        .resolves({ token: accessToken, expiresOnTimestamp: Date.now() + 10000 }),
     };
     const { getConnectOptions } = require("../../src/core/playwrightService");
     await getConnectOptions({


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

Remove fallback logic in authentication

### Describe the problem that is addressed by this PR

Earlier, we used to have fallback logic in authentication. Entra -> PAT or PAT -> Entra. This PR removes the fallback logic.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
