### PR TITLE
Update AzureCommunicationChat Version to 1.5.4

### DIFF
--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.5.4 (2024-10-24)
+
+### Bugs Fixed
+
+- Updated the @azure/communication-chat version in UserAgentPrefix.
+
 ## 1.5.3 (2024-10-23)
 
 ### Other Changes

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-chat",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Azure client library for Azure Communication Chat services",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/communication/communication-chat/src/generated/src/chatApiClient.ts
+++ b/sdk/communication/communication-chat/src/generated/src/chatApiClient.ts
@@ -38,7 +38,7 @@ export class ChatApiClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-chat/1.5.2`;
+    const packageDetails = `azsdk-js-communication-chat/1.5.4`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-chat/src/generated/src/tracing.ts
+++ b/sdk/communication/communication-chat/src/generated/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Azure.Communication",
   packageName: "@azure/communication-chat",
-  packageVersion: "1.5.2",
+  packageVersion: "1.5.4",
 });

--- a/sdk/communication/communication-chat/swagger/README.md
+++ b/sdk/communication/communication-chat/swagger/README.md
@@ -16,7 +16,7 @@ model-date-time-as-string: false
 optional-response-headers: true
 add-credentials: false
 disable-async-iterators: true
-package-version: 1.5.2
+package-version: 1.5.4
 use-extension:
   "@autorest/typescript": "latest"
 tracing-info:


### PR DESCRIPTION
### Describe the problem that is addressed by this PR
Bump @azure/communication-chat version from 1.5.3 to 1.5.4