### PR TITLE
[template] Skip flaky test in Mac OS

### DIFF
--- a/sdk/template/template/test/public/configurationClient.spec.ts
+++ b/sdk/template/template/test/public/configurationClient.spec.ts
@@ -76,19 +76,23 @@ describe("[AAD] ConfigurationClient functional tests", function () {
   });
 
   describe("#getConfigurationSetting", () => {
-    it("predetermined setting has expected value", async () => {
-      const key = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_KEY");
-      const expectedValue = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_EXPECTED_VALUE");
+    // TODO: This test is skipped on macOS pending investigation (see https://github.com/Azure/azure-sdk-for-js/issues/31296)
+    it.skipIf(typeof process !== "undefined" && process.platform === "darwin")(
+      "predetermined setting has expected value",
+      async () => {
+        const key = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_KEY");
+        const expectedValue = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_EXPECTED_VALUE");
 
-      const setting = await client.getConfigurationSetting(key);
+        const setting = await client.getConfigurationSetting(key);
 
-      // Make sure the key returned is the same as the key we asked for
-      assert.equal(key, setting.key);
+        // Make sure the key returned is the same as the key we asked for
+        assert.equal(key, setting.key);
 
-      // Make sure the value of the setting is the same as the value we entered
-      // on the environment
-      assert.equal(expectedValue, setting.value);
-    });
+        // Make sure the value of the setting is the same as the value we entered
+        // on the environment
+        assert.equal(expectedValue, setting.value);
+      },
+    );
 
     // TODO: Waiting on https://github.com/Azure/azure-sdk-for-js/issues/29287
     // The supportsTracing assertion from chaiAzure can be used to verify that


### PR DESCRIPTION
One of the template tests has been flaky on Mac OS. Given that template is run as part of core and likely most PRs we decided to pend the test for now and investigate it as part of #31296 