### PR TITLE
[OpenAI] Fix browser tests

### DIFF
--- a/sdk/openai/openai/test/public/completions.spec.ts
+++ b/sdk/openai/openai/test/public/completions.spec.ts
@@ -21,8 +21,8 @@ import {
   withDeployments,
 } from "./utils/utils.js";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
-import "@azure/openai/types";
 import { functionCallModelsToSkip } from "./utils/models.js";
+import "../../src/types/index.js";
 
 describe("Completions", function () {
   let deployments: DeploymentInfo[] = [];

--- a/sdk/openai/openai/tsconfig.browser.config.json
+++ b/sdk/openai/openai/tsconfig.browser.config.json
@@ -1,9 +1,10 @@
 {
   "extends": "./.tshy/build.json",
-  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts"],
+  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.ts", "./test/**/*.mts"],
   "exclude": ["./test/**/node/**/*.ts"],
   "compilerOptions": {
     "outDir": "./dist-test/browser",
+    "lib": ["DOM"],
     "rootDir": ".",
     "skipLibCheck": true
   }

--- a/sdk/openai/openai/vitest.browser.config.ts
+++ b/sdk/openai/openai/vitest.browser.config.ts
@@ -8,9 +8,6 @@ import viteConfig from "../../../vitest.browser.shared.config.ts";
 export default mergeConfig(
   viteConfig,
   defineConfig({
-    optimizeDeps: {
-      include: ["@azure/openai", "@azure/openai/types"],
-    },
     test: {
       testTimeout: 170000,
       hookTimeout: 25000,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR

The browser test files were not being built correctly because of two things:
- The mts files in the test folder were not being built by TypeScript
- vitest couldn't resolve `@azure/openai/types` import


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This PR fixes the two issues by adding the mts files under the test folder to TypeScript context and rewrites the import to `@azure/openai/types` to the relative path instead.

### Are there test cases added in this PR? _(If not, why?)_

N/A

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
