### PR TITLE
fix(playwrighttesting): fetch access token value from environment variables

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/environmentVariables.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/environmentVariables.ts
@@ -4,7 +4,9 @@
 import { randomUUID } from "crypto";
 
 export class EnvironmentVariables {
-  accessToken: string;
+  get accessToken(): string {
+    return process.env["PLAYWRIGHT_SERVICE_ACCESS_TOKEN"]!;
+  }
   runId: string;
   accountId: string | undefined;
   userId: string | undefined;
@@ -13,7 +15,6 @@ export class EnvironmentVariables {
   shardId: string | undefined;
   region: string | undefined;
   constructor() {
-    this.accessToken = process.env["PLAYWRIGHT_SERVICE_ACCESS_TOKEN"]!;
     this.runId = process.env["PLAYWRIGHT_SERVICE_RUN_ID"]!;
     this.correlationId = randomUUID();
   }


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

### Describe the problem that is addressed by this PR

Fetching and setting access token was a one time operation in reporting. Thus, when the token was rotated, it was not picked up by the reporter worker resulting in expired token calls.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
