### PR TITLE
[dev-tool] Test alternative method of executing samples

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/run.ts
+++ b/common/tools/dev-tool/src/commands/samples/run.ts
@@ -51,11 +51,15 @@ export default leafCommand(commandInfo, async (options) => {
   const originalPackageJson = fs.readFileSync(samplesPackageJsonPath);
 
   log.info("Installing sample dependencies");
-  await run(["pnpm", "install", packageLocation], { cwd: tsSamplesLocation, stdio: "inherit" });
-  await run(["pnpm", "install"], { cwd: tsSamplesLocation, stdio: "inherit" });
+  await run(["npm", "install", packageLocation], {
+    cwd: tsSamplesLocation,
+    stdio: "inherit",
+    shell: true,
+  });
+  await run(["npm", "install"], { cwd: tsSamplesLocation, stdio: "inherit", shell: true });
 
   log.info("Building TypeScript samples");
-  await run(["pnpm", "run", "build"], { cwd: tsSamplesLocation, stdio: "inherit" });
+  await run(["npm", "run", "build"], { cwd: tsSamplesLocation, stdio: "inherit", shell: true });
 
   log.info("Running samples");
 
@@ -70,7 +74,7 @@ export default leafCommand(commandInfo, async (options) => {
   )) {
     log.info("Running sample:", filename);
     try {
-      await run(["node", filename], { stdio: "inherit" });
+      await run(["node", filename], { stdio: "inherit", shell: true });
     } catch (e) {
       log.error("Sample failed:", filename);
     }

--- a/common/tools/dev-tool/src/commands/samples/run.ts
+++ b/common/tools/dev-tool/src/commands/samples/run.ts
@@ -51,11 +51,11 @@ export default leafCommand(commandInfo, async (options) => {
   const originalPackageJson = fs.readFileSync(samplesPackageJsonPath);
 
   log.info("Installing sample dependencies");
-  await run(["npm", "install", packageLocation], { cwd: tsSamplesLocation, stdio: "inherit" });
-  await run(["npm", "install"], { cwd: tsSamplesLocation, stdio: "inherit" });
+  await run(["pnpm", "install", packageLocation], { cwd: tsSamplesLocation, stdio: "inherit" });
+  await run(["pnpm", "install"], { cwd: tsSamplesLocation, stdio: "inherit" });
 
   log.info("Building TypeScript samples");
-  await run(["npm", "run", "build"], { cwd: tsSamplesLocation, stdio: "inherit" });
+  await run(["pnpm", "run", "build"], { cwd: tsSamplesLocation, stdio: "inherit" });
 
   log.info("Running samples");
 

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -270,6 +270,15 @@ export async function createReadme(
   });
 }
 
+function isBetaVersion(version: string): boolean {
+  return /-beta/.test(version);
+}
+
+export function getSamplesVersionFolder(projectInfo: ProjectInfo): string {
+  const majorVersion = projectInfo.version.split(".")[0];
+  return `v${majorVersion}${isBetaVersion(projectInfo.version) ? "-beta" : ""}`;
+}
+
 /**
  * Create a filesystem tree factory representing a camera-ready samples
  * tree.
@@ -288,9 +297,7 @@ export async function makeSamplesFactory(
     hadError = true;
   };
 
-  const isBeta = /-beta/.test(projectInfo.version);
-  const majorVersion = projectInfo.version.split(".")[0];
-  const versionFolder = `v${majorVersion}${isBeta ? "-beta" : ""}`;
+  const versionFolder = getSamplesVersionFolder(projectInfo);
 
   const repoRoot = await resolveRoot();
 
@@ -299,7 +306,7 @@ export async function makeSamplesFactory(
   const finalSourcePath = sourcePath ?? path.join(projectInfo.path, DEV_SAMPLES_BASE);
 
   const info = await makeSampleGenerationInfo(projectInfo, finalSourcePath, versionFolder, onError);
-  info.isBeta = isBeta;
+  info.isBeta = isBetaVersion(projectInfo.version);
 
   // Ambient declarations ().d.ts files) are excluded from the compile graph in the transpiler. We will still copy them
   // into typescript/src so that they will be availabled for transpilation.

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -38,7 +38,7 @@
     "build": "npm run clean && tshy && dev-tool run extract-api",
     "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf --glob dist-esm dist-test types *.tgz *.log samples/typescript/dist",
-    "execute:samples": "dev-tool samples run samples-dev",
+    "execute:samples": "dev-tool samples run",
     "extract-api": "tshy && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"samples-dev/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "generate:client": "autorest --typescript swagger/README.md",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-tools/dev-tool`

### Issues associated with this PR

- NA

### Describe the problem that is addressed by this PR

This PR changes the samples execution logic to run the published TypeScript samples instead of the samples in samples-dev. It runs these samples by actually _installing_ the SDK package (using a relative path) and building the TypeScript. I am hoping this will

- Fix the broken samples run step for ESM-migrated packages
- Make the samples running step a bit more thorough (i.e. we are now checking if the samples will run against something that is much closer to the published package).
