### PR TITLE
[keyvault-certificates] fix minmax failure

### DIFF
--- a/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.create.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { PollerStoppedError } from "@azure/core-lro";
 import { env, Recorder } from "@azure-tools/test-recorder";
 
 import {
@@ -69,7 +68,6 @@ describe("Certificates client - LRO - create", () => {
     expect(poller.getOperationState().isStarted).toBeTruthy();
 
     poller.pollUntilDone().catch((e) => {
-      expect(e).toBeInstanceOf(PollerStoppedError);
       expect(e.name).toEqual("PollerStoppedError");
       expect(e.message).toEqual("This poller is already stopped");
     });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.delete.spec.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { PollerStoppedError } from "@azure/core-lro";
 import { env, Recorder } from "@azure-tools/test-recorder";
 
 import {
@@ -76,7 +75,6 @@ describe("Certificates client - lro - delete", () => {
     expect(poller.getOperationState().isStarted).toBeTruthy();
 
     poller.pollUntilDone().catch((e) => {
-      expect(e).toBeInstanceOf(PollerStoppedError);
       expect(e.name).toEqual("PollerStoppedError");
       expect(e.message).toEqual("This poller is already stopped");
     });

--- a/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/lro.recover.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 import { env, Recorder } from "@azure-tools/test-recorder";
-import { PollerStoppedError } from "@azure/core-lro";
 
 import {
   CertificateClient,
@@ -87,7 +87,6 @@ describe("Certificates client - LRO - recoverDelete", () => {
     expect(recoverPoller.getOperationState().isStarted).toBeTruthy();
 
     recoverPoller.pollUntilDone().catch((e) => {
-      expect(e).toBeInstanceOf(PollerStoppedError);
       expect(e.name).toEqual("PollerStoppedError");
       expect(e.message).toEqual("This poller is already stopped");
     });

--- a/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
+++ b/sdk/keyvault/keyvault-certificates/test/public/mergeAndImport.spec.ts
@@ -14,6 +14,7 @@ import { testPollerProperties } from "./utils/recorderUtils.js";
 import { authenticate } from "./utils/testAuthentication.js";
 import TestClient from "./utils/testClient.js";
 import { describe, it, beforeEach, afterEach } from "vitest";
+import path from "node:path";
 
 describe("Certificates client - merge and import certificates", () => {
   const prefix = `merge${env.CERTIFICATE_NAME || "CertificateName"}`;
@@ -95,6 +96,11 @@ describe("Certificates client - merge and import certificates", () => {
   it.skipIf(!isNodeLike || isPlaybackMode())(
     "can merge a self signed certificate",
     async function (ctx): Promise<void> {
+      // Use a path relative to this test for these static files, since sometimes (e.g. with minmax) the tests
+      // are run from a different working directory to the package root.
+      const caKey = path.join(path.dirname(ctx.task.file.filepath), "..", "..", "ca.key");
+      const caCrt = path.join(path.dirname(ctx.task.file.filepath), "..", "..", "ca.crt");
+
       const certificateName = testClient.formatName(`${prefix}-${ctx.task.name}-${suffix}`);
 
       await client.beginCreateCertificate(
@@ -108,7 +114,7 @@ describe("Certificates client - merge and import certificates", () => {
       );
 
       const certificateOperationPoller = await client.getCertificateOperation(certificateName);
-      const { csr } = await certificateOperationPoller.getOperationState().certificateOperation!;
+      const { csr } = certificateOperationPoller.getOperationState().certificateOperation!;
       const base64Csr = Buffer.from(csr!).toString("base64");
       const wrappedCsr = `-----BEGIN CERTIFICATE REQUEST-----
 ${base64Csr}
@@ -119,7 +125,7 @@ ${base64Csr}
       //   openssl genrsa -out ca.key 2048
       //   openssl req -new -x509 -key ca.key -out ca.crt
       childProcess.execSync(
-        "openssl x509 -req -in test.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out test.crt",
+        `openssl x509 -req -in test.csr -CA ${caCrt} -CAkey ${caKey} -CAcreateserial -out test.crt`,
       );
       const base64Crt = fs.readFileSync("test.crt").toString().split("\n").slice(1, -1).join("");
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-certificates`

### Issues associated with this PR

- Fix #31012

### Describe the problem that is addressed by this PR

1. Minmax tests are not run in the package directory (they are instead run in `test/public`). This PR updates the path for some static test resource files to be relative to the test file itself instead of relative to the working directory.
2. Stop using instanceof for a couple of tests where we are testing the type of the error. The name of the error should be enough. I think this might have been causing failures maybe due to a dual-package hazard kind of interaction?