### PR TITLE
Have ServiceBus SDK accept any return value for processMessage

### DIFF
--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -63,7 +63,7 @@ export interface MessageHandlers {
    *
    * @param message - A message received from Service Bus.
    */
-  processMessage(message: ServiceBusReceivedMessage): Promise<void>;
+  processMessage(message: ServiceBusReceivedMessage): Promise<unknown>;
   /**
    * Handler that processes errors that occur during receiving.
    *


### PR DESCRIPTION
The `processMessage` function explicitly requires the return type of the promise to be `void`. With such limitation, callers are often forced to write additional code to respect such requirement. Here is an example:

```ts
receiver.subscribe({
  processError: () => Promise.resolve(null),
  processMessage: async message => {
      return createPRReport()
        .then(reassign)
        .then(sendNotification)
        .then(() => null) // If I do not add this, it errors out
    }
  }
});
```

The same is with `async/await`:

```ts
receiver.subscribe({
  processError: () => Promise.resolve(null),
  processMessage: async message => {
      const r1 = await createPRReport();
      const r2 = await reassign(r1);

      return sendNotifications(r2); // this errors out

      // this works
      const r3 = sendNotifications(r2);
      return;
    }
  }
});
```

By changing the type to be `unknown`, people can return any value, and the caller (in this case the SDK) can just discard it.

P.S: I am a MSFT employee - you can find me out in Teams for more information.
