### PR TITLE
[ts-http-runtime] Enforce azure diff check

### DIFF
--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -62,7 +62,7 @@
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
-    "lint": "tsx scripts/azure-diff.ts; eslint package.json api-extractor.json src test",
+    "lint": "tsx scripts/azure-diff.ts && eslint package.json api-extractor.json src test",
     "lint:fix": "tsx scripts/azure-diff.ts --update && eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
     "test": "npm run clean && dev-tool run build-package && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",


### PR DESCRIPTION
### Packages impacted by this PR

- `@typespec/ts-http-runtime`

### Describe the problem that is addressed by this PR

The diff check seems to be running as it should, so let's enable it so that failure makes CI go red

- [Example of it passing on main](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4279078&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=70ccc7c9-8d04-5255-456e-9568fe142bcd&l=612)
- [Example of it failing on a PR branch that has not updated the diff](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4276826&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=d31d5e2d-d8df-53bc-da94-87e19f5b2ee4&l=616) (lint step failure is due to ESLint failures, not the unbranded check tool)

### Provide a list of related PRs _(if any)_

- #31285
