### PR TITLE
[core] Create spans using automatic span propagation

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - The token cycler of `BearerTokenCredentialPolicy` now checks the `refreshAfterTimestamp` attribute in the `AccessToken` when determining if a token request should be made in the `shouldRefresh` method. #30402
+- Added support for automatic span propagation and HTTP tracing for consumers using Rest Level Clients. [#31019](https://github.com/Azure/azure-sdk-for-js/pull/31019)
 
 ## 1.16.3 (2024-08-01)
 

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -54,7 +54,7 @@ export function tracingPolicy(options: TracingPolicyOptions = {}): PipelinePolic
   return {
     name: tracingPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (!tracingClient || !request.tracingOptions?.tracingContext) {
+      if (!tracingClient) {
         return next(request);
       }
 

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -227,13 +227,13 @@ describe("tracingPolicy", function () {
     assert.equal(mockSpan.getAttribute("http.status_code"), 400);
   });
 
-  it("will not create a span if tracingContext is missing", async () => {
+  it("will create a span if tracingContext is missing", async () => {
     const policy = tracingPolicy();
     const { request, next } = createTestRequest({ noContext: true });
     await policy.sendRequest(request, next);
 
     const createdSpan = activeInstrumenter.lastSpanCreated;
-    assert.notExists(createdSpan, "span was created without tracingContext being passed!");
+    assert.exists(createdSpan);
   });
 
   describe("span errors", () => {

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -227,7 +227,7 @@ describe("tracingPolicy", function () {
     assert.equal(mockSpan.getAttribute("http.status_code"), 400);
   });
 
-  it("will create a span if tracingContext is missing", async () => {
+  it("will create a span even if tracingContext is missing", async () => {
     const policy = tracingPolicy();
     const { request, next } = createTestRequest({ noContext: true });
     await policy.sendRequest(request, next);

--- a/sdk/core/ts-http-runtime/src/policies/tracingPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/tracingPolicy.ts
@@ -50,7 +50,7 @@ export function tracingPolicy(options: TracingPolicyOptions = {}): PipelinePolic
   return {
     name: tracingPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (!tracingClient || !request.tracingOptions?.tracingContext) {
+      if (!tracingClient) {
         return next(request);
       }
 

--- a/sdk/core/ts-http-runtime/test/tracingPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/tracingPolicy.spec.ts
@@ -225,13 +225,13 @@ describe("tracingPolicy", function () {
     assert.equal(mockSpan.getAttribute("http.status_code"), 400);
   });
 
-  it("will not create a span if tracingContext is missing", async () => {
+  it("will create a span if tracingContext is missing", async () => {
     const policy = tracingPolicy();
     const { request, next } = createTestRequest({ noContext: true });
     await policy.sendRequest(request, next);
 
     const createdSpan = activeInstrumenter.lastSpanCreated;
-    assert.notExists(createdSpan, "span was created without tracingContext being passed!");
+    assert.exists(createdSpan);
   });
 
   describe("span errors", () => {

--- a/sdk/core/ts-http-runtime/test/tracingPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/tracingPolicy.spec.ts
@@ -225,7 +225,7 @@ describe("tracingPolicy", function () {
     assert.equal(mockSpan.getAttribute("http.status_code"), 400);
   });
 
-  it("will create a span if tracingContext is missing", async () => {
+  it("will create a span even if tracingContext is missing", async () => {
     const policy = tracingPolicy();
     const { request, next } = createTestRequest({ noContext: true });
     await policy.sendRequest(request, next);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-rest-pipeline
@typespec/ts-http-runtime

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

Back when we were migrating to the new core tracing we wanted to be cautious and
bail as early as possible in our core tracing policy. This meant that we:
1. Guard against any errors
2. Ignore automatic span propagation, instead expecting HLC libraries to call
tracingClient.withSpan to kick off the manual span propagation (context
parameter passing in options)

Now that we have RLC which does not have a tracingClient, and having had this
code in production for quite some time, we can remove the optimization that
aassumes the tracingContext will be added upstream.

This is a non-impactful change for high-level clients or anyone who has not opted-in to OTel tracing.

For users who use rest-level clients _and_ have opted into OTel, they will now see HTTP spans from core added correctly

### Are there test cases added in this PR? _(If not, why?)_

Updated test expectation

### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
