### PR TITLE
[monitor-opentelemetry] Live Metrics Filtering for Documents

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 1.7.2 (Unreleased)
+## 1.8.0 (Unreleased)
 
 ### Features Added
+- Support for Live Metrics Filtering
 
 ### Breaking Changes
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.8.0 (Unreleased)
+## 1.7.2 (Unreleased)
 
 ### Features Added
 - Support for Live Metrics Filtering

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/filter.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/filter.ts
@@ -7,7 +7,6 @@ import {
   KnownPredicateType,
   FilterConjunctionGroupInfo,
 } from "../../../generated";
-import { FilterConjunctionGroupInfo } from "../../../generated/models/mappers";
 import {
   RequestData,
   TelemetryData,

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/filter.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/filter.ts
@@ -50,7 +50,10 @@ export class Filter {
     return matched;
   }
 
-  public checkFilterConjunctionGroup(filterConjunctionGroupInfo: FilterConjunctionGroupInfo, data: TelemetryData): boolean {
+  public checkFilterConjunctionGroup(
+    filterConjunctionGroupInfo: FilterConjunctionGroupInfo,
+    data: TelemetryData,
+  ): boolean {
     // All of the filters need to match for this to return true (and operation).
     for (const filter of filterConjunctionGroupInfo.filters) {
       if (!this.checkFilter(filter, data)) {

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/filter.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/filter.ts
@@ -7,6 +7,7 @@ import {
   KnownPredicateType,
   FilterConjunctionGroupInfo,
 } from "../../../generated";
+import { FilterConjunctionGroupInfo } from "../../../generated/models/mappers";
 import {
   RequestData,
   TelemetryData,
@@ -45,18 +46,14 @@ export class Filter {
     // Just to be safe, handling the multiple filter conjunction group case as an or operation.
     let matched = false;
     derivedMetricInfo.filterGroups.forEach((filterConjunctionGroup) => {
-      matched = matched || this.checkFilterConjunctionGroup(filterConjunctionGroup.filters, data);
+      matched = matched || this.checkFilterConjunctionGroup(filterConjunctionGroup, data);
     });
     return matched;
   }
 
-  /* public static checkDocumentFilters(documentStreamInfo: DocumentStreamInfo, data: TelemetryData): boolean {
-    return true; // to be implemented
-  }*/
-
-  private checkFilterConjunctionGroup(filters: FilterInfo[], data: TelemetryData): boolean {
+  public checkFilterConjunctionGroup(filterConjunctionGroupInfo: FilterConjunctionGroupInfo, data: TelemetryData): boolean {
     // All of the filters need to match for this to return true (and operation).
-    for (const filter of filters) {
+    for (const filter of filterConjunctionGroupInfo.filters) {
       if (!this.checkFilter(filter, data)) {
         return false;
       }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
@@ -9,6 +9,7 @@ import {
   FilterInfo,
   KnownPredicateType,
   DocumentFilterConjunctionGroupInfo,
+  FilterConjunctionGroupInfo,
 } from "../../../generated";
 import { getMsFromFilterTimestampString } from "../utils";
 
@@ -62,7 +63,9 @@ export class Validator {
   public validateDocumentFilters(
     documentFilterConjuctionGroupInfo: DocumentFilterConjunctionGroupInfo,
   ): void {
-    documentFilterConjuctionGroupInfo.filters.filters.forEach((filter) => {
+    const filterConjunctionGroupInfo: FilterConjunctionGroupInfo =
+      documentFilterConjuctionGroupInfo.filters;
+    filterConjunctionGroupInfo.filters.forEach((filter) => {
       this.validateFieldNames(filter.fieldName, documentFilterConjuctionGroupInfo.telemetryType);
       this.validatePredicateAndComparand(filter);
     });

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
@@ -38,9 +38,7 @@ export class Validator {
         "The telemetry type Metric was specified, but this distro does not send custom live metrics to quickpulse.",
       );
     } else if (!(telemetryType in KnownTelemetryType)) {
-      throw new TelemetryTypeError(
-        `'${telemetryType}' is not a valid telemetry type.`,
-      );
+      throw new TelemetryTypeError(`'${telemetryType}' is not a valid telemetry type.`);
     }
   }
 
@@ -61,7 +59,9 @@ export class Validator {
     });
   }
 
-  public validateDocumentFilters(documentFilterConjuctionGroupInfo: DocumentFilterConjunctionGroupInfo): void {
+  public validateDocumentFilters(
+    documentFilterConjuctionGroupInfo: DocumentFilterConjunctionGroupInfo,
+  ): void {
     documentFilterConjuctionGroupInfo.filters.filters.forEach((filter) => {
       this.validateFieldNames(filter.fieldName, documentFilterConjuctionGroupInfo.telemetryType);
       this.validatePredicateAndComparand(filter);

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
@@ -62,7 +62,10 @@ export class Validator {
   }
 
   public validateDocumentFilters(documentFilterConjuctionGroupInfo: DocumentFilterConjunctionGroupInfo): void {
-
+    documentFilterConjuctionGroupInfo.filters.filters.forEach((filter) => {
+      this.validateFieldNames(filter.fieldName, documentFilterConjuctionGroupInfo.telemetryType);
+      this.validatePredicateAndComparand(filter);
+    });
   }
 
   private isCustomDimOrAnyField(fieldName: string): boolean {

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/filtering/validator.ts
@@ -8,6 +8,7 @@ import {
   KnownTelemetryType,
   FilterInfo,
   KnownPredicateType,
+  DocumentFilterConjunctionGroupInfo,
 } from "../../../generated";
 import { getMsFromFilterTimestampString } from "../utils";
 
@@ -23,22 +24,22 @@ const knownStringColumns = new Set<string>([
 ]);
 
 export class Validator {
-  public validateTelemetryType(derivedMetricInfo: DerivedMetricInfo): void {
-    if (derivedMetricInfo.telemetryType === KnownTelemetryType.PerformanceCounter.toString()) {
+  public validateTelemetryType(telemetryType: string): void {
+    if (telemetryType === KnownTelemetryType.PerformanceCounter.toString()) {
       throw new TelemetryTypeError(
         "The telemetry type PerformanceCounter was specified, but this distro does not send performance counters to quickpulse.",
       );
-    } else if (derivedMetricInfo.telemetryType === KnownTelemetryType.Event.toString()) {
+    } else if (telemetryType === KnownTelemetryType.Event.toString()) {
       throw new TelemetryTypeError(
         "The telemetry type Event was specified, but this telemetry type is not supported via OpenTelemetry.",
       );
-    } else if (derivedMetricInfo.telemetryType === KnownTelemetryType.Metric.toString()) {
+    } else if (telemetryType === KnownTelemetryType.Metric.toString()) {
       throw new TelemetryTypeError(
         "The telemetry type Metric was specified, but this distro does not send custom live metrics to quickpulse.",
       );
-    } else if (!(derivedMetricInfo.telemetryType in KnownTelemetryType)) {
+    } else if (!(telemetryType in KnownTelemetryType)) {
       throw new TelemetryTypeError(
-        `'${derivedMetricInfo.telemetryType}' is not a valid telemetry type.`,
+        `'${telemetryType}' is not a valid telemetry type.`,
       );
     }
   }
@@ -51,13 +52,17 @@ export class Validator {
     }
   }
 
-  public validateFilters(derivedMetricInfo: DerivedMetricInfo): void {
+  public validateMetricFilters(derivedMetricInfo: DerivedMetricInfo): void {
     derivedMetricInfo.filterGroups.forEach((filterGroup) => {
       filterGroup.filters.forEach((filter) => {
         this.validateFieldNames(filter.fieldName, derivedMetricInfo.telemetryType);
         this.validatePredicateAndComparand(filter);
       });
     });
+  }
+
+  public validateDocumentFilters(documentFilterConjuctionGroupInfo: DocumentFilterConjunctionGroupInfo): void {
+
   }
 
   private isCustomDimOrAnyField(fieldName: string): boolean {

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -137,10 +137,10 @@ export class LiveMetrics {
   private lastExceptionRate: { count: number; time: number } = { count: 0, time: 0 };
   private lastCpus:
     | {
-      model: string;
-      speed: number;
-      times: { user: number; nice: number; sys: number; idle: number; irq: number };
-    }[]
+        model: string;
+        speed: number;
+        times: { user: number; nice: number; sys: number; idle: number; irq: number };
+      }[]
     | undefined;
   private statsbeatOptionsUpdated = false;
   private etag: string = "";
@@ -153,7 +153,10 @@ export class LiveMetrics {
   private validator: Validator = new Validator();
   private filter: Filter = new Filter();
   // type: Map<telemetryType, Map<id, FilterConjunctionGroupInfo[]>>
-  private validDocumentFilterConjuctionGroupInfos: Map<string, Map<string, FilterConjunctionGroupInfo[]>> = new Map();
+  private validDocumentFilterConjuctionGroupInfos: Map<
+    string,
+    Map<string, FilterConjunctionGroupInfo[]>
+  > = new Map();
   /**
    * Initializes a new instance of the StandardMetrics class.
    * @param config - Distro configuration.
@@ -179,7 +182,7 @@ export class LiveMetrics {
     };
     const parsedConnectionString = ConnectionStringParser.parse(
       this.config.azureMonitorExporterOptions.connectionString ||
-      process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"],
+        process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"],
     );
     this.pingSender = new QuickpulseSender({
       endpointUrl: parsedConnectionString.liveendpoint || DEFAULT_LIVEMETRICS_ENDPOINT,
@@ -456,10 +459,14 @@ export class LiveMetrics {
       let documentConfiguration: Map<string, FilterConjunctionGroupInfo[]>;
       let derivedMetricInfos: DerivedMetricInfo[];
       if (isRequestData(columns)) {
-        documentConfiguration = this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Request) || new Map<string, FilterConjunctionGroupInfo[]>();
+        documentConfiguration =
+          this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Request) ||
+          new Map<string, FilterConjunctionGroupInfo[]>();
         derivedMetricInfos = this.validDerivedMetrics.get(KnownTelemetryType.Request) || [];
       } else {
-        documentConfiguration = this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Dependency) || new Map<string, FilterConjunctionGroupInfo[]>();
+        documentConfiguration =
+          this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Dependency) ||
+          new Map<string, FilterConjunctionGroupInfo[]>();
         derivedMetricInfos = this.validDerivedMetrics.get(KnownTelemetryType.Dependency) || [];
       }
       this.applyDocumentFilters(documentConfiguration, columns);
@@ -489,8 +496,14 @@ export class LiveMetrics {
               event.attributes,
               span.attributes,
             );
-            documentConfiguration = this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Exception) || new Map<string, FilterConjunctionGroupInfo[]>();
-            this.applyDocumentFilters(documentConfiguration, exceptionColumns, event.attributes[SEMATTRS_EXCEPTION_TYPE] as string);
+            documentConfiguration =
+              this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Exception) ||
+              new Map<string, FilterConjunctionGroupInfo[]>();
+            this.applyDocumentFilters(
+              documentConfiguration,
+              exceptionColumns,
+              event.attributes[SEMATTRS_EXCEPTION_TYPE] as string,
+            );
             derivedMetricInfos = this.validDerivedMetrics.get(KnownTelemetryType.Exception) || [];
             this.checkMetricFilterAndCreateProjection(derivedMetricInfos, exceptionColumns);
             this.totalExceptionCount++;
@@ -510,13 +523,21 @@ export class LiveMetrics {
       let derivedMetricInfos: DerivedMetricInfo[];
       let documentConfiguration: Map<string, FilterConjunctionGroupInfo[]>;
       if (isExceptionData(columns)) {
-        documentConfiguration = this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Exception) || new Map<string, FilterConjunctionGroupInfo[]>();
-        this.applyDocumentFilters(documentConfiguration, columns, logRecord.attributes[SEMATTRS_EXCEPTION_TYPE] as string);
+        documentConfiguration =
+          this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Exception) ||
+          new Map<string, FilterConjunctionGroupInfo[]>();
+        this.applyDocumentFilters(
+          documentConfiguration,
+          columns,
+          logRecord.attributes[SEMATTRS_EXCEPTION_TYPE] as string,
+        );
         derivedMetricInfos = this.validDerivedMetrics.get(KnownTelemetryType.Exception) || [];
         this.totalExceptionCount++;
       } else {
         // trace
-        documentConfiguration = this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Trace) || new Map<string, FilterConjunctionGroupInfo[]>();
+        documentConfiguration =
+          this.validDocumentFilterConjuctionGroupInfos.get(KnownTelemetryType.Trace) ||
+          new Map<string, FilterConjunctionGroupInfo[]>();
         this.applyDocumentFilters(documentConfiguration, columns);
         derivedMetricInfos = this.validDerivedMetrics.get(KnownTelemetryType.Trace) || [];
       }
@@ -717,20 +738,23 @@ export class LiveMetrics {
           this.validator.validateDocumentFilters(documentFilterGroupInfo);
           this.filter.renameExceptionFieldNamesForFiltering(documentFilterGroupInfo.filters);
 
-          if (!this.validDocumentFilterConjuctionGroupInfos.has(documentFilterGroupInfo.telemetryType)) {
+          if (
+            !this.validDocumentFilterConjuctionGroupInfos.has(documentFilterGroupInfo.telemetryType)
+          ) {
             this.validDocumentFilterConjuctionGroupInfos.set(
               documentFilterGroupInfo.telemetryType,
               new Map<string, FilterConjunctionGroupInfo[]>(),
             );
           }
 
-          const innerMap = this.validDocumentFilterConjuctionGroupInfos.get(documentFilterGroupInfo.telemetryType);
+          const innerMap = this.validDocumentFilterConjuctionGroupInfos.get(
+            documentFilterGroupInfo.telemetryType,
+          );
           if (!innerMap?.has(documentStreamInfo.id)) {
             innerMap?.set(documentStreamInfo.id, [documentFilterGroupInfo.filters]);
           } else {
             innerMap.get(documentStreamInfo.id)?.push(documentFilterGroupInfo.filters);
           }
-
         } catch (error) {
           const configError: CollectionConfigurationError = {
             collectionConfigurationErrorType: "",
@@ -759,11 +783,15 @@ export class LiveMetrics {
     });
   }
 
-  private applyDocumentFilters(documentConfiguration: Map<string, FilterConjunctionGroupInfo[]>, data: TelemetryData, exceptionType?: string): void {
+  private applyDocumentFilters(
+    documentConfiguration: Map<string, FilterConjunctionGroupInfo[]>,
+    data: TelemetryData,
+    exceptionType?: string,
+  ): void {
     const streamIds: Set<string> = new Set<string>();
     documentConfiguration.forEach((filterConjunctionGroupInfoList, streamId) => {
       filterConjunctionGroupInfoList.forEach((filterConjunctionGroupInfo) => {
-        // by going though each filterConjuctionGroupInfo, we are implicitly -OR-ing 
+        // by going though each filterConjuctionGroupInfo, we are implicitly -OR-ing
         // different filterConjunctionGroupInfo within documentStreamInfo. If there are multiple
         // documentStreamInfos, this logic will -OR- the filtering results of each documentStreamInfo.
         if (this.filter.checkFilterConjunctionGroup(filterConjunctionGroupInfo, data)) {
@@ -772,7 +800,7 @@ export class LiveMetrics {
       });
     });
 
-    // Emit a document when a telemetry data matches a particular filtering configuration, 
+    // Emit a document when a telemetry data matches a particular filtering configuration,
     // or when filtering configuration is empty.
     if (streamIds.size > 0 || documentConfiguration.size === 0) {
       let document: Request | RemoteDependency | Trace | Exception;

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -172,7 +172,7 @@ export class LiveMetrics {
     const version = getSdkVersion();
     this.baseMonitoringDataPoint = {
       version: version,
-      invariantVersion: 5,
+      invariantVersion: 5, // 5 means we support live metrics filtering of metrics and documents
       instance: instance,
       roleName: roleName,
       machineName: machineName,

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -259,7 +259,6 @@ export class LiveMetrics {
       this.lastSuccessTime = Date.now();
       this.isCollectingData =
         response.xMsQpsSubscribed && response.xMsQpsSubscribed === "true" ? true : false;
-
       if (response.xMsQpsConfigurationEtag && this.etag !== response.xMsQpsConfigurationEtag) {
         this.updateConfiguration(response);
       }
@@ -761,10 +760,6 @@ export class LiveMetrics {
   }
 
   private applyDocumentFilters(documentConfiguration: Map<string, FilterConjunctionGroupInfo[]>, data: TelemetryData, exceptionType?: string): void {
-    // The documentConfiguration map is never empty as quickpulse sends a default configuration for a telemetry type
-    // if the user never explicitly changes the configuration for that type via UI. It is possible for the filterConjunctionGroupInfo.filters 
-    // to be empty, in which case the document should be created/emitted for that documentStreamId.
-
     const streamIds: Set<string> = new Set<string>();
     documentConfiguration.forEach((filterConjunctionGroupInfoList, streamId) => {
       filterConjunctionGroupInfoList.forEach((filterConjunctionGroupInfo) => {
@@ -777,7 +772,9 @@ export class LiveMetrics {
       });
     });
 
-    if (streamIds.size > 0) {
+    // Emit a document when a telemetry data matches a particular filtering configuration, 
+    // or when filtering configuration is empty.
+    if (streamIds.size > 0 || documentConfiguration.size === 0) {
       let document: Request | RemoteDependency | Trace | Exception;
       if (isRequestData(data) || isDependencyData(data)) {
         document = getSpanDocument(data);

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -435,8 +435,8 @@ export function getLogData(log: LogRecord): ExceptionData | TraceData {
   }
 }
 
-export function getLogDocument(data: TelemetryData, exceptionType: string): Trace | Exception {
-  if (isExceptionData(data)) {
+export function getLogDocument(data: TelemetryData, exceptionType?: string): Trace | Exception {
+  if (isExceptionData(data) && exceptionType) {
     return {
       documentType: KnownDocumentType.Exception,
       exceptionMessage: data.Message,

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetricsFilter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetricsFilter.test.ts
@@ -57,13 +57,25 @@ describe("Live Metrics filtering - Validator", () => {
       backEndAggregation: "Sum",
     };
 
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
+    assert.throws(
+      () => validator.validateTelemetryType(derivedMetricInfo.telemetryType),
+      TelemetryTypeError,
+    );
     derivedMetricInfo.telemetryType = "\\Random\\Counter";
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
+    assert.throws(
+      () => validator.validateTelemetryType(derivedMetricInfo.telemetryType),
+      TelemetryTypeError,
+    );
     derivedMetricInfo.telemetryType = "Metric";
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
+    assert.throws(
+      () => validator.validateTelemetryType(derivedMetricInfo.telemetryType),
+      TelemetryTypeError,
+    );
     derivedMetricInfo.telemetryType = "does not exist";
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
+    assert.throws(
+      () => validator.validateTelemetryType(derivedMetricInfo.telemetryType),
+      TelemetryTypeError,
+    );
   });
 
   it("The validator rejects CustomMetrics projections and filters (not supported in Otel)", () => {
@@ -107,7 +119,10 @@ describe("Live Metrics filtering - Validator", () => {
       filters: conjunctionGroup,
     };
     validator.validateTelemetryType(invalidDocFilterConjuctionInfo.telemetryType);
-    assert.throws(() => validator.validateDocumentFilters(invalidDocFilterConjuctionInfo), UnexpectedFilterCreateError);
+    assert.throws(
+      () => validator.validateDocumentFilters(invalidDocFilterConjuctionInfo),
+      UnexpectedFilterCreateError,
+    );
   });
 
   it("The validator rejects invalid filters", () => {
@@ -384,7 +399,7 @@ describe("Live Metrics filtering - Validator", () => {
     const documentFilterConjunctionGroupInfo: DocumentFilterConjunctionGroupInfo = {
       telemetryType: KnownTelemetryType.Request,
       filters: conjunctionGroup,
-    }
+    };
 
     const derivedMetricInfo: DerivedMetricInfo = {
       id: "random-id",
@@ -395,8 +410,14 @@ describe("Live Metrics filtering - Validator", () => {
       backEndAggregation: "Sum",
     };
 
-    assert.throws(() => validator.validateMetricFilters(derivedMetricInfo), UnexpectedFilterCreateError);
-    assert.throws(() => validator.validateDocumentFilters(documentFilterConjunctionGroupInfo), UnexpectedFilterCreateError);
+    assert.throws(
+      () => validator.validateMetricFilters(derivedMetricInfo),
+      UnexpectedFilterCreateError,
+    );
+    assert.throws(
+      () => validator.validateDocumentFilters(documentFilterConjunctionGroupInfo),
+      UnexpectedFilterCreateError,
+    );
   });
 
   it("The validator accepts valid filters", () => {
@@ -1168,7 +1189,9 @@ describe("Live Metrics filtering - Applying valid filters", () => {
       filters: { filters: [] },
     };
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
-    assert.ok(filterClass.checkFilterConjunctionGroup(documentFilterConjunctionGroupInfo.filters, request));
+    assert.ok(
+      filterClass.checkFilterConjunctionGroup(documentFilterConjunctionGroupInfo.filters, request),
+    );
   });
 
   it("Can handle multiple filters in a filter conjunction group", () => {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetricsFilter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetricsFilter.test.ts
@@ -56,13 +56,13 @@ describe("Live Metrics filtering - Validator", () => {
       backEndAggregation: "Sum",
     };
 
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo), TelemetryTypeError);
+    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
     derivedMetricInfo.telemetryType = "\\Random\\Counter";
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo), TelemetryTypeError);
+    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
     derivedMetricInfo.telemetryType = "Metric";
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo), TelemetryTypeError);
+    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
     derivedMetricInfo.telemetryType = "does not exist";
-    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo), TelemetryTypeError);
+    assert.throws(() => validator.validateTelemetryType(derivedMetricInfo.telemetryType), TelemetryTypeError);
   });
 
   it("The validator rejects CustomMetrics projections and filters (not supported in Otel)", () => {
@@ -98,8 +98,8 @@ describe("Live Metrics filtering - Validator", () => {
       () => validator.checkCustomMetricProjection(invalid1),
       UnexpectedFilterCreateError,
     );
-    validator.validateTelemetryType(invalid2); // this shouldn't throw an error as the telemetry type is supported
-    assert.throws(() => validator.validateFilters(invalid2), UnexpectedFilterCreateError);
+    validator.validateTelemetryType(invalid2.telemetryType); // this shouldn't throw an error as the telemetry type is supported
+    assert.throws(() => validator.validateMetricFilters(invalid2), UnexpectedFilterCreateError);
   });
 
   it("The validator rejects invalid filters", () => {
@@ -317,7 +317,7 @@ describe("Live Metrics filtering - Validator", () => {
 
       derivedMetricInfo.filterGroups = [conjunctionGroup];
       assert.throws(
-        () => validator.validateFilters(derivedMetricInfo),
+        () => validator.validateMetricFilters(derivedMetricInfo),
         UnexpectedFilterCreateError || TelemetryTypeError,
       );
     });
@@ -333,7 +333,7 @@ describe("Live Metrics filtering - Validator", () => {
     supportedTelemetryTypes.forEach((telemetryType) => {
       derivedMetricInfo.telemetryType = telemetryType;
       assert.throws(
-        () => validator.validateFilters(derivedMetricInfo),
+        () => validator.validateMetricFilters(derivedMetricInfo),
         UnexpectedFilterCreateError,
       );
     });
@@ -365,7 +365,7 @@ describe("Live Metrics filtering - Validator", () => {
       backEndAggregation: "Sum",
     };
 
-    assert.throws(() => validator.validateFilters(derivedMetricInfo), UnexpectedFilterCreateError);
+    assert.throws(() => validator.validateMetricFilters(derivedMetricInfo), UnexpectedFilterCreateError);
   });
 
   it("The validator accepts valid filters", () => {
@@ -520,7 +520,7 @@ describe("Live Metrics filtering - Validator", () => {
       };
 
       derivedMetricInfo.filterGroups = [conjunctionGroup];
-      validator.validateFilters(derivedMetricInfo);
+      validator.validateMetricFilters(derivedMetricInfo);
     });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetricsFilter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetricsFilter.test.ts
@@ -824,29 +824,35 @@ describe("Live Metrics filtering - Applying valid filters", () => {
 
     // the asked for field is not in the custom dimensions so return false
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // the asked for field is in the custom dimensions but value does not match
     request.CustomDimensions.clear();
     request.CustomDimensions.set("hi", "bye");
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // the asked for field is in the custom dimensions and value matches
     request.CustomDimensions.set("hi", "hi");
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // testing not equal predicate. The CustomDimensions.hi value != hi so return true.
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.NotEqual;
     request.CustomDimensions.set("hi", "bye");
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // testing does not contain predicate. The CustomDimensions.hi value does not contain hi so return true.
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.DoesNotContain;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // testing contains predicate. The CustomDimensions.hi value contains hi so return true.
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.Contains;
     request.CustomDimensions.set("hi", "hi there");
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
   });
 
   it("Can handle filter on known boolean columns", () => {
@@ -891,27 +897,33 @@ describe("Live Metrics filtering - Applying valid filters", () => {
 
     // Request Success filter matches
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // Request Success filter does not match
     request.Success = false;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // Request Success filter matches for != predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.NotEqual;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // Dependency Success filter matches
     derivedMetricInfo.telemetryType = KnownTelemetryType.Dependency;
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.Equal;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency));
 
     // Dependency Success filter does not match
     dependency.Success = false;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency) === false);
 
     // Dependency Success filter matches for != predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.NotEqual;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency));
   });
 
   it("Can handle filter on known numeric columns", () => {
@@ -956,59 +968,72 @@ describe("Live Metrics filtering - Applying valid filters", () => {
 
     // Request ResponseCode filter matches
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // Request ResponseCode filter does not match
     request.ResponseCode = 404;
     request.Success = false;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // Dependency ResultCode filter matches
     derivedMetricInfo.telemetryType = KnownTelemetryType.Dependency;
     derivedMetricInfo.filterGroups[0].filters[0].fieldName = KnownDependencyColumns.ResultCode;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency));
 
     // Dependency ResultCode filter does not match
     dependency.ResultCode = 404;
     dependency.Success = false;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency) === false);
 
     // Dependency duration filter matches
     derivedMetricInfo.filterGroups[0].filters[0].fieldName = KnownDependencyColumns.Duration;
     derivedMetricInfo.filterGroups[0].filters[0].comparand = "14.6:56:7.89"; // 14 days, 6 hours, 56 minutes, 7.89 seconds (1234567890 ms)
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency));
 
     // Dependency duration filter does not match
     dependency.Duration = 400;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency) === false);
 
     // Request duration filter matches
     derivedMetricInfo.telemetryType = KnownTelemetryType.Request;
     derivedMetricInfo.filterGroups[0].filters[0].fieldName = KnownRequestColumns.Duration;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // Request duration filter does not match
     request.Duration = 400;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // != predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.NotEqual;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // < predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.LessThan;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // <= predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.LessThanOrEqual;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // > predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.GreaterThan;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // >= predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.GreaterThanOrEqual;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
   });
 
   it("Can handle filter on known string columns", () => {
@@ -1064,48 +1089,59 @@ describe("Live Metrics filtering - Applying valid filters", () => {
 
     // Request Url filter matches
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // Request Url filter does not match
     request.Url = "https://test.com/bye";
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
 
     // Dependency Data filter matches
     derivedMetricInfo.telemetryType = KnownTelemetryType.Dependency;
     derivedMetricInfo.filterGroups[0].filters[0].fieldName = KnownDependencyColumns.Data;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency));
 
     // Dependency Data filter does not match
     dependency.Data = "https://test.com/bye";
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, dependency) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, dependency) === false);
 
     // Trace Message filter matches
     derivedMetricInfo.telemetryType = KnownTelemetryType.Trace;
     derivedMetricInfo.filterGroups[0].filters[0].fieldName = "Message";
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, trace));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, trace));
 
     // Trace Message filter does not match
     trace.Message = "bye";
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, trace) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, trace) === false);
 
     // Exception Message filter matches. Note that fieldName is still "Message" here and that's intended (we remove the Exception. prefix when validating config)
     derivedMetricInfo.telemetryType = KnownTelemetryType.Exception;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, exception));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, exception));
 
     // Exception Message filter does not match
     exception.Message = "Exception Message";
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, exception) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, exception) === false);
 
     // != predicate
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.NotEqual;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, exception));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, exception));
 
     // not contains
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.DoesNotContain;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, exception));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, exception));
 
     // equal
     derivedMetricInfo.filterGroups[0].filters[0].predicate = KnownPredicateType.Equal;
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, exception) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, exception) === false);
   });
 
   it("Empty filter conjunction group info - should match", () => {
@@ -1172,10 +1208,12 @@ describe("Live Metrics filtering - Applying valid filters", () => {
 
     // matches both filters
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request));
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request));
 
     // only one filter matches, the entire conjunction group should return false
     request.Url = "https://test.com/bye";
     assert.ok(filterClass.checkMetricFilters(derivedMetricInfo, request) === false);
+    assert.ok(filterClass.checkFilterConjunctionGroup(conjunctionGroup, request) === false);
   });
 });
 


### PR DESCRIPTION
### Packages impacted by this PR
monitor-opentelemetry

### Describe the problem that is addressed by this PR
This PR adds support for document filtering in live metrics.

### Are there test cases added in this PR? _(If not, why?)_
Modifications were made to existing unit tests to test documents functionality, as much of the new code added uses existing filtering functionality. Also, many cases for documents were manually tested E2E, such as the single/multi session cases for applying filters to documents and metrics & confirming that SDK conforms to any configuration sent to it by the service. 

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
