### PR TITLE
[template] Add retry/timeout to macOS tests

### DIFF
--- a/sdk/template/template/test/public/configurationClient.spec.ts
+++ b/sdk/template/template/test/public/configurationClient.spec.ts
@@ -80,25 +80,20 @@ describe("[AAD] ConfigurationClient functional tests", function () {
   });
 
   describe("#getConfigurationSetting", () => {
-    // TODO: This test is skipped on macOS pending investigation (see https://github.com/Azure/azure-sdk-for-js/issues/31296)
-    it.skipIf(typeof process !== "undefined" && process.platform === "darwin")(
-      "predetermined setting has expected value",
-      async () => {
-        const key = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_KEY");
-        const expectedValue = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_EXPECTED_VALUE");
+    it("predetermined setting has expected value", { timeout: 50000, retry: 3 }, async () => {
+      const key = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_KEY");
+      const expectedValue = assertEnvironmentVariable("APPCONFIG_TEST_SETTING_EXPECTED_VALUE");
 
-        const setting = await client.getConfigurationSetting(key);
+      const setting = await client.getConfigurationSetting(key);
 
-        // Make sure the key returned is the same as the key we asked for
-        assert.equal(key, setting.key);
+      // Make sure the key returned is the same as the key we asked for
+      assert.equal(key, setting.key);
 
-        // Make sure the value of the setting is the same as the value we entered
-        // on the environment
-        assert.equal(expectedValue, setting.value);
-      },
-    );
+      // Make sure the value of the setting is the same as the value we entered
+      // on the environment
+      assert.equal(expectedValue, setting.value);
+    });
 
-    // TODO: Waiting on https://github.com/Azure/azure-sdk-for-js/issues/29287
     // The supportsTracing assertion from chaiAzure can be used to verify that
     // the `getConfigurationSetting` method is being traced correctly, that the
     // tracing span is properly parented and closed.


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/template

### Issues associated with this PR

- #31296

### Describe the problem that is addressed by this PR

Adds a better timeout and retry logic for the issues with the best being flaky.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
