### PR TITLE
[EngSys] fix `schema-registry-avro` build failure on Windows

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -14,7 +14,7 @@
     "build:samples": "echo Obsolete.",
     "build:test": "dev-tool run build-package & dev-tool run build-test",
     "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "clean": "dev-tool run vendored rimraf --glob dist dist-* temp \"types/!(schema-registry-avro.shims.d.ts)\" *.tgz *.log",
+    "clean": "dev-tool run vendored rimraf --glob dist dist-* *.tgz *.log temp \"types/!(schema-registry-avro.shims.d.ts)\"",
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "tsc -p . && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",


### PR DESCRIPTION
After moving to vendored rimraf, this particular "clean" script is failing likely due to the escaped quoted argument before it and how dev-tool handls arguments. Moving `*.tgz *.log` fixes it.
