### PR TITLE
[engsys] Allow min/max tests to use vitest config of the target package

### DIFF
--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import path from "node:path";
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../../../vitest.shared.config.ts";
 
@@ -15,7 +14,7 @@ try {
   if (e.code === "ERR_MODULE_NOT_FOUND") {
     // If the file does not exist, log a message and default to an empty config
     console.warn(
-      `vitest.config.ts not found in expected location ${path.resolve(__dirname, "../../vitest.config.ts")} - using default min/max vitest config`,
+      `vitest.config.ts not found in the expected location (sdk/packageDirectory/package/vitest.config.ts) - package's vitest config will not be included`,
     );
   } else {
     // If there's another error, rethrow it

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -46,6 +46,7 @@ const baseConfig = mergeConfig(
 // ensuring consistency across the entire codebase.
 const finalViteConfig = mergeConfig(baseConfig, packageConfig);
 
-console.log({ finalViteConfig });
+console.log("Using the following Vitest configuration:");
+console.log(JSON.stringify(finalViteConfig, null, 2));
 
 export default finalViteConfig;

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -1,10 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import path from "node:path";
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../../../vitest.shared.config.ts";
 
-export default mergeConfig(
+// The idea is as follows:
+
+// 1. Try to load the package vite config from the package's vitest.config.ts file, using an empty object if it fails to load
+let packageConfig = {};
+try {
+  packageConfig = (await import("../../vitest.config.ts")).default;
+} catch (e: any) {
+  if (e.code === "ERR_MODULE_NOT_FOUND") {
+    // If the file does not exist, log a message and default to an empty config
+    console.warn(
+      `vitest.config.ts not found in expected location ${path.resolve(__dirname, "../../vitest.config.ts")} - using default min/max vitest config`,
+    );
+  } else {
+    // If there's another error, rethrow it
+    throw e;
+  }
+}
+
+// Taking the base vite config and merging it with the vitest template config we have here
+const config = mergeConfig(
   viteConfig,
   defineConfig({
     test: {
@@ -13,3 +33,6 @@ export default mergeConfig(
     },
   }),
 );
+
+// Finally, the default export mixes in the package config with the merged config, producing the final result
+export default mergeConfig(mergedTestConfig, packageConfig);

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -21,7 +21,7 @@ try {
     // This ensures developers know when package-specific settings are missing,
     // but it's not an error — we simply default to the shared config.
     console.warn(
-      `vitest.config.ts not found in the expected location (sdk/packageDirectory/package/vitest.config.ts) - package's vitest config will not be included`,
+      `vitest.config.ts not found in the expected location (sdk/<service-directory>/<package-directory>/vitest.config.ts) - package's vitest config will not be included`,
     );
   } else {
     // Any other error here indicates a real issue, so we rethrow it.
@@ -44,4 +44,8 @@ const baseConfig = mergeConfig(
 // 3. Merge the package-specific config with the base config to produce the final result.
 // This allows for package-level customizations while still adhering to the shared setup,
 // ensuring consistency across the entire codebase.
-export default mergeConfig(baseConfig, packageConfig);
+const finalViteConfig = mergeConfig(baseConfig, packageConfig);
+
+console.log({ finalViteConfig });
+
+export default finalViteConfig;


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR

Resolves #30578 

### Describe the problem that is addressed by this PR

While simple settings like `test-timeout` and `hook-timeout` are often defined in package.json scripts, there are
other settings that are specified in the vitest.config.ts of the target package.

Our existing setup uses the default vitest template which does not work for libraries that use customized config.

This PR improves that experience by creating a 3-way-merge of:
1. The base config
2. The template config (which specifies the test patterns)
3. The package's config

Only done for node right now. If you need it for browser, you now have a path forward

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

There are some gotchas here:
1. testTimeout is defined in package.json which takes precedence over any config files I believe - it may be surprising that your testTimeout does not take (note that this is somewhat the case today)
2. The package's config adds files under `test/**/*.spec.ts` to the include pattern. This is fine, because the min/max tests are placed under `test/public` so that pattern will not match anything

I really want to clean up min/max - but this is not the time
