### PR TITLE
Use federated auth for smoke testing

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -58,51 +58,19 @@ jobs:
         Mac Node18 (AzureCloud):
           Pool: Azure Pipelines
           OSVmImage: "macos-latest"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "18.x"
         Windows Node20 (AzureCloud):
           Pool: "azsdk-pool-mms-win-2022-general"
           OSVmImage: "MMS2022"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "20.x"
         Linux Node18 (AzureCloud):
           Pool: "azsdk-pool-mms-ubuntu-2004-general"
           OSVmImage: "MMSUbuntu20.04"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "18.x"
         Linux Node20 (AzureCloud):
           Pool: "azsdk-pool-mms-ubuntu-2004-general"
           OSVmImage: "MMSUbuntu20.04"
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          ArmTemplateParameters: $(AzureCloudArmTemplateParameters)
           NodeTestVersion: "20.x"
-#        Linux Node12 (AzureUSGovernment):
-#          Pool: Azure Pipelines
-#          OSVmImage: "ubuntu-18.04"
-#          SubscriptionConfiguration: $(sub-config-gov-test-resources)
-#          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-#          NodeTestVersion: "12.x"
-#        Windows Node14 (AzureUSGovernment):
-#          Pool: Azure Pipelines
-#          OSVmImage: "windows-2022"
-#          SubscriptionConfiguration: $(sub-config-gov-test-resources)
-#          ArmTemplateParameters: $(AzureUSGovernmentArmTemplateParameters)
-#          NodeTestVersion: "14.x"
-#        Linux Node12 (AzureChinaCloud):
-#          Pool: Azure Pipelines
-#          OSVmImage: "ubuntu-18.04"
-#          SubscriptionConfiguration: $(sub-config-cn-test-resources)
-#          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-#          NodeTestVersion: "12.x"
-#        Windows Node12 (AzureChinaCloud):
-#          Pool: Azure Pipelines
-#          OSVmImage: "windows-2022"
-#          SubscriptionConfiguration: $(sub-config-cn-test-resources)
-#          ArmTemplateParameters: $(AzureChinaCloudArmTemplateParameters)
-#          NodeTestVersion: "12.x"
 
     pool:
       name: $(Pool)
@@ -110,14 +78,6 @@ jobs:
 
     variables:
       - template: /eng/pipelines/templates/variables/globals.yml
-      - name: Location
-        value: ""
-      - name: AzureCloudArmTemplateParameters
-        value: "@{ }"
-      - name: AzureUSGovernmentArmTemplateParameters
-        value: "@{ storageEndpointSuffix = 'core.usgovcloudapi.net'; cognitiveServicesEndpointSuffix = 'cognitiveservices.azure.us'; searchSku = 'basic' }"
-      - name: AzureChinaCloudArmTemplateParameters
-        value: "@{ storageEndpointSuffix = 'core.chinacloudapi.cn'; cognitiveServicesEndpointSuffix = 'cognitiveservices.azure.cn'; searchSku = 'basic' }"
 
     steps:
       - template: /eng/pipelines/templates/steps/common.yml
@@ -132,9 +92,11 @@ jobs:
       - download: current
         artifact: ${{parameters.ArtifactName}}
         condition: and(succeeded(), ne('${{ parameters.Daily }}', 'true'))
+
       - pwsh: |
           $(Build.SourcesDirectory)/eng/common/scripts/Import-AzModules.ps1
-
+           
+          # TODO: When we re-enable this pipeline we will need to refactor to use federated auth for deployment
           $subscriptionConfiguration = @"
             $(SubscriptionConfiguration)
           "@ | ConvertFrom-Json -AsHashtable;
@@ -202,4 +164,4 @@ jobs:
 
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:
-          SubscriptionConfiguration: $(SubscriptionConfiguration)
+          ServiceConnection: azure-sdk-tests-public


### PR DESCRIPTION
The smoke-tests pipeline has been disabled but I still cleaned up to smoke tests to remove usages of sub-config-azure-cloud-test-resources and try to use a service connection. When we decide to re-enable the smoke tests pipeline we will want to update the deployment to use federated auth as well.

@xirzec you disabled this pipeline 1/10/2023. Do you have any plans to try and re-enable it? If not perhaps we just delete this instead.
