### PR TITLE
Update Key Vault CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -156,10 +156,10 @@
 /sdk/iot/ @xirzec
 
 # PRLabel: %KeyVault
-/sdk/keyvault/ @timovv @maorleger @Azure/azsdk-keyvault
+/sdk/keyvault/ @maorleger @timovv
 
 # ServiceLabel: %KeyVault
-# AzureSdkOwners:  @timovv @maorleger
+# AzureSdkOwners:  @maorleger @timovv
 
 # PRLabel: %OpenTelemetryInstrumentation
 /sdk/instrumentation/ @maorleger @mpodwysocki


### PR DESCRIPTION
- Remove zombie `@Azure/azsdk-keyvault` team
- Maor to primary Key Vault owner