### PR TITLE
[tracing] Add support for addEvent

### DIFF
--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for attaching events to a span. [#31162](https://github.com/Azure/azure-sdk-for-js/pull/31162)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -5,6 +5,12 @@
 ```ts
 
 // @public
+export interface AddEventOptions {
+    attributes?: Record<string, unknown>;
+    startTime?: Date;
+}
+
+// @public
 export function createTracingClient(options: TracingClientOptions): TracingClient;
 
 // @public
@@ -90,7 +96,7 @@ export interface TracingContext {
 
 // @public
 export interface TracingSpan {
-    addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
+    addEvent?(name: string, options?: AddEventOptions): void;
     end(): void;
     isRecording(): boolean;
     recordException(exception: Error | string): void;

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -90,6 +90,7 @@ export interface TracingContext {
 
 // @public
 export interface TracingSpan {
+    addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
     end(): void;
     isRecording(): boolean;
     recordException(exception: Error | string): void;

--- a/sdk/core/core-tracing/src/index.ts
+++ b/sdk/core/core-tracing/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 export {
+  AddEventOptions,
   Instrumenter,
   InstrumenterSpanOptions,
   OperationTracingOptions,

--- a/sdk/core/core-tracing/src/instrumenter.ts
+++ b/sdk/core/core-tracing/src/instrumenter.ts
@@ -26,6 +26,9 @@ export function createDefaultTracingSpan(): TracingSpan {
     setStatus: () => {
       // noop
     },
+    addEvent: () => {
+      // noop
+    },
   };
 }
 

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -209,6 +209,20 @@ export type SpanStatusError = { status: "error"; error?: Error | string };
 export type SpanStatus = SpanStatusSuccess | SpanStatusError;
 
 /**
+ * Represents options you can pass to {@link TracingSpan.addEvent}.
+ */
+export interface AddEventOptions {
+  /**
+   * A set of attributes to attach to the event.
+   */
+  attributes?: Record<string, unknown>;
+  /**
+   * The start time of the event.
+   */
+  startTime?: Date;
+}
+
+/**
  * Represents an implementation agnostic tracing span.
  */
 export interface TracingSpan {
@@ -252,7 +266,7 @@ export interface TracingSpan {
   /**
    * Adds an event to the span.
    */
-  addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
+  addEvent?(name: string, options?: AddEventOptions): void;
 }
 
 /** An immutable context bag of tracing values for the current operation. */

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -248,6 +248,11 @@ export interface TracingSpan {
    * Depending on the span implementation, this may return false if the span is not being sampled.
    */
   isRecording(): boolean;
+
+  /**
+   * Adds an event to the span.
+   */
+  addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
 }
 
 /** An immutable context bag of tracing values for the current operation. */

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -72,6 +72,7 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
+      span.addEvent?.("I said span not Spren!");
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -72,7 +72,7 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
-      span.addEvent?.("I said span not Spren!");
+      span.addEvent!("I said span not Spren!");
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -72,7 +72,8 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
-      span.addEvent!("I said span not Spren!", { startTime: new Date() });
+      assert.exists(span.addEvent);
+      span.addEvent?.("I said span not Spren!", { startTime: new Date() });
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/core/core-tracing/test/instrumenter.spec.ts
+++ b/sdk/core/core-tracing/test/instrumenter.spec.ts
@@ -72,7 +72,7 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
-      span.addEvent!("I said span not Spren!");
+      span.addEvent!("I said span not Spren!", { startTime: new Date() });
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -43,6 +43,12 @@ export interface AddCredentialPipelinePolicyOptions {
 }
 
 // @public
+export interface AddEventOptions {
+    attributes?: Record<string, unknown>;
+    startTime?: Date;
+}
+
+// @public
 export interface AdditionalPolicyConfig {
     policy: PipelinePolicy;
     position: "perCall" | "perRetry";
@@ -789,7 +795,7 @@ export interface TracingPolicyOptions {
 
 // @public
 export interface TracingSpan {
-    addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
+    addEvent?(name: string, options?: AddEventOptions): void;
     end(): void;
     isRecording(): boolean;
     recordException(exception: Error | string): void;

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -789,6 +789,7 @@ export interface TracingPolicyOptions {
 
 // @public
 export interface TracingSpan {
+    addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
     end(): void;
     isRecording(): boolean;
     recordException(exception: Error | string): void;

--- a/sdk/core/ts-http-runtime/src/index.ts
+++ b/sdk/core/ts-http-runtime/src/index.ts
@@ -88,6 +88,7 @@ export { AbortError } from "./abort-controller/AbortError.js";
 export { AccessToken, GetTokenOptions, TokenCredential } from "./auth/tokenCredential.js";
 export { KeyCredential, isKeyCredential } from "./auth/keyCredential.js";
 export {
+  AddEventOptions,
   Instrumenter,
   InstrumenterSpanOptions,
   OperationTracingOptions,

--- a/sdk/core/ts-http-runtime/src/tracing/instrumenter.ts
+++ b/sdk/core/ts-http-runtime/src/tracing/instrumenter.ts
@@ -24,6 +24,9 @@ export function createDefaultTracingSpan(): TracingSpan {
     setStatus: () => {
       // noop
     },
+    addEvent: () => {
+      // noop
+    },
   };
 }
 

--- a/sdk/core/ts-http-runtime/src/tracing/interfaces.ts
+++ b/sdk/core/ts-http-runtime/src/tracing/interfaces.ts
@@ -209,6 +209,20 @@ export type SpanStatusError = { status: "error"; error?: Error | string };
 export type SpanStatus = SpanStatusSuccess | SpanStatusError;
 
 /**
+ * Represents options you can pass to {@link TracingSpan.addEvent}.
+ */
+export interface AddEventOptions {
+  /**
+   * A set of attributes to attach to the event.
+   */
+  attributes?: Record<string, unknown>;
+  /**
+   * The start time of the event.
+   */
+  startTime?: Date;
+}
+
+/**
  * Represents an implementation agnostic tracing span.
  */
 export interface TracingSpan {
@@ -252,7 +266,7 @@ export interface TracingSpan {
   /**
    * Adds an event to the span.
    */
-  addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
+  addEvent?(name: string, options?: AddEventOptions): void;
 }
 
 /** An immutable context bag of tracing values for the current operation. */

--- a/sdk/core/ts-http-runtime/src/tracing/interfaces.ts
+++ b/sdk/core/ts-http-runtime/src/tracing/interfaces.ts
@@ -248,6 +248,11 @@ export interface TracingSpan {
    * Depending on the span implementation, this may return false if the span is not being sampled.
    */
   isRecording(): boolean;
+
+  /**
+   * Adds an event to the span.
+   */
+  addEvent?(name: string, attributes?: Record<string, unknown>, startTime?: Date): void;
 }
 
 /** An immutable context bag of tracing values for the current operation. */

--- a/sdk/core/ts-http-runtime/test/tracing/instrumenter.spec.ts
+++ b/sdk/core/ts-http-runtime/test/tracing/instrumenter.spec.ts
@@ -72,6 +72,7 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
+      span.addEvent!("I said Span not Spren!");
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/core/ts-http-runtime/test/tracing/instrumenter.spec.ts
+++ b/sdk/core/ts-http-runtime/test/tracing/instrumenter.spec.ts
@@ -72,7 +72,7 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
-      span.addEvent!("I said Span not Spren!");
+      span.addEvent!("I said Span not Spren!", { attributes: { foo: "Bar" } });
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/core/ts-http-runtime/test/tracing/instrumenter.spec.ts
+++ b/sdk/core/ts-http-runtime/test/tracing/instrumenter.spec.ts
@@ -72,7 +72,8 @@ describe("Instrumenter", () => {
       span.setStatus({ status: "success" });
       span.setAttribute("foo", "bar");
       span.recordException(new Error("test"));
-      span.addEvent!("I said Span not Spren!", { attributes: { foo: "Bar" } });
+      assert.exists(span.addEvent);
+      span.addEvent?.("I said Span not Spren!", { attributes: { foo: "Bar" } });
       span.end();
       assert.isFalse(span.isRecording());
     });

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for attaching events to a span. [#31162](https://github.com/Azure/azure-sdk-for-js/pull/31162)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -68,7 +68,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-tracing": "^1.0.0",
+    "@azure/core-tracing": "^1.1.3",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.26.0",

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Span, SpanStatusCode } from "@opentelemetry/api";
-import { SpanStatus, TracingSpan } from "@azure/core-tracing";
+import { SpanStatus, TracingSpan, AddEventOptions } from "@azure/core-tracing";
 import { isAttributeValue, sanitizeAttributes } from "@opentelemetry/core";
 
 export class OpenTelemetrySpanWrapper implements TracingSpan {
@@ -43,8 +43,8 @@ export class OpenTelemetrySpanWrapper implements TracingSpan {
     return this._span.isRecording();
   }
 
-  addEvent(name: string, attributes: Record<string, unknown> = {}, startTime?: Date): void {
-    this._span.addEvent(name, sanitizeAttributes(attributes), startTime);
+  addEvent(name: string, options: AddEventOptions = {}): void {
+    this._span.addEvent(name, sanitizeAttributes(options.attributes), options.startTime);
   }
 
   /**

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Span, AttributeValue, SpanStatusCode } from "@opentelemetry/api";
+import { Span, SpanStatusCode } from "@opentelemetry/api";
 import { SpanStatus, TracingSpan } from "@azure/core-tracing";
-import { toOpenTelemetrySpanAttributes } from "./transformations";
+import { isAttributeValue, sanitizeAttributes } from "@opentelemetry/core";
 
 export class OpenTelemetrySpanWrapper implements TracingSpan {
   private _span: Span;
@@ -26,8 +26,8 @@ export class OpenTelemetrySpanWrapper implements TracingSpan {
   }
 
   setAttribute(name: string, value: unknown): void {
-    if (value !== null && value !== undefined) {
-      this._span.setAttribute(name, value as AttributeValue);
+    if (value !== null && value !== undefined && isAttributeValue(value)) {
+      this._span.setAttribute(name, value);
     }
   }
 
@@ -43,8 +43,8 @@ export class OpenTelemetrySpanWrapper implements TracingSpan {
     return this._span.isRecording();
   }
 
-  addEvent(name: string, attributes?: Record<string, unknown>, startTime?: Date): void {
-    this._span.addEvent(name, toOpenTelemetrySpanAttributes(attributes), startTime);
+  addEvent(name: string, attributes: Record<string, unknown> = {}, startTime?: Date): void {
+    this._span.addEvent(name, sanitizeAttributes(attributes), startTime);
   }
 
   /**

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/src/spanWrapper.ts
@@ -3,6 +3,7 @@
 
 import { Span, AttributeValue, SpanStatusCode } from "@opentelemetry/api";
 import { SpanStatus, TracingSpan } from "@azure/core-tracing";
+import { toOpenTelemetrySpanAttributes } from "./transformations";
 
 export class OpenTelemetrySpanWrapper implements TracingSpan {
   private _span: Span;
@@ -40,6 +41,10 @@ export class OpenTelemetrySpanWrapper implements TracingSpan {
 
   isRecording(): boolean {
     return this._span.isRecording();
+  }
+
+  addEvent(name: string, attributes?: Record<string, unknown>, startTime?: Date): void {
+    this._span.addEvent(name, toOpenTelemetrySpanAttributes(attributes), startTime);
   }
 
   /**

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
@@ -71,7 +71,10 @@ describe("OpenTelemetrySpanWrapper", () => {
 
   describe("#addEvent", () => {
     it("records events on the span", () => {
-      span.addEvent("test", { key: "value" }, new Date(2024, 1, 1));
+      span.addEvent("test", {
+        startTime: new Date(2024, 1, 1),
+        attributes: { key: "value" },
+      });
 
       const otSpan = getExportedSpan(span);
       assert.lengthOf(otSpan.events, 1);
@@ -85,7 +88,9 @@ describe("OpenTelemetrySpanWrapper", () => {
     });
 
     it("drops invalid attributes", () => {
-      span.addEvent("test", { key: { key1: 5 } }); // objects are not valid per the spec
+      span.addEvent("test", {
+        attributes: { key: { key1: 5 } }, // objects are not valid per the spec
+      });
 
       const otSpan = getExportedSpan(span);
       assert.lengthOf(otSpan.events, 1);

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
@@ -69,6 +69,31 @@ describe("OpenTelemetrySpanWrapper", () => {
     });
   });
 
+  describe("#addEvent", () => {
+    it("records events on the span", () => {
+      span.addEvent("test", { key: "value" }, new Date(2024, 1, 1));
+
+      const otSpan = getExportedSpan(span);
+      assert.lengthOf(otSpan.events, 1);
+      const event = otSpan.events[0];
+      assert.equal(event.name, "test");
+      assert.deepEqual(event.attributes, { key: "value" });
+      assert.equal(
+        event.time[0],
+        new Date(2024, 1, 1).getTime() / 1000 /** Millseconds to seconds */,
+      );
+    });
+
+    it("drops invalid attributes", () => {
+      span.addEvent("test", { key: { key1: 5 } }); // objects are not valid
+
+      const otSpan = getExportedSpan(span);
+      assert.lengthOf(otSpan.events, 1);
+      const event = otSpan.events[0];
+      assert.deepEqual(event.attributes, {});
+    });
+  });
+
   describe("#recordException", () => {
     it("sets the error on the wrapped span", () => {
       const error = new Error("test");

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/spanWrapper.spec.ts
@@ -85,7 +85,7 @@ describe("OpenTelemetrySpanWrapper", () => {
     });
 
     it("drops invalid attributes", () => {
-      span.addEvent("test", { key: { key1: 5 } }); // objects are not valid
+      span.addEvent("test", { key: { key1: 5 } }); // objects are not valid per the spec
 
       const otSpan = getExportedSpan(span);
       assert.lengthOf(otSpan.events, 1);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-tracing
@azure/opentelemetry-instrumentation-azure-sdk
@typespec/ts-http-runtime

### Issues associated with this PR

Resolves #31158

### Describe the problem that is addressed by this PR

OpenTelemetry supports adding events to a span, and part of the gen-ai
specification expects events to be added on a span. 

This PR adds support for the `addEvent` API in our core-tracing library as well
as our otel-sdk.

Adding a required field is a breaking change, so this is added as optional. The
implementation will need to use the safe-navigation operator syntax or check for
the function's existence before calling it.

In passing, I am updating some of our internal transformations to use OTel's APIs instead.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added a changelog (if necessary).
- [x] Unbranded core 