### PR TITLE
[template] Add role assignment to test-resources.bicep

### DIFF
--- a/sdk/template/test-resources.bicep
+++ b/sdk/template/test-resources.bicep
@@ -1,7 +1,9 @@
 param baseName string = resourceGroup().name
 param sku string = 'Standard'
 param uniqueString string = newGuid()
+param testApplicationOid string
 
+var roleDefinitionId = '5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b'
 var configurationApiVersion = '2020-07-01-preview'
 var accountName = baseName
 var testKeyName = 'test-key'
@@ -23,6 +25,15 @@ resource keyValue 'Microsoft.AppConfiguration/configurationStores/keyValues@2023
     contentType: 'text/plain'
   }
   parent: configurationStore
+}
+
+// Assign Role to Test Application
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id)
+  properties: {
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+    principalId: testApplicationOid
+  }
 }
 
 // Outputs


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/template`

### Describe the problem that is addressed by this PR

Grants the "App Configuration Data Owner" when deploying the template live test resources. This fixes some issues recording tests for the template package (and possibly the live tests too).

Copied from the App Config test-resources.bicep [here](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/appconfiguration/test-resources.bicep)