### PR TITLE
fix(playwrighttesting): change policy name in rush.json to client

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -2231,7 +2231,7 @@
     {
       "packageName": "@azure/create-microsoft-playwright-testing",
       "projectFolder": "sdk/playwrighttesting/create-microsoft-playwright-testing",
-      "versionPolicyName": "utility"
+      "versionPolicyName": "client"
     },
     {
       "packageName": "@azure/microsoft-playwright-testing",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/create-microsoft-playwright-testing

### Issues associated with this PR

Dev version cannot be published for utility packages

- VersionPolicy should be client or core in rush.json to get alpha version build.

### Describe the problem that is addressed by this PR

Change version policy to `client` from `utility`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
