### PR TITLE
[dev-tool] only process api.json files if they are generated

### DIFF
--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -214,15 +214,18 @@ export default leafCommand(commandInfo, async () => {
     // normal extraction
     succeed = extractApi(extractorConfigObject, apiExtractorJsonPath, packageJsonPath);
   }
-  const reportTempDir = path.join(projectInfo.path, "temp");
-  const unscopedPackageName = projectInfo.name.split("/")[1];
 
-  await buildMergedApiJson(
-    unscopedPackageName,
-    reportTempDir,
-    exports,
-    packageJson["dependencies"],
-  );
+  if (extractorConfigObject.docModel?.enabled) {
+    const reportTempDir = path.join(projectInfo.path, "temp");
+    const unscopedPackageName = projectInfo.name.split("/")[1];
+
+    await buildMergedApiJson(
+      unscopedPackageName,
+      reportTempDir,
+      exports,
+      packageJson["dependencies"],
+    );
+  }
 
   return succeed;
 });


### PR DESCRIPTION
This PR fixes an error in extra-api command when a package doesn't enable the docModel generation, we were trying to open an api.md file that doesn't exists.
