### PR TITLE
Modify existing azure pipelines credential test to see if invalid system access token test fails as expected

### DIFF
--- a/sdk/identity/identity/test/public/node/azurePipelinesCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/azurePipelinesCredential.spec.ts
@@ -87,4 +87,19 @@ describe("AzurePipelinesCredential", function () {
     );
     await assert.isRejected(credential.getToken(scope), /Status code: 302/);
   });
+
+  it("fails with with invalid system access token, redirect?", async function () {
+    if (!isLiveMode()) {
+      this.skip();
+    }
+    const clientId = process.env.AZURE_SERVICE_CONNECTION_CLIENT_ID!;
+    const existingServiceConnectionId = process.env.AZURE_SERVICE_CONNECTION_ID!;
+    const credential = new AzurePipelinesCredential(
+      tenantId,
+      clientId,
+      existingServiceConnectionId,
+      "systemAccessToken",
+    );
+    await assert.isRejected(credential.getToken(scope), /Status code: 203/);
+  });
 });


### PR DESCRIPTION
Investigating a similar test to https://github.com/Azure/azure-sdk-for-cpp/pull/5875