### PR TITLE
[Identity] Client assertion add token cache persistence

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for the field `refreshAfterTimestamp` in `AccessToken` [#30402](https://github.com/Azure/azure-sdk-for-js/pull/30402)
 - Added support for providing an object ID to `ManagedIdentityCredential`. [#30771](https://github.com/Azure/azure-sdk-for-js/pull/30771)
+- Added support for token cache persistence via the `CredentialTokenPersistence` options to the `ClientAssertionCredential`. [#31129](https://github.com/Azure/azure-sdk-for-js/pull/31129)
 
 ### Breaking Changes
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -177,7 +177,7 @@ export class ClientAssertionCredential implements TokenCredential {
 }
 
 // @public
-export interface ClientAssertionCredentialOptions extends MultiTenantTokenCredentialOptions, AuthorityValidationOptions {
+export interface ClientAssertionCredentialOptions extends MultiTenantTokenCredentialOptions, CredentialPersistenceOptions, AuthorityValidationOptions {
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/clientAssertionCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/clientAssertionCredentialOptions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { AuthorityValidationOptions } from "./authorityValidationOptions";
+import { CredentialPersistenceOptions } from "./credentialPersistenceOptions";
 import { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialOptions";
 
 /**
@@ -9,4 +10,5 @@ import { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialO
  */
 export interface ClientAssertionCredentialOptions
   extends MultiTenantTokenCredentialOptions,
+    CredentialPersistenceOptions,
     AuthorityValidationOptions {}


### PR DESCRIPTION
To have ClientAssertionCredentialOptions implement ISupportsTokenCachePersistenceOptions. As a consumer of Identity, Azure PowerShell is dependent on the Azure Identity library for .NET. Now the client assertion workflow has increasing usage, so the ask should have higher priority.

Business Impact:
In the client assertion auth flow, Azure PowerShell customers acquire the access token with the federated token. The access token must be used by the subsequent Azure PowerShell cmdlets. We depend on Azure.Identity to save the tokens to the MSAL cache. As the federated token has a short lifetime, it's impossible to cache the federated token and reauthenticate every time a cmdlet is run.