### PR TITLE
[keyvault] keyvault-common: use released @azure/logger dependency

### DIFF
--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -59,7 +59,7 @@
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/core-tracing": "^1.0.0",
-    "@azure/logger": "^1.1.5",
+    "@azure/logger": "^1.1.4",
     "tslib": "^2.2.0",
     "@azure/core-util": "^1.10.1"
   },


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Exactly the same as https://github.com/Azure/azure-sdk-for-js/pull/31418 except for logger