### PR TITLE
[OpenAI] Remove outdated definitions

### DIFF
--- a/sdk/openai/openai/CHANGELOG.md
+++ b/sdk/openai/openai/CHANGELOG.md
@@ -13,7 +13,9 @@ This release adds types for Azure features supported in Azure OpenAI Service API
 ### Breaking Changes
 
 - Remove the Azure ML connection in Azure On Your Data.
+- Remove the enhancements feature from chat completions.
 - Remove the now deprecated `finish_details` field in chat completion responses. Use `finish_reason` instead.
+- Remove the `role_information` field from the On Your Data request models.
 
 ## 2.0.0-beta.2 (2024-09-09)
 

--- a/sdk/openai/openai/review/openai-types.api.md
+++ b/sdk/openai/openai/review/openai-types.api.md
@@ -15,17 +15,6 @@ import type { CompletionCreateParamsStreaming } from 'openai/resources/index';
 import type { ErrorModel } from '@azure-rest/core-client';
 
 // @public
-export interface AzureChatEnhancementConfiguration {
-    grounding?: AzureChatGroundingEnhancementConfiguration;
-    ocr?: AzureChatOCREnhancementConfiguration;
-}
-
-// @public
-export interface AzureChatEnhancementsOutput {
-    grounding?: AzureGroundingEnhancementOutput;
-}
-
-// @public
 export type AzureChatExtensionConfiguration = AzureChatExtensionConfigurationParent | AzureSearchChatExtensionConfiguration | AzureCosmosDBChatExtensionConfiguration | ElasticsearchChatExtensionConfiguration | PineconeChatExtensionConfiguration | MongoDBChatExtensionConfiguration;
 
 // @public
@@ -71,16 +60,6 @@ export interface AzureChatExtensionsMessageContextOutput {
 }
 
 // @public
