### PR TITLE
Enable publishing for packages previously excluded from Docs MS

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -68,5 +68,3 @@ extends:
         safeName: azurecoresse
       - name: typespec-ts-http-runtime
         safeName: typespectshttpruntime
-        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
-        skipPublishDocMs: true

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -30,11 +30,7 @@ extends:
         safeName: azureidentity
       - name: azure-identity-cache-persistence
         safeName: azureidentitycachepersistence
-        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
-        skipPublishDocMs: true
       - name: azure-identity-broker
         safeName: azureidentitybroker
       - name: azure-identity-vscode
         safeName: azureidentityvscode
-        # TODO: Remove when REX validation tool is integrated: https://github.com/Azure/azure-sdk-for-js/issues/26770
-        skipPublishDocMs: true

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -34,3 +34,4 @@ extends:
         safeName: azureidentitybroker
       - name: azure-identity-vscode
         safeName: azureidentityvscode
+        skipPublishDocMs: true


### PR DESCRIPTION
Fixes #26770 

I have tested and validated that these packages will work with the new `type2docfx` docs build system and this PR enables docs.ms publishing. 

@xirzec -- When searching through `ci.yml` files I noticed two places where we intentionally skip publishing docs on docs.ms: 

* https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/communication/ci.yml#L64-L69
* https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/ci.yml#L32-L49

In both of these instances these are `@azure-tools/___` packages. I left these untouched. Should docs be published for these on docs.microsoft.com whenever they release? 