### PR TITLE
[core-amqp] move geographic replication constant to Event Hubs

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.4.0-beta.2 (Unreleased)
+## 4.3.3 (Unreleased)
 
 ### Features Added
 
@@ -8,9 +8,19 @@
 
 ### Bugs Fixed
 
-- Address React-Native regression after ESM migration [Issue #30065](https://github.com/Azure/azure-sdk-for-js/issues/30065)
-
 ### Other Changes
+
+- Move the constant for the geographic replication feature to Event Hubs.
+
+## 4.3.2 (2024-08-01)
+
+- Adding React-Native support at top level [PR #30521](https://github.com/Azure/azure-sdk-for-js/pull/30521)
+
+## 4.3.1 (2024-07-18)
+
+### Bugs Fixed
+
+- Address React-Native regression after ESM migration [Issue #30065](https://github.com/Azure/azure-sdk-for-js/issues/30065)
 
 ## 4.4.0-beta.1 (2024-06-06)
 

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "4.4.0-beta.2",
+  "version": "4.3.3",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -274,7 +274,6 @@ export const Constants: {
     readonly attachEpoch: "com.microsoft:epoch";
     readonly receiverIdentifierName: "com.microsoft:receiver-name";
     readonly enableReceiverRuntimeMetricName: "com.microsoft:enable-receiver-runtime-metric";
-    readonly geoReplication: "com.microsoft:georeplication";
     readonly timespan: "com.microsoft:timespan";
     readonly uri: "com.microsoft:uri";
     readonly dateTimeOffset: "com.microsoft:datetime-offset";

--- a/sdk/core/core-amqp/src/util/constants.ts
+++ b/sdk/core/core-amqp/src/util/constants.ts
@@ -45,7 +45,6 @@ export const Constants = {
   attachEpoch: `com.microsoft:epoch`,
   receiverIdentifierName: `com.microsoft:receiver-name`,
   enableReceiverRuntimeMetricName: `com.microsoft:enable-receiver-runtime-metric`,
-  geoReplication: `com.microsoft:georeplication`,
   timespan: `com.microsoft:timespan`,
   uri: `com.microsoft:uri`,
   dateTimeOffset: `com.microsoft:datetime-offset`,

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -12,7 +12,6 @@ import {
   types,
 } from "rhea-promise";
 import {
-  Constants,
   ErrorNameConditionMapper,
   RetryConfig,
   RetryOperationType,
@@ -45,6 +44,7 @@ import { getRetryAttemptTimeoutInMs } from "./util/retries.js";
 import {
   idempotentProducerAmqpPropertyNames,
   PENDING_PUBLISH_SEQ_NUM_SYMBOL,
+  geoReplication,
 } from "./util/constants.js";
 import { isDefined } from "@azure/core-util";
 import { translateError } from "./util/error.js";
@@ -429,7 +429,7 @@ export class EventHubSender {
       onSessionClose: this._onSessionClose,
     };
 
-    srOptions.desired_capabilities = [Constants.geoReplication];
+    srOptions.desired_capabilities = [geoReplication];
     if (this._isIdempotentProducer) {
       srOptions.desired_capabilities.push(idempotentProducerAmqpPropertyNames.capability);
       const idempotentProperties = generateIdempotentLinkProperties(

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -22,6 +22,9 @@ export const idempotentProducerAmqpPropertyNames = {
 /** @internal */
 export const receiverIdPropertyName = "com.microsoft:receiver-name";
 
+/** @internal */
+export const geoReplication = "com.microsoft:georeplication";
+
 /**
  * @internal
  */


### PR DESCRIPTION
So that we can release GA fixes from main branch.

While at it, also port CHANGELOG entries from hotfix branch.