### PR TITLE
fix(playwrighttesting): optional fields in playwright config are compulsory in service reporter

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/model/testResult.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/model/testResult.ts
@@ -27,7 +27,7 @@ export class TestResult {
 export type WebTestConfig = {
   jobName: string;
   projectName: string;
-  browserType: string;
+  browserType ?: string;
   os: string;
 };
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/model/testResult.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/model/testResult.ts
@@ -27,7 +27,7 @@ export class TestResult {
 export type WebTestConfig = {
   jobName: string;
   projectName: string;
-  browserType ?: string;
+  browserType?: string;
   os: string;
 };
 

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
@@ -158,7 +158,7 @@ class ReporterUtils {
     testResult.webTestConfig = {
       jobName: jobName,
       projectName: test.parent.project()!.name,
-      browserType: browserName ? browserName.toUpperCase() : '',
+      browserType: browserName ? browserName.toUpperCase() : "",
       os: this.getOsName(),
     };
     testResult.annotations = this.extractTestAnnotations(test.annotations);

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
@@ -158,7 +158,7 @@ class ReporterUtils {
     testResult.webTestConfig = {
       jobName: jobName,
       projectName: test.parent.project()!.name,
-      browserType: browserName!.toUpperCase(),
+      browserType: browserName ? browserName.toUpperCase() : '',
       os: this.getOsName(),
     };
     testResult.annotations = this.extractTestAnnotations(test.annotations);

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/reporterUtils.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/reporterUtils.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from "@azure-tools/test-utils";
+import ReporterUtils from "../../src/utils/reporterUtils";
+import { TestResult as MPTTestResult } from "../../src/model/testResult";
+import { TestCase, TestResult } from "@playwright/test/reporter";
+
+describe("Reporter Utils", () => {
+  let reporterUtils: ReporterUtils;
+  let environmentVariables: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    const envVariablesMock = {
+      runId: "test-run-id",
+      shardId: "shard-id",
+      accountId: "account-id",
+      accessToken: "test-access-token",
+      userId: "test-user-id",
+      userName: "test-user-name",
+      correlationId: "test-correlation-id",
+      region: "test-region",
+    };
+
+    reporterUtils = new ReporterUtils(envVariablesMock, {} as any, {} as any);
+  });
+  afterEach(() => {
+    process.env = { ...environmentVariables };
+  });
+  it("should set browserType to an empty string when browserName is undefined without throwing an error", () => {
+    const testMock: TestCase = {
+      outcome: () => "expected",
+      parent: {
+        project: () => ({
+          use: {
+            browserName: undefined,
+            defaultBrowserType: undefined,
+          },
+        }),
+        title: "Test Parent Title",
+      },
+      location: {
+        file: "test-file.ts",
+        line: 100,
+      },
+      id: "test-id",
+      title: "Test Case Title",
+      retries: 0,
+      annotations: [],
+    } as any;
+    const resultMock: TestResult = {
+      retry: 0,
+      status: "passed",
+      duration: 5000,
+      startTime: new Date(),
+      attachments: [],
+    } as any;
+    expect(() => {
+      const result: MPTTestResult = reporterUtils.getTestResultObject(
+        testMock,
+        resultMock,
+        "job-name",
+      );
+      expect(result.webTestConfig.browserType).to.equal("");
+    }).not.to.throw();
+  });
+});


### PR DESCRIPTION

### Packages impacted by this PR
`
@azure/microsoft-playwright-testing`

### Issues associated with this PR

Made browser name optional.
### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
