### PR TITLE
[Event Hubs] Add message structure validation to the producer

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - The producer now verifies that the input message follows the expected structure.
 
-### Other Changes
-
 ## 5.13.0-beta.2 (2024-06-27)
 
 ### Bugs Fixed

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.12.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.12.1 (2024-10-08)
 
 ### Bugs Fixed
 
-- Revert the change to the definition of the earliest event position.
+- The producer now verifies that the input message follows the expected structure.
 
 ### Other Changes
 

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -288,7 +288,7 @@ export function toRheaMessage(
       body: defaultDataTransformer.encode(data.body, bodyType),
     };
     // As per the AMQP 1.0 spec If the message-annotations or delivery-annotations section is omitted,
-    // it is equivalent to a message-annotations section containing anempty map of annotations.
+    // it is equivalent to a message-annotations section containing empty map of annotations.
     rheaMessage.message_annotations = {};
 
     if (data.properties) {
@@ -378,9 +378,60 @@ export interface EventData {
 }
 
 /**
+ * Asserts that the provided data conforms to the `EventData` interface.
+ *
+ * This function performs runtime checks on the `data` object to ensure it matches the expected
+ * structure and types defined in the `EventData` interface. If any of the checks fail, it throws
+ * an error with a descriptive message indicating the mismatch.
+ *
+ * @param data - The data object to validate as `EventData`.
+ * @throws \{Error\} Throws an error if the data does not conform to the `EventData` interface.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function assertIsEventData(data: any): asserts data is EventData {
+  if (data.contentType !== undefined && typeof data.contentType !== "string") {
+    throw new Error(
+      `Invalid 'contentType': expected 'string' or 'undefined', but received '${typeof data.contentType}'.`,
+    );
+  }
+
+  if (
+    data.correlationId !== undefined &&
+    typeof data.correlationId !== "string" &&
+    typeof data.correlationId !== "number" &&
+    !Buffer.isBuffer(data.correlationId)
+  ) {
+    throw new Error(
+      `Invalid 'correlationId': expected 'string', 'number', 'Buffer', or 'undefined', but received '${typeof data.correlationId}'.`,
+    );
+  }
+
+  if (
+    data.messageId !== undefined &&
+    typeof data.messageId !== "string" &&
+    typeof data.messageId !== "number" &&
+    !Buffer.isBuffer(data.messageId)
+  ) {
+    throw new Error(
+      `Invalid 'messageId': expected 'string', 'number', 'Buffer', or 'undefined', but received '${typeof data.messageId}'.`,
+    );
+  }
+
+  if (
+    data.properties !== undefined &&
+    (typeof data.properties !== "object" || Array.isArray(data.properties))
+  ) {
+    const actualType = Array.isArray(data.properties) ? "array" : typeof data.properties;
+    throw new Error(
+      `Invalid 'properties': expected an object or 'undefined', but received '${actualType}'.`,
+    );
+  }
+}
+
+/**
  * The interface that describes the structure of the event received from Event Hub.
  * Use this as a reference when creating the `processEvents` function to process the events
- * recieved from an Event Hub when using the `EventHubConsumerClient`.
+ * received from an Event Hub when using the `EventHubConsumerClient`.
  */
 export interface ReceivedEventData {
   /**

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -14,6 +14,7 @@ import {
   idempotentProducerAmqpPropertyNames,
   PENDING_PUBLISH_SEQ_NUM_SYMBOL,
 } from "./util/constants.js";
+import isBuffer from "is-buffer";
 
 /**
  * Describes the delivery annotations.
@@ -389,14 +390,14 @@ export interface EventData {
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function assertIsEventData(data: any): asserts data is EventData {
-  if (data.contentType !== undefined && typeof data.contentType !== "string") {
+  if (data.contentType != null && typeof data.contentType !== "string") {
     throw new Error(
       `Invalid 'contentType': expected 'string' or 'undefined', but received '${typeof data.contentType}'.`,
     );
   }
 
   if (
-    data.correlationId !== undefined &&
+    data.correlationId != null &&
     typeof data.correlationId !== "string" &&
     typeof data.correlationId !== "number" &&
     !Buffer.isBuffer(data.correlationId)
@@ -407,10 +408,10 @@ export function assertIsEventData(data: any): asserts data is EventData {
   }
 
   if (
-    data.messageId !== undefined &&
+    data.messageId != null &&
     typeof data.messageId !== "string" &&
     typeof data.messageId !== "number" &&
-    !Buffer.isBuffer(data.messageId)
+    !isBuffer(data.messageId)
   ) {
     throw new Error(
       `Invalid 'messageId': expected 'string', 'number', 'Buffer', or 'undefined', but received '${typeof data.messageId}'.`,

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT License.
 
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
-import { EventData, populateIdempotentMessageAnnotations, toRheaMessage } from "./eventData.js";
+import {
+  assertIsEventData,
+  EventData,
+  isAmqpAnnotatedMessage,
+  populateIdempotentMessageAnnotations,
+  toRheaMessage,
+} from "./eventData.js";
 import { ConnectionContext } from "./connectionContext.js";
 import { MessageAnnotations, message, Message as RheaMessage } from "rhea-promise";
 import { isDefined, isObjectWithProperties } from "@azure/core-util";
@@ -370,6 +376,9 @@ export class EventDataBatchImpl implements EventDataBatch {
    */
   public tryAdd(eventData: EventData | AmqpAnnotatedMessage, options: TryAddOptions = {}): boolean {
     throwTypeErrorIfParameterMissing(this._context.connectionId, "tryAdd", "eventData", eventData);
+    if (!isAmqpAnnotatedMessage(eventData)) {
+      assertIsEventData(eventData);
+    }
 
     const { entityPath, host } = this._context.config;
     const { event: instrumentedEvent, spanContext } = instrumentEventData(

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -26,7 +26,7 @@ import {
   validateProducerPartitionSettings,
 } from "./util/error.js";
 import { AmqpAnnotatedMessage } from "@azure/core-amqp";
-import { EventData, EventDataInternal } from "./eventData.js";
+import { assertIsEventData, EventData, EventDataInternal } from "./eventData.js";
 import { EventHubSender } from "./eventHubSender.js";
 import { OperationOptions } from "./util/operationOptions.js";
 import { toSpanOptions, tracingClient } from "./diagnostics/tracing.js";
@@ -410,6 +410,7 @@ export class EventHubProducerClient {
       if (!Array.isArray(batch)) {
         batch = [batch];
       }
+      batch.forEach(assertIsEventData);
       if (batch.some((event) => isDefined((event as EventDataInternal)._publishedSequenceNumber))) {
         throw new Error(idempotentSomeAlreadyPublished);
       }

--- a/sdk/eventhub/event-hubs/test/internal/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/sender.spec.ts
@@ -10,7 +10,7 @@ import {
   SendBatchOptions,
 } from "../../src/index.js";
 import { EventDataBatchImpl } from "../../src/eventDataBatch.js";
-import { should } from "../utils/chai.js";
+import { expect, should } from "../utils/chai.js";
 import { SubscriptionHandlerForTests } from "../utils/subscriptionHandlerForTests.js";
 import { getStartingPositionsForTests } from "../utils/testUtils.js";
 import { describe, it, beforeEach, afterEach } from "vitest";
@@ -311,6 +311,18 @@ describe("EventHub Sender", function () {
       await producerClient.sendBatch(eventDataBatch);
       eventDataBatch.count.should.equal(1);
     });
+
+    it("Invalid messages should be rejected.", async function () {
+      const eventDataBatch = await producerClient.createBatch();
+      expect(() => eventDataBatch.tryAdd({ body: "Hello World", properties: [] })).to.throw(
+        /Invalid 'properties': expected an object or 'undefined', but received 'array'/,
+      );
+      await expect(
+        producerClient.sendBatch([{ body: "Hello World", properties: [] }]),
+      ).to.eventually.be.rejectedWith(
+        /Invalid 'properties': expected an object or 'undefined', but received 'array'/,
+      );
+    });
   });
 
   describe("Multiple sendBatch calls", function () {
@@ -520,7 +532,7 @@ describe("EventHub Sender", function () {
         try {
           const data: EventData[] = [
             {
-              body: "Sender paritition id and partition key",
+              body: "Sender partition id and partition key",
             },
           ];
           await producerClient.sendBatch(data, { partitionKey: "1", partitionId: "0" });


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-sdk-for-js/issues/31067

This PR adds runtime validation to the input message structure. This is needed so that strict receivers that follow the AMQP spec don't reject non-compliant messages.