### PR TITLE
[EngSys] remove Use Python step from JS pipelines

### DIFF
--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -3,9 +3,4 @@ steps:
     parameters:
       AgentImage: $(OSVmImage)
 
-  - task: UsePythonVersion@0
-    displayName: "Use Python 3.9"
-    inputs:
-      versionSpec: "3.9"
-
   - template: use-node-version.yml


### PR DESCRIPTION
we don't need a specific version of Python. The one available on the build agent should be enough.