### PR TITLE
[identity] Use helper from core-util

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -113,7 +113,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-rest-pipeline": "^1.17.0",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/core-util": "^1.3.0",
+    "@azure/core-util": "^1.10.0",
     "@azure/logger": "^1.0.0",
     "@azure/msal-node": "^2.9.2",
     "@azure/msal-browser": "^3.14.0",

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsRetryPolicy.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/imdsRetryPolicy.ts
@@ -4,7 +4,7 @@
 import { PipelinePolicy, retryPolicy } from "@azure/core-rest-pipeline";
 
 import { MSIConfiguration } from "./models";
-import { getRandomIntegerInclusive } from "@azure/core-util";
+import { calculateRetryDelay } from "@azure/core-util";
 
 // Matches the default retry configuration in expontentialRetryStrategy.ts
 const DEFAULT_CLIENT_MAX_RETRY_INTERVAL = 1000 * 64;
@@ -27,21 +27,10 @@ export function imdsRetryPolicy(msiRetryConfig: MSIConfiguration["retryConfig"])
             return { skipStrategy: true };
           }
 
-          // Exponentially increase the delay each time
-          const exponentialDelay = msiRetryConfig.startDelayInMs * Math.pow(2, retryCount);
-
-          // Don't let the delay exceed the maximum
-          const clampedExponentialDelay = Math.min(
-            DEFAULT_CLIENT_MAX_RETRY_INTERVAL,
-            exponentialDelay,
-          );
-
-          // Allow the final value to have some "jitter" (within 50% of the delay size) so
-          // that retries across multiple clients don't occur simultaneously.
-          const retryAfterInMs =
-            clampedExponentialDelay / 2 + getRandomIntegerInclusive(0, clampedExponentialDelay / 2);
-
-          return { retryAfterInMs };
+          return calculateRetryDelay(retryCount, {
+            retryDelayInMs: msiRetryConfig.startDelayInMs,
+            maxRetryDelayInMs: DEFAULT_CLIENT_MAX_RETRY_INTERVAL,
+          });
         },
       },
     ],


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity 

### Issues associated with this PR

#30187

### Describe the problem that is addressed by this PR

Now that core-util is published with a `calculateRetryDelay` helper, we can use
that instead of duplicating the logic from core-rest-pipeline

### Are there test cases added in this PR? _(If not, why?)_

There's an existing test suite for this policy, and this should be considered a
pure refactor now