-export interface AzureChatGroundingEnhancementConfiguration {
-    enabled: boolean;
-}
-
-// @public
-export interface AzureChatOCREnhancementConfiguration {
-    enabled: boolean;
-}
-
-// @public
 export interface AzureCosmosDBChatExtensionConfiguration extends AzureChatExtensionConfigurationParent {
     parameters: AzureCosmosDBChatExtensionParameters;
     type: "azure_cosmos_db";
@@ -111,31 +90,6 @@ export interface AzureCosmosDBFieldMappingOptions {
     title_field?: string;
     url_field?: string;
     vector_fields: string[];
-}
-
-// @public
-export interface AzureGroundingEnhancementCoordinatePointOutput {
-    x: number;
-    y: number;
-}
-
-// @public
-export interface AzureGroundingEnhancementLineOutput {
-    spans: Array<AzureGroundingEnhancementLineSpanOutput>;
-    text: string;
-}
-
-// @public
-export interface AzureGroundingEnhancementLineSpanOutput {
-    length: number;
-    offset: number;
-    polygon: Array<AzureGroundingEnhancementCoordinatePointOutput>;
-    text: string;
-}
-
-// @public
-export interface AzureGroundingEnhancementOutput {
-    lines: Array<AzureGroundingEnhancementLineOutput>;
 }
 
 // @public

--- a/sdk/openai/openai/src/types/index.ts
+++ b/sdk/openai/openai/src/types/index.ts
@@ -18,15 +18,11 @@ import type {
 import type {
   ContentFilterResultsForPromptOutput,
   ContentFilterResultsForChoiceOutput,
-  AzureChatEnhancementsOutput,
   AzureChatExtensionsMessageContextOutput,
   ImageGenerationPromptFilterResults,
   ImageGenerationContentFilterResults,
 } from "./outputModels.js";
-import type {
-  AzureChatExtensionConfiguration,
-  AzureChatEnhancementConfiguration,
-} from "./models.js";
+import type { AzureChatExtensionConfiguration } from "./models.js";
 
 declare module "openai/resources/index" {
   interface Completion {
@@ -43,8 +39,6 @@ declare module "openai/resources/index" {
      *   This additional specification is only compatible with Azure OpenAI.
      */
     data_sources?: Array<AzureChatExtensionConfiguration>;
-    /** If provided, the configuration options for available Azure OpenAI chat enhancements. */
-    enhancements?: AzureChatEnhancementConfiguration;
   }
 
   interface ChatCompletionCreateParamsStreaming {
@@ -53,8 +47,6 @@ declare module "openai/resources/index" {
      *   This additional specification is only compatible with Azure OpenAI.
      */
     data_sources?: Array<AzureChatExtensionConfiguration>;
-    /** If provided, the configuration options for available Azure OpenAI chat enhancements. */
-    enhancements?: AzureChatEnhancementConfiguration;
   }
 
   interface ChatCompletion {
@@ -90,12 +82,6 @@ declare module "openai/resources/index" {
        * determines the intensity and risk level of harmful content) and if it has been filtered or not.
        */
       content_filter_results?: ContentFilterResultsForChoiceOutput;
-      /**
-       * Represents the output results of Azure OpenAI enhancements to chat completions, as configured via the matching input
-       * provided in the request. This supplementary information is only available when using Azure OpenAI and only when the
-       * request is configured to use enhancements.
-       */
-      enhancements?: AzureChatEnhancementsOutput;
     }
   }
 
@@ -115,12 +101,6 @@ declare module "openai/resources/index" {
        * determines the intensity and risk level of harmful content) and if it has been filtered or not.
        */
       content_filter_results?: ContentFilterResultsForChoiceOutput;
-      /**
-       * Represents the output results of Azure OpenAI enhancements to chat completions, as configured via the matching input
-       * provided in the request. This supplementary information is only available when using Azure OpenAI and only when the
-       * request is configured to use enhancements.
-       */
-      enhancements?: AzureChatEnhancementsOutput;
     }
 
     namespace Choice {
@@ -156,6 +136,13 @@ declare module "openai/resources/index" {
      * been filtered and its id.
      */
     prompt_filter_results?: ImageGenerationPromptFilterResults;
+  }
+
+  export interface UploadPart {
+    /**
+     * Azure-only field.
+     */
+    azure_block_id?: string;
   }
 }
 

--- a/sdk/openai/openai/src/types/models.ts
+++ b/sdk/openai/openai/src/types/models.ts
@@ -443,25 +443,6 @@ export interface PineconeFieldMappingOptions {
   content_fields_separator?: string;
 }
 
-/** A representation of the available Azure OpenAI enhancement configurations. */
-export interface AzureChatEnhancementConfiguration {
-  /** A representation of the available options for the Azure OpenAI grounding enhancement. */
-  grounding?: AzureChatGroundingEnhancementConfiguration;
-  /** A representation of the available options for the Azure OpenAI optical character recognition (OCR) enhancement. */
-  ocr?: AzureChatOCREnhancementConfiguration;
-}
-/** A representation of the available options for the Azure OpenAI grounding enhancement. */
-export interface AzureChatGroundingEnhancementConfiguration {
-  /** Specifies whether the enhancement is enabled. */
-  enabled: boolean;
-}
-
-/** A representation of the available options for the Azure OpenAI optical character recognition (OCR) enhancement. */
-export interface AzureChatOCREnhancementConfiguration {
-  /** Specifies whether the enhancement is enabled. */
-  enabled: boolean;
-}
-
 /**
  * A specific representation of configurable options for Mongo DB when using it as an Azure OpenAI chat
  * extension.

--- a/sdk/openai/openai/src/types/outputModels.ts
+++ b/sdk/openai/openai/src/types/outputModels.ts
@@ -67,52 +67,6 @@ export interface ContentFilterCitedDetectionResultOutput {
 }
 
 /**
- * Represents the output results of Azure enhancements to chat completions, as configured via the matching input provided
- * in the request.
- */
-export interface AzureChatEnhancementsOutput {
-  /** The grounding enhancement that returns the bounding box of the objects detected in the image. */
-  grounding?: AzureGroundingEnhancementOutput;
-}
-
-/** The grounding enhancement that returns the bounding box of the objects detected in the image. */
-export interface AzureGroundingEnhancementOutput {
-  /** The lines of text detected by the grounding enhancement. */
-  lines: Array<AzureGroundingEnhancementLineOutput>;
-}
-
-/** A content line object consisting of an adjacent sequence of content elements, such as words and selection marks. */
-export interface AzureGroundingEnhancementLineOutput {
-  /** The text within the line. */
-  text: string;
-  /** An array of spans that represent detected objects and its bounding box information. */
-  spans: Array<AzureGroundingEnhancementLineSpanOutput>;
-}
-
-/** A span object that represents a detected object and its bounding box information. */
-export interface AzureGroundingEnhancementLineSpanOutput {
-  /** The text content of the span that represents the detected object. */
-  text: string;
-  /**
-   * The character offset within the text where the span begins. This offset is defined as the position of the first
-   * character of the span, counting from the start of the text as Unicode codepoints.
-   */
-  offset: number;
-  /** The length of the span in characters, measured in Unicode codepoints. */
-  length: number;
-  /** An array of objects representing points in the polygon that encloses the detected object. */
-  polygon: Array<AzureGroundingEnhancementCoordinatePointOutput>;
-}
-
-/** A representation of a single polygon point as used by the Azure grounding enhancement. */
-export interface AzureGroundingEnhancementCoordinatePointOutput {
-  /** The x-coordinate (horizontal axis) of the point. */
-  x: number;
-  /** The y-coordinate (vertical axis) of the point. */
-  y: number;
-}
-
-/**
  * A representation of the additional context information available when Azure OpenAI chat extensions are involved
  * in the generation of a corresponding chat completions response. This context information is only populated when
  * using an Azure OpenAI request configured to use a matching extension.

--- a/sdk/openai/openai/test/public/utils/asserts.ts
+++ b/sdk/openai/openai/test/public/utils/asserts.ts
@@ -11,13 +11,6 @@ import {
   ContentFilterResultDetailsForPromptOutput,
   ContentFilterResultsForChoiceOutput,
   ContentFilterResultsForPromptOutput,
-  ChatFinishDetailsOutput,
-  StopFinishDetailsOutput,
-  AzureChatEnhancementsOutput,
-  AzureGroundingEnhancementOutput,
-  AzureGroundingEnhancementLineSpanOutput,
-  AzureGroundingEnhancementCoordinatePointOutput,
-  AzureGroundingEnhancementLineOutput,
   ContentFilterDetailedResults,
 } from "../../../src/types/index.js";
 import { Assistant, AssistantCreateParams } from "openai/resources/beta/assistants.mjs";
@@ -254,8 +247,6 @@ function assertChoice(
   }
   assert.isNumber(choice.index);
   ifDefined(choice.content_filter_results, assertContentFilterResultsForChoice);
-  ifDefined(choice.enhancements, assertAzureChatEnhancements);
-  ifDefined(choice.finish_details, assertChatFinishDetails);
   ifDefined(choice.logprobs, assertLogProbability);
   ifDefined(choice.finish_reason, assert.isString);
 }
@@ -362,17 +353,6 @@ function assertToolCall(
   }
 }
 
-function assertChatFinishDetails(val: ChatFinishDetailsOutput): void {
-  switch (val.type) {
-    case "max_tokens":
-      break;
-    case "stop": {
-      assert.isString((val as StopFinishDetailsOutput).stop);
-      break;
-    }
-  }
-}
-
 export function assertNonEmptyArray<T>(val: T[], validate: (x: T) => void): void {
   assert.isNotEmpty(val);
   assertArray(val, validate);
@@ -453,34 +433,6 @@ function assertMessage(
 function assertContext(context: AzureChatExtensionsMessageContextOutput): void {
   ifDefined(context.intent, assert.isString);
   ifDefined(context.citations, (arr) => assertArray(arr, assertCitations));
-}
-
-function assertAzureChatEnhancements(val: AzureChatEnhancementsOutput): void {
-  ifDefined(val.grounding, assertAzureGroundingEnhancement);
-}
-
-function assertAzureGroundingEnhancementLine(val: AzureGroundingEnhancementLineOutput): void {
-  assertNonEmptyArray(val.spans, assertAzureGroundingEnhancementLineSpan);
-}
-
-function assertAzureGroundingEnhancement(val: AzureGroundingEnhancementOutput): void {
-  assertNonEmptyArray(val.lines, assertAzureGroundingEnhancementLine);
-}
-
-function assertAzureGroundingEnhancementLineSpan(
-  val: AzureGroundingEnhancementLineSpanOutput,
-): void {
-  assert.isNumber(val.length);
-  assert.isNumber(val.offset);
-  assert.isString(val.text);
-  assertNonEmptyArray(val.polygon, assertAzureGroundingEnhancementCoordinatePoint);
-}
-
-function assertAzureGroundingEnhancementCoordinatePoint(
-  val: AzureGroundingEnhancementCoordinatePointOutput,
-): void {
-  assert.isNumber(val.x);
-  assert.isNumber(val.y);
 }
 
 function assertCitations(citations: AzureChatExtensionDataSourceResponseCitationOutput): void {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/openai

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
This PR adds `azure_block_id` to the response model of file uploads and removes the [enhancement](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation#changes-between-2024-03-01-preview-and-2024-04-01-preview-api-specification) feature from chat completions and the [`role_information`](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation#changes-between-2024-07-01-preview-and-2024-08-01-preview-api-specification) field from On Your Data requests.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
