### PR TITLE
[ai] Update core-tracing min-version

### DIFF
--- a/sdk/ai/ai-inference-rest/package.json
+++ b/sdk/ai/ai-inference-rest/package.json
@@ -82,7 +82,7 @@
     "@azure/core-auth": "^1.7.2",
     "@azure/core-lro": "^2.6.0",
     "@azure/core-rest-pipeline": "^1.14.0",
-    "@azure/core-tracing": "^1.1.3",
+    "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.6.2"
   },


### PR DESCRIPTION
### Packages impacted by this PR

@azure-rest/ai-inference

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

`@azure/core-tracing` will release as 1.2.0 as per https://github.com/Azure/azure-sdk-for-js/pull/31272/files

This PR prepares ai-inference to use the correct version of `@azure/core-tracing` and get support for `addEvent`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
