### PR TITLE
[dev-tool] Generate detailed report for ESM migrations

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/list/esm-migrations.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/esm-migrations.ts
@@ -4,6 +4,7 @@
 import { leafCommand, makeCommandInfo } from "../../../framework/command";
 import { readFile, writeFile } from "node:fs/promises";
 import { resolveRoot } from "../../../util/resolveProject";
+import os from "node:os";
 import path from "node:path";
 import stripJsonComments from "strip-json-comments";
 
@@ -123,6 +124,7 @@ function setMigrationResult(
 
 function echoMigrationResult(category: string, result: MigrationResult, verbose: boolean): void {
   console.log(`## Category: ${category}`);
+  console.log();
   console.log(`- Total projects: ${result.totalProjects}`);
   console.log(`- Total CJS: ${result.totalCjs}`);
   console.log(`- Total ESM: ${result.totalEsm}`);
@@ -142,7 +144,7 @@ function echoMigrationResult(category: string, result: MigrationResult, verbose:
 }
 
 function generateDetailedReport(category: string, result: MigrationResult): void {
-  const header = `\n| Package Name | Project Folder | Type | Migrated to ESM |`;
+  const header = `${os.EOL}| Package Name | Project Folder | Type | Migrated to ESM |`;
   const separator = `| --- | --- | --- | --- |`;
 
   console.log(header);
@@ -156,8 +158,6 @@ function generateDetailedReport(category: string, result: MigrationResult): void
   for (const [packageName, projectFolder, migrated] of allEntries) {
     console.log(`| ${packageName} | ${projectFolder} | ${category} | ${migrated} |`);
   }
-
-  console.log();
 }
 
 export default leafCommand(commandInfo, async ({ output, verbose }) => {
@@ -206,16 +206,17 @@ export default leafCommand(commandInfo, async ({ output, verbose }) => {
     await writeFile(outputPath, JSON.stringify(results, null, 2));
   }
 
+  console.log(`# Migration report${os.EOL}`);
   echoMigrationResult("core", results.core, verbose);
-  console.log(`\n---------------------------------\n`);
+  console.log(`${os.EOL}---------------------------------${os.EOL}`);
   echoMigrationResult("management", results.management, verbose);
-  console.log(`\n---------------------------------\n`);
+  console.log(`${os.EOL}---------------------------------${os.EOL}`);
   echoMigrationResult("client", results.client, verbose);
-  console.log(`\n---------------------------------\n`);
+  console.log(`${os.EOL}---------------------------------${os.EOL}`);
   echoMigrationResult("utility", results.utility, verbose);
-  console.log(`\n---------------------------------\n`);
+  console.log(`${os.EOL}---------------------------------${os.EOL}`);
   echoMigrationResult("test", results.test, verbose);
-  console.log(`\n---------------------------------\n`);
+  console.log(`${os.EOL}---------------------------------${os.EOL}`);
 
   return true;
 });

--- a/common/tools/dev-tool/src/commands/admin/list/esm-migrations.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/esm-migrations.ts
@@ -17,7 +17,7 @@ export const commandInfo = makeCommandInfo(
       shortName: "o",
     },
     verbose: {
-      description: "the format of the output",
+      description: "generate a detailed report by package",
       kind: "boolean",
       default: false,
     },
@@ -142,23 +142,21 @@ function echoMigrationResult(category: string, result: MigrationResult, verbose:
 }
 
 function generateDetailedReport(category: string, result: MigrationResult): void {
-  console.log("## Detailed Report:");
-  const header = `| Package Name | Project Folder | Type | Migrated |`;
+  const header = `\n| Package Name | Project Folder | Type | Migrated to ESM |`;
   const separator = `| --- | --- | --- | --- |`;
 
   console.log(header);
   console.log(separator);
 
-  const allEntries = [...Object.entries(result.esm).map(f => [...f, "✅"]), ...Object.entries(result.cjs).map(f => [...f, "❌"])].sort((a, b) => )
+  const allEntries = [
+    ...Object.entries(result.esm).map((f) => [...f, "✅"]),
+    ...Object.entries(result.cjs).map((f) => [...f, "❌"]),
+  ].sort((a, b) => a[0].localeCompare(b[0]));
 
-
-
-  for (const [packageName, projectFolder] of Object.entries(result.esm)) {
-    console.log(`| ${packageName} | ${projectFolder} | ${category} | ✅ |`);
+  for (const [packageName, projectFolder, migrated] of allEntries) {
+    console.log(`| ${packageName} | ${projectFolder} | ${category} | ${migrated} |`);
   }
-  for (const [packageName, projectFolder] of Object.entries(result.cjs)) {
-    console.log(`| ${packageName} | ${projectFolder} | ${category} | ❌ |`);
-  }
+
   console.log();
 }
 


### PR DESCRIPTION
### Packages impacted by this PR

dev-tool

### Issues associated with this PR

### Describe the problem that is addressed by this PR

A few QoL additions as we aim to complete the ESM migration:

- output markdown
- Add verbose mode to output individual package status

I only focused on ESM migration as we plan to migrate ESM + Vitest in a single
commit. This all builds off of the work Matt started and allows us to keep an up-to-date 
wiki for folks to follow the migration status
