### PR TITLE
[keyvault] keyvault-common: use core-util@^1.10.0

### DIFF
--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.6.0 (2024-10-15)
+## 4.6.0 (2024-10-16)
 
 ### Features Added
 
@@ -15,11 +15,13 @@
 ### Features Added
 
 Since 4.4.0:
+
 - Managed Identity can now be used in place of a SAS token to access the blob storage resource when performing backup and restore operations.
 
 ### Breaking Changes
 
 Since 4.5.0-beta.1:
+
 - Change signature of backup and restore operations to use an overload when using Managed Identity to access the blob storage resource. This means
   `undefined` no longer has to be passed in the `sasToken` parameter in order to set additional request options when using Managed Identity.
   This change is only breaking for customers using 4.5.0-beta.1 and does not impact customers using the previous GA version, 4.4.0.

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0 (2024-10-15)
+## 4.9.0 (2024-10-16)
 
 ### Features Added
 
@@ -15,6 +15,7 @@
 ### Features Added
 
 Since 4.7.0:
+
 - Added property `x509ThumbprintString` to `CertificateProperties`. This property is a hex string representation of the existing `x509Thumbprint` property added for convenience.
 
 ### Other Changes

--- a/sdk/keyvault/keyvault-common/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (2024-10-15)
+## 2.0.0 (2024-10-16)
 
 ### Features Added
 

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -61,7 +61,7 @@
     "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.1.5",
     "tslib": "^2.2.0",
-    "@azure/core-util": "^1.10.1"
+    "@azure/core-util": "^1.10.0"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "^1.0.0",

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0 (2024-10-15)
+## 4.9.0 (2024-10-16)
 
 ### Features Added
 
@@ -15,6 +15,7 @@
 ### Features Added
 
 Since 4.7.2:
+
 - Added `hsmPlatform` property to `KeyProperties`.
 
 ### Other Changes

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0 (2024-10-15)
+## 4.9.0 (2024-10-16)
 
 ### Features Added
 


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/keyvault-common`

### Describe the problem that is addressed by this PR

Caught this while doing pre-release checks. `@azure/core-util@^1.10.1` has not released yet