### PR TITLE
[instrumentation] Fix test assertion

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/instrumenter.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/public/instrumenter.spec.ts
@@ -20,26 +20,32 @@ describe("OpenTelemetryInstrumenter", () => {
 
   describe("#createRequestHeaders", () => {
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
 
-    // TODO: Investigate mocking of propagator
-    it.skip("uses the passed in context if it exists", () => {
-      const propagationSpy = vi.mocked(propagator);
+    it("uses the passed in context if it exists", () => {
+      const propagationSpy = vi.spyOn(propagator, "inject");
       const span = trace.getTracer("test").startSpan("test");
       const tracingContext = trace.setSpan(context.active(), span);
       instrumenter.createRequestHeaders(tracingContext);
 
-      expect(propagationSpy.inject).toHaveBeenCalledWith(tracingContext);
+      expect(propagationSpy).toHaveBeenCalledWith(
+        tracingContext,
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
-    // TODO: Investigate mocking of propagator
-    it.skip("uses the active context if no context was provided", () => {
-      const propagationSpy = vi.mocked(propagator);
+    it("uses the active context if no context was provided", () => {
+      const propagationSpy = vi.spyOn(propagator, "inject");
       instrumenter.createRequestHeaders();
       const activeContext = context.active();
 
-      expect(propagationSpy.inject).toHaveBeenCalledWith(activeContext);
+      expect(propagationSpy).toHaveBeenCalledWith(
+        activeContext,
+        expect.anything(),
+        expect.anything(),
+      );
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/opentelemetry-instrumentation-azure-sdk

### Issues associated with this PR

Resolves #31287

### Describe the problem that is addressed by this PR

Looks like Sinon's matchers are a little looser than vitest's - while we are
calling inject with 3 arguments we only care about the first in this test.

This PR restores the tests and updates the assertion

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
