### PR TITLE
Improve API docs for DAC and ChainedTokenCredential

### DIFF
--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -62,7 +62,7 @@ export class ChainedTokenCredential implements TokenCredential {
 
   private async getTokenInternal(
     scopes: string | string[],
-    options: GetTokenOptions = {},
+    options: GetTokenOptions = {}
   ): Promise<{ token: AccessToken; successfulCredential: TokenCredential }> {
     let token: AccessToken | null = null;
     let successfulCredential: TokenCredential;
@@ -92,21 +92,21 @@ export class ChainedTokenCredential implements TokenCredential {
         if (!token && errors.length > 0) {
           const err = new AggregateAuthenticationError(
             errors,
-            "ChainedTokenCredential authentication failed.",
+            "ChainedTokenCredential authentication failed."
           );
           logger.getToken.info(formatError(scopes, err));
           throw err;
         }
 
         logger.getToken.info(
-          `Result for ${successfulCredential.constructor.name}: ${formatSuccess(scopes)}`,
+          `Result for ${successfulCredential.constructor.name}: ${formatSuccess(scopes)}`
         );
 
         if (token === null) {
           throw new CredentialUnavailableError("Failed to retrieve a valid token");
         }
         return { token, successfulCredential };
-      },
+      }
     );
   }
 }

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -12,8 +12,9 @@ import { tracingClient } from "../util/tracing";
 export const logger = credentialLogger("ChainedTokenCredential");
 
 /**
- * Enables multiple `TokenCredential` implementations to be tried in order
- * until one of the getToken methods returns an access token.
+ * Enables multiple `TokenCredential` implementations to be tried in order until
+ * one of the getToken methods returns an access token. For more information, see
+ * [ChainedTokenCredential overview](https://aka.ms/azsdk/js/identity/credential-chains#use-chainedtokencredential-for-granularity).
  */
 export class ChainedTokenCredential implements TokenCredential {
   private _sources: TokenCredential[] = [];

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -62,7 +62,7 @@ export class ChainedTokenCredential implements TokenCredential {
 
   private async getTokenInternal(
     scopes: string | string[],
-    options: GetTokenOptions = {}
+    options: GetTokenOptions = {},
   ): Promise<{ token: AccessToken; successfulCredential: TokenCredential }> {
     let token: AccessToken | null = null;
     let successfulCredential: TokenCredential;
@@ -92,21 +92,21 @@ export class ChainedTokenCredential implements TokenCredential {
         if (!token && errors.length > 0) {
           const err = new AggregateAuthenticationError(
             errors,
-            "ChainedTokenCredential authentication failed."
+            "ChainedTokenCredential authentication failed.",
           );
           logger.getToken.info(formatError(scopes, err));
           throw err;
         }
 
         logger.getToken.info(
-          `Result for ${successfulCredential.constructor.name}: ${formatSuccess(scopes)}`
+          `Result for ${successfulCredential.constructor.name}: ${formatSuccess(scopes)}`,
         );
 
         if (token === null) {
           throw new CredentialUnavailableError("Failed to retrieve a valid token");
         }
         return { token, successfulCredential };
-      }
+      },
     );
   }
 }

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -194,71 +194,39 @@ export class UnavailableDefaultCredential implements TokenCredential {
 }
 
 /**
- * Provides a default {@link ChainedTokenCredential} configuration that should
- * work for most applications that use the Azure SDK.
+ * Provides a default {@link ChainedTokenCredential} configuration that works for most
+ * applications that use Azure SDK client libraries. For more information, see
+ * [DefaultAzureCredential overview](https://aka.ms/azsdk/js/identity/credential-chains#use-defaultazurecredential-for-flexibility).
+ *
+ * The following credential types will be tried, in order:
+ * 
+ * - {@link EnvironmentCredential}
+ * - {@link WorkloadIdentityCredential}
+ * - {@link ManagedIdentityCredential}
+ * - {@link AzureCliCredential}
+ * - {@link AzurePowerShellCredential}
+ * - {@link AzureDeveloperCliCredential}
+ *
+ * Consult the documentation of these credential types for more information
+ * on how they attempt authentication.
  */
 export class DefaultAzureCredential extends ChainedTokenCredential {
   /**
-   * Creates an instance of the DefaultAzureCredential class with {@link DefaultAzureCredentialClientIdOptions}
-   *
-   * This credential provides a default {@link ChainedTokenCredential} configuration that should
-   * work for most applications that use the Azure SDK.
-   *
-   * The following credential types will be tried, in order:
-   *
-   * - {@link EnvironmentCredential}
-   * - {@link WorkloadIdentityCredential}
-   * - {@link ManagedIdentityCredential}
-   * - {@link AzureCliCredential}
-   * - {@link AzurePowerShellCredential}
-   * - {@link AzureDeveloperCliCredential}
-   *
-   * Consult the documentation of these credential types for more information
-   * on how they attempt authentication.
+   * Creates an instance of the DefaultAzureCredential class with {@link DefaultAzureCredentialClientIdOptions}.
    *
    * @param options - Optional parameters. See {@link DefaultAzureCredentialClientIdOptions}.
    */
   constructor(options?: DefaultAzureCredentialClientIdOptions);
 
   /**
-   *  Creates an instance of the DefaultAzureCredential class with {@link DefaultAzureCredentialResourceIdOptions}
-   *
-   * This credential provides a default {@link ChainedTokenCredential} configuration that should
-   * work for most applications that use the Azure SDK.
-   *
-   * The following credential types will be tried, in order:
-   *
-   * - {@link EnvironmentCredential}
-   * - {@link WorkloadIdentityCredential}
-   * - {@link ManagedIdentityCredential}
-   * - {@link AzureCliCredential}
-   * - {@link AzurePowerShellCredential}
-   * - {@link AzureDeveloperCliCredential}
-   *
-   * Consult the documentation of these credential types for more information
-   * on how they attempt authentication.
+   * Creates an instance of the DefaultAzureCredential class with {@link DefaultAzureCredentialResourceIdOptions}.
    *
    * @param options - Optional parameters. See {@link DefaultAzureCredentialResourceIdOptions}.
    */
   constructor(options?: DefaultAzureCredentialResourceIdOptions);
 
   /**
-   * Creates an instance of the DefaultAzureCredential class with {@link DefaultAzureCredentialOptions}
-   *
-   * This credential provides a default {@link ChainedTokenCredential} configuration that should
-   * work for most applications that use the Azure SDK.
-   *
-   * The following credential types will be tried, in order:
-   *
-   * - {@link EnvironmentCredential}
-   * - {@link WorkloadIdentityCredential}
-   * - {@link ManagedIdentityCredential}
-   * - {@link AzureCliCredential}
-   * - {@link AzurePowerShellCredential}
-   * - {@link AzureDeveloperCliCredential}
-   *
-   * Consult the documentation of these credential types for more information
-   * on how they attempt authentication.
+   * Creates an instance of the DefaultAzureCredential class with {@link DefaultAzureCredentialOptions}.
    *
    * @param options - Optional parameters. See {@link DefaultAzureCredentialOptions}.
    */

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -34,7 +34,7 @@ export function createDefaultManagedIdentityCredential(
   options:
     | DefaultAzureCredentialOptions
     | DefaultAzureCredentialResourceIdOptions
-    | DefaultAzureCredentialClientIdOptions = {}
+    | DefaultAzureCredentialClientIdOptions = {},
 ): TokenCredential {
   options.retryOptions ??= {
     maxRetries: 5,
@@ -66,7 +66,7 @@ export function createDefaultManagedIdentityCredential(
 
     return new ManagedIdentityCredential(
       workloadIdentityClientId,
-      workloadIdentityCredentialOptions
+      workloadIdentityCredentialOptions,
     );
   }
 
@@ -90,7 +90,7 @@ export function createDefaultManagedIdentityCredential(
  * @internal
  */
 function createDefaultWorkloadIdentityCredential(
-  options?: DefaultAzureCredentialOptions | DefaultAzureCredentialClientIdOptions
+  options?: DefaultAzureCredentialOptions | DefaultAzureCredentialClientIdOptions,
 ): TokenCredential {
   const managedIdentityClientId =
     (options as DefaultAzureCredentialClientIdOptions)?.managedIdentityClientId ??
@@ -128,7 +128,7 @@ function createDefaultWorkloadIdentityCredential(
  * @internal
  */
 function createDefaultAzureDeveloperCliCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzureDeveloperCliCredential({ processTimeoutInMs, ...options });
@@ -141,7 +141,7 @@ function createDefaultAzureDeveloperCliCredential(
  * @internal
  */
 function createDefaultAzureCliCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzureCliCredential({ processTimeoutInMs, ...options });
@@ -154,7 +154,7 @@ function createDefaultAzureCliCredential(
  * @internal
  */
 function createDefaultAzurePowershellCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzurePowerShellCredential({ processTimeoutInMs, ...options });
@@ -167,7 +167,7 @@ function createDefaultAzurePowershellCredential(
  * @internal
  */
 export function createEnvironmentCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   return new EnvironmentCredential(options);
 }
@@ -187,7 +187,7 @@ export class UnavailableDefaultCredential implements TokenCredential {
 
   getToken(): Promise<null> {
     logger.getToken.info(
-      `Skipping ${this.credentialName}, reason: ${this.credentialUnavailableErrorMessage}`
+      `Skipping ${this.credentialName}, reason: ${this.credentialUnavailableErrorMessage}`,
     );
     return Promise.resolve(null);
   }
@@ -253,7 +253,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
         return createCredentialFn(options);
       } catch (err: any) {
         logger.warning(
-          `Skipped ${createCredentialFn.name} because of an error creating the credential: ${err}`
+          `Skipped ${createCredentialFn.name} because of an error creating the credential: ${err}`,
         );
         return new UnavailableDefaultCredential(createCredentialFn.name, err.message);
       }

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -34,7 +34,7 @@ export function createDefaultManagedIdentityCredential(
   options:
     | DefaultAzureCredentialOptions
     | DefaultAzureCredentialResourceIdOptions
-    | DefaultAzureCredentialClientIdOptions = {},
+    | DefaultAzureCredentialClientIdOptions = {}
 ): TokenCredential {
   options.retryOptions ??= {
     maxRetries: 5,
@@ -66,7 +66,7 @@ export function createDefaultManagedIdentityCredential(
 
     return new ManagedIdentityCredential(
       workloadIdentityClientId,
-      workloadIdentityCredentialOptions,
+      workloadIdentityCredentialOptions
     );
   }
 
@@ -90,7 +90,7 @@ export function createDefaultManagedIdentityCredential(
  * @internal
  */
 function createDefaultWorkloadIdentityCredential(
-  options?: DefaultAzureCredentialOptions | DefaultAzureCredentialClientIdOptions,
+  options?: DefaultAzureCredentialOptions | DefaultAzureCredentialClientIdOptions
 ): TokenCredential {
   const managedIdentityClientId =
     (options as DefaultAzureCredentialClientIdOptions)?.managedIdentityClientId ??
@@ -128,7 +128,7 @@ function createDefaultWorkloadIdentityCredential(
  * @internal
  */
 function createDefaultAzureDeveloperCliCredential(
-  options: DefaultAzureCredentialOptions = {},
+  options: DefaultAzureCredentialOptions = {}
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzureDeveloperCliCredential({ processTimeoutInMs, ...options });
@@ -141,7 +141,7 @@ function createDefaultAzureDeveloperCliCredential(
  * @internal
  */
 function createDefaultAzureCliCredential(
-  options: DefaultAzureCredentialOptions = {},
+  options: DefaultAzureCredentialOptions = {}
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzureCliCredential({ processTimeoutInMs, ...options });
@@ -154,7 +154,7 @@ function createDefaultAzureCliCredential(
  * @internal
  */
 function createDefaultAzurePowershellCredential(
-  options: DefaultAzureCredentialOptions = {},
+  options: DefaultAzureCredentialOptions = {}
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzurePowerShellCredential({ processTimeoutInMs, ...options });
@@ -167,7 +167,7 @@ function createDefaultAzurePowershellCredential(
  * @internal
  */
 export function createEnvironmentCredential(
-  options: DefaultAzureCredentialOptions = {},
+  options: DefaultAzureCredentialOptions = {}
 ): TokenCredential {
   return new EnvironmentCredential(options);
 }
@@ -187,7 +187,7 @@ export class UnavailableDefaultCredential implements TokenCredential {
 
   getToken(): Promise<null> {
     logger.getToken.info(
-      `Skipping ${this.credentialName}, reason: ${this.credentialUnavailableErrorMessage}`,
+      `Skipping ${this.credentialName}, reason: ${this.credentialUnavailableErrorMessage}`
     );
     return Promise.resolve(null);
   }
@@ -199,7 +199,7 @@ export class UnavailableDefaultCredential implements TokenCredential {
  * [DefaultAzureCredential overview](https://aka.ms/azsdk/js/identity/credential-chains#use-defaultazurecredential-for-flexibility).
  *
  * The following credential types will be tried, in order:
- * 
+ *
  * - {@link EnvironmentCredential}
  * - {@link WorkloadIdentityCredential}
  * - {@link ManagedIdentityCredential}
@@ -253,7 +253,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
         return createCredentialFn(options);
       } catch (err: any) {
         logger.warning(
-          `Skipped ${createCredentialFn.name} because of an error creating the credential: ${err}`,
+          `Skipped ${createCredentialFn.name} because of an error creating the credential: ${err}`
         );
         return new UnavailableDefaultCredential(createCredentialFn.name, err.message);
       }


### PR DESCRIPTION
Drive traffic to the new credential chains doc on Learn. Also, eliminate duplication in the `DefaultAzureCredential` API docs.