### PR TITLE
[eslint-plugin] exclude *.config.*ts from linting

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
@@ -18,7 +18,7 @@ import rootConfig from "./azure-sdk-base";
 function recommended(plugin: FlatConfig.Plugin, options: { typeChecked: boolean }) {
   return typescriptEslint.config(
     {
-      ignores: ["**/generated/**", "**/*.config.{js,cjs,mjs}"],
+      ignores: ["**/generated/**", "**/*.config.{js,cjs,mjs,ts,cts,mts}"],
     },
     {
       languageOptions: {
@@ -102,7 +102,7 @@ export default (plugin: FlatConfig.Plugin) => ({
   "azure-sdk-base": rootConfig,
   internal: typescriptEslint.config(
     {
-      ignores: ["**/generated/**", "**/*.config.{js,cjs,mjs}"],
+      ignores: ["**/generated/**", "**/*.config.{js,cjs,mjs,ts,cts,mts}"],
     },
     {
       languageOptions: {


### PR DESCRIPTION
so we don't have errors in editors when opening vitest configs