### PR TITLE
[core-client-rest] use helpers for isCredential

### DIFF
--- a/sdk/core/core-client-rest/src/getClient.ts
+++ b/sdk/core/core-client-rest/src/getClient.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { KeyCredential, TokenCredential, isKeyCredential, isTokenCredential } from "@azure/core-auth";
+import {
+  KeyCredential,
+  TokenCredential,
+  isKeyCredential,
+  isTokenCredential,
+} from "@azure/core-auth";
 import { HttpClient, HttpMethods, Pipeline, PipelineOptions } from "@azure/core-rest-pipeline";
 import { createDefaultPipeline } from "./clientHelpers.js";
 import {

--- a/sdk/core/core-client-rest/src/getClient.ts
+++ b/sdk/core/core-client-rest/src/getClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { KeyCredential, TokenCredential, isTokenCredential } from "@azure/core-auth";
+import { KeyCredential, TokenCredential, isKeyCredential, isTokenCredential } from "@azure/core-auth";
 import { HttpClient, HttpMethods, Pipeline, PipelineOptions } from "@azure/core-rest-pipeline";
 import { createDefaultPipeline } from "./clientHelpers.js";
 import {
@@ -198,9 +198,5 @@ function buildOperation(
 function isCredential(
   param: (TokenCredential | KeyCredential) | PipelineOptions,
 ): param is TokenCredential | KeyCredential {
-  if ((param as KeyCredential).key !== undefined || isTokenCredential(param)) {
-    return true;
-  }
-
-  return false;
+  return isKeyCredential(param) || isTokenCredential(param);
 }

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -546,14 +546,19 @@ index eabe718..0000000
 -
 -/// <reference lib="dom" />
 diff --git a/src/client/getClient.ts b/src/client/getClient.ts
-index 549d26f..4029937 100644
+index 079c3ac..4029937 100644
 --- a/src/client/getClient.ts
 +++ b/src/client/getClient.ts
-@@ -1,8 +1,10 @@
+@@ -1,13 +1,10 @@
  // Copyright (c) Microsoft Corporation.
  // Licensed under the MIT License.
  
--import { KeyCredential, TokenCredential, isKeyCredential, isTokenCredential } from "@azure/core-auth";
+-import {
+-  KeyCredential,
+-  TokenCredential,
+-  isKeyCredential,
+-  isTokenCredential,
+-} from "@azure/core-auth";
 -import { HttpClient, HttpMethods, Pipeline, PipelineOptions } from "@azure/core-rest-pipeline";
 +import { TokenCredential, isTokenCredential } from "../auth/tokenCredential.js";
 +import { KeyCredential, isKeyCredential } from "../auth/keyCredential.js";
@@ -562,7 +567,7 @@ index 549d26f..4029937 100644
  import { createDefaultPipeline } from "./clientHelpers.js";
  import {
    Client,
-@@ -10,10 +12,12 @@ import {
+@@ -15,10 +12,12 @@ import {
    HttpBrowserStreamResponse,
    HttpNodeStreamResponse,
    RequestParameters,
@@ -575,7 +580,7 @@ index 549d26f..4029937 100644
  
  /**
   * Creates a client with a default pipeline
-@@ -60,8 +64,8 @@ export function getClient(
+@@ -65,8 +64,8 @@ export function getClient(
  
    const { allowInsecureConnection, httpClient } = clientOptions;
    const endpointUrl = clientOptions.endpoint ?? endpoint;


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-rest/core-client`

### Describe the problem that is addressed by this PR

Simplify `isCredential` helper used in getClient.ts. This change was already made in the unbranded package but not in Azure core.

No change in the Unbranded diff report for this PR because I made the change and updated the diff as part of #31487, just forgot to check in this particular change. The unbranded diff check is currently reporting a failure on main and this change should fix that.