### PR TITLE
[core-amqp] don't log request on `RequestResponseLink`

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 4.3.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.3.3 (2024-11-07)
 
 ### Other Changes
 

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Move the constant for the geographic replication feature to Event Hubs.
+- Remove request from `RequestResponseLink` logging.
 
 ## 4.3.2 (2024-08-01)
 

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -189,7 +189,6 @@ export class RequestResponseLink implements ReqResLink {
         "[%s] %s request sent: %O",
         this.connection.id,
         request.to || "$management",
-        request,
       );
       this.sender.send(request);
     });

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -185,11 +185,7 @@ export class RequestResponseLink implements ReqResLink {
         },
       });
 
-      logger.verbose(
-        "[%s] %s request sent: %O",
-        this.connection.id,
-        request.to || "$management",
-      );
+      logger.verbose("[%s] %s request sent: %O", this.connection.id, request.to || "$management");
       this.sender.send(request);
     });
   }


### PR DESCRIPTION
even on verbose as it can contains secrets.