### PR TITLE
[test-utils] Port CHANGELOG from 1.x branch

### DIFF
--- a/sdk/test-utils/test-credential/CHANGELOG.md
+++ b/sdk/test-utils/test-credential/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ### Other Changes
 
+## 1.3.1 (2024-09-09)
+
+### Bugs Fixed
+
+- Fix an issue where the published package was missing TypeScript types. [#31039](https://github.com/Azure/azure-sdk-for-js/pull/31039)
+
+## 1.3.0 (2024-09-03)
+
+### Breaking Changes
+
+Updates the `createTestCredential` method to consume `AzurePipelineCredential` when it is running in Azure Pipeline environment or `ChainedTokenCredential`.
+
 ## 2.1.0 (2024-08-12)
 
 ### Breaking Changes
@@ -21,6 +33,25 @@ Updates the `createTestCredential` method to consume `AzurePipelineCredential` w
   - In Node, `AzurePipelinesCredential` is run when the environment is Azure Pipelines with service connection. Otherwise `ChainedTokenCredential` is offered. The credential will try `AzurePowershelLCredential`, `AzureCliCredential`, `EnvironmentCredential`, and `AzureDeveloperCliCredential` in the listed order.
   - In the browser, a custom credential is provided that fetches tokens from a locally running Node server. The server is provided in the dev-tool package, and must be running while the browser
     tests are running for the credential to work. The server uses `ChainedTokenCredential` on the host machine to generate tokens.
+- [`User Auth` and `Auth via development tools`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#authenticate-users) are preferred in record mode to record the tests.
+
+## 1.2.0 (2024-06-13)
+
+### Breaking Changes
+
+Updates the `createTestCredential` method to consume `ChainedTokenCredential` instead of `DefaultAzureCredential` in order to ensure live test pipeline can authenticate successfully. The `ChainedTokenCredential` will try `AzurePowershelLCredential`, `AzureCliCredential`, `AzureDeveloperCliCredential`, and `EnvironmentCredential` in the listed order.
+
+## 1.1.0 (2024-05-08)
+
+### Breaking Changes
+
+Updates the `createTestCredential` method to consume `DefaultAzureCredential` instead of `ClientSecretCredential` in order to offer autonomy to the devs and to move away from client secrets in environment varaibles.
+
+- `NoOpCredential` is offered for playback.
+- In record and live modes:
+  - `DefaultAzureCredential` is offered in Node.
+  - In the browser, a custom credential is provided that fetches tokens from a locally running Node server. The server is provided in the dev-tool package, and must be running while the browser
+    tests are running for the credential to work. The server uses `DefaultAzureCredential` on the host machine to generate tokens.
 - [`User Auth` and `Auth via development tools`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#authenticate-users) are preferred in record mode to record the tests.
 
 ## 2.0.0 (2024-04-09)


### PR DESCRIPTION
### Packages impacted by this PR

@azure-tools/test-utils

### Describe the problem that is addressed by this PR

I noticed that the hotfix changes from 1.x branch were not listed in the
CHANGELOG on main. This PR just ports those over so they are listed in
chronological order

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
