### PR TITLE
[test-credential] Include the correct types in package

### DIFF
--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.3.1 (2024-09-09)
+
+- Fix an issue where the published package was missing TypeScript types. [#31039](https://github.com/Azure/azure-sdk-for-js/pull/31039)
+
 ## 1.3.0 (2024-09-03)
 
 ### Breaking Changes

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/test-credential",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "sdk-type": "utility",
   "description": "Test utilities library that provides the test credential",
   "main": "dist/index.js",

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -34,7 +34,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/tools-test-credential.d.ts",
+    "types/test-credential.d.ts",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
### Packages impacted by this PR

@azure-tools/test-credential

### Issues associated with this PR

N/A - hotfix 1.3.0

### Describe the problem that is addressed by this PR

In https://github.com/Azure/azure-sdk-for-js/pull/30977/files#diff-f69713a41b4518b09d100824cfa2dc13e3105ab66b0f81f12a8290df980f441dL8 we updated the filename for the rollup dts file but forgot to update the `files` section to ensure the new file is included in the published package.

This hotfix focuses on the straightforward fix which is updating the `files` declaration. Once this is released, I will also look at opportunities for us to catch this before publishing the package. I don't know what that will look like yet, but for now let's fix the published package

