### PR TITLE
[monitor-opentelemetry] Fix document spam bug

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -107,10 +107,10 @@ export class LiveMetrics {
   private lastExceptionRate: { count: number; time: number } = { count: 0, time: 0 };
   private lastCpus:
     | {
-        model: string;
-        speed: number;
-        times: { user: number; nice: number; sys: number; idle: number; irq: number };
-      }[]
+      model: string;
+      speed: number;
+      times: { user: number; nice: number; sys: number; idle: number; irq: number };
+    }[]
     | undefined;
   private statsbeatOptionsUpdated = false;
 
@@ -139,7 +139,7 @@ export class LiveMetrics {
     };
     const parsedConnectionString = ConnectionStringParser.parse(
       this.config.azureMonitorExporterOptions.connectionString ||
-        process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"],
+      process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"],
     );
     this.pingSender = new QuickpulseSender({
       endpointUrl: parsedConnectionString.liveendpoint || DEFAULT_LIVEMETRICS_ENDPOINT,
@@ -368,7 +368,9 @@ export class LiveMetrics {
   }
 
   public getDocuments(): DocumentIngress[] {
-    return this.documents;
+    const result: DocumentIngress[] = this.documents;
+    this.documents = [];
+    return result;
   }
 
   private addDocument(document: DocumentIngress): void {

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -107,10 +107,10 @@ export class LiveMetrics {
   private lastExceptionRate: { count: number; time: number } = { count: 0, time: 0 };
   private lastCpus:
     | {
-      model: string;
-      speed: number;
-      times: { user: number; nice: number; sys: number; idle: number; irq: number };
-    }[]
+        model: string;
+        speed: number;
+        times: { user: number; nice: number; sys: number; idle: number; irq: number };
+      }[]
     | undefined;
   private statsbeatOptionsUpdated = false;
 
@@ -139,7 +139,7 @@ export class LiveMetrics {
     };
     const parsedConnectionString = ConnectionStringParser.parse(
       this.config.azureMonitorExporterOptions.connectionString ||
-      process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"],
+        process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"],
     );
     this.pingSender = new QuickpulseSender({
       endpointUrl: parsedConnectionString.liveendpoint || DEFAULT_LIVEMETRICS_ENDPOINT,


### PR DESCRIPTION
### Packages impacted by this PR
monitor-opentelemetry


### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/30970


### Describe the problem that is addressed by this PR
This PR addresses the issue where the live metrics component of the SDK was re-emitting old documents at every time interval along with the new documents. 

Testing was manually done by including the app insights sdk in a test application & checking the documents that appear on the documents pane on the live metrics page.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
