### PR TITLE
Disable codeql to avoid timeouts / long runtimes

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -60,5 +60,9 @@ extends:
         compiled: true
         break: true
       policy: M365
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: "CodeQL times our pipelines out by running for hours before being force canceled."
 
     stages: ${{ parameters.stages }}


### PR DESCRIPTION
This is how it [used to run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4248236&view=logs&j=b1e79959-24d8-5aa9-2799-72d40c3e051b&t=1a422346-a7fc-5798-c84d-6e5b319d46e3).

In the past week, we started seeing very long builds due to codeQL kicking on:

- [example 1](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4319395&view=logs&j=b1e79959-24d8-5aa9-2799-72d40c3e051b&t=1a422346-a7fc-5798-c84d-6e5b319d46e3)
- [example 2](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4317694&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=ce3b9047-3f2a-5c21-9248-60a34a33907c)