### PR TITLE
[Monitor OpenTelemetry Exporter] Add Non-Essential Statsbeat

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Enforce property length limits on telemetry using truncation.
 - Updated OTel dependencies.
+- Add non-essential statsbeat metrics.
 
 ## 1.0.0-beta.25 (2024-08-14)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -16,6 +16,10 @@ export class NetworkStatsbeat {
 
   public totalSuccesfulRequestCount: number;
 
+  public totalReadFailureCount: number;
+
+  public totalWriteFailureCount: number;
+
   public totalFailedRequestCount: { statusCode: number; count: number }[];
 
   public retryCount: { statusCode: number; count: number }[];
@@ -35,6 +39,8 @@ export class NetworkStatsbeat {
     this.host = host;
     this.totalRequestCount = 0;
     this.totalSuccesfulRequestCount = 0;
+    this.totalReadFailureCount = 0;
+    this.totalWriteFailureCount = 0;
     this.totalFailedRequestCount = [];
     this.retryCount = [];
     this.exceptionCount = [];
@@ -66,6 +72,8 @@ export enum StatsbeatCounter {
   THROTTLE_COUNT = "Throttle_Count",
   EXCEPTION_COUNT = "Exception_Count",
   AVERAGE_DURATION = "Request_Duration",
+  READ_FAILURE_COUNT = "Read_Failure_Count",
+  WRITE_FAILURE_COUNT = "Write_Failure_Count",
   ATTACH = "Attach",
   FEATURE = "Feature",
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -199,9 +199,6 @@ export abstract class BaseSender {
   private async persist(envelopes: unknown[]): Promise<ExportResult> {
     try {
       const success = await this.persister.push(envelopes);
-      if (!success) {
-        this.networkStatsbeatMetrics?.countWriteFailure();
-      }
       return success
         ? { code: ExportResultCode.SUCCESS }
         : {
@@ -209,6 +206,7 @@ export abstract class BaseSender {
             error: new Error("Failed to persist envelope in disk."),
           };
     } catch (ex: any) {
+      this.networkStatsbeatMetrics?.countWriteFailure();
       return { code: ExportResultCode.FAILED, error: ex };
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -199,6 +199,9 @@ export abstract class BaseSender {
   private async persist(envelopes: unknown[]): Promise<ExportResult> {
     try {
       const success = await this.persister.push(envelopes);
+      if (!success) {
+        this.networkStatsbeatMetrics?.countWriteFailure();
+      }
       return success
         ? { code: ExportResultCode.SUCCESS }
         : {
@@ -237,6 +240,7 @@ export abstract class BaseSender {
         await this.send(envelopes);
       }
     } catch (err: any) {
+      this.networkStatsbeatMetrics?.countReadFailure();
       diag.warn(`Failed to fetch persisted file`, err);
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.test.ts
@@ -332,7 +332,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const scopeMetrics = resourceMetrics.scopeMetrics;
         assert.strictEqual(scopeMetrics.length, 1, "Scope Metrics count");
         const metrics = scopeMetrics[0].metrics;
-        assert.strictEqual(metrics.length, 6, "Metrics count");
+        assert.strictEqual(metrics.length, 8, "Metrics count");
         assert.strictEqual(metrics[0].descriptor.name, StatsbeatCounter.SUCCESS_COUNT);
         assert.strictEqual(metrics[1].descriptor.name, StatsbeatCounter.FAILURE_COUNT);
         assert.strictEqual(metrics[2].descriptor.name, StatsbeatCounter.RETRY_COUNT);
@@ -361,6 +361,9 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         statsbeat.countThrottle(439);
         statsbeat.countException({ name: "Statsbeat", message: "Statsbeat Exception" });
         statsbeat.countException({ name: "Statsbeat2", message: "Second Statsbeat Exception" });
+        statsbeat.countReadFailure();
+        statsbeat.countWriteFailure();
+        statsbeat.countWriteFailure();
 
         await new Promise((resolve) => setTimeout(resolve, 500));
         assert.ok(mockExport.called);
@@ -369,7 +372,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const metrics = scopeMetrics[0].metrics;
 
         assert.ok(metrics, "Statsbeat metrics not properly initialized");
-        assert.strictEqual(metrics.length, 6);
+        assert.strictEqual(metrics.length, 8);
         // Represents the last observation called for each callback
         // Successful
         assert.strictEqual(metrics[0].dataPoints[0].value, 4);
@@ -407,6 +410,12 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
         // Average Duration
         assert.strictEqual(metrics[5].dataPoints[0].value, 137.5);
+
+        // Disk Read Failure
+        assert.strictEqual(metrics[6].dataPoints[0].value, 1);
+
+        // Disk Write Failure
+        assert.strictEqual(metrics[7].dataPoints[0].value, 2);
       });
 
       it("should track long interval statsbeats", async () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
We should collect non-essential statsbeat about disk retry.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
