### PR TITLE
[Dev-Tool] Update the build-test command to check for browser files

### DIFF
--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -65,7 +65,8 @@ export default leafCommand(commandInfo, async (options) => {
   // Build the overrides - hard code to browser for now
   const overrides = new Map<string, OverrideSet>();
   overrides.set("esm", new OverrideSet("esm", "browser"));
-  const sources = new Set(getSources());
+  // Check for browser specific file under "src" and "test"
+  const sources = new Set([...getSources(), ...getSources("test")]);
   for (const file of sources) {
     for (const override of overrides.values()) {
       override.addOverride(file, sources);


### PR DESCRIPTION
### Describe the problem that is addressed by this PR
The current overrides for the browser specific files only replace them if they are under "src" directory. This PR adds the "test" directory for test coverage