### PR TITLE
[identity] Support AZURE_AUTHORITY_HOST in cross cloud requests

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bugs Fixed
 
 - `ManagedIdentityCredential` now throws an error when attempting to pass a user-assigned Managed Identity in a CloudShell environment instead of silently ignoring it. [#30955](https://github.com/Azure/azure-sdk-for-js/pull/30955)
+- Fixed an issue where cross-tenant federation did not read the AZURE_AUTHORITY_HOST environment in all scenarios. [#31134](https://github.com/Azure/azure-sdk-for-js/pull/31134)
 
 ### Other Changes
 

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -11,6 +11,7 @@ import {
   defaultLoggerCallback,
   ensureValidMsalToken,
   getAuthority,
+  getAuthorityHost,
   getKnownAuthorities,
   getMSALLogLevel,
   handleMsalError,
@@ -269,10 +270,7 @@ export function generateMsalConfiguration(
   );
 
   // TODO: move and reuse getIdentityClientAuthorityHost
-  const authority = getAuthority(
-    resolvedTenant,
-    msalClientOptions.authorityHost ?? process.env.AZURE_AUTHORITY_HOST,
-  );
+  const authority = getAuthority(resolvedTenant, getAuthorityHost(msalClientOptions));
 
   const httpClient = new IdentityClient({
     ...msalClientOptions.tokenCredentialOptions,
@@ -478,7 +476,7 @@ To work with multiple accounts for the same Client ID and Tenant ID, please prov
    */
   function calculateRequestAuthority(options?: GetTokenOptions): string | undefined {
     if (options?.tenantId) {
-      return getAuthority(options.tenantId, createMsalClientOptions.authorityHost);
+      return getAuthority(options.tenantId, getAuthorityHost(createMsalClientOptions));
     }
     return state.msalConfig.auth.authority;
   }

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -57,9 +57,11 @@ export function ensureValidMsalToken(
 
 /**
  * Returns the authority host from either the options bag or the AZURE_AUTHORITY_HOST environment variable.
+ *
+ * Defaults to {@link DefaultAuthorityHost}.
  * @internal
  */
-export function getAuthorityHost(options?: { authorityHost?: string }): string | undefined {
+export function getAuthorityHost(options?: { authorityHost?: string }): string {
   let authorityHost = options?.authorityHost;
 
   if (!authorityHost && isNodeLike) {

--- a/sdk/identity/identity/src/msal/utils.ts
+++ b/sdk/identity/identity/src/msal/utils.ts
@@ -5,7 +5,7 @@ import { AuthenticationRecord, MsalAccountInfo, MsalToken, ValidMsalToken } from
 import { AuthenticationRequiredError, CredentialUnavailableError } from "../errors";
 import { CredentialLogger, credentialLogger, formatError } from "../util/logging";
 import { DefaultAuthorityHost, DefaultTenantId } from "../constants";
-import { randomUUID as coreRandomUUID, isNode } from "@azure/core-util";
+import { randomUUID as coreRandomUUID, isNode, isNodeLike } from "@azure/core-util";
 
 import { AbortError } from "@azure/abort-controller";
 import { AzureLogLevel } from "@azure/logger";
@@ -53,6 +53,20 @@ export function ensureValidMsalToken(
   if (!msalToken.accessToken) {
     throw error(`Response had no "accessToken" property.`);
   }
+}
+
+/**
+ * Returns the authority host from either the options bag or the AZURE_AUTHORITY_HOST environment variable.
+ * @internal
+ */
+export function getAuthorityHost(options?: { authorityHost?: string }): string | undefined {
+  let authorityHost = options?.authorityHost;
+
+  if (!authorityHost && isNodeLike) {
+    authorityHost = process.env.AZURE_AUTHORITY_HOST;
+  }
+
+  return authorityHost ?? DefaultAuthorityHost;
 }
 
 /**

--- a/sdk/identity/identity/test/internal/node/msalClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/msalClient.spec.ts
@@ -473,30 +473,58 @@ describe("MsalClient", function () {
       await assert.isRejected(request, AbortError);
     });
 
-    it("supports cross-tenant federation", async function (this: Context) {
-      const tenantIdOne = "tenantOne";
-      const tenantIdTwo = "tenantTwo";
-      const authorityHost = "https://custom.authority.com";
+    describe("cross-tenant federation", function () {
+      it("allows passing an authority host", async function (this: Context) {
+        const tenantIdOne = "tenantOne";
+        const tenantIdTwo = "tenantTwo";
+        const authorityHost = "https://custom.authority.com";
 
-      const expectedAuthority = `${authorityHost}/${tenantIdTwo}`;
+        const expectedAuthority = `${authorityHost}/${tenantIdTwo}`;
 
-      const clientCredentialAuthStub = sinon
-        .stub(PublicClientApplication.prototype, "acquireTokenByDeviceCode")
-        .resolves({
-          accessToken: "token",
-          expiresOn: new Date(Date.now() + 3600 * 1000),
-        } as AuthenticationResult);
+        const clientCredentialAuthStub = sinon
+          .stub(PublicClientApplication.prototype, "acquireTokenByDeviceCode")
+          .resolves({
+            accessToken: "token",
+            expiresOn: new Date(Date.now() + 3600 * 1000),
+          } as AuthenticationResult);
 
-      const client = msalClient.createMsalClient(clientId, tenantIdOne, {
-        authorityHost,
+        const client = msalClient.createMsalClient(clientId, tenantIdOne, {
+          authorityHost,
+        });
+
+        const scopes = ["https://vault.azure.net/.default"];
+
+        await client.getTokenByDeviceCode(scopes, deviceCodeCallback, { tenantId: tenantIdTwo });
+
+        const { authority: requestAuthority } = clientCredentialAuthStub.firstCall.firstArg;
+        assert.equal(requestAuthority, expectedAuthority);
       });
 
-      const scopes = ["https://vault.azure.net/.default"];
+      it("allows using the AZURE_AUTHORITY_HOST environment variable", async function (this: Context) {
+        const tenantIdOne = "tenantOne";
+        const tenantIdTwo = "tenantTwo";
+        const authorityHost = "https://custom.authority.com";
 
-      await client.getTokenByDeviceCode(scopes, deviceCodeCallback, { tenantId: tenantIdTwo });
+        const expectedAuthority = `${authorityHost}/${tenantIdTwo}`;
 
-      const { authority: requestAuthority } = clientCredentialAuthStub.firstCall.firstArg;
-      assert.equal(requestAuthority, expectedAuthority);
+        sinon.stub(process, "env").value({ AZURE_AUTHORITY_HOST: authorityHost });
+
+        const clientCredentialAuthStub = sinon
+          .stub(PublicClientApplication.prototype, "acquireTokenByDeviceCode")
+          .resolves({
+            accessToken: "token",
+            expiresOn: new Date(Date.now() + 3600 * 1000),
+          } as AuthenticationResult);
+
+        const client = msalClient.createMsalClient(clientId, tenantIdOne);
+
+        const scopes = ["https://vault.azure.net/.default"];
+
+        await client.getTokenByDeviceCode(scopes, deviceCodeCallback, { tenantId: tenantIdTwo });
+
+        const { authority: requestAuthority } = clientCredentialAuthStub.firstCall.firstArg;
+        assert.equal(requestAuthority, expectedAuthority);
+      });
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

#30557

### Describe the problem that is addressed by this PR

Looks like we missed one place where we need to read the AZURE_AUTHORITY_HOST
env var when porting logic over to msalClient. This PR addresses the issue and
allows for environment variable to be read when needed.


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
