### PR TITLE
Allow dashes in path parameter templates

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Allow dashes (`-`) in path parameter identifiers. PR [#31731](https://github.com/Azure/azure-sdk-for-js/pull/31731)
+
 ### Other Changes
 
 ## 2.3.1 (2024-10-10)

--- a/sdk/core/core-client-rest/src/urlHelpers.ts
+++ b/sdk/core/core-client-rest/src/urlHelpers.ts
@@ -198,7 +198,7 @@ function buildRoutePath(
       value = encodeURIComponent(value);
     }
 
-    routePath = routePath.replace(/\{\w+\}/, String(value));
+    routePath = routePath.replace(/\{[\w-]+\}/, String(value));
   }
   return routePath;
 }

--- a/sdk/core/core-client-rest/test/urlHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/urlHelpers.spec.ts
@@ -123,6 +123,12 @@ describe("urlHelpers", () => {
     assert.equal(result, `https://example.org/foo?existing=hey&arrayQuery=`);
   });
 
+  it("should build url with dashes in path parameters", () => {
+    const result = buildRequestUrl(mockBaseUrl, "/foo/{settings-name}", ["example"]);
+
+    assert.equal(result, `https://example.org/foo/example`);
+  });
+
   it("should handle full urls as path", () => {
     const result = buildRequestUrl(mockBaseUrl, "https://example2.org", []);
     assert.equal(result, `https://example2.org`);

--- a/sdk/core/ts-http-runtime/src/client/urlHelpers.ts
+++ b/sdk/core/ts-http-runtime/src/client/urlHelpers.ts
@@ -198,7 +198,7 @@ function buildRoutePath(
       value = encodeURIComponent(value);
     }
 
-    routePath = routePath.replace(/\{\w+\}/, String(value));
+    routePath = routePath.replace(/\{[\w-]+\}/, String(value));
   }
   return routePath;
 }

--- a/sdk/core/ts-http-runtime/test/client/urlHelpers.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/urlHelpers.spec.ts
@@ -117,6 +117,12 @@ describe("urlHelpers", () => {
     assert.equal(result, `https://example.org/foo?existing=hey&arrayQuery=`);
   });
 
+  it("should build url with dashes in path parameters", () => {
+    const result = buildRequestUrl(mockBaseUrl, "/foo/{settings-name}", ["example"]);
+
+    assert.equal(result, `https://example.org/foo/example`);
+  });
+
   it("should handle full urls as path", () => {
     const result = buildRequestUrl(mockBaseUrl, "https://example2.org", []);
     assert.equal(result, `https://example2.org`);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/core-client-rest 
@azure/ts-http-runtime

### Issues associated with this PR

N/A - found in passing

### Describe the problem that is addressed by this PR

The existing regex for finding template values to replace assumes only `\w` characters are allowed in the template, but 
`-` should be valid for a template name as this [playground](https://azure.github.io/typespec-azure/playground/?c=aW1wb3J0ICJAdHlwZXNwZWMvaHR0cCI7CtIZcmVzdNUZdmVyc2lvbmluZ8wfYXp1cmUtdG9vbHMvyCstxhVjb3JlIjsKCnVzaW5nIFR5cGVTcGVjLkh0dHA70BVSZXN00RVWyXLIG0HEWS5Db3Jl0hIuVHJhaXRzOwoKQHVzZUF1dGgoCiAgQXBpS2V5xA48xgtMb2NhdGlvbi5oZWFkZXIsICJhcGkta2V5Ij4gfCBPxCoyxS9bCiAgICB7xQYgIOQA3DrHH0Zsb3fkAKUuaW1wbGljaXQsxyVhdXRob3JpesVhVXJsOiAi5AFoczovL2xvZ2luLmNvbnRvc28uY29tL2NvbW1vbi9vxDUyL3YyLjAvyEBlIshSc2NvcGVzOiBbyUl3aWRnZXTNSi5kZWZhdWx0Il3GN30KICBdPgopCkBzZXJ2aWNlKOQAxnRpdGxlOiAiQ8Y6IFfFSSBNYW5hZ2VyIiwKfccxZXLkATkie2VuZHBvaW50fcd05QCV0D9BUElzxRnEYyAgLyoqIApTdXDkAh5lZMglU%2BYAh3MgyFNzIChwcm90b2NvbCBhbmQgaG9zdG5hbWUsIGZvciBleGFtcGxlOgrpAPRlc3R1cy5hcGku8gD%2FKS4KICovxX7IXzogc3RyaW5n5ACYfeQBCOcCvGVkKOcAvy7mAJrnAP3oAmpzKQrkAIZzcGFjZSDVKjsKCuQA41RoySDvAUgg5wFzIMdzLuQAnGVudW0gyGTlASrERccRIDIwMjItMDgtMzHELCAg5AK%2FRGVwZW5kZW5jeSjrAuLIQy52MV8wX1ByZXZpZXdfMikKICBgyUYwYCwKfQoKLy8gT3BlcuUCi3MgL9MBCgphbGlhc%2BgBnuYDPyA9IOcBv3NSZXBlYXRhYmxlUmVxdWVzdHMgJgogyR9Db25kacReYWzWIGxpZW50xxtJZDvIb%2BsAlj3sA79SZXNvdXJjZcogPO0Amj47CgppbnRlcmbkAZ7mAXbmAU1Ac3VtbWFyeSgiR2V0IOQEgmlmaWVkIGFjY291bnQgc2V0dOQELG9iamVjdC4i5AEwQHJvdXRlKCIvxx1zL3vHCi3kAgN9xiVnZXQKICBvcCBnZXRTx0Zpc%2BwAtkZvdW5k5gCvLukAujztBDvoAjHEWCBvZiB0aGXwAJsuIE11c3QgYmUgYSB2YWxpZMgZcyBvcMRS5QJHxk9AcGF0aCgi7ACu5QCtxAHHFU5hbWXoAwQ7xRt95gQaxhMKICA%2BOwp9Cg%3D%3D&e=%40azure-tools%2Ftypespec-autorest&options=%7B%22linterRuleSet%22%3A%7B%22extends%22%3A%5B%22%40azure-tools%2Ftypespec-azure-rulesets%2Fdata-plane%22%5D%7D%7D) shows and [this typespec PR](https://github.com/Azure/azure-rest-api-specs/pull/30239/commits/436505080d4ed908c1d9ab35bfac3682acf2ca43) tries to do

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could update the typespec but shouldn't core-client-rest support this scenario?

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [x] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [x] Added a changelog (if necessary).
