### PR TITLE
fix(playwrighttesting): suppress POST test result API failures to prevent node process from being terminated

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/constants.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/constants.ts
@@ -58,7 +58,7 @@ export class Constants {
   public static readonly TEST_TYPE = "WebTest";
   public static readonly TEST_SDK_LANGUAGE = "JAVASCRIPT";
   // Placeholder version
-  public static readonly REPORTER_PACKAGE_VERSION = "1.0.0-beta.2";
+  public static readonly REPORTER_PACKAGE_VERSION = "1.0.0-beta.3";
   public static readonly DEFAULT_DASHBOARD_ENDPOINT = "https://playwright.microsoft.com";
   public static readonly DEFAULT_SERVICE_ENDPOINT =
     "https://{region}.reporting.api.playwright-test.io";

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/serviceClient.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/serviceClient.ts
@@ -139,8 +139,6 @@ export class ServiceClient {
       return;
     }
     this.handleErrorResponse(response, Constants.postTestResults);
-
-    throw new Error(`Received status ${response.status} from service from POST TestResults call.`);
   }
 
   async createStorageUri(): Promise<StorageUri> {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/serviceClient.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/serviceClient.ts
@@ -12,6 +12,7 @@ import { TestRun } from "../model/testRun";
 import { CIInfo } from "./cIInfoProvider";
 import ReporterUtils from "./reporterUtils";
 import { PipelineResponse } from "@azure/core-rest-pipeline";
+import { reporterLogger } from "../common/logger";
 
 export class ServiceClient {
   private httpService: HttpService;
@@ -124,21 +125,25 @@ export class ServiceClient {
 
   // eslint-disable-next-line @azure/azure-sdk/ts-use-interface-parameters
   async postTestResults(testResults: TestResult[]): Promise<void> {
-    const payload: any = {
-      value: testResults,
-    };
-    const response: PipelineResponse = await this.httpService.callAPI(
-      "POST",
-      `${this.getServiceEndpoint()}/${Constants.testResultsEndpoint.replace("{workspaceId}", this.envVariables.accountId!)}?api-version=${Constants.API_VERSION}`,
-      JSON.stringify(payload),
-      this.envVariables.accessToken,
-      "application/json",
-      this.envVariables.correlationId!,
-    );
-    if (response.status === 200) {
-      return;
+    try {
+      const payload: any = {
+        value: testResults,
+      };
+      const response: PipelineResponse = await this.httpService.callAPI(
+        "POST",
+        `${this.getServiceEndpoint()}/${Constants.testResultsEndpoint.replace("{workspaceId}", this.envVariables.accountId!)}?api-version=${Constants.API_VERSION}`,
+        JSON.stringify(payload),
+        this.envVariables.accessToken,
+        "application/json",
+        this.envVariables.correlationId!,
+      );
+      if (response.status === 200) {
+        return;
+      }
+      this.handleErrorResponse(response, Constants.postTestResults);
+    } catch (error) {
+      reporterLogger.error(`Error occurred while posting test results: ${error}`);
     }
-    this.handleErrorResponse(response, Constants.postTestResults);
   }
 
   async createStorageUri(): Promise<StorageUri> {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

### Describe the problem that is addressed by this PR

Any API failure in post test result API call would terminate the node process immediately. This PR swallows the exception and allows the execution to proceed.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
