### PR TITLE
[core] Use core-util's helper for exponential retry delay

### DIFF
--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -93,7 +93,7 @@
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-auth": "^1.8.0",
     "@azure/core-tracing": "^1.0.1",
-    "@azure/core-util": "^1.9.0",
+    "@azure/core-util": "^1.10.0",
     "@azure/logger": "^1.0.0",
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.0",

--- a/sdk/core/core-rest-pipeline/src/retryStrategies/exponentialRetryStrategy.ts
+++ b/sdk/core/core-rest-pipeline/src/retryStrategies/exponentialRetryStrategy.ts
@@ -3,7 +3,7 @@
 
 import type { PipelineResponse } from "../interfaces.js";
 import type { RestError } from "../restError.js";
-import { getRandomIntegerInclusive } from "@azure/core-util";
+import { calculateRetryDelay } from "@azure/core-util";
 import type { RetryStrategy } from "./retryStrategy.js";
 import { isThrottlingRetryResponse } from "./throttlingRetryStrategy.js";
 
@@ -45,8 +45,6 @@ export function exponentialRetryStrategy(
   const retryInterval = options.retryDelayInMs ?? DEFAULT_CLIENT_RETRY_INTERVAL;
   const maxRetryInterval = options.maxRetryDelayInMs ?? DEFAULT_CLIENT_MAX_RETRY_INTERVAL;
 
-  let retryAfterInMs = retryInterval;
-
   return {
     name: "exponentialRetryStrategy",
     retry({ retryCount, response, responseError }) {
@@ -65,15 +63,10 @@ export function exponentialRetryStrategy(
         return { errorToThrow: responseError };
       }
 
-      // Exponentially increase the delay each time
-      const exponentialDelay = retryAfterInMs * Math.pow(2, retryCount);
-      // Don't let the delay exceed the maximum
-      const clampedExponentialDelay = Math.min(maxRetryInterval, exponentialDelay);
-      // Allow the final value to have some "jitter" (within 50% of the delay size) so
-      // that retries across multiple clients don't occur simultaneously.
-      retryAfterInMs =
-        clampedExponentialDelay / 2 + getRandomIntegerInclusive(0, clampedExponentialDelay / 2);
-      return { retryAfterInMs };
+      return calculateRetryDelay(retryCount, {
+        retryDelayInMs: retryInterval,
+        maxRetryDelayInMs: maxRetryInterval,
+      });
     },
   };
 }

--- a/sdk/core/ts-http-runtime/src/retryStrategies/exponentialRetryStrategy.ts
+++ b/sdk/core/ts-http-runtime/src/retryStrategies/exponentialRetryStrategy.ts
@@ -3,7 +3,7 @@
 
 import { PipelineResponse } from "../interfaces.js";
 import { RestError } from "../restError.js";
-import { getRandomIntegerInclusive } from "../util/random.js";
+import { calculateRetryDelay } from "../util/delay.js";
 import { RetryStrategy } from "./retryStrategy.js";
 import { isThrottlingRetryResponse } from "./throttlingRetryStrategy.js";
 
@@ -45,8 +45,6 @@ export function exponentialRetryStrategy(
   const retryInterval = options.retryDelayInMs ?? DEFAULT_CLIENT_RETRY_INTERVAL;
   const maxRetryInterval = options.maxRetryDelayInMs ?? DEFAULT_CLIENT_MAX_RETRY_INTERVAL;
 
-  let retryAfterInMs = retryInterval;
-
   return {
     name: "exponentialRetryStrategy",
     retry({ retryCount, response, responseError }) {
@@ -65,15 +63,10 @@ export function exponentialRetryStrategy(
         return { errorToThrow: responseError };
       }
 
-      // Exponentially increase the delay each time
-      const exponentialDelay = retryAfterInMs * Math.pow(2, retryCount);
-      // Don't let the delay exceed the maximum
-      const clampedExponentialDelay = Math.min(maxRetryInterval, exponentialDelay);
-      // Allow the final value to have some "jitter" (within 50% of the delay size) so
-      // that retries across multiple clients don't occur simultaneously.
-      retryAfterInMs =
-        clampedExponentialDelay / 2 + getRandomIntegerInclusive(0, clampedExponentialDelay / 2);
-      return { retryAfterInMs };
+      return calculateRetryDelay(retryCount, {
+        retryDelayInMs: retryInterval,
+        maxRetryDelayInMs: maxRetryInterval,
+      });
     },
   };
 }


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-rest-pipeline

### Issues associated with this PR

#30187

### Describe the problem that is addressed by this PR

Now that core-util is published with a `calculateRetryDelay` helper, we can use
that instead of duplicating the logic from core-rest-pipeline

