### PR TITLE
Pin API view parser version

### DIFF
--- a/eng/scripts/Generate-APIView-CodeFile.ps1
+++ b/eng/scripts/Generate-APIView-CodeFile.ps1
@@ -11,7 +11,7 @@ if (!(Test-Path -Path $ArtifactPath))
   exit 1
 }
 
-$apiviewParser = "@azure-tools/ts-genapi@latest"
+$apiviewParser = "@azure-tools/ts-genapi@1.0.7"
 # Find and install dependencies from public npm registry
 $deps = npm view $apiviewParser --registry $NpmDevopsFeedRegistry dependencies
 if ($deps)


### PR DESCRIPTION
Pin API view parser version to avoid causing build failures when a new API view parser version is released. This change is required before JS API view is migrated to new model.