### PR TITLE
fix(CosmosDB: http protocol endpoints no longer break CosmosClient

### DIFF
--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -82,7 +82,8 @@ async function httpRequest(
     pipelineRequest.agent = requestContext.requestAgent;
   } else {
     const parsedUrl = new URL(url);
-    pipelineRequest.agent = parsedUrl.protocol === "http" ? defaultHttpAgent : defaultHttpsAgent;
+    pipelineRequest.agent = parsedUrl.protocol === "http:" ? defaultHttpAgent : defaultHttpsAgent;
+    pipelineRequest.allowInsecureConnection = parsedUrl.protocol === "http:";
   }
 
   const startTimeUTCInMs = getCurrentTimestampInMs();
@@ -130,12 +131,12 @@ async function httpRequest(
     const errorResponse: ErrorResponse = new ErrorResponse(result.message);
     logger.warning(
       response.status +
-        " " +
-        requestContext.endpoint +
-        " " +
-        requestContext.path +
-        " " +
-        result.message,
+      " " +
+      requestContext.endpoint +
+      " " +
+      requestContext.path +
+      " " +
+      result.message,
     );
 
     errorResponse.code = response.status;

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -131,12 +131,12 @@ async function httpRequest(
     const errorResponse: ErrorResponse = new ErrorResponse(result.message);
     logger.warning(
       response.status +
-      " " +
-      requestContext.endpoint +
-      " " +
-      requestContext.path +
-      " " +
-      result.message,
+        " " +
+        requestContext.endpoint +
+        " " +
+        requestContext.path +
+        " " +
+        result.message,
     );
 
     errorResponse.code = response.status;

--- a/sdk/cosmosdb/cosmos/test/public/common/setup.ts
+++ b/sdk/cosmosdb/cosmos/test/public/common/setup.ts
@@ -14,6 +14,8 @@ process.on("unhandledRejection", (error: any) => {
     }
   }
   const nestedError = new Error("Unhandled exception found");
-  Object.defineProperty(nestedError, 'errors', { value: [error] })
-  console.error(util.formatWithOptions({ colors: true, compact: true, depth: 6 }, "%O", nestedError));
+  Object.defineProperty(nestedError, "errors", { value: [error] });
+  console.error(
+    util.formatWithOptions({ colors: true, compact: true, depth: 6 }, "%O", nestedError),
+  );
 });

--- a/sdk/cosmosdb/cosmos/test/public/common/setup.ts
+++ b/sdk/cosmosdb/cosmos/test/public/common/setup.ts
@@ -3,6 +3,7 @@
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require("source-map-support").install();
+import util from "util";
 
 process.on("unhandledRejection", (error: any) => {
   if (error.body) {
@@ -12,6 +13,7 @@ process.on("unhandledRejection", (error: any) => {
       /* NO OP */
     }
   }
-  console.error(new Error("Unhandled exception found"));
-  console.error(JSON.stringify(error, null, " "));
+  const nestedError = new Error("Unhandled exception found");
+  Object.defineProperty(nestedError, 'errors', { value: [error] })
+  console.error(util.formatWithOptions({ colors: true, compact: true, depth: 6 }, "%O", nestedError));
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#31119 

### Describe the problem that is addressed by this PR
1. "http:" protocol now works properly
2. Unhandled errors in tests now properly include stack trace in STDERR

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
We could possibly have done a further bifurcation of the logic for http: vs https:. I chose this design because it was a minimal change and maintains the original intent.

### Are there test cases added in this PR? _(If not, why?)_
No. There's not currently a good means to test http: against Cosmos DB, but that's a WIP.

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_ - N/A
- [ ] Added a changelog (if necessary) - N/A
