### PR TITLE
We want to pull down ci.mgmt.yml as well as ci.yml for Matrix resolution

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -75,7 +75,7 @@ jobs:
           MatrixFilters: ${{ parameters.MatrixFilters }}
           MatrixReplace: ${{ parameters.MatrixReplace }}
           ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-            SparseCheckoutPaths: [ "**/package.json", "**/ci.yml"]
+            SparseCheckoutPaths: [ "**/package.json", "**/ci*.yml"]
           CloudConfig:
             Cloud: Public
           AdditionalParameters:


### PR DESCRIPTION
During pr matrix generation. Follow-up on #31631