### PR TITLE
[Identity] update recordings for msal-common and msal-node updates

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,10 +16,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "chai": "4.3.10",
-    "@azure/msal-node": "2.15.0",
-    "@azure/msal-browser": "3.26.1",
-    "@azure/msal-node-extensions": "1.3.0"
+    "chai": "4.3.10"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,15 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@azure/msal-browser':
-    specifier: 3.26.1
-    version: 3.26.1
-  '@azure/msal-node':
-    specifier: 2.15.0
-    version: 2.15.0
-  '@azure/msal-node-extensions':
-    specifier: 1.3.0
-    version: 1.3.0
   '@rush-temp/abort-controller':
     specifier: file:./projects/abort-controller.tgz
     version: file:projects/abort-controller.tgz
@@ -1292,7 +1283,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       tslib: 2.8.1
@@ -1306,7 +1297,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       tslib: 2.8.1
@@ -1332,7 +1323,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
     transitivePeerDependencies:
@@ -1363,7 +1354,7 @@ packages:
       '@azure/core-http-compat': 2.1.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
@@ -1382,7 +1373,7 @@ packages:
       '@azure/core-http-compat': 2.1.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
@@ -1400,7 +1391,7 @@ packages:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -1415,7 +1406,7 @@ packages:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -1430,7 +1421,7 @@ packages:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -1445,7 +1436,7 @@ packages:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -1457,7 +1448,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       events: 3.3.0
@@ -1477,7 +1468,7 @@ packages:
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/logger': 1.1.4
       events: 3.3.0
@@ -1494,7 +1485,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
@@ -1520,7 +1511,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
@@ -1535,7 +1526,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1567,8 +1558,8 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /@azure/core-rest-pipeline@1.18.0:
-    resolution: {integrity: sha512-QSoGUp4Eq/gohEFNJaUOwTN7BCc2nHTjjbm75JT0aD7W65PWM1H/tItz0GsABn22uaKyGxiMhWQLt2r+FGU89Q==}
+  /@azure/core-rest-pipeline@1.18.1:
+    resolution: {integrity: sha512-/wS73UEDrxroUEVywEm7J0p2c+IIiVxyfigCGfsKvCxxCET4V/Hef2aURqltrXMRjNmdmt5IuOgIpl8f6xdO5A==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -1629,12 +1620,12 @@ packages:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
-      '@azure/msal-browser': 3.26.1
-      '@azure/msal-node': 2.15.0
+      '@azure/msal-browser': 3.27.0
+      '@azure/msal-node': 2.16.2
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.2
@@ -1651,7 +1642,7 @@ packages:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
@@ -1670,7 +1661,7 @@ packages:
       '@azure/core-http-compat': 2.1.2
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/core-util': 1.11.0
       '@azure/keyvault-common': 2.0.0
@@ -1695,21 +1686,16 @@ packages:
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@azure/msal-browser@3.26.1:
-    resolution: {integrity: sha512-y78sr9g61aCAH9fcLO1um+oHFXc1/5Ap88RIsUSuzkm0BHzFnN+PXGaQeuM1h5Qf5dTnWNOd6JqkskkMPAhh7Q==}
+  /@azure/msal-browser@3.27.0:
+    resolution: {integrity: sha512-+b4ZKSD8+vslCtVRVetkegEhOFMLP3rxDWJY212ct+2r6jVg6OSQKc1Qz3kCoXo0FgwaXkb+76TMZfpHp8QtgA==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      '@azure/msal-common': 14.15.0
-    dev: false
-
-  /@azure/msal-common@14.15.0:
-    resolution: {integrity: sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==}
-    engines: {node: '>=0.8.0'}
+      '@azure/msal-common': 14.16.0
     dev: false
 
   /@azure/msal-common@14.16.0:
@@ -1717,12 +1703,12 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /@azure/msal-node-extensions@1.3.0:
-    resolution: {integrity: sha512-7rXN+9hDm3NncIfNnMyoFtsnz2AlUtmK5rsY3P+fhhbH+GOk0W5Y1BASvAB6RCcKdO+qSIK3ZA6VHQYy4iS/1w==}
+  /@azure/msal-node-extensions@1.5.0:
+    resolution: {integrity: sha512-UfEyh2xmJHKH64zPS/SbN1bd9adV4ZWGp1j2OSwIuhVraqpUXyXZ1LpDpiUqg/peTgLLtx20qrHOzYT0kKzmxQ==}
     engines: {node: '>=16'}
     requiresBuild: true
     dependencies:
-      '@azure/msal-common': 14.15.0
+      '@azure/msal-common': 14.16.0
       '@azure/msal-node-runtime': 0.17.1
       keytar: 7.9.0
     dev: false
@@ -1730,15 +1716,6 @@ packages:
   /@azure/msal-node-runtime@0.17.1:
     resolution: {integrity: sha512-qAfTg+iGJsg+XvD9nmknI63+XuoX32oT+SX4wJdFz7CS6ETVpSHoroHVaUmsTU1H7H0+q1/ZkP988gzPRMYRsg==}
     requiresBuild: true
-    dev: false
-
-  /@azure/msal-node@2.15.0:
-    resolution: {integrity: sha512-gVPW8YLz92ZeCibQH2QUw96odJoiM3k/ZPH3f2HxptozmH6+OnyyvKXo/Egg39HAM230akarQKHf0W74UHlh0Q==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@azure/msal-common': 14.15.0
-      jsonwebtoken: 9.0.2
-      uuid: 8.3.2
     dev: false
 
   /@azure/msal-node@2.16.2:
@@ -1756,7 +1733,7 @@ packages:
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-sse': 2.1.3
       '@azure/core-util': 1.11.0
       '@azure/logger': 1.1.4
@@ -1772,7 +1749,7 @@ packages:
       '@azure-rest/core-client': 2.3.1
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/logger': 1.1.4
       tslib: 2.8.1
@@ -1788,7 +1765,7 @@ packages:
       '@azure/core-client': 1.9.2
       '@azure/core-http-compat': 2.1.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/logger': 1.1.4
       events: 3.3.0
@@ -1804,7 +1781,7 @@ packages:
       '@azure/core-auth': 1.9.0
       '@azure/core-client': 1.9.2
       '@azure/core-lro': 2.7.2
-      '@azure/core-rest-pipeline': 1.18.0
+      '@azure/core-rest-pipeline': 1.18.1
       '@azure/core-tracing': 1.2.0
       '@azure/logger': 1.1.4
       tslib: 2.8.1
@@ -2034,6 +2011,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/aix-ppc64@0.24.0:
+    resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/android-arm64@0.21.5:
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -2045,6 +2031,15 @@ packages:
 
   /@esbuild/android-arm64@0.23.1:
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-arm64@0.24.0:
+    resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2070,6 +2065,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/android-arm@0.24.0:
+    resolution: {integrity: sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/android-x64@0.21.5:
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -2081,6 +2085,15 @@ packages:
 
   /@esbuild/android-x64@0.23.1:
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-x64@0.24.0:
+    resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2106,6 +2119,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/darwin-arm64@0.24.0:
+    resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/darwin-x64@0.21.5:
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -2117,6 +2139,15 @@ packages:
 
   /@esbuild/darwin-x64@0.23.1:
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-x64@0.24.0:
+    resolution: {integrity: sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2142,6 +2173,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/freebsd-arm64@0.24.0:
+    resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/freebsd-x64@0.21.5:
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -2153,6 +2193,15 @@ packages:
 
   /@esbuild/freebsd-x64@0.23.1:
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-x64@0.24.0:
+    resolution: {integrity: sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2178,6 +2227,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-arm64@0.24.0:
+    resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-arm@0.21.5:
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -2189,6 +2247,15 @@ packages:
 
   /@esbuild/linux-arm@0.23.1:
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm@0.24.0:
+    resolution: {integrity: sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2214,6 +2281,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-ia32@0.24.0:
+    resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-loong64@0.21.5:
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -2225,6 +2301,15 @@ packages:
 
   /@esbuild/linux-loong64@0.23.1:
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-loong64@0.24.0:
+    resolution: {integrity: sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2250,6 +2335,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-mips64el@0.24.0:
+    resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-ppc64@0.21.5:
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -2261,6 +2355,15 @@ packages:
 
   /@esbuild/linux-ppc64@0.23.1:
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ppc64@0.24.0:
+    resolution: {integrity: sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2286,6 +2389,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-riscv64@0.24.0:
+    resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-s390x@0.21.5:
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -2297,6 +2409,15 @@ packages:
 
   /@esbuild/linux-s390x@0.23.1:
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-s390x@0.24.0:
+    resolution: {integrity: sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2322,6 +2443,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/linux-x64@0.24.0:
+    resolution: {integrity: sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/netbsd-x64@0.21.5:
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
@@ -2340,8 +2470,26 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/netbsd-x64@0.24.0:
+    resolution: {integrity: sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/openbsd-arm64@0.23.1:
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.24.0:
+    resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2367,6 +2515,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/openbsd-x64@0.24.0:
+    resolution: {integrity: sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/sunos-x64@0.21.5:
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
@@ -2378,6 +2535,15 @@ packages:
 
   /@esbuild/sunos-x64@0.23.1:
     resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/sunos-x64@0.24.0:
+    resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -2403,6 +2569,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/win32-arm64@0.24.0:
+    resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/win32-ia32@0.21.5:
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -2421,6 +2596,15 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/win32-ia32@0.24.0:
+    resolution: {integrity: sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/win32-x64@0.21.5:
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -2432,6 +2616,15 @@ packages:
 
   /@esbuild/win32-x64@0.23.1:
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-x64@0.24.0:
+    resolution: {integrity: sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3351,7 +3544,7 @@ packages:
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       rollup: 4.27.4
     dev: false
 
@@ -3366,7 +3559,7 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
       estree-walker: 2.0.2
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       rollup: 4.27.4
     dev: false
 
@@ -4299,18 +4492,18 @@ packages:
         optional: true
     dependencies:
       '@vitest/utils': 1.6.0
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       playwright: 1.49.0
       sirv: 2.0.4
       vitest: 1.6.0(@types/node@18.19.66)(@vitest/browser@1.6.0)
     dev: false
 
-  /@vitest/browser@2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5):
-    resolution: {integrity: sha512-JrpnxvkrjlBrF7oXbK/YytWVYfJIzWYeDKppANlUaisBKwDso+yXlWocAJrANx8gUxyirF355Yx80S+SKQqayg==}
+  /@vitest/browser@2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6):
+    resolution: {integrity: sha512-GTBY78bkRd5BL3jnwQr9J+uIkZjpvRzq0G1uHNy2GeJYfTvmYFh4QE5W2HH6AfEKLFQwPXHFiXgI2o4CEtAtJw==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 2.1.5
+      vitest: 2.1.6
       webdriverio: '*'
     peerDependenciesMeta:
       playwright:
@@ -4322,14 +4515,14 @@ packages:
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.5(msw@2.6.6)
-      '@vitest/utils': 2.1.5
-      magic-string: 0.30.13
+      '@vitest/mocker': 2.1.6(msw@2.6.6)
+      '@vitest/utils': 2.1.6
+      magic-string: 0.30.14
       msw: 2.6.6(@types/node@18.19.66)(typescript@5.6.3)
       playwright: 1.49.0
       sirv: 3.0.0
       tinyrainbow: 1.2.0
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@types/node'
@@ -4358,10 +4551,10 @@ packages:
       - supports-color
     dev: false
 
-  /@vitest/coverage-istanbul@2.1.5(vitest@2.1.5):
-    resolution: {integrity: sha512-jJsS5jeHncmSvzMNE03F1pk8F9etmjzGmGyQnGMkdHdVek/bxK/3vo8Qr3e9XmVuDM3UZKOy1ObeQHgC2OxvHg==}
+  /@vitest/coverage-istanbul@2.1.6(vitest@2.1.6):
+    resolution: {integrity: sha512-tJBsODJ8acDxwt4J+HERV0+FxOhjOXn+yVYWHQ25iFqcbQNyvptQLBFxEoRvaMbqJqSaYatGOg0/ctiQdB3mSg==}
     peerDependencies:
-      vitest: 2.1.5
+      vitest: 2.1.6
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.3.7(supports-color@8.1.1)
@@ -4373,7 +4566,7 @@ packages:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4386,51 +4579,51 @@ packages:
       chai: 4.3.10
     dev: false
 
-  /@vitest/expect@2.1.5:
-    resolution: {integrity: sha512-nZSBTW1XIdpZvEJyoP/Sy8fUg0b8od7ZpGDkTUcfJ7wz/VoZAFzFfLyxVxGFhUjJzhYqSbIpfMtl/+k/dpWa3Q==}
+  /@vitest/expect@2.1.6:
+    resolution: {integrity: sha512-9M1UR9CAmrhJOMoSwVnPh2rELPKhYo0m/CSgqw9PyStpxtkwhmdM6XYlXGKeYyERY1N6EIuzkQ7e3Lm1WKCoUg==}
     dependencies:
-      '@vitest/spy': 2.1.5
-      '@vitest/utils': 2.1.5
+      '@vitest/spy': 2.1.6
+      '@vitest/utils': 2.1.6
       chai: 5.1.2
       tinyrainbow: 1.2.0
     dev: false
 
-  /@vitest/mocker@2.1.5(msw@2.6.6):
-    resolution: {integrity: sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==}
+  /@vitest/mocker@2.1.6(msw@2.6.6):
+    resolution: {integrity: sha512-MHZp2Z+Q/A3am5oD4WSH04f9B0T7UvwEb+v5W0kCYMhtXGYbdyl2NUk1wdSMqGthmhpiThPDp/hEoVwu16+u1A==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
     dependencies:
-      '@vitest/spy': 2.1.5
+      '@vitest/spy': 2.1.6
       estree-walker: 3.0.3
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       msw: 2.6.6(@types/node@18.19.66)(typescript@5.6.3)
     dev: false
 
-  /@vitest/mocker@2.1.5(vite@5.4.11):
-    resolution: {integrity: sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==}
+  /@vitest/mocker@2.1.6(vite@6.0.0):
+    resolution: {integrity: sha512-MHZp2Z+Q/A3am5oD4WSH04f9B0T7UvwEb+v5W0kCYMhtXGYbdyl2NUk1wdSMqGthmhpiThPDp/hEoVwu16+u1A==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
     dependencies:
-      '@vitest/spy': 2.1.5
+      '@vitest/spy': 2.1.6
       estree-walker: 3.0.3
-      magic-string: 0.30.13
-      vite: 5.4.11(@types/node@18.19.66)
+      magic-string: 0.30.14
+      vite: 6.0.0(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
     dev: false
 
-  /@vitest/pretty-format@2.1.5:
-    resolution: {integrity: sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==}
+  /@vitest/pretty-format@2.1.6:
+    resolution: {integrity: sha512-exZyLcEnHgDMKc54TtHca4McV4sKT+NKAe9ix/yhd/qkYb/TP8HTyXRFDijV19qKqTZM0hPL4753zU/U8L/gAA==}
     dependencies:
       tinyrainbow: 1.2.0
     dev: false
@@ -4443,26 +4636,26 @@ packages:
       pathe: 1.1.2
     dev: false
 
-  /@vitest/runner@2.1.5:
-    resolution: {integrity: sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==}
+  /@vitest/runner@2.1.6:
+    resolution: {integrity: sha512-SjkRGSFyrA82m5nz7To4CkRSEVWn/rwQISHoia/DB8c6IHIhaE/UNAo+7UfeaeJRE979XceGl00LNkIz09RFsA==}
     dependencies:
-      '@vitest/utils': 2.1.5
+      '@vitest/utils': 2.1.6
       pathe: 1.1.2
     dev: false
 
   /@vitest/snapshot@1.6.0:
     resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
     dependencies:
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: false
 
-  /@vitest/snapshot@2.1.5:
-    resolution: {integrity: sha512-zmYw47mhfdfnYbuhkQvkkzYroXUumrwWDGlMjpdUr4jBd3HZiV2w7CQHj+z7AAS4VOtWxI4Zt4bWt4/sKcoIjg==}
+  /@vitest/snapshot@2.1.6:
+    resolution: {integrity: sha512-5JTWHw8iS9l3v4/VSuthCndw1lN/hpPB+mlgn1BUhFbobeIUj1J1V/Bj2t2ovGEmkXLTckFjQddsxS5T6LuVWw==}
     dependencies:
-      '@vitest/pretty-format': 2.1.5
-      magic-string: 0.30.13
+      '@vitest/pretty-format': 2.1.6
+      magic-string: 0.30.14
       pathe: 1.1.2
     dev: false
 
@@ -4472,8 +4665,8 @@ packages:
       tinyspy: 2.2.1
     dev: false
 
-  /@vitest/spy@2.1.5:
-    resolution: {integrity: sha512-aWZF3P0r3w6DiYTVskOYuhBc7EMc3jvn1TkBg8ttylFFRqNN2XGD7V5a4aQdk6QiUzZQ4klNBSpCLJgWNdIiNw==}
+  /@vitest/spy@2.1.6:
+    resolution: {integrity: sha512-oTFObV8bd4SDdRka5O+mSh5w9irgx5IetrD5i+OsUUsk/shsBoHifwCzy45SAORzAhtNiprUVaK3hSCCzZh1jQ==}
     dependencies:
       tinyspy: 3.0.2
     dev: false
@@ -4487,10 +4680,10 @@ packages:
       pretty-format: 29.7.0
     dev: false
 
-  /@vitest/utils@2.1.5:
-    resolution: {integrity: sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==}
+  /@vitest/utils@2.1.6:
+    resolution: {integrity: sha512-ixNkFy3k4vokOUTU2blIUvOgKq/N2PW8vKIjZZYsGJCMX69MRa9J2sKqX5hY/k5O5Gty3YJChepkqZ3KM9LyIQ==}
     dependencies:
-      '@vitest/pretty-format': 2.1.5
+      '@vitest/pretty-format': 2.1.6
       loupe: 3.1.2
       tinyrainbow: 1.2.0
     dev: false
@@ -5970,6 +6163,38 @@ packages:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+    dev: false
+
+  /esbuild@0.24.0:
+    resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.0
+      '@esbuild/android-arm': 0.24.0
+      '@esbuild/android-arm64': 0.24.0
+      '@esbuild/android-x64': 0.24.0
+      '@esbuild/darwin-arm64': 0.24.0
+      '@esbuild/darwin-x64': 0.24.0
+      '@esbuild/freebsd-arm64': 0.24.0
+      '@esbuild/freebsd-x64': 0.24.0
+      '@esbuild/linux-arm': 0.24.0
+      '@esbuild/linux-arm64': 0.24.0
+      '@esbuild/linux-ia32': 0.24.0
+      '@esbuild/linux-loong64': 0.24.0
+      '@esbuild/linux-mips64el': 0.24.0
+      '@esbuild/linux-ppc64': 0.24.0
+      '@esbuild/linux-riscv64': 0.24.0
+      '@esbuild/linux-s390x': 0.24.0
+      '@esbuild/linux-x64': 0.24.0
+      '@esbuild/netbsd-x64': 0.24.0
+      '@esbuild/openbsd-arm64': 0.24.0
+      '@esbuild/openbsd-x64': 0.24.0
+      '@esbuild/sunos-x64': 0.24.0
+      '@esbuild/win32-arm64': 0.24.0
+      '@esbuild/win32-ia32': 0.24.0
+      '@esbuild/win32-x64': 0.24.0
     dev: false
 
   /escalade@3.2.0:
@@ -7936,8 +8161,8 @@ packages:
     hasBin: true
     dev: false
 
-  /magic-string@0.30.13:
-    resolution: {integrity: sha512-8rYBO+MsWkgjDSOvLomYnzhdwEG51olQ4zL5KXnNJWV5MNmrb4rTZdrtkhxjnD/QyZUqR/Z/XDsUs/4ej2nx0g==}
+  /magic-string@0.30.14:
+    resolution: {integrity: sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
     dev: false
@@ -8356,7 +8581,7 @@ packages:
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       strict-event-emitter: 0.5.1
-      type-fest: 4.28.0
+      type-fest: 4.28.1
       typescript: 5.6.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -8386,8 +8611,8 @@ packages:
       thenify-all: 1.6.0
     dev: false
 
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  /nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: false
@@ -9026,7 +9251,7 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: false
@@ -9088,8 +9313,8 @@ packages:
     hasBin: true
     dev: false
 
-  /prettier@3.4.0:
-    resolution: {integrity: sha512-/OXNZcLyWkfo13ofOW5M7SLh+k5pnIs07owXK2teFpnfaOEcycnSy7HQxldaVX1ZP/7Q8oO1eDuQJNwbomQq5Q==}
+  /prettier@3.4.1:
+    resolution: {integrity: sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==}
     engines: {node: '>=14'}
     hasBin: true
     dev: false
@@ -10601,8 +10826,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /type-fest@4.28.0:
-    resolution: {integrity: sha512-jXMwges/FVbFRe5lTMJZVEZCrO9kI9c8k0PA/z7nF3bo0JSCCLysvokFjNPIUK/itEMas10MQM+AiHoHt/T/XA==}
+  /type-fest@4.28.1:
+    resolution: {integrity: sha512-LO/+yb3mf46YqfUC7QkkoAlpa7CTYh//V1Xy9+NQ+pKqDqXIq0NTfPfQRwFfCt+if4Qkwb9gzZfsl6E5TkXZGw==}
     engines: {node: '>=16'}
     dev: false
 
@@ -10878,18 +11103,19 @@ packages:
       - terser
     dev: false
 
-  /vite-node@2.1.5(@types/node@18.19.66):
-    resolution: {integrity: sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vite-node@2.1.6(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1):
+    resolution: {integrity: sha512-DBfJY0n9JUwnyLxPSSUmEePT21j8JZp/sR9n+/gBwQU6DcQOioPdb8/pibWfXForbirSagZCilseYIwaL3f95A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.7(supports-color@8.1.1)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@18.19.66)
+      vite: 6.0.0(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -10898,20 +11124,23 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
-  /vite-node@2.1.5(@types/node@20.17.8):
-    resolution: {integrity: sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vite-node@2.1.6(@types/node@20.17.8):
+    resolution: {integrity: sha512-DBfJY0n9JUwnyLxPSSUmEePT21j8JZp/sR9n+/gBwQU6DcQOioPdb8/pibWfXForbirSagZCilseYIwaL3f95A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.7(supports-color@8.1.1)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@20.17.8)
+      vite: 6.0.0(@types/node@20.17.8)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -10920,6 +11149,8 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   /vite@5.4.11(@types/node@18.19.66):
@@ -10961,21 +11192,26 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vite@5.4.11(@types/node@20.17.8):
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vite@6.0.0(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1):
+    resolution: {integrity: sha512-Q2+5yQV79EdnpbNxjD3/QHVMCBaQ3Kpd4/uL51UGuh38bIIM+s4o3FqyCzRvTRwFb+cWIUeZvaWwS9y2LD2qeQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -10991,9 +11227,63 @@ packages:
         optional: true
       terser:
         optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.66
+      esbuild: 0.24.0
+      postcss: 8.4.49
+      rollup: 4.27.4
+      tsx: 4.19.2
+      yaml: 2.6.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: false
+
+  /vite@6.0.0(@types/node@20.17.8):
+    resolution: {integrity: sha512-Q2+5yQV79EdnpbNxjD3/QHVMCBaQ3Kpd4/uL51UGuh38bIIM+s4o3FqyCzRvTRwFb+cWIUeZvaWwS9y2LD2qeQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
     dependencies:
       '@types/node': 20.17.8
-      esbuild: 0.21.5
+      esbuild: 0.24.0
       postcss: 8.4.49
       rollup: 4.27.4
     optionalDependencies:
@@ -11037,7 +11327,7 @@ packages:
       debug: 4.3.7(supports-color@8.1.1)
       execa: 8.0.1
       local-pkg: 0.5.1
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       pathe: 1.1.2
       picocolors: 1.1.1
       std-env: 3.8.0
@@ -11058,15 +11348,15 @@ packages:
       - terser
     dev: false
 
-  /vitest@2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5):
-    resolution: {integrity: sha512-P4ljsdpuzRTPI/kbND2sDZ4VmieerR2c9szEZpjc+98Z9ebvnXmM5+0tHEKqYZumXqlvnmfWsjeFOjXVriDG7A==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vitest@2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6):
+    resolution: {integrity: sha512-isUCkvPL30J4c5O5hgONeFRsDmlw6kzFEdLQHLezmDdKQHy8Ke/B/dgdTMEgU0vm+iZ0TjW8GuK83DiahBoKWQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.5
-      '@vitest/ui': 2.1.5
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 2.1.6
+      '@vitest/ui': 2.1.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -11084,28 +11374,29 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/expect': 2.1.5
-      '@vitest/mocker': 2.1.5(vite@5.4.11)
-      '@vitest/pretty-format': 2.1.5
-      '@vitest/runner': 2.1.5
-      '@vitest/snapshot': 2.1.5
-      '@vitest/spy': 2.1.5
-      '@vitest/utils': 2.1.5
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/expect': 2.1.6
+      '@vitest/mocker': 2.1.6(vite@6.0.0)
+      '@vitest/pretty-format': 2.1.6
+      '@vitest/runner': 2.1.6
+      '@vitest/snapshot': 2.1.6
+      '@vitest/spy': 2.1.6
+      '@vitest/utils': 2.1.6
       chai: 5.1.2
       debug: 4.3.7(supports-color@8.1.1)
       expect-type: 1.1.0
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@18.19.66)
-      vite-node: 2.1.5(@types/node@18.19.66)
+      vite: 6.0.0(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
+      vite-node: 2.1.6(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
       - msw
@@ -11115,17 +11406,142 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
-  /vitest@2.1.5(@types/node@20.17.8):
-    resolution: {integrity: sha512-P4ljsdpuzRTPI/kbND2sDZ4VmieerR2c9szEZpjc+98Z9ebvnXmM5+0tHEKqYZumXqlvnmfWsjeFOjXVriDG7A==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vitest@2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)(tsx@4.19.2):
+    resolution: {integrity: sha512-isUCkvPL30J4c5O5hgONeFRsDmlw6kzFEdLQHLezmDdKQHy8Ke/B/dgdTMEgU0vm+iZ0TjW8GuK83DiahBoKWQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.5
-      '@vitest/ui': 2.1.5
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 2.1.6
+      '@vitest/ui': 2.1.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.66
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/expect': 2.1.6
+      '@vitest/mocker': 2.1.6(vite@6.0.0)
+      '@vitest/pretty-format': 2.1.6
+      '@vitest/runner': 2.1.6
+      '@vitest/snapshot': 2.1.6
+      '@vitest/spy': 2.1.6
+      '@vitest/utils': 2.1.6
+      chai: 5.1.2
+      debug: 4.3.7(supports-color@8.1.1)
+      expect-type: 1.1.0
+      magic-string: 0.30.14
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 6.0.0(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
+      vite-node: 2.1.6(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: false
+
+  /vitest@2.1.6(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1):
+    resolution: {integrity: sha512-isUCkvPL30J4c5O5hgONeFRsDmlw6kzFEdLQHLezmDdKQHy8Ke/B/dgdTMEgU0vm+iZ0TjW8GuK83DiahBoKWQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 2.1.6
+      '@vitest/ui': 2.1.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.66
+      '@vitest/expect': 2.1.6
+      '@vitest/mocker': 2.1.6(vite@6.0.0)
+      '@vitest/pretty-format': 2.1.6
+      '@vitest/runner': 2.1.6
+      '@vitest/snapshot': 2.1.6
+      '@vitest/spy': 2.1.6
+      '@vitest/utils': 2.1.6
+      chai: 5.1.2
+      debug: 4.3.7(supports-color@8.1.1)
+      expect-type: 1.1.0
+      magic-string: 0.30.14
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 6.0.0(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
+      vite-node: 2.1.6(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: false
+
+  /vitest@2.1.6(@types/node@20.17.8):
+    resolution: {integrity: sha512-isUCkvPL30J4c5O5hgONeFRsDmlw6kzFEdLQHLezmDdKQHy8Ke/B/dgdTMEgU0vm+iZ0TjW8GuK83DiahBoKWQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 2.1.6
+      '@vitest/ui': 2.1.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -11143,27 +11559,28 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.17.8
-      '@vitest/expect': 2.1.5
-      '@vitest/mocker': 2.1.5(vite@5.4.11)
-      '@vitest/pretty-format': 2.1.5
-      '@vitest/runner': 2.1.5
-      '@vitest/snapshot': 2.1.5
-      '@vitest/spy': 2.1.5
-      '@vitest/utils': 2.1.5
+      '@vitest/expect': 2.1.6
+      '@vitest/mocker': 2.1.6(vite@6.0.0)
+      '@vitest/pretty-format': 2.1.6
+      '@vitest/runner': 2.1.6
+      '@vitest/snapshot': 2.1.6
+      '@vitest/spy': 2.1.6
+      '@vitest/utils': 2.1.6
       chai: 5.1.2
       debug: 4.3.7(supports-color@8.1.1)
       expect-type: 1.1.0
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.1
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@20.17.8)
-      vite-node: 2.1.5(@types/node@20.17.8)
+      vite: 6.0.0(@types/node@20.17.8)
+      vite-node: 2.1.6(@types/node@20.17.8)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
       - msw
@@ -11173,6 +11590,8 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   /void-elements@2.0.1:
@@ -11490,18 +11909,18 @@ packages:
     dev: false
 
   file:projects/abort-controller.tgz:
-    resolution: {integrity: sha512-Ibs4EGGgbpw0LEoDt3EGXdsXD4/PZORrGn9cHzY7ojEMByVAUsGV4EkWLm6PlClIcf6uRtJk91wKXyzLdandcQ==, tarball: file:projects/abort-controller.tgz}
+    resolution: {integrity: sha512-FENn94uWf8RJw+QIe8EKbFYRh9whYCZPf3VpSoWxoQc4SJTRkVwQ8gj4gU4zzS1RVAurxGnvUgu2X2Lt3E5zWQ==, tarball: file:projects/abort-controller.tgz}
     name: '@rush-temp/abort-controller'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -11519,13 +11938,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/agrifood-farming.tgz:
-    resolution: {integrity: sha512-T2u6/U1Taf+UQZFVKjbe4SUjxgjzsIZ2n95+WKn7yu+qPwj7vuEiHHRslAZQGPIZ4+2JTj8evtzBkNtzdc8xug==, tarball: file:projects/agrifood-farming.tgz}
+    resolution: {integrity: sha512-rcZcRdL5Z9+wohurnGgCBZ8ASDLQo2hq7EdggS10P/N/tFfQqVgahXKAuBgQ0DkCdo/4UyZ3Lo4lqMdfH9bECg==, tarball: file:projects/agrifood-farming.tgz}
     name: '@rush-temp/agrifood-farming'
     version: 0.0.0
     dependencies:
@@ -11568,7 +11989,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-Vg9Ig9UyZPqzWR18l8yeVOm7lvMJNOmGjQNv+faB+FnfTCeORBZ/xEyXBM/gIJyaB1pM9IIA6RoAJ2yp3NU6LA==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-gxBBn4UD9KRoOu+ZGE4xQNmvdcFcpvVGXYrgm3BU8mmItr+KjAREDH0JmGW949W+qXk3HjKQLmsUVfDa1qfVkQ==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -11611,13 +12032,13 @@ packages:
     dev: false
 
   file:projects/ai-content-safety.tgz:
-    resolution: {integrity: sha512-wYg56r/F6an8nPb6NlNYV4IkMT+vOk6QewQFK3Gef2DuAHLtxmq5feJG247k4z4jVkEE2pf9BOC3dLPGp/rPCQ==, tarball: file:projects/ai-content-safety.tgz}
+    resolution: {integrity: sha512-zJUDWtYW+tKsF8QJBNZmYyLwAjyrQtJLN0RDCp/Vm/DHbfCmCIWOCS6+ezJ4ruvzP0hEJvvhmIwXSKHjM9XX1A==, tarball: file:projects/ai-content-safety.tgz}
     name: '@rush-temp/ai-content-safety'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
@@ -11625,7 +12046,7 @@ packages:
       rollup-plugin-copy: 3.5.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -11643,26 +12064,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/ai-document-intelligence.tgz:
-    resolution: {integrity: sha512-rK979Zu3i9HdmjhkPAgXOzd0NeXbFrY3YZVRjpjV2wogivrRPGkZZzbNRYCJ7jJbjdFmyOW0xaVddvmfvbqYuw==, tarball: file:projects/ai-document-intelligence.tgz}
+    resolution: {integrity: sha512-JmSFKGVcsiDMAVVSFvPSvEBErynSj+66cEK7zfZjnjyHs/FHcGUfxKFgdobn//N4zdZeYksJ0ZuRJ6sxlp4+Ug==, tarball: file:projects/ai-document-intelligence.tgz}
     name: '@rush-temp/ai-document-intelligence'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -11680,25 +12103,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/ai-document-translator.tgz:
-    resolution: {integrity: sha512-MVtb7N/AgQW4ZKsGGYz5mXyBCy3FCBQfpi/IVVe4jGEUoQMkqInzp3Qr2czfYJF1Aw5m9mFu04z/qufBOc8mkA==, tarball: file:projects/ai-document-translator.tgz}
+    resolution: {integrity: sha512-Ysj7tlB3IISPke1isbXiuvZZABKeTS8uYd13/sIo2hhlFQ6gC0dOj9NBwW3F2DJexWZZD/mz39F3CsKPfowXHg==, tarball: file:projects/ai-document-translator.tgz}
     name: '@rush-temp/ai-document-translator'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -11716,13 +12141,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-EBXzinBP+gU+pPWHZxAyHwbHVnUEwNUtT5zKziC9PBpBJAhN+If2ydDfSzm60VgY0m6xVuiq68UZB8bF7+TE1Q==, tarball: file:projects/ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-FzAzx9YoDE9z2GKpihQ9EaSBWSE5bHe5SRPqd2S/arobDGnmgkEcij96YIWivczmBXSpnKSXh4dbin64zYIlJg==, tarball: file:projects/ai-form-recognizer.tgz}
     name: '@rush-temp/ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -11747,10 +12174,10 @@ packages:
       karma-mocha: 2.0.1
       karma-mocha-reporter: 2.2.5(karma@6.4.4)
       karma-sourcemap-loader: 0.3.8
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       mocha: 10.8.2
       nyc: 17.1.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       rollup: 4.27.4
       sinon: 17.0.1
       ts-node: 10.9.2(@types/node@18.19.66)(typescript@5.6.3)
@@ -11767,7 +12194,7 @@ packages:
     dev: false
 
   file:projects/ai-inference.tgz:
-    resolution: {integrity: sha512-GPQuD9GPmOBORk2aS5Q37iooxLuLgm9H9q1DItVZreZ7a5zDwL2HvzE4sxx40s0idT+3bd97X4u6IyTkkPzrpQ==, tarball: file:projects/ai-inference.tgz}
+    resolution: {integrity: sha512-tpDSf9QeGEe/lf0fT1+RstQhHesk41y976HeMtUXBfdLPChPRHwDSmy8WmtWu9/gXdIt90a9dwO4x1zJcWnH5A==, tarball: file:projects/ai-inference.tgz}
     name: '@rush-temp/ai-inference'
     version: 0.0.0
     dependencies:
@@ -11775,8 +12202,8 @@ packages:
       '@azure/core-lro': 2.7.2
       '@opentelemetry/api': 1.9.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
@@ -11784,7 +12211,7 @@ packages:
       source-map-support: 0.5.21
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -11802,13 +12229,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/ai-language-conversations.tgz:
-    resolution: {integrity: sha512-XI06FmsZFJNP5OI6JTMo5ugJrKcepGhXlyGY8VwVDYlQDKNN+DUR0eK+J6hif3QS0RWZnhCZURqICMFrxjFErw==, tarball: file:projects/ai-language-conversations.tgz}
+    resolution: {integrity: sha512-OwcU4XhSmmV0/CkFrvBxd77xmNupBjmDruACRLjI7ieeABgJs+294rwHIEa4jEBD7DogfEmGAb/eIHWgcU84NQ==, tarball: file:projects/ai-language-conversations.tgz}
     name: '@rush-temp/ai-language-conversations'
     version: 0.0.0
     dependencies:
@@ -11852,7 +12281,7 @@ packages:
     dev: false
 
   file:projects/ai-language-text.tgz:
-    resolution: {integrity: sha512-9X7PLNIh261De3RD0N8VbHh/u96Gc6j3eiQEzgLeakHXl1UJGx6p97Gpe/SOqxt75fdsXx6mA3BJwpoayTD1KQ==, tarball: file:projects/ai-language-text.tgz}
+    resolution: {integrity: sha512-Cn58L4whaP5fErJ7aOhGYUcTvbknPN6QZdniQDy4ljSUslMxTb45Auboz/Vh8rIFsYJKbkz+iyOv9WAeJ5jvjw==, tarball: file:projects/ai-language-text.tgz}
     name: '@rush-temp/ai-language-text'
     version: 0.0.0
     dependencies:
@@ -11898,7 +12327,7 @@ packages:
     dev: false
 
   file:projects/ai-language-textauthoring.tgz:
-    resolution: {integrity: sha512-ZAeh5Zqie21QbDaZ6+swrDHQWD7BR7bPzy3mwL40dGfo0hCkp6Ty3DhRnNdjDlS+WbbKjIxU5igtKg3TdzjXaQ==, tarball: file:projects/ai-language-textauthoring.tgz}
+    resolution: {integrity: sha512-hrlnT354x8NjGhCTn/6TQGyL1uk2UdAcaxXOhh+96DexuVIYgOFVk7cHRCGHURFLm21Vl2dZ6S1YHyhd3OJlUg==, tarball: file:projects/ai-language-textauthoring.tgz}
     name: '@rush-temp/ai-language-textauthoring'
     version: 0.0.0
     dependencies:
@@ -11923,7 +12352,7 @@ packages:
     dev: false
 
   file:projects/ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-jn39f8RDR/vv7W3R88kr3FmheVJBS+lAdSmlatM6LyGIpm4/IgXKlb/IDE+DtHtkmntkXzGTngDWHhoTYn2l7A==, tarball: file:projects/ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-90vvirp3NIECJz5cH16+iJdhGiutAgIdhwVKGczQ0vrpkB1mqguaejOO4olsmldhvpfj7DLS4EiDV5aeaahWLQ==, tarball: file:projects/ai-metrics-advisor.tgz}
     name: '@rush-temp/ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -11965,7 +12394,7 @@ packages:
     dev: false
 
   file:projects/ai-text-analytics.tgz:
-    resolution: {integrity: sha512-ZMOZvwcAG+Gg2dwnR+a/4y5KcuGWw3zdgs7whycUlFpTfLNRJ7i9rCEN2uo4oQZITtC1XGyWDigdkgLMZxJgEA==, tarball: file:projects/ai-text-analytics.tgz}
+    resolution: {integrity: sha512-1uXf5N6nTpulsUwgrecwfI/beAX6y67ZxwtdTBbBSAp6IjDLHxqAygzcJSeRUte8IBPTW7vb91+ewT2dmvDVtg==, tarball: file:projects/ai-text-analytics.tgz}
     name: '@rush-temp/ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -12009,7 +12438,7 @@ packages:
     dev: false
 
   file:projects/ai-translation-document.tgz:
-    resolution: {integrity: sha512-yoBCF7jU6tqs56zEWqmxSrQFUyANWDN6MON5uafyNkK1R7Qno9wGNpCSqMOJUZ//Tkc82O0PXW7RAuw7l8VpIw==, tarball: file:projects/ai-translation-document.tgz}
+    resolution: {integrity: sha512-cMH86bXds1Pg7oI1Jcd15f+Wn94YgU+Y3C0eYCKKpGtZXC5XG6FdbksWfO1PYeg5unXiTyAfiwS7ykCjRi6wjw==, tarball: file:projects/ai-translation-document.tgz}
     name: '@rush-temp/ai-translation-document'
     version: 0.0.0
     dependencies:
@@ -12049,20 +12478,20 @@ packages:
     dev: false
 
   file:projects/ai-translation-text.tgz:
-    resolution: {integrity: sha512-3XHDssLX0ri0CjiccRr82uxLp55vWhz/mOIB2bz6zjrGD7QRPSsvIjzh1enrZwVX1/w73UcBKtPMxioOvDyfJA==, tarball: file:projects/ai-translation-text.tgz}
+    resolution: {integrity: sha512-ripHLIx9ITltPGGTnsxg/fwRiQ59fWpTuzd5MERXNrUHltgVpdvEPo+blsAgpc4cSHHagrNp1YCV/3EY7OtKew==, tarball: file:projects/ai-translation-text.tgz}
     name: '@rush-temp/ai-translation-text'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -12080,27 +12509,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/ai-vision-face.tgz:
-    resolution: {integrity: sha512-ktM3Ox3D54Pau2C1Ggi84dOAExqiKEoH0JI9PoVUmaT0UssSCuhz9Til/3cA+2MlIJ2+BYTbFuuh6QjyafFhlA==, tarball: file:projects/ai-vision-face.tgz}
+    resolution: {integrity: sha512-6YKNg9JzNa/Jet5gI8Zc3i+oxDzloluDji52MKdOYTPqDdd0f3e7/eGV8LGlEGygQ8YQbwL/cc/D1pgbsNBoSg==, tarball: file:projects/ai-vision-face.tgz}
     name: '@rush-temp/ai-vision-face'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tshy: 1.18.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -12118,26 +12549,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/ai-vision-image-analysis.tgz:
-    resolution: {integrity: sha512-wNM3J9/H4ST0bOPIsjtDoTIy6xu2fdb/fLJRuny5XVr+L0QPIsjzzhr9ZW6c8ngTrYlamlKDXhF9a0Tu0pNhGg==, tarball: file:projects/ai-vision-image-analysis.tgz}
+    resolution: {integrity: sha512-+aAT6CxfGSInHhAYQW5ZB/u3cJ/jhUcxO9W9ZCsrit6dB/DgivDEJYV21KXtQc3A9DBahMN5Xf6u2RcsLjSthg==, tarball: file:projects/ai-vision-image-analysis.tgz}
     name: '@rush-temp/ai-vision-image-analysis'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -12155,13 +12588,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/api-management-custom-widgets-scaffolder.tgz:
-    resolution: {integrity: sha512-9eh7MlgIf2tFsx3qR16GIeljbB7gT0wCaSdd3J9nIqo/dSg+ncVMcoQLfh8DLoEXl567PqCX0R1OcXjN8Y6hWQ==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
+    resolution: {integrity: sha512-wSlXslCDDky3Fop48Xp6MWG3t/v0nZTIEx0rP+6nJ/nNaZ9uN8d+BiTP8lEbbo9rNW+AkVHz8GZXmovWboYCcg==, tarball: file:projects/api-management-custom-widgets-scaffolder.tgz}
     name: '@rush-temp/api-management-custom-widgets-scaffolder'
     version: 0.0.0
     dependencies:
@@ -12171,18 +12606,18 @@ packages:
       '@types/node': 18.19.66
       '@types/yargs': 17.0.33
       '@types/yargs-parser': 21.0.3
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       chalk: 4.1.2
       eslint: 9.15.0
       glob: 10.4.5
       inquirer: 9.3.7
-      magic-string: 0.30.13
+      magic-string: 0.30.14
       mustache: 4.2.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       rollup: 4.27.4
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
       yargs: 17.7.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -12201,23 +12636,25 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   file:projects/api-management-custom-widgets-tools.tgz:
-    resolution: {integrity: sha512-dMAIacqzLU3uGgVdn+A8r+/Vv7vC4Emr0Z0T3lCVhq7JoQmL3I7yyUueYdP6tPVYSGzko9MdRYXA11RvB9GHPA==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
+    resolution: {integrity: sha512-iSBVwTg8Ehp+g5YJTV/6GXmKI0AwPGNmwgEO4WRRPKrLy+kCsmjZXbGG7l0qrX5mkTFNgNjjXmGNi7RhER4FMw==, tarball: file:projects/api-management-custom-widgets-tools.tgz}
     name: '@rush-temp/api-management-custom-widgets-tools'
     version: 0.0.0
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       mime: 4.0.4
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -12235,27 +12672,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/app-configuration.tgz:
-    resolution: {integrity: sha512-XhwqKUAITo1k9UGUOfsulMGMig1cs4NLpxF5hIwK91cMo+EbLHvYzUl6SypPw4IxasziMoyVtUobTvEsafDDDg==, tarball: file:projects/app-configuration.tgz}
+    resolution: {integrity: sha512-r5o9Oh71BhTCm/9b2xwVZuBKv66eAHSFxjBJBauD/lL8yAf4Mb6Ar/3GYDo2zeTF7JAhD1suZLOoR1Xkd7DhnA==, tarball: file:projects/app-configuration.tgz}
     name: '@rush-temp/app-configuration'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       nock: 13.5.6
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -12273,13 +12712,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-advisor.tgz:
-    resolution: {integrity: sha512-luFaksCkDe/cPkt4WKzXCqaJRUhumsLemd5yNSsMvSVFrrYBGyHx4fFbwvSEutDhlLRPosEz86Y2LLePFdHFfg==, tarball: file:projects/arm-advisor.tgz}
+    resolution: {integrity: sha512-OiOjLkQJ0y6mTyjM2aMos3c2V9U2YHiOihRuUjBVQLLRi/vyzf7+tHw5sB1O427N39G5fqgCGWcNNupk1QBhAg==, tarball: file:projects/arm-advisor.tgz}
     name: '@rush-temp/arm-advisor'
     version: 0.0.0
     dependencies:
@@ -12301,7 +12742,7 @@ packages:
     dev: false
 
   file:projects/arm-agrifood.tgz:
-    resolution: {integrity: sha512-UG0JLX/D+zBtUL4O4RMDEJ256xkzjvxAmsc8icuNoJEUIRReSrBwx3FDOlOHNrs4VIciWPO70/rGMcxyuhyjHg==, tarball: file:projects/arm-agrifood.tgz}
+    resolution: {integrity: sha512-IIqjs2SYAwpzfIE04toj029/0/k9yHH//t/hgajqFvZRIX0ciWNi8XNg1n/d3a/EdhprlrwDgQ2yuZJRL0/SJw==, tarball: file:projects/arm-agrifood.tgz}
     name: '@rush-temp/arm-agrifood'
     version: 0.0.0
     dependencies:
@@ -12324,7 +12765,7 @@ packages:
     dev: false
 
   file:projects/arm-analysisservices.tgz:
-    resolution: {integrity: sha512-+6YcsY9hb/cykHslp+nli23ANpt4ofj3Q7x7ZtPKorstI/6LlsT7/X3ojADGnMbjErMp777woQrcazbyqE7D0Q==, tarball: file:projects/arm-analysisservices.tgz}
+    resolution: {integrity: sha512-AnMF6+ifVmjxiqoIU87+9ZyvkXPV3Uy/pmTQPEF/86TJIax+uU4LgCanwtbZcEplYjr+4M3YhvDFagPj/2i1uA==, tarball: file:projects/arm-analysisservices.tgz}
     name: '@rush-temp/arm-analysisservices'
     version: 0.0.0
     dependencies:
@@ -12347,7 +12788,7 @@ packages:
     dev: false
 
   file:projects/arm-apicenter.tgz:
-    resolution: {integrity: sha512-LArXmmz1vMmMMBNbxKRZf6hxgszeSCYSibkyW7+QUXF7hBTf2HI4T4v9+EGDzuOVdTC/pQEnJwxG8cpODbcu8g==, tarball: file:projects/arm-apicenter.tgz}
+    resolution: {integrity: sha512-1KxlA9lIXA0N7EmJOnv7g/weu3gR5G0UojTbUEICXf/zw5aNi3C+kyFl/riDWh9ExACEDhx+++TeLedQbPBoSw==, tarball: file:projects/arm-apicenter.tgz}
     name: '@rush-temp/arm-apicenter'
     version: 0.0.0
     dependencies:
@@ -12371,7 +12812,7 @@ packages:
     dev: false
 
   file:projects/arm-apimanagement.tgz:
-    resolution: {integrity: sha512-qtJg71n+r7Et7oBmNLavVCZ/Q8krIEoMZ1eaKPHtFNFJD/nmqVo6lH3uW4e+GfiUIEu4TgbJRz+oi2lNf9hn0g==, tarball: file:projects/arm-apimanagement.tgz}
+    resolution: {integrity: sha512-qYcmRrNih9HqioaI0fwHTntNHsogHnE5ep1bIKqyUG+u0v5vQ7IFBhLv/CbF/EwMDlOSeIHMEOZ78pvtII//kA==, tarball: file:projects/arm-apimanagement.tgz}
     name: '@rush-temp/arm-apimanagement'
     version: 0.0.0
     dependencies:
@@ -12395,7 +12836,7 @@ packages:
     dev: false
 
   file:projects/arm-appcomplianceautomation.tgz:
-    resolution: {integrity: sha512-zCEUKxh1xO6XneZtzv/TyD+HN8rTFBd8uxPmgatb3d4pwUucCvv0XyL2K+OZIUSxlbnBONi8PXVSb0TXZi98SQ==, tarball: file:projects/arm-appcomplianceautomation.tgz}
+    resolution: {integrity: sha512-GGaNWgFe0jRAuBrUx2dLgD3NZ/x+B6pKL/aWKZPErtqLbSj9I3DdoA1Encyw2Z3TDakAZClg6QYn7MUFb0n+PA==, tarball: file:projects/arm-appcomplianceautomation.tgz}
     name: '@rush-temp/arm-appcomplianceautomation'
     version: 0.0.0
     dependencies:
@@ -12420,7 +12861,7 @@ packages:
     dev: false
 
   file:projects/arm-appconfiguration.tgz:
-    resolution: {integrity: sha512-5sEU/bwa68Xuicl7B/9ZrSURgbVEcWd2lQWO7Hq6rhxyn8z1VvORi3MOPmPVE+94JTYG6Du0fLQPdt3DuwQkuQ==, tarball: file:projects/arm-appconfiguration.tgz}
+    resolution: {integrity: sha512-VGmGCnCfT6ImGTDq7Iq7Rdo1CkB/o4VQ6wYuzEBq1Wrkt290v/DCYnrR7cX02W7kqeAC7KI06NXwMPy3Z6QQMw==, tarball: file:projects/arm-appconfiguration.tgz}
     name: '@rush-temp/arm-appconfiguration'
     version: 0.0.0
     dependencies:
@@ -12449,7 +12890,7 @@ packages:
     dev: false
 
   file:projects/arm-appcontainers.tgz:
-    resolution: {integrity: sha512-S560QlF+asU6nmH/t71xfAdNBvnl8CdbRSOWixoPuaL+5Df4n1s7MmORKkecb4I1aPNSCs2jWb01tdA7e3dIOQ==, tarball: file:projects/arm-appcontainers.tgz}
+    resolution: {integrity: sha512-FzwwWnQuTtUQSfxU62TGwRqc/QLgdbU/DQn6VvBrmD0ius8HHbvHWk+u742+RYUboO6lFMKCCemoOHB1fqc5jA==, tarball: file:projects/arm-appcontainers.tgz}
     name: '@rush-temp/arm-appcontainers'
     version: 0.0.0
     dependencies:
@@ -12473,7 +12914,7 @@ packages:
     dev: false
 
   file:projects/arm-appinsights.tgz:
-    resolution: {integrity: sha512-cEoeA4GJ98/hokOZRs4WrVFown2hOUsG/1RYM+ctp3vaYiUEK71vCj7HgKczd0UvQiRbYLKeQGi1yTMLPVpoeQ==, tarball: file:projects/arm-appinsights.tgz}
+    resolution: {integrity: sha512-od3UPaB+ocunNTQ2GQrCyOuPcsoRTBscFOjyVrWKbwkuGuTMGImSfZZWPc5U1nVdiPA7/5F99vCqsWMYnq4oIQ==, tarball: file:projects/arm-appinsights.tgz}
     name: '@rush-temp/arm-appinsights'
     version: 0.0.0
     dependencies:
@@ -12494,7 +12935,7 @@ packages:
     dev: false
 
   file:projects/arm-appplatform.tgz:
-    resolution: {integrity: sha512-01Ga6Ziv1GAADP5HKAa1DTykHD0iM+OHABqC5fCkC9kTXiEsoNbJngN+MT4bK4TnD/FPjSPcf1WnXdot+YMl9A==, tarball: file:projects/arm-appplatform.tgz}
+    resolution: {integrity: sha512-XVLXr2uf8M7eAwarZqD4RuHOuV5nDHNalNNr4ozUYrujVIxg94sF9bQpexcRhk63OJ4MqVmPC9isLJuPlS0Ycw==, tarball: file:projects/arm-appplatform.tgz}
     name: '@rush-temp/arm-appplatform'
     version: 0.0.0
     dependencies:
@@ -12518,7 +12959,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-1.tgz:
-    resolution: {integrity: sha512-TsYCwAjLN6a5+K+UZWdbRugRvMpUUHJbPNa923RA4w01pjEzv3f4SXT3rhzgqCFyErmYhdIy1ljSIHVzeIlJmg==, tarball: file:projects/arm-appservice-1.tgz}
+    resolution: {integrity: sha512-UgGmRXtGDVR3CmVSWOx7JTerCzuv5yfX05+lVNCVFmyEy44Btt9l/BVPngS9KDxM0wM+s2Ak+/vJiViMZpaHKg==, tarball: file:projects/arm-appservice-1.tgz}
     name: '@rush-temp/arm-appservice-1'
     version: 0.0.0
     dependencies:
@@ -12543,7 +12984,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-zBnLDEdo/mvAFYdemABaYxhl6URzjGjfIwkCwZClW2Ar2ePAWjkcI7vmAyIF0uojxiPI4hH3YqEfMA8dYMn7IA==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-KxWiNWG9byHCNjWbBuaOVw7WNxQ+mVOGVYKDT2XdsbSIYao9w5EVCaxSKEJk8+2dx3E5xWVniFjMtFyrqHMGmQ==, tarball: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-appservice-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12567,7 +13008,7 @@ packages:
     dev: false
 
   file:projects/arm-appservice.tgz:
-    resolution: {integrity: sha512-6FXHqHZEpNPMprA7DzLLcvlAWLcY5v2GFnmHOLGkE9wxv/PPeFA8c17G9D1CUYkWSH/Ig6xWjIce/+uLNkGHqw==, tarball: file:projects/arm-appservice.tgz}
+    resolution: {integrity: sha512-fzqv7qIH1mulP3Ly8b53apUuhgyZw+pGm+XWE/HQm8CxgWxjVBzmJhQSrl9bYEYCXnbi7xpWNzx49pnLyQnOSQ==, tarball: file:projects/arm-appservice.tgz}
     name: '@rush-temp/arm-appservice'
     version: 0.0.0
     dependencies:
@@ -12609,7 +13050,7 @@ packages:
     dev: false
 
   file:projects/arm-astro.tgz:
-    resolution: {integrity: sha512-jPnHxVLP76XpRsFj6i4WZP+k52kDT9y01rCFpzIGK16AxXpwkXmLY4pZ1TOKcaEgL0PwdGDGA7ANg5s5FAQ1Cg==, tarball: file:projects/arm-astro.tgz}
+    resolution: {integrity: sha512-DadKVnDatzfDqZzemysvdprunqHSK7uxOOyKkuks2Rr1qEHOtfsvNuEhhXvtTEw71U/IC8KwUc3HvBxtMb5kMQ==, tarball: file:projects/arm-astro.tgz}
     name: '@rush-temp/arm-astro'
     version: 0.0.0
     dependencies:
@@ -12633,7 +13074,7 @@ packages:
     dev: false
 
   file:projects/arm-attestation.tgz:
-    resolution: {integrity: sha512-m5nxReJeR0MrK3UaAUJMCgn9qn/K4pZXNZFmzym1pznr/nIa8Jcj/VdkkqmphLXjqBKEv0Z6PnQ2MeRpipj2LA==, tarball: file:projects/arm-attestation.tgz}
+    resolution: {integrity: sha512-Fkp+mkV2B+gScmeasgiaIJdrz11ZQUt+Mfs1IN7GO+NOiEwbkAbMmh4ADYjCG3p5RIERKt7tn3CTiU/vIXDa0g==, tarball: file:projects/arm-attestation.tgz}
     name: '@rush-temp/arm-attestation'
     version: 0.0.0
     dependencies:
@@ -12654,7 +13095,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-XFDA/SS+X6alNkSi6NzGmvRrGp1pMLh9t2w8UppFDcDf0Fn11WnVnskLqERDXs2oWBkNd1muUOhHbNCzA23f/Q==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-9MG9VYzyZIYeV8UN480v5So+wRSUc2rrvHGoGSgfxWB8mcaYeOXBjuCqrS27wOGluzH8o2KcgDOX1KfZzELfkQ==, tarball: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-authorization-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -12676,7 +13117,7 @@ packages:
     dev: false
 
   file:projects/arm-authorization.tgz:
-    resolution: {integrity: sha512-zibbXMglj+ndwehX12c4rSHEnRbT0kNjkWaHFMYGUCgz8zarQQQh6LDEhG5E6DaJNU+MAWUA8aYM+FCiaT3kFA==, tarball: file:projects/arm-authorization.tgz}
+    resolution: {integrity: sha512-Fw1FTzaT8NWF637SDKTEV1ZvpSMrBTdusIxN33mgE5RrRFqqwojvxQ0PV6Hpsg3uXLd/OjVWo9rPYHELsoZRsQ==, tarball: file:projects/arm-authorization.tgz}
     name: '@rush-temp/arm-authorization'
     version: 0.0.0
     dependencies:
@@ -12700,7 +13141,7 @@ packages:
     dev: false
 
   file:projects/arm-automanage.tgz:
-    resolution: {integrity: sha512-D1jk83JsK1u+NaDH8LRnlS0OjG2bxd9N18ad5gmgcRF2JAz49h+EtGUG6+XTeQ9gDM+Byx/k/p9vISYPUZP8TA==, tarball: file:projects/arm-automanage.tgz}
+    resolution: {integrity: sha512-lAN9Jfp0uEsHfdRU7sQIi607y7e6ehOr/C06VqoX53ueTT4n+XAXuvf2gdnaqYKyuyhFlPpS4JibmsK6vJxKUA==, tarball: file:projects/arm-automanage.tgz}
     name: '@rush-temp/arm-automanage'
     version: 0.0.0
     dependencies:
@@ -12722,7 +13163,7 @@ packages:
     dev: false
 
   file:projects/arm-automation.tgz:
-    resolution: {integrity: sha512-Xp3hnnhwSfgKAkjyzZVQ9OhpB6fLPSRC8HwZD8LxRFz0Imqhr695OHugyY7OHjYsIao4K+fWif8UUMvKgf+WUg==, tarball: file:projects/arm-automation.tgz}
+    resolution: {integrity: sha512-jpJ+3WJDt/gMb4Uc9YbD0UdwNTJryU6gkEHz+KB9ENZwYpTuiqyr8DdHVqSq6Nm6uxdrYXoYtUe0esMhKB4bhA==, tarball: file:projects/arm-automation.tgz}
     name: '@rush-temp/arm-automation'
     version: 0.0.0
     dependencies:
@@ -12746,7 +13187,7 @@ packages:
     dev: false
 
   file:projects/arm-avs.tgz:
-    resolution: {integrity: sha512-e2heOPeLZmF6fOgxVeok/TFXdTXxdmNLeQqLXfi24YaSgAHQOFIr2Jo5bdEjR4ExaW3E2XasmFfDh4aunPRyOg==, tarball: file:projects/arm-avs.tgz}
+    resolution: {integrity: sha512-Wp2FzeSlG9g3UZ9l0Np7GYCOyqh//ysrxnOafrliZeNpR5yEkt69YV5iKIJPEoAzmZ6iUt7ZMUdGLFZYAldcoA==, tarball: file:projects/arm-avs.tgz}
     name: '@rush-temp/arm-avs'
     version: 0.0.0
     dependencies:
@@ -12771,7 +13212,7 @@ packages:
     dev: false
 
   file:projects/arm-azureadexternalidentities.tgz:
-    resolution: {integrity: sha512-+7CK31G2H0x9t+fCcKCNuJHyLeSeS5CdH4AILj3HKm0ZFtXtWzG5MKMGxI3Y2mCUyj+z7mIaYeGle+y0ss4Yow==, tarball: file:projects/arm-azureadexternalidentities.tgz}
+    resolution: {integrity: sha512-gXWeEJ4v6yBfILSc9yDRz3GabIIzg8NWmu9wQqsEqwiKPycyDfmVRmTkKFO1/v7o9Xc9h0ub2AW69EDvAmT97Q==, tarball: file:projects/arm-azureadexternalidentities.tgz}
     name: '@rush-temp/arm-azureadexternalidentities'
     version: 0.0.0
     dependencies:
@@ -12794,7 +13235,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestack.tgz:
-    resolution: {integrity: sha512-8AXuzAhciJ0A3iBNom7VsJhljULaPMlD1IeRRW19svP3Ps1iKrHU05FkulySiKBIU2FDlGjxHRKopDmVwbA0kg==, tarball: file:projects/arm-azurestack.tgz}
+    resolution: {integrity: sha512-KXWGnaF8XoxrT8Frzwjk5oVp9gIvF+YmQrLpIBjGRVmimSJwsnpYb2uNxfDXPWlCRSfnxFoT/w763tVZeflLWg==, tarball: file:projects/arm-azurestack.tgz}
     name: '@rush-temp/arm-azurestack'
     version: 0.0.0
     dependencies:
@@ -12815,7 +13256,7 @@ packages:
     dev: false
 
   file:projects/arm-azurestackhci.tgz:
-    resolution: {integrity: sha512-xLo7zCcLoXhktrVjbHdIzHW5DQa6ojH4kFBwj/Xi3ARgtXvxIyJBzT2YIIY2i/fzHS4OaWIPnmwWT4FYZwMB0Q==, tarball: file:projects/arm-azurestackhci.tgz}
+    resolution: {integrity: sha512-YPcpeMFRwY4tV2vqoqq8Mhsn7s+Shk+NeqlJ99ui5Q/HttYP14zfpRTwqK/tVR25Mgbpn74QmWLDz25OKvqwpA==, tarball: file:projects/arm-azurestackhci.tgz}
     name: '@rush-temp/arm-azurestackhci'
     version: 0.0.0
     dependencies:
@@ -12840,7 +13281,7 @@ packages:
     dev: false
 
   file:projects/arm-baremetalinfrastructure.tgz:
-    resolution: {integrity: sha512-VvnnJLzitmFFibcCito8gcYsPQdmO+AROPhldTWMfVokn/dWvMfogLaJ+bFz3m7q7jzke69lvQaA/NaErCIvUQ==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
+    resolution: {integrity: sha512-R0KC6+5qazXk/vFvhwMOz9iajKcFc34aeSH3hLXB4YwPHtGm9AlBOPgCeexNHbYgONPWCzv45Sw6mgYbR3/R5Q==, tarball: file:projects/arm-baremetalinfrastructure.tgz}
     name: '@rush-temp/arm-baremetalinfrastructure'
     version: 0.0.0
     dependencies:
@@ -12864,7 +13305,7 @@ packages:
     dev: false
 
   file:projects/arm-batch.tgz:
-    resolution: {integrity: sha512-l71U4B8PypyscPdpEk6BSRA0kLTanf4kg/yLBZkpp+vRVwwWTuX/0li16uGOGqrC+iqlN2msnCwqWNjVOtBE/w==, tarball: file:projects/arm-batch.tgz}
+    resolution: {integrity: sha512-QIPRjOoSqYwwmr4d2zonDjxloi0BkIMydA/CfTLwcrxJe0YWJLg7oN0b1dNyCegCogLhSvBOcp3oVNIY8f9PBg==, tarball: file:projects/arm-batch.tgz}
     name: '@rush-temp/arm-batch'
     version: 0.0.0
     dependencies:
@@ -12888,7 +13329,7 @@ packages:
     dev: false
 
   file:projects/arm-billing.tgz:
-    resolution: {integrity: sha512-eZrZgRnFLJjOwrQPoCth/gE1LJTY3qNKc7vF36yijW47qa/5SiVkeAJapSwUYoAMNKq5D9wrsXR1hzQcKm0nNA==, tarball: file:projects/arm-billing.tgz}
+    resolution: {integrity: sha512-s0viqGTgyGY36OCdEw4WaJDZV0+OkG+lkpLjfxScWlzlNVO5VbQNyF42mXzTnVVgHIldBx9nkbgGxliWWBI19A==, tarball: file:projects/arm-billing.tgz}
     name: '@rush-temp/arm-billing'
     version: 0.0.0
     dependencies:
@@ -12912,7 +13353,7 @@ packages:
     dev: false
 
   file:projects/arm-billingbenefits.tgz:
-    resolution: {integrity: sha512-fIT5gA0TD0ensDtMOvsmv1gSvnOilPN0+7c92ivt/v84KqfU5tWEF+s5ZAssliO1xSzR7HVtkT800qJVEBfnzg==, tarball: file:projects/arm-billingbenefits.tgz}
+    resolution: {integrity: sha512-a0RroUNvAfWLt/0KNKMv2CEdjFoayJIyhmmG2fxyNq57XHoM28XeO8fltMODrewiSakD/vxe0+xDkLC9Mm2wHw==, tarball: file:projects/arm-billingbenefits.tgz}
     name: '@rush-temp/arm-billingbenefits'
     version: 0.0.0
     dependencies:
@@ -12935,7 +13376,7 @@ packages:
     dev: false
 
   file:projects/arm-botservice.tgz:
-    resolution: {integrity: sha512-oihtx5BpbzLiwmNpdaJNKnKzTtDs0ZS6g5lQzoCChp5X6oc60YmR9AOE1adtaCUn3vALmk1+hF0aic4xeVjKWA==, tarball: file:projects/arm-botservice.tgz}
+    resolution: {integrity: sha512-m6n3P8SOBgg0i6htP9kFVpj7AcbMU3uANKBXjWRbbW/7+as+LUiB5T4FOoFldt2q28NtxCaNutjUPT0brtl6Tg==, tarball: file:projects/arm-botservice.tgz}
     name: '@rush-temp/arm-botservice'
     version: 0.0.0
     dependencies:
@@ -12959,7 +13400,7 @@ packages:
     dev: false
 
   file:projects/arm-cdn.tgz:
-    resolution: {integrity: sha512-h68hL2sMA2HflbN5UnFe76wd8ICDgwWWAr8EVHooJU5qx2gpNeZgsfOxVpOyowbfLi+0gcA0b83sHRDsVifU9w==, tarball: file:projects/arm-cdn.tgz}
+    resolution: {integrity: sha512-dGmjvLvWc18w/WRJXo/vrQ3s0XzidqKyn1yF2IkqpRrdLMiuFC0rJ3WSWnEi1IkmbyNL2XokLIgRR/FEYYo99Q==, tarball: file:projects/arm-cdn.tgz}
     name: '@rush-temp/arm-cdn'
     version: 0.0.0
     dependencies:
@@ -12983,7 +13424,7 @@ packages:
     dev: false
 
   file:projects/arm-changeanalysis.tgz:
-    resolution: {integrity: sha512-9gYHWzCg+XEBERVccze3blGNGBnEmbzF0B8LOn34A29W7QSm7qsLYWkuPSMMeM6GoSigBZcjw6b3ijS1KBKpdA==, tarball: file:projects/arm-changeanalysis.tgz}
+    resolution: {integrity: sha512-mEX3QcPke3RTeRi2mhrEtTYr/Aq/ss8T58LlT3Pewfn235iiTHhrvZNPsFRZb4N6RNzhERfy8FjTHeb1JfMihA==, tarball: file:projects/arm-changeanalysis.tgz}
     name: '@rush-temp/arm-changeanalysis'
     version: 0.0.0
     dependencies:
@@ -13004,7 +13445,7 @@ packages:
     dev: false
 
   file:projects/arm-changes.tgz:
-    resolution: {integrity: sha512-XbyA6YqnlG6gUXAp0lUMYyMIpkXLvhJ6XlSfDORymIvFWyrc6SDj2arE23v+CISvenpyN6xgyi7hGqb8YpeYaA==, tarball: file:projects/arm-changes.tgz}
+    resolution: {integrity: sha512-efglcKVkUVxmbojXpQgwl6orOV7tPyIjFL8WpSe95U8EHbQVXB3q856lzO1trwixqeX+OMuIOVzbzOoAlUzNBw==, tarball: file:projects/arm-changes.tgz}
     name: '@rush-temp/arm-changes'
     version: 0.0.0
     dependencies:
@@ -13025,7 +13466,7 @@ packages:
     dev: false
 
   file:projects/arm-chaos.tgz:
-    resolution: {integrity: sha512-p8cFZ7EmqQU/LtbbMyulQ4MEozyzGFuvwZ//2CYbQCzcGy/60Iqi808+jBPCv/xKqCwURySZrNJOLMqaTH8puQ==, tarball: file:projects/arm-chaos.tgz}
+    resolution: {integrity: sha512-KK3YArj1Ldhf2XQuHzHt2hPt5rJV9Q7gdwiDrqIlKu7RmOfEYo5bZWZcaO+t6b5UmsD3K7roAqsHIa8wmkgtMA==, tarball: file:projects/arm-chaos.tgz}
     name: '@rush-temp/arm-chaos'
     version: 0.0.0
     dependencies:
@@ -13050,7 +13491,7 @@ packages:
     dev: false
 
   file:projects/arm-cognitiveservices.tgz:
-    resolution: {integrity: sha512-9tEMdT8rzdLZbdjBT+2hgzRtOCZ/sbBbE7hOEwiZL7PwbGNtL0bDy52FdXCHLHjNg2mfXDag4989Qj/YPD0QcQ==, tarball: file:projects/arm-cognitiveservices.tgz}
+    resolution: {integrity: sha512-h7yOGtHNS6a4aAKdAdVQnnYlljFS1bKNSvT7o4r0riGqBk5N/aBFL4WSrQag0uuG9wgCTWRdruK6wcUw/6YnKA==, tarball: file:projects/arm-cognitiveservices.tgz}
     name: '@rush-temp/arm-cognitiveservices'
     version: 0.0.0
     dependencies:
@@ -13074,7 +13515,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-XWOGoDcZktPVP86yN97yCWOFsPIvY/IPAKbZCc5tRrmsOMLDN/uddfRWDkRNYVYcFso93JCSfcM2MJKI5SEP1A==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-oAi7+ymS/AHgcHih6PGjotyaNkvTfQFaSpVOS8obcCY8a68WYFNYKmp7x09MPPWlqc62T0DHVYwOetq2M+HH6g==, tarball: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-commerce-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13096,7 +13537,7 @@ packages:
     dev: false
 
   file:projects/arm-commerce.tgz:
-    resolution: {integrity: sha512-mkDk+8FnnWSXBKV9ElKFnNd9UdEPt/yMcIVD1aQWIAiLO6hUL0/XrhbBrT3fSmo69H0kvcDTS/+M6PCt8wYZ0Q==, tarball: file:projects/arm-commerce.tgz}
+    resolution: {integrity: sha512-v2jxAV6X7t5fs/2+byGyYTfqcPMhgPdn2+kyRWF8aFEjvT/zRUq+HtsrARZAcggoe+tgnQmkCTx+twuaUyfxFA==, tarball: file:projects/arm-commerce.tgz}
     name: '@rush-temp/arm-commerce'
     version: 0.0.0
     dependencies:
@@ -13117,7 +13558,7 @@ packages:
     dev: false
 
   file:projects/arm-commitmentplans.tgz:
-    resolution: {integrity: sha512-H/ayQgnS8IABBf2GTWaDR4YgWcz340CZ6H0KrLWregcnzhlAfHQ9K5zzYRcRrtlCDU+FsN3BmoRYMpK6YKudKw==, tarball: file:projects/arm-commitmentplans.tgz}
+    resolution: {integrity: sha512-zM3RkSTCVVpgyOYKIiGctS5G9+fD0KCtYV8dnvSzGNGNRaQOcGpqyMLFCko87TVcyyNRJc13JJXVYPUyzooXig==, tarball: file:projects/arm-commitmentplans.tgz}
     name: '@rush-temp/arm-commitmentplans'
     version: 0.0.0
     dependencies:
@@ -13138,7 +13579,7 @@ packages:
     dev: false
 
   file:projects/arm-communication.tgz:
-    resolution: {integrity: sha512-8eXV1Fyz9DGFgphWOl5oiiRPGNR1iIvdqiFmrp8/ut4dUm7MOHXvDOUFu/qEJh2irVk2KL4DMlWWWtxq0QdJxg==, tarball: file:projects/arm-communication.tgz}
+    resolution: {integrity: sha512-fQAv5dC/T1iIsCYGTWnLVu/h2zxWNmdv3ypa4AFRbf+ZQMkHf+AufjnnEhh5fRQMP1L2VZk0gWrd7i9h113M0Q==, tarball: file:projects/arm-communication.tgz}
     name: '@rush-temp/arm-communication'
     version: 0.0.0
     dependencies:
@@ -13162,7 +13603,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-1.tgz:
-    resolution: {integrity: sha512-4WuA5JVJ3vs5hma1nm1REXjWEjD1j6vN2ykcwbYtnOZH5PwJnS7eA7DUMO55OQQM2+cLt1YmcS1BUlx92rrWtg==, tarball: file:projects/arm-compute-1.tgz}
+    resolution: {integrity: sha512-YURevGFP6aOSHtW+rrPYgvSqV20dAai+Vk2/Tt8H0nX2nzHTeNWY2pElM/fHexsFAAYix5lDFWucE7HcUbpurQ==, tarball: file:projects/arm-compute-1.tgz}
     name: '@rush-temp/arm-compute-1'
     version: 0.0.0
     dependencies:
@@ -13188,7 +13629,7 @@ packages:
     dev: false
 
   file:projects/arm-compute-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-mQ46C/5e5xrK5m/O42ei8zv63zCZPFdBrk81sR+6exk1uGJOA5hks6RBOwQqg1sA6a/yAI2qVpo2xMJKI+CZJA==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-huV/WhxDbT2Oz9ch64So5nlkhj4VC4pH+7O8Mp/AHGnby2PbkLPcermZyMhccuKEAQaXoPMiv5MfXSkv1RJrDQ==, tarball: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-compute-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13212,7 +13653,7 @@ packages:
     dev: false
 
   file:projects/arm-compute.tgz:
-    resolution: {integrity: sha512-xO63sO30JAuGb4JrtytEiqFmCmFy9fbF1koz77ZZGIXKNT1xCz7ojfyx/bvw1BqQOn/TbTonibqI0BbGYDYAZw==, tarball: file:projects/arm-compute.tgz}
+    resolution: {integrity: sha512-NbnxVzAxn6+Lo1Hq7DqmdJuquejSF3E7Go6HiafKzfGqAU37PhNkzE9z3uqGC8QOJqqAJgHkIhgdEVHVkoMUDA==, tarball: file:projects/arm-compute.tgz}
     name: '@rush-temp/arm-compute'
     version: 0.0.0
     dependencies:
@@ -13255,19 +13696,19 @@ packages:
     dev: false
 
   file:projects/arm-computefleet.tgz:
-    resolution: {integrity: sha512-KNacYssZkHv1/lsUIsCMJ1wsVZw6ssf4feH9W6Pmnz8R/K0rHDiF7E7ambEa+euPWPT6kHal7J9fjxAA1rOIWg==, tarball: file:projects/arm-computefleet.tgz}
+    resolution: {integrity: sha512-l8kRczB476OnRNXovF5AyVEpK1rxOabaeQqebe4rf1P2VGSSVKSHAVzdHrNt4qGP5YPgdr0jfh9sRozxvDE45g==, tarball: file:projects/arm-computefleet.tgz}
     name: '@rush-temp/arm-computefleet'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -13285,26 +13726,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-computeschedule.tgz:
-    resolution: {integrity: sha512-LikjGLDhppCKtO9/RI42l+TovuXgyFifllzgtNrGC3+mkan99xV0Vw/2jCqTL0v+HrFXKsPwrHzvtaWrGfJ14g==, tarball: file:projects/arm-computeschedule.tgz}
+    resolution: {integrity: sha512-WY/oFL6FEeW9P/XRIyrbD3rbi7hEcguRuWEUNkL0P0wxMshMv6m+3mBWUck/wieFPhexzRCUYgmoc7hnBVUPCw==, tarball: file:projects/arm-computeschedule.tgz}
     name: '@rush-temp/arm-computeschedule'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -13322,13 +13765,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-confidentialledger.tgz:
-    resolution: {integrity: sha512-h3gqZFNl1CP8aYBer40iijHXFDQeHilbufSGA0T4VU1zjy8E5czR8sOiU/EuqZflsqE/3cMD5UMktSFIyOfWAg==, tarball: file:projects/arm-confidentialledger.tgz}
+    resolution: {integrity: sha512-dwiNzVskFSKAAqebw6e/XIkYnN/b3LTNiztlMsWo8jvKlUMb8N1f6+Yf0b8MTzINgIrU7i8+/HcQjH3xeWN6aA==, tarball: file:projects/arm-confidentialledger.tgz}
     name: '@rush-temp/arm-confidentialledger'
     version: 0.0.0
     dependencies:
@@ -13353,7 +13798,7 @@ packages:
     dev: false
 
   file:projects/arm-confluent.tgz:
-    resolution: {integrity: sha512-6q2MsXkF5Ji5L1LpZnxa7tnZ3nTPKxz2cMQvtj9MiwEd8vmlIa+TFvz8eOBbXZ5hutkIxyF69drTveiBd9uHcQ==, tarball: file:projects/arm-confluent.tgz}
+    resolution: {integrity: sha512-3rvOibEjTlWMulIqOktAqX4Gko90s6EXEcH6KPKhMxMw7PPrShi5J8fD0OIbhGNSYsPhH0gLcL6l+/msqpVXbg==, tarball: file:projects/arm-confluent.tgz}
     name: '@rush-temp/arm-confluent'
     version: 0.0.0
     dependencies:
@@ -13377,21 +13822,21 @@ packages:
     dev: false
 
   file:projects/arm-connectedcache.tgz:
-    resolution: {integrity: sha512-br4EU3We4o4ri3cAJhHvkAh/yEeu924X37t899KkKtNmqgI2vP6YX09aWowD9KalMEKuxsXOJtVKuX8IfIa2gQ==, tarball: file:projects/arm-connectedcache.tgz}
+    resolution: {integrity: sha512-20kajiR9drjbrWCmvu9vWLImmP4tW2BqHb3eZ23/AbADEb/6V8iLVap6r3VxzUv6hx/BT+VV+QWWXPQgCgfQFQ==, tarball: file:projects/arm-connectedcache.tgz}
     name: '@rush-temp/arm-connectedcache'
     version: 0.0.0
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@18.19.66)
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tshy: 2.0.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -13409,13 +13854,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-connectedvmware.tgz:
-    resolution: {integrity: sha512-vhQ7ZhjOJ0BmjhBsyAvkQLyF9VgXGOcW83y+4X2y03VpkYuTF4nh/lREFr87lhx6j9IGAZHVMoLNIzwMiqpMTg==, tarball: file:projects/arm-connectedvmware.tgz}
+    resolution: {integrity: sha512-RTpEei2eVS4hEtN0edLBn3+Gr86YuwWlKuVzNcUXgucTjahkDEmEDmyNRUb8CNxp+iEJpEpYw4YaVcOhM7pUYQ==, tarball: file:projects/arm-connectedvmware.tgz}
     name: '@rush-temp/arm-connectedvmware'
     version: 0.0.0
     dependencies:
@@ -13439,7 +13886,7 @@ packages:
     dev: false
 
   file:projects/arm-consumption.tgz:
-    resolution: {integrity: sha512-tzRd+8FzWjcLw/90SE67sVQZcjiu10k3cq1gTNkMJBKGSyMfk5VmUI7tZ3SGSPNDIS04JH3yMpa8B9knLF3Plg==, tarball: file:projects/arm-consumption.tgz}
+    resolution: {integrity: sha512-UJ3pLMX8xQlnszGf6COKkr8kxNavAa1ueDdTx5CaxnUC5uV5fyVCCvqfV3o+WQdkSlaUW4K2qt4M+Glbfz3m4g==, tarball: file:projects/arm-consumption.tgz}
     name: '@rush-temp/arm-consumption'
     version: 0.0.0
     dependencies:
@@ -13461,7 +13908,7 @@ packages:
     dev: false
 
   file:projects/arm-containerinstance.tgz:
-    resolution: {integrity: sha512-sEInnQ7E1jvHYEL3rKytvF0m7JEn6CTOwoUL76x5KJJg4FSGnn0yYez4y+FmsfviUbY0Fncd6x0O5XxfSctnsw==, tarball: file:projects/arm-containerinstance.tgz}
+    resolution: {integrity: sha512-Qy53fZNaettXRdw2rKG62ygBDuWWw2SwU2kUnTPsvHWGRXsgm3tXPPcoMcjvXR7LHyJucVAswsQHyeJIDPgK8g==, tarball: file:projects/arm-containerinstance.tgz}
     name: '@rush-temp/arm-containerinstance'
     version: 0.0.0
     dependencies:
@@ -13485,19 +13932,19 @@ packages:
     dev: false
 
   file:projects/arm-containerorchestratorruntime.tgz:
-    resolution: {integrity: sha512-jYkdD3JE46i6HXD5rnOW9rRu6d7u3bSM/OFtK8BXKUM/OHVIDZL5zJjAb5wE669ZO02Pp6D9+sNPrMXgapIZpw==, tarball: file:projects/arm-containerorchestratorruntime.tgz}
+    resolution: {integrity: sha512-9OtGqQWRa0dCAB5XHk2PMMV0jDnaVnA6vx8BlXB0eiLzPVqaO4k+0Plqp5Vzl0BVHEX8Kfn+2FdakAFXqEAEmA==, tarball: file:projects/arm-containerorchestratorruntime.tgz}
     name: '@rush-temp/arm-containerorchestratorruntime'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -13515,13 +13962,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-containerregistry.tgz:
-    resolution: {integrity: sha512-MAE9g1OeBcdvTrIMNlzc3QcUD6gN9n9QBkmofKxtO7Eqx89gwmHyJMd2CwNIsAAeln04+Det4EWKLww4M5WGJw==, tarball: file:projects/arm-containerregistry.tgz}
+    resolution: {integrity: sha512-2x6s1u2Fg9Vwx/5SsVBg+J2l1BvOiBtpnopRehhFhrSQQCOfut2L33uCofqNZNoaV/Xx+kzyf/Uy/Dae9bXixQ==, tarball: file:projects/arm-containerregistry.tgz}
     name: '@rush-temp/arm-containerregistry'
     version: 0.0.0
     dependencies:
@@ -13545,7 +13994,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice-1.tgz:
-    resolution: {integrity: sha512-s7pcgXSyMJcxDuhA9Y7aavPBCQ5h/TowVP7Ni7LsaWMm55Dges6xYWeVwZ13VPtab99BVIc0/E5ZWrd+VXmj+Q==, tarball: file:projects/arm-containerservice-1.tgz}
+    resolution: {integrity: sha512-6YbzJbUp+0S1pPxmYylm9Qxa6u7AOCVrDpUQBOSM+6i0HbCliEMxNq0k1cZqfSFljVCeHK7hYhmiQKepB4w1KA==, tarball: file:projects/arm-containerservice-1.tgz}
     name: '@rush-temp/arm-containerservice-1'
     version: 0.0.0
     dependencies:
@@ -13570,7 +14019,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservice.tgz:
-    resolution: {integrity: sha512-jeP/daGRsku5ktfFyNC3UhrPtnr1i4xqLPMsKKSWMZhy0u1AQIoB8JNak9YDZScQM/+oE2XKtzirERGMdA35DQ==, tarball: file:projects/arm-containerservice.tgz}
+    resolution: {integrity: sha512-wFncDx6qvitNqC9g0U+/cIalQcWHevSA3jE4W/uhdZKVbJHl1cVI4Hwcx/7Lt4Zq5OSezUJ7lWrCqxc1SaZudg==, tarball: file:projects/arm-containerservice.tgz}
     name: '@rush-temp/arm-containerservice'
     version: 0.0.0
     dependencies:
@@ -13612,7 +14061,7 @@ packages:
     dev: false
 
   file:projects/arm-containerservicefleet.tgz:
-    resolution: {integrity: sha512-jHANTC9AXz6io9RuS0AgGwdsE4J3sQxV5/PjUYNN9cYc9UyoivaoiR8dA7Z/hxZgYWR6oEvbZHTakvIfOdZT7Q==, tarball: file:projects/arm-containerservicefleet.tgz}
+    resolution: {integrity: sha512-Kq32c6FDW8dpLSucayIteWE+v+WO5vULu06/pjQDa9cuBCExaJr139WppxWGrzwuEhwz2Chicebbd7+wMudPwQ==, tarball: file:projects/arm-containerservicefleet.tgz}
     name: '@rush-temp/arm-containerservicefleet'
     version: 0.0.0
     dependencies:
@@ -13636,7 +14085,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdb.tgz:
-    resolution: {integrity: sha512-kmqhn/287Woxs/rYzZ4yVqjNwjYXELwiJBAsORmGCTrff1EAKJHrJtLjB7JGDzByRhXu33zfK6u9dxaslnmv6w==, tarball: file:projects/arm-cosmosdb.tgz}
+    resolution: {integrity: sha512-HrbYYAkVX3DXsMGVpWIgHmUNwZedzPorNtWQVMOu8FSaLJSPAGkfHrNrtRBxCnpLcg43j3rV0eVCBL+qr1XimQ==, tarball: file:projects/arm-cosmosdb.tgz}
     name: '@rush-temp/arm-cosmosdb'
     version: 0.0.0
     dependencies:
@@ -13660,7 +14109,7 @@ packages:
     dev: false
 
   file:projects/arm-cosmosdbforpostgresql.tgz:
-    resolution: {integrity: sha512-r7fByIEZifeiEdgn0a28j1n+vOheKS+GfXEbcdBTCnS3VKcSGN9cG6enTXtPRmGlThxm0rsXWLMPx9GB+aZnJA==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
+    resolution: {integrity: sha512-WPUra7YFTZDzaLKZ9UGCiJ07Ftrcw14/UxXzVvKIsjyXDTxZnCCyXvx4r16fwlOqTRK74jTlj3A7kAhvmgqiqA==, tarball: file:projects/arm-cosmosdbforpostgresql.tgz}
     name: '@rush-temp/arm-cosmosdbforpostgresql'
     version: 0.0.0
     dependencies:
@@ -13684,7 +14133,7 @@ packages:
     dev: false
 
   file:projects/arm-costmanagement.tgz:
-    resolution: {integrity: sha512-BiFxTCvxO5ReyZodgCjmnhpr1uA4TS7rfUTJO1NXytF/RKVLmRuwB7MDW6lkn4p3/bTodcFKWmT9JwBBPId2UQ==, tarball: file:projects/arm-costmanagement.tgz}
+    resolution: {integrity: sha512-CKygZWjPq7Glvi7M4moDg+0CFmSlHf8lt1Or6SJyAtAUjZRabtGOg4nYCHH7vQsenbITWGIT2vrcBHNyvmn/1A==, tarball: file:projects/arm-costmanagement.tgz}
     name: '@rush-temp/arm-costmanagement'
     version: 0.0.0
     dependencies:
@@ -13708,7 +14157,7 @@ packages:
     dev: false
 
   file:projects/arm-customerinsights.tgz:
-    resolution: {integrity: sha512-FqmGEE2rR01vOI2w2iOz8kQqN46tOFoaXv//ZFsWIK5KM/n6Dl+Teln32PIl5QvmFZAXYSLEHCvToyV4ShVFoA==, tarball: file:projects/arm-customerinsights.tgz}
+    resolution: {integrity: sha512-QIqrZG7Vt7cppmiL00BRfYTCTFNvQmo8eKMCqwZeOMEMndOBjgCPx48Ggz8tkViZc0dSO/B1L8+7ZJdEU1Yrew==, tarball: file:projects/arm-customerinsights.tgz}
     name: '@rush-temp/arm-customerinsights'
     version: 0.0.0
     dependencies:
@@ -13731,7 +14180,7 @@ packages:
     dev: false
 
   file:projects/arm-dashboard.tgz:
-    resolution: {integrity: sha512-bPCn9VT5vOjBqDUAmkHcpdAUmoHfypM91W60Sdsx7fjPsB1KHeR+iXkxgaVkj0mf/ASCtXsOBDnJxfzf/2Glpg==, tarball: file:projects/arm-dashboard.tgz}
+    resolution: {integrity: sha512-VLj6fhoO0Ys1cnLLM9HlTsXjE8nsUbQo6rLkgcWTVCRMDe6oKHNLF18cDvcgDnp+mFiZT3HDJ/tICbIlickNCw==, tarball: file:projects/arm-dashboard.tgz}
     name: '@rush-temp/arm-dashboard'
     version: 0.0.0
     dependencies:
@@ -13755,7 +14204,7 @@ packages:
     dev: false
 
   file:projects/arm-databoundaries.tgz:
-    resolution: {integrity: sha512-MeXKswuXdfANPbll+wgADKFbptytrEoucE46DUyjJ9WDaRT4x2/u30BIYP9/7XvXXoT/135dIHwoTlV11Rw4EA==, tarball: file:projects/arm-databoundaries.tgz}
+    resolution: {integrity: sha512-8C9Xdh41XyFKrp0XnxhRitDZ4TAh+trfXevhRA6NW47E3LHbFK1TlmmZQlTaZkPNTgAId1GRFC4LKglDibJWXg==, tarball: file:projects/arm-databoundaries.tgz}
     name: '@rush-temp/arm-databoundaries'
     version: 0.0.0
     dependencies:
@@ -13781,7 +14230,7 @@ packages:
     dev: false
 
   file:projects/arm-databox.tgz:
-    resolution: {integrity: sha512-VWqfwgCL9CdUYaY3zPmTCHlqa4vbRFTohoZVhtr3uXxhDfcLAhOHlDXwlfq82uW8e/ekVIUkDFJFbTeSMhXZOw==, tarball: file:projects/arm-databox.tgz}
+    resolution: {integrity: sha512-8j+V5kSXgdN2Vjq6dEaTsKor1hTcGO4YzZ6CVDCrzpTsXDBWq8HAtCdVSMHxuhB/rKZAcpOh25bIRg/Jf0RUag==, tarball: file:projects/arm-databox.tgz}
     name: '@rush-temp/arm-databox'
     version: 0.0.0
     dependencies:
@@ -13805,7 +14254,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-2oh2tcxRY7h79ucTRIimToTooB3PEAEr6RxndWhdptzdfrQpdpXZhxjcD4U1CrNS5qRQyjJTufh1FcaK3iEDfA==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-+NXIea0fk9XutvKs6SmPRIT78z2PBHSsWpHlHm+j5+Gi2vPpzQliKRZv96jUl1Sa6p+l7jMe2kCMxOfa6OgQuQ==, tarball: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -13829,7 +14278,7 @@ packages:
     dev: false
 
   file:projects/arm-databoxedge.tgz:
-    resolution: {integrity: sha512-eIOCmquEXKm4mUDm9UvO5rJfW197pSF8rwUz/rBrd8dUXi/9btkj8nkmCuFqtaJw1Yf3147VpuD+2nvG9eYL2A==, tarball: file:projects/arm-databoxedge.tgz}
+    resolution: {integrity: sha512-agQbWRJYM4DCWaZzWZml5oQcZJJlY6y2KvKbHMpPODQqwkpPa7xG9jAjFP6BJkgmHCR0F+Ma8jtc/J7CCgt2/w==, tarball: file:projects/arm-databoxedge.tgz}
     name: '@rush-temp/arm-databoxedge'
     version: 0.0.0
     dependencies:
@@ -13852,7 +14301,7 @@ packages:
     dev: false
 
   file:projects/arm-databricks.tgz:
-    resolution: {integrity: sha512-7TRsxJAe51LCvUuEp3S5i+Xx3ayJ6d/KtOLMwmAfmC19EcQGUeTuCt2yhdMCJUMFZOF3hqRMK5UuR0GbgHyJkg==, tarball: file:projects/arm-databricks.tgz}
+    resolution: {integrity: sha512-Q+hy1JRQm9F8Zin7v8F7yvGQdopvtUsHkig2BuL33aRuOlyyOnrNkgNnxsnRMHicQT8qsLRcBJSzOKkByFsSGw==, tarball: file:projects/arm-databricks.tgz}
     name: '@rush-temp/arm-databricks'
     version: 0.0.0
     dependencies:
@@ -13876,7 +14325,7 @@ packages:
     dev: false
 
   file:projects/arm-datacatalog.tgz:
-    resolution: {integrity: sha512-ur1aN2W4aMvmtszY1VIoEYW4o7a+MuaZY+xu7Dhhx4Y9qE3F2aCGuquzW4ZRC0IwCW48mFPlx1Xl0lPu2l/99w==, tarball: file:projects/arm-datacatalog.tgz}
+    resolution: {integrity: sha512-mHnv3hhxGUHLqSeq9FtA7a8VIcr/AKOg/zPDFyIxNjmwO0+ltjnTyS21lPwanQS5uIbAiyY4PKOV6JbOSCG/Pg==, tarball: file:projects/arm-datacatalog.tgz}
     name: '@rush-temp/arm-datacatalog'
     version: 0.0.0
     dependencies:
@@ -13899,7 +14348,7 @@ packages:
     dev: false
 
   file:projects/arm-datadog.tgz:
-    resolution: {integrity: sha512-DvAsBS5CEwhbvzn1jxO533XjCgtgNrnM0vbxH4Lh6A7UUj1EOkF47Ctrk5kaVXNAFm1RFtMHlkCzOs2aGCH0hQ==, tarball: file:projects/arm-datadog.tgz}
+    resolution: {integrity: sha512-psMBscl7Svkz3jkMOaM6I5Dj3R5Md1qwM8pIBRU6o9+vPa04GWZiX7JQk0FOkuaf0PqUZiku/TUR4WBUq7deig==, tarball: file:projects/arm-datadog.tgz}
     name: '@rush-temp/arm-datadog'
     version: 0.0.0
     dependencies:
@@ -13923,7 +14372,7 @@ packages:
     dev: false
 
   file:projects/arm-datafactory.tgz:
-    resolution: {integrity: sha512-zHvoqoMyH8FfrToITub+Gvt76bKa79yFXoFPY0bgWugzkG5uCME/JS27V0jDcfZeAna2UwWS664Z00D3ubMMiQ==, tarball: file:projects/arm-datafactory.tgz}
+    resolution: {integrity: sha512-ELqUG9PuI+mQVlRb5Eyz6ch435nrH/vZ67a/+EF0GSWkLnPeFC58EJN6tjg5oXijQg9iJ3A54oALmJ7A1VfQYQ==, tarball: file:projects/arm-datafactory.tgz}
     name: '@rush-temp/arm-datafactory'
     version: 0.0.0
     dependencies:
@@ -13947,7 +14396,7 @@ packages:
     dev: false
 
   file:projects/arm-datalake-analytics.tgz:
-    resolution: {integrity: sha512-hnsz3nfHLwPyi2P7YtnFSXN6Tln1Ngguvl+XvK5mMnDsbCXSVwYmgOmBh73GwN+jCI/qdr6G/99iMqnZBhXkHQ==, tarball: file:projects/arm-datalake-analytics.tgz}
+    resolution: {integrity: sha512-dCsKwQbRPM2084hnaIqqM3Pwor6MH0u3qEvgbbWFFIbnUsDguXy3ahQe1dAgTE5dJ5qOJYtA2qwJhRtfxIOAXA==, tarball: file:projects/arm-datalake-analytics.tgz}
     name: '@rush-temp/arm-datalake-analytics'
     version: 0.0.0
     dependencies:
@@ -13970,7 +14419,7 @@ packages:
     dev: false
 
   file:projects/arm-datamigration.tgz:
-    resolution: {integrity: sha512-HdvIXRBzAT+xlkUNCJDF1DOg5us+jceIuFxDmJzL4AKAf+A5+FcMcFh50a5udXewiOpKa6BVgNQD+Jjgurzokg==, tarball: file:projects/arm-datamigration.tgz}
+    resolution: {integrity: sha512-4Dpv39nMKqcSk4njOngk/Ug8u51Y1Gqwn223UC+HFzMStwkQ9/+QOfY9tY73u1mQAzFj1Gx+0pstZ3Eb+SVq4A==, tarball: file:projects/arm-datamigration.tgz}
     name: '@rush-temp/arm-datamigration'
     version: 0.0.0
     dependencies:
@@ -13993,7 +14442,7 @@ packages:
     dev: false
 
   file:projects/arm-dataprotection.tgz:
-    resolution: {integrity: sha512-aaL4a9X4t8IGUX1WRnrple+K1lkdfqQ1wolOBv/YTXIoJx7vpfuUunkPS+zfv6NlzRB+ug8AGquHK6UHBWbeeg==, tarball: file:projects/arm-dataprotection.tgz}
+    resolution: {integrity: sha512-TKFWwgPjYSwT0xVuZZj434+uSbuC2it5GH1HENuVDLTHZxjF7WCJs4zTyEfzGyJ4bRXjh0zqI0m857MoS/9u8g==, tarball: file:projects/arm-dataprotection.tgz}
     name: '@rush-temp/arm-dataprotection'
     version: 0.0.0
     dependencies:
@@ -14018,7 +14467,7 @@ packages:
     dev: false
 
   file:projects/arm-defendereasm.tgz:
-    resolution: {integrity: sha512-P9n4xlIfobW7FlALFrPocM2w9zI1XGWgvCuambu894eqpqsBtvN2vaF3VWzg/shH3PnKjSLuDKFt+3MUXCRYGg==, tarball: file:projects/arm-defendereasm.tgz}
+    resolution: {integrity: sha512-kpAlRkrWShGbO6TWEpnHCqaGXcjeArUUAH83sMVp1l0Ee8v30aBMah9m7wlVxPORe78h9ddheSgdtJ7Er8GcHQ==, tarball: file:projects/arm-defendereasm.tgz}
     name: '@rush-temp/arm-defendereasm'
     version: 0.0.0
     dependencies:
@@ -14042,7 +14491,7 @@ packages:
     dev: false
 
   file:projects/arm-deploymentmanager.tgz:
-    resolution: {integrity: sha512-Fi1ZT3FjQAWyl21TN8w6G36e7CKWEwYerxs+IJQyfS4fYPeoBAAj40PE+eR05Revn5TzqAZWbS1beESgyit8bQ==, tarball: file:projects/arm-deploymentmanager.tgz}
+    resolution: {integrity: sha512-EguuNkl7KC3v9yHJeOqhckCy28WC+SU19nwB+5fzTAHdztQRhSZ3akwB3CQa8A2i+dSKr2jM0XpjW9qNB1gPBA==, tarball: file:projects/arm-deploymentmanager.tgz}
     name: '@rush-temp/arm-deploymentmanager'
     version: 0.0.0
     dependencies:
@@ -14065,7 +14514,7 @@ packages:
     dev: false
 
   file:projects/arm-desktopvirtualization.tgz:
-    resolution: {integrity: sha512-WkSGGVJ7TsaSYvPgPwyP1aTNfSYiosFNzGulvUaDdHJVsyYL6Z1d9VLjJuRg/9PXVpm+UHgh8ozbp7+QzF2egg==, tarball: file:projects/arm-desktopvirtualization.tgz}
+    resolution: {integrity: sha512-zFfJ3AdWVkcPzuktRXrmy1kc9nmWUsh6EmaIiGgbQFneZGayFVtM0INUHxdFPu9ecECICe9Len4HajJskYuRuw==, tarball: file:projects/arm-desktopvirtualization.tgz}
     name: '@rush-temp/arm-desktopvirtualization'
     version: 0.0.0
     dependencies:
@@ -14087,7 +14536,7 @@ packages:
     dev: false
 
   file:projects/arm-devcenter.tgz:
-    resolution: {integrity: sha512-ElA3kJr4VYHRur5LNH+3eqk888Y4eELoHjBZwUp7ny9lmicmT8CSSfYPcA3wtRU+ONfnPzcbtNxvA5OLyg5Jkw==, tarball: file:projects/arm-devcenter.tgz}
+    resolution: {integrity: sha512-TYv/2fqZKni1Zfgd5xYDMpU0ojHEkGZGk8QcxJn4CroJjowC7C9vDUY75gHKTUCKM0aYzMsqVBFGwzteZn71vA==, tarball: file:projects/arm-devcenter.tgz}
     name: '@rush-temp/arm-devcenter'
     version: 0.0.0
     dependencies:
@@ -14112,7 +14561,7 @@ packages:
     dev: false
 
   file:projects/arm-devhub.tgz:
-    resolution: {integrity: sha512-/ulUNfGy6F3WwIwEgke+C964nIphU941jinhAqSlREVan7unJ+HKZ50WhSlFeuPnpLirKLshKnS25DaixwjIzQ==, tarball: file:projects/arm-devhub.tgz}
+    resolution: {integrity: sha512-gmRHlNrbgGgyL+7xUORh0Y2rVy+mO/vxExBf2V1CydHveniDvzoJ/vx6yYAEn9jcuGGeoSa8VhAFjPP29GU83A==, tarball: file:projects/arm-devhub.tgz}
     name: '@rush-temp/arm-devhub'
     version: 0.0.0
     dependencies:
@@ -14134,7 +14583,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceprovisioningservices.tgz:
-    resolution: {integrity: sha512-riqpYWIE2mxkYZ/N5ElOcLRk552/nOLKjK4zINVet7ujMLBMl5tJXc6tyjOAyeuOJQMEoYAPwdYs2RIJHMaqMA==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
+    resolution: {integrity: sha512-o5LeCxkoi+UlY0F5tPi75zJ0ka8JnDKjEZZfN5gGeTcLrKD5jL5H1WuiDbKfyId8As9BmJT81tb1d7DRjdyn2Q==, tarball: file:projects/arm-deviceprovisioningservices.tgz}
     name: '@rush-temp/arm-deviceprovisioningservices'
     version: 0.0.0
     dependencies:
@@ -14158,7 +14607,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceregistry.tgz:
-    resolution: {integrity: sha512-quCDiEA+ReWg69Cr/mNGXWYJgBUcRiUNEx0297eq9t8js5mUlpBgSkqHoV4D8gp4CqCGDFsicizrO4gooDMPeA==, tarball: file:projects/arm-deviceregistry.tgz}
+    resolution: {integrity: sha512-6i6+UBrlAdm8AjwODz3gfqCLsqi/3w4EE6uCWVGOhjKfGQHVPtUae8T4TCMir8ad2Tp6+6x0Ee60Jv3mWVsfDw==, tarball: file:projects/arm-deviceregistry.tgz}
     name: '@rush-temp/arm-deviceregistry'
     version: 0.0.0
     dependencies:
@@ -14183,7 +14632,7 @@ packages:
     dev: false
 
   file:projects/arm-deviceupdate.tgz:
-    resolution: {integrity: sha512-znlJEhy36SrWO0Dknteg6+9FxZwqbtg80pLUl4m8j/y3blmUz5smv/SH7G8tsTf9Q68mT/G/t1XPgcuhoF6XCg==, tarball: file:projects/arm-deviceupdate.tgz}
+    resolution: {integrity: sha512-4LXaXeo1mei+0hnDXj85pxyEYK5BNo7yFWtx5CZpZ/QWjDFzCmdZmLX9UnK8fMtZqyNT+jp3Kdwhw7f+tOse3g==, tarball: file:projects/arm-deviceupdate.tgz}
     name: '@rush-temp/arm-deviceupdate'
     version: 0.0.0
     dependencies:
@@ -14207,7 +14656,7 @@ packages:
     dev: false
 
   file:projects/arm-devopsinfrastructure.tgz:
-    resolution: {integrity: sha512-zm1zJUacHQHrVisNSNKl6fuuO1JO3qpkdcnAIv2TeISXJYJFxIkSTyv70j+TIUa0C/c9MWgtNaCNp35yGhnc0g==, tarball: file:projects/arm-devopsinfrastructure.tgz}
+    resolution: {integrity: sha512-gS0Q0gyUqvD1sE0f5NPG3eKIX/bPaVJibUpk/u9zosYfMsQdOBG7PjXIXZNhXxLEC6kPXnrbfBiLXTSsYJfI8Q==, tarball: file:projects/arm-devopsinfrastructure.tgz}
     name: '@rush-temp/arm-devopsinfrastructure'
     version: 0.0.0
     dependencies:
@@ -14232,7 +14681,7 @@ packages:
     dev: false
 
   file:projects/arm-devspaces.tgz:
-    resolution: {integrity: sha512-Q/eqbhZ3g9xqnK3N72VTwD1x1nJWysHmAZgMnwSIz4/rMT/YT+1Bt3ffVTAQHlBo8qkR4V/aEm2Ch0OEGAcCMA==, tarball: file:projects/arm-devspaces.tgz}
+    resolution: {integrity: sha512-Y1n2iR9uFAhtZMLjt8+6DUFkMcZf+UxEbr13y+N1RAAuQ3H8NWM67YyIYufRGL7Cu5f1G3Ox+6eg14jFJVtbfg==, tarball: file:projects/arm-devspaces.tgz}
     name: '@rush-temp/arm-devspaces'
     version: 0.0.0
     dependencies:
@@ -14255,7 +14704,7 @@ packages:
     dev: false
 
   file:projects/arm-devtestlabs.tgz:
-    resolution: {integrity: sha512-EvNRBBYLBtA89dqEo5Fatkk6tZBn6EzmNIO6WxohGfzR0A9c3Cq9Rtq6TvD3A2wljBORnTXf2vtCqMHtyjDD0g==, tarball: file:projects/arm-devtestlabs.tgz}
+    resolution: {integrity: sha512-0jvxh04pw9/fWmMs3K421iM1KciOnJ303GoyQqZzv8tVJ+PRYnfn3v7HEx2QJglECaGV9bDXi4Amn0LGT0DnxA==, tarball: file:projects/arm-devtestlabs.tgz}
     name: '@rush-temp/arm-devtestlabs'
     version: 0.0.0
     dependencies:
@@ -14278,7 +14727,7 @@ packages:
     dev: false
 
   file:projects/arm-digitaltwins.tgz:
-    resolution: {integrity: sha512-BqBVEKbkughTL3GaQaq+X3WHjb5CiGmhWD4S+whVx8BleXQvAejhD0skYioQuRZSkKE6eAHR1qWSrpgcE9rqQg==, tarball: file:projects/arm-digitaltwins.tgz}
+    resolution: {integrity: sha512-4GMsdoqRAxPG0CqA1CQuP9WrAPsxjemsMJ1qtEiSoi7xblfEnYBMi07vEFzWlkRpYk+pl4uWqNeqnPzEf/6XlQ==, tarball: file:projects/arm-digitaltwins.tgz}
     name: '@rush-temp/arm-digitaltwins'
     version: 0.0.0
     dependencies:
@@ -14302,7 +14751,7 @@ packages:
     dev: false
 
   file:projects/arm-dns-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-WXZYZVdS+6GytB3EkjJ6JxYk/uW7hpRsTIFwaxeMhCpdLkUScMCN0Ol2Ks6oqllFCxsxYjXA1IFVlxAbP9bRgA==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-mq58+Y4pyI2gTV9t+GVXFovU+ekB4V677dmoWHqvQY0tA/BzKK7WZVzZwK2WnCNb+iUWlO2hWNarC3kdAel/fg==, tarball: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-dns-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14326,7 +14775,7 @@ packages:
     dev: false
 
   file:projects/arm-dns.tgz:
-    resolution: {integrity: sha512-rkpnVZ4XZBxJd87suiuOua26e4WuHXpJZEVJF7ushwKGJOR1GIQX7x4RNrMncZXoQIPh14IQdL+SGdHVKCAUJQ==, tarball: file:projects/arm-dns.tgz}
+    resolution: {integrity: sha512-4aRh4CNuAuNmxtW33Ps8okMGVmu2mD/9EALK88aZ9enQY6NJ5+9pZI2WFBC7YADT4x5f0m2eSI7/I2Hp9/SCEw==, tarball: file:projects/arm-dns.tgz}
     name: '@rush-temp/arm-dns'
     version: 0.0.0
     dependencies:
@@ -14350,7 +14799,7 @@ packages:
     dev: false
 
   file:projects/arm-dnsresolver.tgz:
-    resolution: {integrity: sha512-rjjLREmJ5YdK9W8SPOjUPV3wCXr1sgVzMV/1xNR6NR6a9AxK0HAhjJVrx0dSJj/jzRkcpxLTML4ZJhT+UQ1gTA==, tarball: file:projects/arm-dnsresolver.tgz}
+    resolution: {integrity: sha512-MnQMLAjhxjfk6YPX0FcSX95YQyrELar9Naak/pWyNuDql6lgwGGMvlrQsGp81Kt7v4U8VIE9+maISKMW8zLCVg==, tarball: file:projects/arm-dnsresolver.tgz}
     name: '@rush-temp/arm-dnsresolver'
     version: 0.0.0
     dependencies:
@@ -14374,7 +14823,7 @@ packages:
     dev: false
 
   file:projects/arm-domainservices.tgz:
-    resolution: {integrity: sha512-zy0vOxh4ejLEQ3WC8uyePpPMx90stIG+vN3MgWIct81IDBXWeQagObK8Q1DI73DkT2K8WEN0l15hC5tOzolVgA==, tarball: file:projects/arm-domainservices.tgz}
+    resolution: {integrity: sha512-r6DG8qT3SZQ1qL8xWsyxZMjuV9fQmzsx7zM0wwMC1W3klswe8v72YKFfnZsHSvoSZniy+akz9uImkj4lkEsPBQ==, tarball: file:projects/arm-domainservices.tgz}
     name: '@rush-temp/arm-domainservices'
     version: 0.0.0
     dependencies:
@@ -14397,7 +14846,7 @@ packages:
     dev: false
 
   file:projects/arm-dynatrace.tgz:
-    resolution: {integrity: sha512-zo7HeAx6Z3iis3m4wNn2fOZEz/zpWJQuZVsIStuMq5cr0jO6hE2sy9bbf6VGQu6Te3MmX2zlIDQ4jZtwgva/+Q==, tarball: file:projects/arm-dynatrace.tgz}
+    resolution: {integrity: sha512-+ELrmcLwSTA1Au7SsD+6ndrsx2eXhO0jDNjdwLWdIXXbDsk9LaOxMd+Uo1/nW2nnqVut4U/JcMWrPJUONEWMZw==, tarball: file:projects/arm-dynatrace.tgz}
     name: '@rush-temp/arm-dynatrace'
     version: 0.0.0
     dependencies:
@@ -14421,21 +14870,21 @@ packages:
     dev: false
 
   file:projects/arm-edgezones.tgz:
-    resolution: {integrity: sha512-7Lx+GC3XiUXQHYTMYyxOJZ1oNmYQO17cc4GvuXpm6dv7siGj5rCidZiebA53JEWr/TspcctIeGnG8AHLAVsBYw==, tarball: file:projects/arm-edgezones.tgz}
+    resolution: {integrity: sha512-D4ZewPwqjnxkMDhHAqygy0bESmFdVFz8eYfzeRUb9XS+UhTbn2vsfLBVToxVuWIVNXZymMnIr6rOLUydLpQ1mg==, tarball: file:projects/arm-edgezones.tgz}
     name: '@rush-temp/arm-edgezones'
     version: 0.0.0
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@18.19.66)
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tshy: 2.0.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -14453,13 +14902,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-education.tgz:
-    resolution: {integrity: sha512-88a/609dDLOdicZXsf71q0OsyCgHFls8EeNL8vPsaiDuhbM4AlMvY1jX4WP4tJ2ooCTWrYNrIt20bBYSyV+JTA==, tarball: file:projects/arm-education.tgz}
+    resolution: {integrity: sha512-v0bVNAxYukPmkSUdPYJn5TcBHxLVnJJmp9qJMg88ohzMxRsaQBPEBs+Ut8Zvc2aBCpjGSnXqToVXH57LkOeyJg==, tarball: file:projects/arm-education.tgz}
     name: '@rush-temp/arm-education'
     version: 0.0.0
     dependencies:
@@ -14481,7 +14932,7 @@ packages:
     dev: false
 
   file:projects/arm-elastic.tgz:
-    resolution: {integrity: sha512-vYEgApwAVo0sQii09y2eY+0gNX1oYD/vxZrQnxDlAZtOPjNOs9b/p2zISW1kEdQkYlkr1Dt+QqlRCm9oKDrCHw==, tarball: file:projects/arm-elastic.tgz}
+    resolution: {integrity: sha512-XoGs/h+nzy4vHSgB4d7esAxtTqI+ME21KOet+4kKYPm4BIg7Q/eW2yBql3QHqjsyLlRGuNCz0G800qHnF1FbhA==, tarball: file:projects/arm-elastic.tgz}
     name: '@rush-temp/arm-elastic'
     version: 0.0.0
     dependencies:
@@ -14505,7 +14956,7 @@ packages:
     dev: false
 
   file:projects/arm-elasticsan.tgz:
-    resolution: {integrity: sha512-XUrItPvl7C8t5EhDxKic5rFcLVlHhAHGqgt2RgZccYj1duwANGcFaLkZ0dvGeKeDKk7wJNH6KCIU8IxHHhZESQ==, tarball: file:projects/arm-elasticsan.tgz}
+    resolution: {integrity: sha512-EB7ceENjVwyvToS6YLK3X0eACZ8e4ZY4BAinsOoGhedHqhAgDaWG5luIOyJCZb5bEukfcGcOFW7+Y+XYuilUSw==, tarball: file:projects/arm-elasticsan.tgz}
     name: '@rush-temp/arm-elasticsan'
     version: 0.0.0
     dependencies:
@@ -14529,7 +14980,7 @@ packages:
     dev: false
 
   file:projects/arm-eventgrid.tgz:
-    resolution: {integrity: sha512-gRWNCIfD/9EKzXFYF7nmUth3NdHRHQMOWT0RWrYRixYQvN0bW9O2KJ6Al99WGhu8kwc/pQv88CMTLlE4RmY+Gw==, tarball: file:projects/arm-eventgrid.tgz}
+    resolution: {integrity: sha512-MhLhkcJ7CDarRQYlfrvzqarL6hRporiCOnPfOcY78cEffT2MrLug1oHbAbTP1A1F9qHjZ8btfFju16uUXqwqLg==, tarball: file:projects/arm-eventgrid.tgz}
     name: '@rush-temp/arm-eventgrid'
     version: 0.0.0
     dependencies:
@@ -14553,7 +15004,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-yXy86SvXV0Y6gL+8fLrskodDhslyY+3pNtEUV+8rh6opnEXVt5sIlZGoGGFjrFwxwHEVQkoN5WTl48qeU7gw8w==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-HqT2+3BlQd949npjVwuCLuTYfzxltedZWBSVWa0Mk4ipXHHRWRmyia/6xOqbnbe8Kurm+NV2+dAE9sCuHNsnyw==, tarball: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -14577,7 +15028,7 @@ packages:
     dev: false
 
   file:projects/arm-eventhub.tgz:
-    resolution: {integrity: sha512-zcgis5xWMGFSTthGMHcAN0+nE6BngUdeYgebRalPbAffdCrE0dyLzoRNfNhD9nZuHX3Z/ppJahX9N4pidusqNA==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-aqPXY+mC7bzEcNXEzHBlivSjKhgiAz2Esk4h5IR0OPQyfFzTGZ2dnc5vf5YmBzMOAfejtvB6aKRPiX7s2XqK4g==, tarball: file:projects/arm-eventhub.tgz}
     name: '@rush-temp/arm-eventhub'
     version: 0.0.0
     dependencies:
@@ -14603,7 +15054,7 @@ packages:
     dev: false
 
   file:projects/arm-extendedlocation.tgz:
-    resolution: {integrity: sha512-3F9Slv8CGuLibBUsVp8SU4YdvJgqsJ4ohkcoD5eR+64tWh1IohEzIpspFfDFxKTz2HrlI9f/PzMXZeBuaylmVA==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-WJ4NB7QvkJY/Afz1PgigCqzyVAVn3AmeUbCi7uT8hzlL9zAbIRemKCOzeb1usfN+C+S7bCV4MTHZXXtjl2U1jQ==, tarball: file:projects/arm-extendedlocation.tgz}
     name: '@rush-temp/arm-extendedlocation'
     version: 0.0.0
     dependencies:
@@ -14627,20 +15078,20 @@ packages:
     dev: false
 
   file:projects/arm-fabric.tgz:
-    resolution: {integrity: sha512-ICWVjR6hU0iagAV8KUf4dINj8JVMdphqd+y6bJH97q45JuzNuOdSFTw4XA/cI7bZn6OuanDSpwQN0JIFlgZZnw==, tarball: file:projects/arm-fabric.tgz}
+    resolution: {integrity: sha512-Fc8f9/K/t3TDwfCiPAnnD+nKnxmutzR2PXah+3ioYz0iQeS/SN+llYXokhloYSZskTtoooFdk1XvBkT25jFw7A==, tarball: file:projects/arm-fabric.tgz}
     name: '@rush-temp/arm-fabric'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -14658,13 +15109,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-features.tgz:
-    resolution: {integrity: sha512-3J1i0VtufpuE01Oe1MgQf7FvVsjtpIof6ivbMIN78m7O2vjBqpIP2XgAFTv9SXUUxcDV6EnYm6aBaDke7PzCnw==, tarball: file:projects/arm-features.tgz}
+    resolution: {integrity: sha512-X26StFEs/h3/o+b6s9Mku3D2qaiHT0J5H5/YWKymkbYdEIAJTLui8WCgzSB7r01UrO1V14fk6cM3THfi2B/v1w==, tarball: file:projects/arm-features.tgz}
     name: '@rush-temp/arm-features'
     version: 0.0.0
     dependencies:
@@ -14685,7 +15138,7 @@ packages:
     dev: false
 
   file:projects/arm-fluidrelay.tgz:
-    resolution: {integrity: sha512-FWg+mamMfp4ajNuErKosqaqcPr+YUEQHYoecgi6PiD3e3evBUfKZ0ei3KURtIKqSNEUncEKe3WTQgMAGOe4KZA==, tarball: file:projects/arm-fluidrelay.tgz}
+    resolution: {integrity: sha512-Cg79oEDC4QwdXygQwadLm4A3tk/ANt98gGmsVcEp8lQ201+pgXlo3wbiGrF4pA4NnKGmGWhfJDofbrXx8jC8rg==, tarball: file:projects/arm-fluidrelay.tgz}
     name: '@rush-temp/arm-fluidrelay'
     version: 0.0.0
     dependencies:
@@ -14707,7 +15160,7 @@ packages:
     dev: false
 
   file:projects/arm-frontdoor.tgz:
-    resolution: {integrity: sha512-Z5FhbslXhH+EVg34AQZZKFhxRA/WoevO2IA1fF+/L//fj11FrUuSa1CDDKPmp+xHuBDfcALCZ3e+pg1smbR2Ew==, tarball: file:projects/arm-frontdoor.tgz}
+    resolution: {integrity: sha512-mqbFcngxEtTri33H+/8ji2RQHDeEAqo0U/0m4OD5pOxDOQNUF6fB58tQlfGaI6gElYrQboummXvVsLLK5Dj1Mw==, tarball: file:projects/arm-frontdoor.tgz}
     name: '@rush-temp/arm-frontdoor'
     version: 0.0.0
     dependencies:
@@ -14731,7 +15184,7 @@ packages:
     dev: false
 
   file:projects/arm-graphservices.tgz:
-    resolution: {integrity: sha512-f+H6SKPg0tkXroI0QtenN+ayzUNMIsXQD1T05BDyU3xnd88ZZrWuKNO/nIumI2VJTiKXGC4oIa/eRlaXLlpMnQ==, tarball: file:projects/arm-graphservices.tgz}
+    resolution: {integrity: sha512-bu3cz3XtfnOeSl8+hdZqhaxnuP2pPK6bHfeNrY90iDB7bodOXnOqKDZcGxWvzWWiJkQjYmFWmJ3/6jsZeWXl+g==, tarball: file:projects/arm-graphservices.tgz}
     name: '@rush-temp/arm-graphservices'
     version: 0.0.0
     dependencies:
@@ -14755,7 +15208,7 @@ packages:
     dev: false
 
   file:projects/arm-guestconfiguration.tgz:
-    resolution: {integrity: sha512-78pHXlczVccH5+mEB8bDhBsPsmi+7A7gSohvSNoyBw7MPn3N7WGmhd857hyO9Wj5kguISMLZr/eaQSdDFitvFA==, tarball: file:projects/arm-guestconfiguration.tgz}
+    resolution: {integrity: sha512-UUoBOWHLZc0egsstd7DnWejHbDM/HsKMBZCXjdPUc1fGLk8AeZB8g1hIzdUx7uTbEpuLaOmYmviUoUyoGwSscQ==, tarball: file:projects/arm-guestconfiguration.tgz}
     name: '@rush-temp/arm-guestconfiguration'
     version: 0.0.0
     dependencies:
@@ -14778,7 +15231,7 @@ packages:
     dev: false
 
   file:projects/arm-hanaonazure.tgz:
-    resolution: {integrity: sha512-fj9E9V/EMbUHXFGfDxjq0huS23HUABH9GPCAXr2MvbfTm9w8JZRiUOItobkzNUo/d9KaiZF5xtSVwCfHUoXhPw==, tarball: file:projects/arm-hanaonazure.tgz}
+    resolution: {integrity: sha512-xfrU9drWhNu0rLLVFeEGLxPx1lH4OegTUAXXpq2EI3SmPpY4c1IBKXR2uAqAHVMS4N5paZFNcchyCmg11v4OAg==, tarball: file:projects/arm-hanaonazure.tgz}
     name: '@rush-temp/arm-hanaonazure'
     version: 0.0.0
     dependencies:
@@ -14801,7 +15254,7 @@ packages:
     dev: false
 
   file:projects/arm-hardwaresecuritymodules.tgz:
-    resolution: {integrity: sha512-o/8lBLIUz3s8F+IAf4zlTBEe+By1vGq0RbaMAyTb7xGkKxZW9V7LBEeQ3ZdbhYYbWgF81BabbJV3/2HC2RUwGQ==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
+    resolution: {integrity: sha512-Gum6XjZKsxZ2QR/aVlEIYJP38h8g8oB5n40EAIybq/UygmCnIKYMceS/l0QwhtoyzoYPTlnBd1LcQ8V8TPvEHw==, tarball: file:projects/arm-hardwaresecuritymodules.tgz}
     name: '@rush-temp/arm-hardwaresecuritymodules'
     version: 0.0.0
     dependencies:
@@ -14830,7 +15283,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsight.tgz:
-    resolution: {integrity: sha512-VOcE7P3czCYwQBzwuNanhWB08NeiOjQ0aPzox0UhB1oom5xohaL63Ba92Vlo5uQQJgcuhMHIXu7E7/1TrfbjUw==, tarball: file:projects/arm-hdinsight.tgz}
+    resolution: {integrity: sha512-1A5zExgBiTDj70dHf15mB9vSNIBXhA3EZEGWvevvsv3CNGhwWDS4VONFA2I5H7SxybfTOuIUk2uJEn0yzwoJ2Q==, tarball: file:projects/arm-hdinsight.tgz}
     name: '@rush-temp/arm-hdinsight'
     version: 0.0.0
     dependencies:
@@ -14855,7 +15308,7 @@ packages:
     dev: false
 
   file:projects/arm-hdinsightcontainers.tgz:
-    resolution: {integrity: sha512-AA9+lzlxT5caxRabXKUuQ7zwFdFlOJOoiB1/RlSVUroKF9iirSeAiLELq6DpaoGi7HZRbGs9cUJjKzUTIAchvw==, tarball: file:projects/arm-hdinsightcontainers.tgz}
+    resolution: {integrity: sha512-aK5pva48IYIvd1OqjClKqRV7R1g4iBCBG+x8apmwC3KAJk3t0PBgYFMNdsbeyAg99OorSGJsIO3grkqHX1zNaQ==, tarball: file:projects/arm-hdinsightcontainers.tgz}
     name: '@rush-temp/arm-hdinsightcontainers'
     version: 0.0.0
     dependencies:
@@ -14879,7 +15332,7 @@ packages:
     dev: false
 
   file:projects/arm-healthbot.tgz:
-    resolution: {integrity: sha512-O2LN29m9874F/od+0d8s5m/g/aoHpbPm9saVlwSOmoZvwJeU7Kt/eYRdcP3EFEf3zgIWfiWPVIgc8jJlp4edMw==, tarball: file:projects/arm-healthbot.tgz}
+    resolution: {integrity: sha512-whcldGZ0U+AGemQz9RD9UrJUCkBwrrPNHX2FVClEZCYgfo4qWk/3R3l/mZ2k2CaTwyF6NMHYRwQjbj++bVJ/jA==, tarball: file:projects/arm-healthbot.tgz}
     name: '@rush-temp/arm-healthbot'
     version: 0.0.0
     dependencies:
@@ -14902,7 +15355,7 @@ packages:
     dev: false
 
   file:projects/arm-healthcareapis.tgz:
-    resolution: {integrity: sha512-0XRdjxPkw3yi0dAWTmWwEERzg4HKKGE6QE5kM5QoYfz5T/HwN9PaJEI1tmjthKhuWylzT/Sqi2pSlrJaDa5EdA==, tarball: file:projects/arm-healthcareapis.tgz}
+    resolution: {integrity: sha512-Lkk/WhTqv9vWlAZbQ3RbR4dG94yZYOdzWd6IwK12NEEs72D5gkveh54MHkNaC9dPi9ipT/MX3BDYQcVPqQq2bQ==, tarball: file:projects/arm-healthcareapis.tgz}
     name: '@rush-temp/arm-healthcareapis'
     version: 0.0.0
     dependencies:
@@ -14926,20 +15379,20 @@ packages:
     dev: false
 
   file:projects/arm-healthdataaiservices.tgz:
-    resolution: {integrity: sha512-Fx9bTzlUJwLWjfbKxpAlDJezkzYhmcPwAGPSzRpgi2L0spP9j5d/bVG3x578z2RqRQ5ztW4nReWoTVV17uLkdQ==, tarball: file:projects/arm-healthdataaiservices.tgz}
+    resolution: {integrity: sha512-mOW7c9b+agoqd2b7krLWFYKZak2ihLaNrytyIereiTjgixNnPQfbYhHgIuYtVGSjdLA8qvraacEaKbaO9p2cew==, tarball: file:projects/arm-healthdataaiservices.tgz}
     name: '@rush-temp/arm-healthdataaiservices'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -14957,13 +15410,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-hybridcompute.tgz:
-    resolution: {integrity: sha512-IxFMCCeH0D2P6u+4Vwi9ROrWBKeO0DJEfs2jxyfJnrGNMrRKAWfplx0QVZY6ETK5Thjlm3myTMffxO2BT5PBiA==, tarball: file:projects/arm-hybridcompute.tgz}
+    resolution: {integrity: sha512-E8OwjPZlhWk94zPCS6SiI+tRRkYTjh9iD6z+ZoB1UIu/UAbHKE2jxzz5CPmVD3w4txoqZj/3sd3pQQLVTBW21A==, tarball: file:projects/arm-hybridcompute.tgz}
     name: '@rush-temp/arm-hybridcompute'
     version: 0.0.0
     dependencies:
@@ -14988,7 +15443,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridconnectivity.tgz:
-    resolution: {integrity: sha512-+eeEq1U3g4/4BXTYyMsZ7v969HBo5JJO8r+HU6W/HDjnRRt2TJFTqEm7qh7CV4aMPLN/OKXnAmkjSQpIfhlDgA==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-AIhJKBuE/RgniW0RM6AvHPTIDGobkGk1DqI9XnJR3zfejk45zEuqZUqUIaw+VIJ0Ne+bY0fQNnKhlhqInBx+tQ==, tarball: file:projects/arm-hybridconnectivity.tgz}
     name: '@rush-temp/arm-hybridconnectivity'
     version: 0.0.0
     dependencies:
@@ -15010,7 +15465,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridcontainerservice.tgz:
-    resolution: {integrity: sha512-3e5eRzb0E3EGHK/UlFRvyNfPYNtN9feI09Z6fOd8g5rYT/U9ZK9/OAEK86qiUYsw13ffUzESf+cirlYevG+gpw==, tarball: file:projects/arm-hybridcontainerservice.tgz}
+    resolution: {integrity: sha512-cbc8vnMpRUlFSiTZ5Gf7UVGkX8TrmrlLs2TGJWGfMeM1kXblWyriZj772hLJqRLStIzuwhR98a18/wIyNLf8pg==, tarball: file:projects/arm-hybridcontainerservice.tgz}
     name: '@rush-temp/arm-hybridcontainerservice'
     version: 0.0.0
     dependencies:
@@ -15034,7 +15489,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridkubernetes.tgz:
-    resolution: {integrity: sha512-rylWrR4t9uivdZ3KDK4RsX0SLvrO1CFLausWih/XT+KSWORydxfFMNOcX9VAM3rWD7R+yCK9xANLrWEVmet6Lg==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-iPPhdisQFhAfRTG0HHK4jlex3qqG22s0utHfa+xv8lBXlTwoZ2Rgl5toS/nFAZtx5phnng0oLoQfErhLS7urbQ==, tarball: file:projects/arm-hybridkubernetes.tgz}
     name: '@rush-temp/arm-hybridkubernetes'
     version: 0.0.0
     dependencies:
@@ -15057,7 +15512,7 @@ packages:
     dev: false
 
   file:projects/arm-hybridnetwork.tgz:
-    resolution: {integrity: sha512-qyxSkFkMssHKDQXW3W7lWod6MBHbdiHopZTy6AguczaBURA2eU88no1xoFWXzs2wC5Oxkc59LVXk+qSuyL8AXQ==, tarball: file:projects/arm-hybridnetwork.tgz}
+    resolution: {integrity: sha512-pndVRs+7yyEBo1YCLKjxC/4i28BS2z/y6aqmJEtFE6zSVWPERM3pZ+Y6FQVIRLuIg0smbMF3UHpezqFx8+Auug==, tarball: file:projects/arm-hybridnetwork.tgz}
     name: '@rush-temp/arm-hybridnetwork'
     version: 0.0.0
     dependencies:
@@ -15081,7 +15536,7 @@ packages:
     dev: false
 
   file:projects/arm-imagebuilder.tgz:
-    resolution: {integrity: sha512-c7XSTAu4eiKGa8w7gZydqCYKvOxGnBj2qVRzhB15cGQ0IZWS27MYEhwoYe8hq6O+iPF9yregg2l33ASY0vREmw==, tarball: file:projects/arm-imagebuilder.tgz}
+    resolution: {integrity: sha512-cVUy6mxAs4MhcJmCZoD1U0jcT9Z2zamdKVuWV+JMoI/tY+exlFk58IioNL16TEZ3CfDFp32O73oyLXHclXFANw==, tarball: file:projects/arm-imagebuilder.tgz}
     name: '@rush-temp/arm-imagebuilder'
     version: 0.0.0
     dependencies:
@@ -15107,7 +15562,7 @@ packages:
     dev: false
 
   file:projects/arm-informaticadatamanagement.tgz:
-    resolution: {integrity: sha512-lcWSAf5y5zeosf4IQkPtk+qTs295m+rHavC4RUjsdu/LqksCoyk3fWVSbISH06AkcdfnkqIMiUUKq3GN7g9itA==, tarball: file:projects/arm-informaticadatamanagement.tgz}
+    resolution: {integrity: sha512-7d9NddvHXdioJNGpPKz/mMLhZrRsTgSu7Dne2jIxX8OfJKyAsh6BAldJeybBn1yWV1gMVu03d5SmkyZdhRvJqw==, tarball: file:projects/arm-informaticadatamanagement.tgz}
     name: '@rush-temp/arm-informaticadatamanagement'
     version: 0.0.0
     dependencies:
@@ -15132,7 +15587,7 @@ packages:
     dev: false
 
   file:projects/arm-iotcentral.tgz:
-    resolution: {integrity: sha512-Ipeplw+wc6Xu3OvNMbWQjcM3YoQcPHwPwQb4BPZwxn99+rJX55iY4fPAgBH6Eapqf/Ne6OsradyHrGEkaCYGGg==, tarball: file:projects/arm-iotcentral.tgz}
+    resolution: {integrity: sha512-eVhsh0/zDynyyn1h8oD6TTPSEeVaZOE8cUbk+jY8etI4G+MoYtCEhb8DANLSCn8ycaTJZz8P/PlE4FrgwD1JmA==, tarball: file:projects/arm-iotcentral.tgz}
     name: '@rush-temp/arm-iotcentral'
     version: 0.0.0
     dependencies:
@@ -15155,7 +15610,7 @@ packages:
     dev: false
 
   file:projects/arm-iotfirmwaredefense.tgz:
-    resolution: {integrity: sha512-nMkxzVE9O3lGQOcxtkiAlDzzIsurguFUCmMIcZD8JmNetg3qBShqHYzP6VH1NOyg9gePepTq/Hqe3diVo2s0YQ==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
+    resolution: {integrity: sha512-KgrmBXZ3LV33gGvw+k/e31ME+2v3K4z/Kfx0fv9xmaXXC/XGwI1ihVPH8yQ2wDm7Xzydn4L3G5VxCaEJhgLkzw==, tarball: file:projects/arm-iotfirmwaredefense.tgz}
     name: '@rush-temp/arm-iotfirmwaredefense'
     version: 0.0.0
     dependencies:
@@ -15177,7 +15632,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-zOGR0KmXqxB2dtPyZ4orbhIuw/s/8j6ONxVc2JmwDiZHVjafdsR+8BSffelXk18w8crFQiVG5HTPkn43CAVWJw==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-UjaQGlyeNlG7vL8MgWn9Eq3BL3J9m+Mpk4h01eMTI826O2VMsVh7n3RQBIXrGCM/+cBgg3K2eAH8UkIzl5p/8Q==, tarball: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-iothub-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15201,7 +15656,7 @@ packages:
     dev: false
 
   file:projects/arm-iothub.tgz:
-    resolution: {integrity: sha512-6kiDpHx9E4gVCP0pqGFCqKKVWOpqE1bqs82SGeZ6WYKoqszZzpqoqMNzuBeJp17a9ugeTo9LMaNM5DH4GoW8LA==, tarball: file:projects/arm-iothub.tgz}
+    resolution: {integrity: sha512-0wXW8Z6snGa9MHbPk6jjZgOv+ehmAGQMsZ3FAr5/nxg0RYCgx2WrZRydP3Rvjx6BuS0XjBHF9hwjAuQomBxDjA==, tarball: file:projects/arm-iothub.tgz}
     name: '@rush-temp/arm-iothub'
     version: 0.0.0
     dependencies:
@@ -15225,19 +15680,19 @@ packages:
     dev: false
 
   file:projects/arm-iotoperations.tgz:
-    resolution: {integrity: sha512-cSjFFCKmI/3TAVPk7BHWbSTCBg6JOVJ3jvJURbPxmeiIaab+SIvBHRH2d5N/sT1ktQirW+wr1aF410IqvfDEKw==, tarball: file:projects/arm-iotoperations.tgz}
+    resolution: {integrity: sha512-DWHCrtJFXu0WemWrVBkM3vBZYEFNET1XpU6ikXAnZwf6B5ARl56idinAAVvXBXniPFnxDj7Ci9mXWS/MaVHMLA==, tarball: file:projects/arm-iotoperations.tgz}
     name: '@rush-temp/arm-iotoperations'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -15255,13 +15710,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-aBlEXffw5kclfY9WxK62Tt9iBT27qWU8Np4uQss9+FBpApXhVafF3UaLbYMMfLfebWcMhrY91msKMG3/LvB3gg==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-dAcnuA8vruoXWhL9UDNQ+8iocILMbuCZsPcLL1/R+iA7vLdGdPFfoEnADX3LstZm97lvs4iwbfqdUOTkIv6kYA==, tarball: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15285,7 +15742,7 @@ packages:
     dev: false
 
   file:projects/arm-keyvault.tgz:
-    resolution: {integrity: sha512-+Zynps5rECLM22IFGDWuOsLks6pDM8ITZ0kWZyZ4Z8o9EGwdKw+RY4cugVqdK5V8sjKOorv79ItDiB7YZHNyHA==, tarball: file:projects/arm-keyvault.tgz}
+    resolution: {integrity: sha512-cWjJA/49CVXcVqyO8GUvCE4lxg8BPCcjC3UlVMqNBFxDGDPIRYIwvCtgCSFQsv6kM+DOhfb8EVwzaSJV4CpbJA==, tarball: file:projects/arm-keyvault.tgz}
     name: '@rush-temp/arm-keyvault'
     version: 0.0.0
     dependencies:
@@ -15309,7 +15766,7 @@ packages:
     dev: false
 
   file:projects/arm-kubernetesconfiguration.tgz:
-    resolution: {integrity: sha512-FS2Wh1SRGyCAjRiE6MHcYEanZ8xXG765WyfHkdOMHnYlzSspQ4lkP5vU+4qfG7Q9ikSlQGFiWPvyzuCiHj0Eog==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
+    resolution: {integrity: sha512-YSsz1Skqm8BMExjYFT7JSBUNaTjQxYNWE7JFIujbd6gWgKNzW9Tw/pkr4va/yJPsBPiCkMhj30nZVoBv8sHUGg==, tarball: file:projects/arm-kubernetesconfiguration.tgz}
     name: '@rush-temp/arm-kubernetesconfiguration'
     version: 0.0.0
     dependencies:
@@ -15333,7 +15790,7 @@ packages:
     dev: false
 
   file:projects/arm-kusto.tgz:
-    resolution: {integrity: sha512-jcM3EDNIBAzt4bO02zloThcTs3V8ktbe554KveHVegDJZWeKHsFk9D4VoOZ8mgNHjHCHJky28VIFsi3kagudew==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-gV+Y3A3PQRRxiVOLQO1K6OVeW6xvGcVOiITK+rUx+fVaz42y2cTswgrAJFl237vKLhJ1sG+u8Lm5ur/QxxojvA==, tarball: file:projects/arm-kusto.tgz}
     name: '@rush-temp/arm-kusto'
     version: 0.0.0
     dependencies:
@@ -15357,7 +15814,7 @@ packages:
     dev: false
 
   file:projects/arm-labservices.tgz:
-    resolution: {integrity: sha512-l0jJUPsuGEbeHN4YIxOOXaJU3TpNj7/KwJ9a63P5cUk88qb5JMWNfHPjM/8ar5E2azJBXjV1tiX+8ZhuT6GoAQ==, tarball: file:projects/arm-labservices.tgz}
+    resolution: {integrity: sha512-EIWhDl1ie2vYYDt0J/6GdKeDR0PX2YrltYwMCwTb8AN0pUQ9/m5yOJL6fDM8gk24PVhD89c7STvVGb9wIET5lQ==, tarball: file:projects/arm-labservices.tgz}
     name: '@rush-temp/arm-labservices'
     version: 0.0.0
     dependencies:
@@ -15381,7 +15838,7 @@ packages:
     dev: false
 
   file:projects/arm-largeinstance.tgz:
-    resolution: {integrity: sha512-VmCOH04+RD765M3jzOpVV1+nBw21wx0LAvPS/bFinlNmH+smiyoszdWvITpAwOqTte2BkxKCbY47o/icfnrJFQ==, tarball: file:projects/arm-largeinstance.tgz}
+    resolution: {integrity: sha512-G+pDE6kMjvFKKiR6FbEP1oF1URwCyu8REWZDGromyNqtjsbSwASgm/ufFPvo96/NsQ6FQg7tF2/cj8jevViEww==, tarball: file:projects/arm-largeinstance.tgz}
     name: '@rush-temp/arm-largeinstance'
     version: 0.0.0
     dependencies:
@@ -15405,7 +15862,7 @@ packages:
     dev: false
 
   file:projects/arm-links.tgz:
-    resolution: {integrity: sha512-SAq28hNVWMbzQrmTGq3U/hOZchN+hIwEBtni/sA28q0ALmrFgU5KDH99BobXFWUE6JjyI0oPbDWlh2rdYWtJew==, tarball: file:projects/arm-links.tgz}
+    resolution: {integrity: sha512-QJzIRdT1BeaPs4QJD5JQc5fSFqP0Xt7Q+kGLDDOraVLJaHOgiOnjGvaT73aJy0jM/dU8zrs7j/qRrBznuCtZDw==, tarball: file:projects/arm-links.tgz}
     name: '@rush-temp/arm-links'
     version: 0.0.0
     dependencies:
@@ -15426,7 +15883,7 @@ packages:
     dev: false
 
   file:projects/arm-loadtesting.tgz:
-    resolution: {integrity: sha512-fcPMZrU0Zu26MlVx45rQ2mfR1utJ71u43X8LmU++Z8Cicv8WCwS7X46WC3IQL3N5f6MlYz1CFWwLojRDoRjWlg==, tarball: file:projects/arm-loadtesting.tgz}
+    resolution: {integrity: sha512-OJjeAWDMJVB9PBONKD4D/WXlS3iSoBXTn3prTlP3721goDy/+YwfiseIWskcyaGX6XhBKvA88SVWjtZ8Ors+Ag==, tarball: file:projects/arm-loadtesting.tgz}
     name: '@rush-temp/arm-loadtesting'
     version: 0.0.0
     dependencies:
@@ -15449,7 +15906,7 @@ packages:
     dev: false
 
   file:projects/arm-locks-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-ov7jV8EVQhTpSSSKCF2SuE9Ek+f2rCwpPYtdOGyM+aftpgK2dRrxdef0FCv2jpOZNq+TQkR5SuBzZ83+PxVArA==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-/5b5Sm1V6xbxDYe81/AZqzLgHfV4Evw7VLo2LJjxtQnGT8HBd/QGxza81rnClMaZx7TIYFtsQOkYLf/KQofznw==, tarball: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-locks-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15471,7 +15928,7 @@ packages:
     dev: false
 
   file:projects/arm-locks.tgz:
-    resolution: {integrity: sha512-q+L9dE7eKW0UvBYki3NfKeIZRENydUPJD0NU03PRG1FSoPZ5juMvxj5rFsdMl3bJPBrIMsb/OUcDKN/gqWTtMw==, tarball: file:projects/arm-locks.tgz}
+    resolution: {integrity: sha512-xYuQqVb9AhSPmpQSURr9tLmuRun0R2MA+RgpfyOxeHZh92webqzI9yD5bNe3Lrf+JRsvkspg64z6nuBLQ9dXrg==, tarball: file:projects/arm-locks.tgz}
     name: '@rush-temp/arm-locks'
     version: 0.0.0
     dependencies:
@@ -15492,7 +15949,7 @@ packages:
     dev: false
 
   file:projects/arm-logic.tgz:
-    resolution: {integrity: sha512-JkxWZFdZuO8GdyIQQARI1uWDimln+6vXYONAnJjg9x5MBrocbX+ORjveQFOJNaQU9zMPA/iNAAGIsE8McjftiQ==, tarball: file:projects/arm-logic.tgz}
+    resolution: {integrity: sha512-l1j06tLrb6UthPuE5vrk1McaOXcL6kiIapb/AxtU7IYoefIUctkfXmKeKz/FXvf0RbkoCkAhJa6iHyXdN5tXDw==, tarball: file:projects/arm-logic.tgz}
     name: '@rush-temp/arm-logic'
     version: 0.0.0
     dependencies:
@@ -15516,7 +15973,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearning.tgz:
-    resolution: {integrity: sha512-6ZGcr0ApAgwzwZoQDcWv8DDPdvsYxwlALT4s3H+EcwrzVsI8XyJzyDnY3Kbtj7z3oEE9yKTJLWk5Tig5h36mHw==, tarball: file:projects/arm-machinelearning.tgz}
+    resolution: {integrity: sha512-ZloLgf/yygsu4TB+z0aN1KB1GKr7YWHpDfHepeTG7qtttWchlWCPual6GD6s0hG60VFtzICcZAzNumZW+6RSLg==, tarball: file:projects/arm-machinelearning.tgz}
     name: '@rush-temp/arm-machinelearning'
     version: 0.0.0
     dependencies:
@@ -15541,7 +15998,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningcompute.tgz:
-    resolution: {integrity: sha512-EfSCXmaM9LziwJVfjgs4DLho75tJEA5AIDYbJwdrYQL4NrN2a/5kj3cy8Bx5t2EbuZYrXKiHBc5mP8zRWzhwWA==, tarball: file:projects/arm-machinelearningcompute.tgz}
+    resolution: {integrity: sha512-IYoISJNbWOzU9gTqAjWrox+ORdvuK5YRfZCQLjDGxjh2sYrNjM/rIMgf2L9JXGECJIJ90V7K8epWKKY42CVlrw==, tarball: file:projects/arm-machinelearningcompute.tgz}
     name: '@rush-temp/arm-machinelearningcompute'
     version: 0.0.0
     dependencies:
@@ -15564,7 +16021,7 @@ packages:
     dev: false
 
   file:projects/arm-machinelearningexperimentation.tgz:
-    resolution: {integrity: sha512-23bGM9zPrRiDrvWOnJ37i9X7sfbbYDS3Rxo39GMj3rPaCNbDdhnlB2uvGkkC+tQfkFtGP6ICjL1Hc+S6vlIr7g==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
+    resolution: {integrity: sha512-xncTI2/+3yI2o0KVmQkM9NROgv8FmdhJlDKkRNzuKhaN60TrXkc+h3SfnNs0qhEpQDPxLYVsKDKz6zoBVnZCgw==, tarball: file:projects/arm-machinelearningexperimentation.tgz}
     name: '@rush-temp/arm-machinelearningexperimentation'
     version: 0.0.0
     dependencies:
@@ -15586,7 +16043,7 @@ packages:
     dev: false
 
   file:projects/arm-maintenance.tgz:
-    resolution: {integrity: sha512-pvU9dT2fvcPhQnOa4q0N+CcIF/vVWPq0sDa6ivky/yX4sdLOg/B5/btEjY7WaLI9pe1QKcF9SLpMtsxrtDTF8w==, tarball: file:projects/arm-maintenance.tgz}
+    resolution: {integrity: sha512-RwjonTPPblWoXjKqzB0NE9eRWbIVudGgZiGia2TtziCsJ0MZ40caX5sv9YSFrkta2+hAYCzBz975wMKA+FoKhA==, tarball: file:projects/arm-maintenance.tgz}
     name: '@rush-temp/arm-maintenance'
     version: 0.0.0
     dependencies:
@@ -15609,7 +16066,7 @@ packages:
     dev: false
 
   file:projects/arm-managedapplications.tgz:
-    resolution: {integrity: sha512-pDeCYpGJzH+jAH8EM7kXMkzrs1KVugDG14fMz/ttq7DoSPFNwjaRt50hFCm551LfpjaQVFBRJmMEhfZUUjEzaA==, tarball: file:projects/arm-managedapplications.tgz}
+    resolution: {integrity: sha512-js7Tj5p1Xp0zIjbkc3HUKnboi8+f/kfnla4gbvyf6WmFG6N/35hPlj26qDdr51yxlcg13xxSVqC1xGIvaEH9qg==, tarball: file:projects/arm-managedapplications.tgz}
     name: '@rush-temp/arm-managedapplications'
     version: 0.0.0
     dependencies:
@@ -15633,7 +16090,7 @@ packages:
     dev: false
 
   file:projects/arm-managednetworkfabric.tgz:
-    resolution: {integrity: sha512-PYHQewLqXgozun0nTPvyu+1QrE2DNF30YzRDubzNXdDpEKB/1wcBePxyauExdYiy23sL7HeNwW3xdESrQKhgmQ==, tarball: file:projects/arm-managednetworkfabric.tgz}
+    resolution: {integrity: sha512-gomm2UI01q/y191Tm25+fNQAqD/PLdiDVGrag5kGHkIEFKF+QM4KQ4Vvm6B6A6HNROn5RLAGirqPrT7WrEEZPw==, tarball: file:projects/arm-managednetworkfabric.tgz}
     name: '@rush-temp/arm-managednetworkfabric'
     version: 0.0.0
     dependencies:
@@ -15657,7 +16114,7 @@ packages:
     dev: false
 
   file:projects/arm-managementgroups.tgz:
-    resolution: {integrity: sha512-1dEm0DZ92JyajDfCaFJniOYZSnbPTAdBZ0bq1SeXwuU0UcPnsyZ/OVEvRho0Uem3FyFTb9xAIYuH4KQFVT2QdA==, tarball: file:projects/arm-managementgroups.tgz}
+    resolution: {integrity: sha512-l/a6j+Vd1n6fJtZ9LROuY1/iDYazlZya/YL+5Asd4Aq+VYIYLIChP8qCI0F5FRSAhUjsVBO/av/3x6Hoxy0YRw==, tarball: file:projects/arm-managementgroups.tgz}
     name: '@rush-temp/arm-managementgroups'
     version: 0.0.0
     dependencies:
@@ -15680,7 +16137,7 @@ packages:
     dev: false
 
   file:projects/arm-managementpartner.tgz:
-    resolution: {integrity: sha512-m3FMYXmIPy4Cz6EBTXmympSlxdiu6OgUY5RJRsqGQ8y7QZTJAeHajyHz0ShsXnLS6uYAZsCxvOrMgBimUWb4yQ==, tarball: file:projects/arm-managementpartner.tgz}
+    resolution: {integrity: sha512-pNVNVRYdoBVHqf0EotbC0IDWJyeGw2M1fWyMoxc4H6G0lGSJR9h5EaAqQwOvicjEsR+EpElgAMWnGQqLwUr8XA==, tarball: file:projects/arm-managementpartner.tgz}
     name: '@rush-temp/arm-managementpartner'
     version: 0.0.0
     dependencies:
@@ -15702,7 +16159,7 @@ packages:
     dev: false
 
   file:projects/arm-maps.tgz:
-    resolution: {integrity: sha512-tni5MLBgobo5Dt+PwWmVLPyLvDz/YL9ww22k9NkvP4SY/wENoRgw+fnHwRZ4u45qqr39qgPPmgcQzNdDwBfAXA==, tarball: file:projects/arm-maps.tgz}
+    resolution: {integrity: sha512-Yiq64myzCbkMz3NbHyQsf9BWGP0s93lcrj2SwHBaLptqtQ+nottwxNH/fVCdS4hufdE83mTPlMmAJPpG7L9Vvg==, tarball: file:projects/arm-maps.tgz}
     name: '@rush-temp/arm-maps'
     version: 0.0.0
     dependencies:
@@ -15724,7 +16181,7 @@ packages:
     dev: false
 
   file:projects/arm-mariadb.tgz:
-    resolution: {integrity: sha512-xBJeIwvP+jIr9e7wbrn0jW46ktD/b+R/qjBIfOfBuBpA6O02oFWoxILbh21dQ53aMKwexZw2F96jz1Vdn7fhwg==, tarball: file:projects/arm-mariadb.tgz}
+    resolution: {integrity: sha512-lYXl76DY5amSlK3h3i4ByQpsYyV+jKbgnh/ktOavIkIRC/OyopxNLvSE2arrAtq2yoRhjiKs/7ITuBqBV2KKmg==, tarball: file:projects/arm-mariadb.tgz}
     name: '@rush-temp/arm-mariadb'
     version: 0.0.0
     dependencies:
@@ -15747,7 +16204,7 @@ packages:
     dev: false
 
   file:projects/arm-marketplaceordering.tgz:
-    resolution: {integrity: sha512-QGrdndJ5NxBYCIT40+JA+hDmi2jyxQNfjrapsN8YtYUDdOO/R+s+mZyfCDGu78OaGGcC8qSdBipjzVtTCMFdew==, tarball: file:projects/arm-marketplaceordering.tgz}
+    resolution: {integrity: sha512-XadKDA8YMio2zTaNjx9mXjo50Wr71Xe3FIssvuFXgIjwN9fgA0wGOmR1GZhNKLi/gKfWU68Fyk71/Y5fmGw5HQ==, tarball: file:projects/arm-marketplaceordering.tgz}
     name: '@rush-temp/arm-marketplaceordering'
     version: 0.0.0
     dependencies:
@@ -15769,7 +16226,7 @@ packages:
     dev: false
 
   file:projects/arm-mediaservices.tgz:
-    resolution: {integrity: sha512-aCQzzQZ2UN9OdZvd8m3Muu1eVFXnhbXDvER2nlCUMprCrp3c80GG1/5lx5qiGaf9IYlAIlo/e0bHxsqvMSnYpQ==, tarball: file:projects/arm-mediaservices.tgz}
+    resolution: {integrity: sha512-5WYQjrLJKiEvi1mXW4Hjr8h8wXdErSXwZ/fEai5v0iSh7nd+WNvyc5FBG1rAqj2yxmpEChysyM/Z/prVOifuqg==, tarball: file:projects/arm-mediaservices.tgz}
     name: '@rush-temp/arm-mediaservices'
     version: 0.0.0
     dependencies:
@@ -15793,7 +16250,7 @@ packages:
     dev: false
 
   file:projects/arm-migrate.tgz:
-    resolution: {integrity: sha512-nUXB1Y+/g4aD4wc24sQe4EpTs62beuZY+gHYGzqwdeERk0oPQJIin3rPbFbSmMSnpd/Pexx+5ysNCWsKw4uXMA==, tarball: file:projects/arm-migrate.tgz}
+    resolution: {integrity: sha512-SZ6m97YchDJxo6HVwzyJ5vhKQsl/ZunpZiEYzqPBrG75XZy74LmBHmfhNkFmLqoeYRTn8G7Sy7joVo00aVIc2Q==, tarball: file:projects/arm-migrate.tgz}
     name: '@rush-temp/arm-migrate'
     version: 0.0.0
     dependencies:
@@ -15815,7 +16272,7 @@ packages:
     dev: false
 
   file:projects/arm-migrationdiscoverysap.tgz:
-    resolution: {integrity: sha512-QOR3en+Notm7gZn6jNamnf3gha6OYl0AxJOWSLQxdJMs/QF5H4Lvl9qe2Rc6jSQtxwojZ7aVO2s7NowK8Y6aRg==, tarball: file:projects/arm-migrationdiscoverysap.tgz}
+    resolution: {integrity: sha512-UuVroxbMvMQL6QDhfccAO15nsYcr0Cvs4dBqRLCCbT0QJtDqI35F/XSiPuaKAj6nrmS09covvx/dDWUGhMjlFg==, tarball: file:projects/arm-migrationdiscoverysap.tgz}
     name: '@rush-temp/arm-migrationdiscoverysap'
     version: 0.0.0
     dependencies:
@@ -15839,7 +16296,7 @@ packages:
     dev: false
 
   file:projects/arm-mixedreality.tgz:
-    resolution: {integrity: sha512-zSTuGUQZyjaHGYudS/m7I+l8wfnXDWaxh4p9lw7q9IMYXJRfLrSb7VfPxtCnl3A79kTLC8IgCfWxbyqAzNuvXg==, tarball: file:projects/arm-mixedreality.tgz}
+    resolution: {integrity: sha512-XapAVkXw2exRmPtvb7+nBr5IpBZpo6n47/DTcqt8Hi3McB/Twu6E63VAAA/GfKtd6Txhg26xM7CMwejJnawVLg==, tarball: file:projects/arm-mixedreality.tgz}
     name: '@rush-temp/arm-mixedreality'
     version: 0.0.0
     dependencies:
@@ -15860,7 +16317,7 @@ packages:
     dev: false
 
   file:projects/arm-mobilenetwork.tgz:
-    resolution: {integrity: sha512-Rz51zXFR4E0WXeAAAun1rvZdcaF9NwPH0hDUprHo0D0zents07Vxf5i3KBhbSCD7IG4DAc9sfmchggOUu+r6IA==, tarball: file:projects/arm-mobilenetwork.tgz}
+    resolution: {integrity: sha512-YgDApUSeg2jc/ZOB1qdC/IbyPDqftB+AcEBSDJze1hwV8oV1b0EkpgqyhIBHTBesK0SyQY8Y3DT52SKxox16yQ==, tarball: file:projects/arm-mobilenetwork.tgz}
     name: '@rush-temp/arm-mobilenetwork'
     version: 0.0.0
     dependencies:
@@ -15885,20 +16342,20 @@ packages:
     dev: false
 
   file:projects/arm-mongocluster.tgz:
-    resolution: {integrity: sha512-uHXY8aiy59HNsKOlADr+OcpDG8TihgYdOW4ZXH1ap6Lc+nlMFoMVFYFbM2O0w40S2Me9pQaUbHOe+/94MCjoWQ==, tarball: file:projects/arm-mongocluster.tgz}
+    resolution: {integrity: sha512-p8NlVjoYmPlUYAcQnv52gucati52H1fyMPW8II/ws/UEQc2bCZ2yOpQJi8Necgf52mrnDflcyZ4lJjjIz8abQA==, tarball: file:projects/arm-mongocluster.tgz}
     name: '@rush-temp/arm-mongocluster'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -15916,13 +16373,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-2u3n9oV3RTNdkSnOWEf6i/xnBNdlsuy2V6q60YlIu56GXUjmyBkmWuOJ6YI0K7xagWlauYyXlULYtf/awX2eWw==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-oreuSBZZ9ZGWodZBwi3uQUKaGpKgbb8ojToHrSCH7CN9IkMIr998ySeYjb9zUbzyE1EzXfmJnpnmIZdj+fHvNQ==, tarball: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-monitor-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -15944,7 +16403,7 @@ packages:
     dev: false
 
   file:projects/arm-monitor.tgz:
-    resolution: {integrity: sha512-+5tR0/8imeG87xGD8pU1peJPQTPEgNuwJry5owZ5p8AtQ3bqkWV6MiUQkUWfC7p4Tc/gpgDTxbSOCxFzDt1GeA==, tarball: file:projects/arm-monitor.tgz}
+    resolution: {integrity: sha512-HVYQHLaWHMjC2ZSACODRxcNI7Gki9Mjwptj1U+50o/n+uozA5zkqtz7YN1jgl6kzp3DWzvLGvCKsiPzjHpz1Sw==, tarball: file:projects/arm-monitor.tgz}
     name: '@rush-temp/arm-monitor'
     version: 0.0.0
     dependencies:
@@ -15968,7 +16427,7 @@ packages:
     dev: false
 
   file:projects/arm-msi.tgz:
-    resolution: {integrity: sha512-qlbY+DddnbljL9sOMygqjVNhhZ5gksINQ/T3jBKJG1X0kx5XORTV2u85Wq8px0NaEHSuYERny95YqU5H/Dty4Q==, tarball: file:projects/arm-msi.tgz}
+    resolution: {integrity: sha512-HcuorKdVNkJ3n1aWeM5dkMBmR6o+Lt5jk93Zbca7z2xg3yG42ye1sEAyBccihFdJBXYQtHwiMuQ6xuHGS5uNzw==, tarball: file:projects/arm-msi.tgz}
     name: '@rush-temp/arm-msi'
     version: 0.0.0
     dependencies:
@@ -15990,7 +16449,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql-flexible.tgz:
-    resolution: {integrity: sha512-GBqZruxKHdDLtzTowyuiVYplLL9YuQ+CsXTDE/mAAsskSPMmBnxSRLPF/RvCz8zF06gpTS25wH7wbU8ALPjzDQ==, tarball: file:projects/arm-mysql-flexible.tgz}
+    resolution: {integrity: sha512-uULEO3gerUDuON1PXwOPPNSp8s+d1dFmBhbhTWWi9RUPta6ADYmEl49g/28lKZ4TzOzK6LRPxNX1GntiMT+i6w==, tarball: file:projects/arm-mysql-flexible.tgz}
     name: '@rush-temp/arm-mysql-flexible'
     version: 0.0.0
     dependencies:
@@ -16015,7 +16474,7 @@ packages:
     dev: false
 
   file:projects/arm-mysql.tgz:
-    resolution: {integrity: sha512-+KXHTwyGlRxmH128Ew2VCxgMAO5j9ayyXGb/W44J26BwGgBxHeE9m4YDUPu/2yiBUVgu587W4nExQwRMJD8ZrA==, tarball: file:projects/arm-mysql.tgz}
+    resolution: {integrity: sha512-rJ2p0A/q+Kk55yEeNT59rhCfgwpRi49d8cbwsFA1z4OzIF3pba/X838gjJTrOXUqaFCEBb1bANTsNAxmGH7xdw==, tarball: file:projects/arm-mysql.tgz}
     name: '@rush-temp/arm-mysql'
     version: 0.0.0
     dependencies:
@@ -16038,7 +16497,7 @@ packages:
     dev: false
 
   file:projects/arm-netapp.tgz:
-    resolution: {integrity: sha512-t+R19DeTmy9lenQFbaBgiJXx8vvRwsiQ+EtFLODfk/IWGP1ZodnrZdUu2AcsfAKE+PrKhLcvnLavSEDWmrZqSw==, tarball: file:projects/arm-netapp.tgz}
+    resolution: {integrity: sha512-402smffySDfGCu9nZWWnJ2UoKmxZk1jq7NhDWrMMnYY7jmdAsbryPI5XwjQz99NX0tcnVEd/m6XHasSh9XQpHg==, tarball: file:projects/arm-netapp.tgz}
     name: '@rush-temp/arm-netapp'
     version: 0.0.0
     dependencies:
@@ -16063,7 +16522,7 @@ packages:
     dev: false
 
   file:projects/arm-network-1.tgz:
-    resolution: {integrity: sha512-7L6R1v4XvFy+9xMsI5CDBDzm24pl28G0PL7pwX6yqCVsQD79uAQ6Iwq8rx6lq4hDlLulPs87ypkEIkAhv4XzBg==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-GtYsI0jqj31GTVo6p3XGXd6NjOP/o+XissPyQ4BDXJbK0ml3SWbUD8L3mU9sBuuTkybr1B9C9+5Ro+9DmKvLbg==, tarball: file:projects/arm-network-1.tgz}
     name: '@rush-temp/arm-network-1'
     version: 0.0.0
     dependencies:
@@ -16088,7 +16547,7 @@ packages:
     dev: false
 
   file:projects/arm-network-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-ejN+oaQApqfnqbYU3obP7EcLOYVLXN0LefVtbfPVJHMS7ocY6GV2bH9gvZDwPAWZYDAJixkpvTGDno3f9N75LQ==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-3NSc8u5bDaoCieMYc9pqj4J74ZLsrAX+870d4+AufhNY3EWE6UMq2l4iryiOAUwgGaD24Do/koui5fvxH2OyGA==, tarball: file:projects/arm-network-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-network-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16112,7 +16571,7 @@ packages:
     dev: false
 
   file:projects/arm-network.tgz:
-    resolution: {integrity: sha512-DzevbMVu9wMnsaM3IFSPZuQqm0HCUTP11UdiXErwtAsFycgqEgZSpiKVUxPOk8t3Xlm3rv/jaIf/umzesPG65Q==, tarball: file:projects/arm-network.tgz}
+    resolution: {integrity: sha512-/xUxHpIRH+Mz8g34T5kofL8ljoschz4Ww3HRgWtOijzA1MEXK4gMI8FFN8P/PsoniLudi9hVq5Qn3bPhRUGTcw==, tarball: file:projects/arm-network.tgz}
     name: '@rush-temp/arm-network'
     version: 0.0.0
     dependencies:
@@ -16154,7 +16613,7 @@ packages:
     dev: false
 
   file:projects/arm-networkanalytics.tgz:
-    resolution: {integrity: sha512-OKKweI38TlBADpU+9V9TOlq4W6n7/TsyCY1oA7pmAETjf34rmgpNZNUWDA5UjQyB1T2xJ0lTDeLbWWfVg8Shrw==, tarball: file:projects/arm-networkanalytics.tgz}
+    resolution: {integrity: sha512-m7al4lpV3hCjt/Fog6Tri+iqIzHAnmGxnK1CsOY8tx57++sQUKv3j/ArjpE+UE72fJP7IDGaqMcC80wsoTCNmQ==, tarball: file:projects/arm-networkanalytics.tgz}
     name: '@rush-temp/arm-networkanalytics'
     version: 0.0.0
     dependencies:
@@ -16178,7 +16637,7 @@ packages:
     dev: false
 
   file:projects/arm-networkcloud.tgz:
-    resolution: {integrity: sha512-LaOlA/TKoXjoy4wZfzCOzFLQYEbbFJjQb4jqcf6UtfKWLloToXzmbjFc0UP00IeGSeDS2qAA4Q9hOZ1bx51/Gw==, tarball: file:projects/arm-networkcloud.tgz}
+    resolution: {integrity: sha512-Nn7gqpWWWgV5OOOYqSzcj8tugmWel+3UAyUgyP8h3ch5bUw8dp2pQ4kFjTdxcWdr77/OT8NQ5rUf4eZ5N0haUQ==, tarball: file:projects/arm-networkcloud.tgz}
     name: '@rush-temp/arm-networkcloud'
     version: 0.0.0
     dependencies:
@@ -16203,7 +16662,7 @@ packages:
     dev: false
 
   file:projects/arm-networkfunction.tgz:
-    resolution: {integrity: sha512-BQ9kxerRKj3FNWxg+B1x9nbJBXoEYdekkRqqUV7D6x1DBl8cpVSh3tUbcykQU6J0eOorD8VyH3HwWlh0G6ozJw==, tarball: file:projects/arm-networkfunction.tgz}
+    resolution: {integrity: sha512-bzys7xgwvGR2L/Ob+G8vB8KkfPXrdys25Gt1h1uz70utk/O21PwZGO7ahOtpCWmWPSfBi5UpnPwgNEqdb+0wvg==, tarball: file:projects/arm-networkfunction.tgz}
     name: '@rush-temp/arm-networkfunction'
     version: 0.0.0
     dependencies:
@@ -16226,7 +16685,7 @@ packages:
     dev: false
 
   file:projects/arm-newrelicobservability.tgz:
-    resolution: {integrity: sha512-mA5zNhZCz0gnT/Ep1ovJxpMnvbZUz6Fl/upbIVrNj/9zXS+vgHYOggKRDNJR6roaxGkjyYgIAyiYzQV/to8Etw==, tarball: file:projects/arm-newrelicobservability.tgz}
+    resolution: {integrity: sha512-SEuMwwXMV27rmiR0TIl2flMyH+PFWOmFCXkeEUWGIUvJUSKp2EZcD3OqIsceeK/n4F40lVdlaT1puAbJ6MeBAA==, tarball: file:projects/arm-newrelicobservability.tgz}
     name: '@rush-temp/arm-newrelicobservability'
     version: 0.0.0
     dependencies:
@@ -16250,7 +16709,7 @@ packages:
     dev: false
 
   file:projects/arm-nginx.tgz:
-    resolution: {integrity: sha512-sZ+t3R3unS1hs4aWT+OfMo3ak9fdZY/rWTJV6V6SUbEYWuPE4ykT922OI8ub7cWSMR3hJTHrhDSK4zPJyxP60Q==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-cbK97FljQcEDExPLrOmQJ2FBkR/ca2t2AGP8Casnc1TasnGIi0r6VuFSphWPlRHeVLSdNBd/ud8ZqXhWNeiLCQ==, tarball: file:projects/arm-nginx.tgz}
     name: '@rush-temp/arm-nginx'
     version: 0.0.0
     dependencies:
@@ -16274,7 +16733,7 @@ packages:
     dev: false
 
   file:projects/arm-notificationhubs.tgz:
-    resolution: {integrity: sha512-EJXA8jzvtkMVkbJxhkQRPZDKOkxxYULGyMUawk7UCml37l8h7AgLLdwvlTYUUb823elP/+V4KH4E/Ztaee6Ecg==, tarball: file:projects/arm-notificationhubs.tgz}
+    resolution: {integrity: sha512-S6GsKpJaMkIHsiqf1NFgZAfYx5iwINPXWQWUVGKd0PNAAuuvuAHrVdlUU6bzmtkrGY71E9cYLpS9mKAA/crdHA==, tarball: file:projects/arm-notificationhubs.tgz}
     name: '@rush-temp/arm-notificationhubs'
     version: 0.0.0
     dependencies:
@@ -16298,7 +16757,7 @@ packages:
     dev: false
 
   file:projects/arm-oep.tgz:
-    resolution: {integrity: sha512-pEl5Y8rl+5pHH+0mDJoQX1fsvB44immOomylMrLKK93QMRsAiAmVaLqFU+FRXy3E34+z2N0rxxkwmCmNrUJH7Q==, tarball: file:projects/arm-oep.tgz}
+    resolution: {integrity: sha512-69mEUDJKnYeC33JFQzFmaMoH83RtGiUQY2PRfNGOE0Ou+/GuGrH6s/I9iHhNlrJ9TnQoaLEmdbY3xlkNnN0LYw==, tarball: file:projects/arm-oep.tgz}
     name: '@rush-temp/arm-oep'
     version: 0.0.0
     dependencies:
@@ -16321,7 +16780,7 @@ packages:
     dev: false
 
   file:projects/arm-operationalinsights.tgz:
-    resolution: {integrity: sha512-kKSowCUKdrNIdfm3F56a/ZSfG/ke2A+hWweqbp/CTHmLz2/uTthRjA+aHWIhHrZLwpUeGFOCRI7GlW5kChR4sg==, tarball: file:projects/arm-operationalinsights.tgz}
+    resolution: {integrity: sha512-rjyl5DBEL2zVmnjOh8chvUhsExWi6MCOGEUEXu1xG9nEGcZx3qS5gix+WtdBIm3U9i+hm5k7oEY/DmpnHBRlgw==, tarball: file:projects/arm-operationalinsights.tgz}
     name: '@rush-temp/arm-operationalinsights'
     version: 0.0.0
     dependencies:
@@ -16345,7 +16804,7 @@ packages:
     dev: false
 
   file:projects/arm-operations.tgz:
-    resolution: {integrity: sha512-4cpdsuqoAK0IXgtyR4YFICP8+LuElqJVJHei3VqMdlKcHc8+uP6bRJvuBaAsPT14Qlre9fXtRPkPZSG82gPI+A==, tarball: file:projects/arm-operations.tgz}
+    resolution: {integrity: sha512-o+A5EdtNVS9nwW783wkGG7c4yFgCo4PxYj0wYsh0xxoHXNZA8NUKnGteADMQqph99gzO1A+XtBCsGE6zyg0OqA==, tarball: file:projects/arm-operations.tgz}
     name: '@rush-temp/arm-operations'
     version: 0.0.0
     dependencies:
@@ -16368,7 +16827,7 @@ packages:
     dev: false
 
   file:projects/arm-oracledatabase.tgz:
-    resolution: {integrity: sha512-qv15hluStPcbZGPBeFN1XQ2pdHiy/tZ6PV9G0k+G56vzKJBLKmBEN6dzv87AeDwR2LeKMYEKL9bPJ//BXJxD5A==, tarball: file:projects/arm-oracledatabase.tgz}
+    resolution: {integrity: sha512-ne2TYtNsAwnnZbB+QSLO+gclY9SzUMeHnjZaqJE4IbtbPQgER2nPg2eOncVafGtQWnzt/F2OJphMXecQ52aTnw==, tarball: file:projects/arm-oracledatabase.tgz}
     name: '@rush-temp/arm-oracledatabase'
     version: 0.0.0
     dependencies:
@@ -16393,7 +16852,7 @@ packages:
     dev: false
 
   file:projects/arm-orbital.tgz:
-    resolution: {integrity: sha512-tboXLpBmieO2RYZvAZoSqPLgr+hmVl5pqEBvwm3O+1pDHmczsto4jcipae8ydoX4YziFKk0JRYIlw+1tLMJ+ag==, tarball: file:projects/arm-orbital.tgz}
+    resolution: {integrity: sha512-am0/8pWjUGxW/tM+y5rAOMSCeivGuks9vrdpsa+KnSkWhzTxYUBO9OPLTi8mSPmBfZIN19Xu98b2FwMvAxFNDg==, tarball: file:projects/arm-orbital.tgz}
     name: '@rush-temp/arm-orbital'
     version: 0.0.0
     dependencies:
@@ -16417,7 +16876,7 @@ packages:
     dev: false
 
   file:projects/arm-paloaltonetworksngfw.tgz:
-    resolution: {integrity: sha512-nWLWCqIg28ZeGyO1G64LACMo2eXnRvGskzQDHSAcLnDqZePcCI+fmuk3Vp3jcRes0QctZCzBhV0Op8fDxeiiQA==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
+    resolution: {integrity: sha512-f356ISCwYJwgSJFUpgVfkqrZjGdfFiGlJvpv+WxfMxOPWJKg6jGZv9Q68IjeBvMKeFQiFo5ofN2yJNnuX8tzow==, tarball: file:projects/arm-paloaltonetworksngfw.tgz}
     name: '@rush-temp/arm-paloaltonetworksngfw'
     version: 0.0.0
     dependencies:
@@ -16441,7 +16900,7 @@ packages:
     dev: false
 
   file:projects/arm-peering.tgz:
-    resolution: {integrity: sha512-MGiRC8woIysJikeK0l7Qs/jWe42TJh2sT4DS0kcccu/EjAf0+TTJZ2p9me6YUX7OMBY4YdYAkDRq5kAktHUHvQ==, tarball: file:projects/arm-peering.tgz}
+    resolution: {integrity: sha512-FucyTPTMWzJSK1ZfjBCuiEKtuYhEsXPuYF9wxDDHzNVTtRLElzrMhksjSWVTYVdU22L0GJf5hT6FCwoA+LykMw==, tarball: file:projects/arm-peering.tgz}
     name: '@rush-temp/arm-peering'
     version: 0.0.0
     dependencies:
@@ -16462,7 +16921,7 @@ packages:
     dev: false
 
   file:projects/arm-playwrighttesting.tgz:
-    resolution: {integrity: sha512-bhBwI3jHqE9BwNM6Zz2sOoVSJ/myKFL8ug90fuybXDO5+kO8gL9Y738UIk7qwsrZbfVPBhh8Zp2KrSdenZx9NQ==, tarball: file:projects/arm-playwrighttesting.tgz}
+    resolution: {integrity: sha512-ca7/qGV3l+Q4g4J+Bt+LqSTWRGuoCZZxYMC13qgMwx7uxGBOUQXJfs5eq5/yaJujKTzeeDtnA6uBJrqBCYiihA==, tarball: file:projects/arm-playwrighttesting.tgz}
     name: '@rush-temp/arm-playwrighttesting'
     version: 0.0.0
     dependencies:
@@ -16486,7 +16945,7 @@ packages:
     dev: false
 
   file:projects/arm-policy-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-+eC3OppT80BczhsPtHHmb9QKyBGnOhRMrwcGqWHI/SPixnOkdVgoEaDlNCXCSaJaN7Or41ATo/vrgOBQ5VuZtA==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-Y7399Y+rlqrh00oa6x5uptyDx7K3kjaBXhchERb5aBsexQTqHnBT6sDqlodl6c1bFKG80qYnOqvxGbFaet07Dw==, tarball: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-policy-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -16508,7 +16967,7 @@ packages:
     dev: false
 
   file:projects/arm-policy.tgz:
-    resolution: {integrity: sha512-qH/2Y8CeI6TdGJUhtzZ87XKF2uqD3E+TuMMPCdShRQdLF8hispL8PwPsbHGGSCHNcdxaRUsPyxZX9yM8BXQD3Q==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-Rur+4IhBXxNQWYKZ+WHegABAE2g7zP4HCgc55UoB+oUsoAujKyBGio07Wyqp4YBKSwcCmyq7UBUe9HNrHpOG3Q==, tarball: file:projects/arm-policy.tgz}
     name: '@rush-temp/arm-policy'
     version: 0.0.0
     dependencies:
@@ -16530,7 +16989,7 @@ packages:
     dev: false
 
   file:projects/arm-policyinsights.tgz:
-    resolution: {integrity: sha512-5jEGtro8qZc1iyghTtBwd6j5lyqvIwm7UfRrjJ92+H2gqMws5IjWkYdoBnY0L82hIRZT+c/QwaFFm4jzRI0XLA==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-hwr4utCxH2iPmEvROdK+xO1UKND1b8G5iRDpkCZY1k3MwdEYbd87dXjELK0QqH8kXsNbzBfZ+titvn2s+G7TQQ==, tarball: file:projects/arm-policyinsights.tgz}
     name: '@rush-temp/arm-policyinsights'
     version: 0.0.0
     dependencies:
@@ -16554,7 +17013,7 @@ packages:
     dev: false
 
   file:projects/arm-portal.tgz:
-    resolution: {integrity: sha512-N5ngufPYiSaOxRZ91y/DQbsL4PPHDsNDrsjkFVM+J+pHvwZUf/k6zs5uoeD45INzUD3cLhXOIFfc4xQnH3I0iQ==, tarball: file:projects/arm-portal.tgz}
+    resolution: {integrity: sha512-SZiPunnD0/GSIZe/xkpJ9eAipZCuD/WlekQv4wyP85gXkUZL3gAijcunh4JL/yxnzHgEKehP1kr/T+23L8t1bA==, tarball: file:projects/arm-portal.tgz}
     name: '@rush-temp/arm-portal'
     version: 0.0.0
     dependencies:
@@ -16576,7 +17035,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql-flexible.tgz:
-    resolution: {integrity: sha512-TCBQbpVe33farAIxoBcDw2Tku0cCvH32o+Qb56xP+6cVbxnvS5Es/uWa6XSXIjVSjHTnj69iezQL9zkForNG6w==, tarball: file:projects/arm-postgresql-flexible.tgz}
+    resolution: {integrity: sha512-2+tt3mU7fLXiXLQZ8r1P0YypW8IHpkHu9A4FX+zp4UGeB2wPznWnjAGV1tw6iQf9N4nG+c2QQAZd71oWfhleDA==, tarball: file:projects/arm-postgresql-flexible.tgz}
     name: '@rush-temp/arm-postgresql-flexible'
     version: 0.0.0
     dependencies:
@@ -16600,7 +17059,7 @@ packages:
     dev: false
 
   file:projects/arm-postgresql.tgz:
-    resolution: {integrity: sha512-Lxg50ITwCpeG1j+mk75u3IiqnjtQyVd2+tEnlw0/Im6xGhugC8lN0PhbTl7g5shC7ZcB8Y5JaDen2clix1b1jQ==, tarball: file:projects/arm-postgresql.tgz}
+    resolution: {integrity: sha512-11q1xdFEKbEI90Xuu6+bnLhL78PUQnMkMx8L4S1rzYOmlcnP9TfSLpeTXLoSqBs93Wj2hWvM9iQZ3jGHsA5z7A==, tarball: file:projects/arm-postgresql.tgz}
     name: '@rush-temp/arm-postgresql'
     version: 0.0.0
     dependencies:
@@ -16623,7 +17082,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbidedicated.tgz:
-    resolution: {integrity: sha512-WMe4GNQqlKuZZEn1lx7+EleazTIBsR1mS3eKleYHFRwSvW6MxoBKdOYf2K9+jUlICHkhc5pmuSu2fB4MSYSEPQ==, tarball: file:projects/arm-powerbidedicated.tgz}
+    resolution: {integrity: sha512-hHNg4IEUiji0ZQg/GfCAzvPeWDNvsPTvIpFbqr/i5UzItoR7RCG9Ksyo/KbYrfJjqU9BX1BMPA7YPaWpbqwsDg==, tarball: file:projects/arm-powerbidedicated.tgz}
     name: '@rush-temp/arm-powerbidedicated'
     version: 0.0.0
     dependencies:
@@ -16647,7 +17106,7 @@ packages:
     dev: false
 
   file:projects/arm-powerbiembedded.tgz:
-    resolution: {integrity: sha512-8IOcvcLooZQdaT4p/ogxGcyZ0tuVkPqbvg6YU69DfSQ2GbADsZhf8uagTG/GgDiWW3e2U4wNRVJAMM4WGeTDgQ==, tarball: file:projects/arm-powerbiembedded.tgz}
+    resolution: {integrity: sha512-FswWt17hJPs747pd5LSYP93DVaR3nm24WWqPhfhj09avd6VKlg7a/Y/C/tUBJ0D9g6U7P4hri6oQenHSslcteQ==, tarball: file:projects/arm-powerbiembedded.tgz}
     name: '@rush-temp/arm-powerbiembedded'
     version: 0.0.0
     dependencies:
@@ -16670,7 +17129,7 @@ packages:
     dev: false
 
   file:projects/arm-privatedns.tgz:
-    resolution: {integrity: sha512-8lOK/U8iOPeqfIjnDQP/CoEXglw/qG8mTkGzuP7ZPPNPHIjqQNL39xmcN8GnSu8J07Af8UypAmsqGWqudoez4w==, tarball: file:projects/arm-privatedns.tgz}
+    resolution: {integrity: sha512-RDCdPoPc02BVMsap1AoH8dVHsHW/3B5XziFBh+FLDSqbonT3NSRrmgGpF1Eqo4eEemNNIqhrSFGp1E6rk1izyA==, tarball: file:projects/arm-privatedns.tgz}
     name: '@rush-temp/arm-privatedns'
     version: 0.0.0
     dependencies:
@@ -16694,7 +17153,7 @@ packages:
     dev: false
 
   file:projects/arm-purview.tgz:
-    resolution: {integrity: sha512-f1xLdHbzRMp4M1L5BHOVPfLsXdhxwadW7EklRNW8e0EeIelJzYVLZnBEjZAT2KPTxXm2kF+DzDZ7eL3cRPcvLA==, tarball: file:projects/arm-purview.tgz}
+    resolution: {integrity: sha512-bfj88fPQeaEuviYvs973vCH1eJq73pUKqWNzTL9kyurwXR9Qp950D/eV8R+Zin/PN2D8Rr0QLOLlEHcvZWQHUw==, tarball: file:projects/arm-purview.tgz}
     name: '@rush-temp/arm-purview'
     version: 0.0.0
     dependencies:
@@ -16717,7 +17176,7 @@ packages:
     dev: false
 
   file:projects/arm-quantum.tgz:
-    resolution: {integrity: sha512-7yd0nkPcawC0B+tXU0lg/RwBDWxAte+ALCBWJR2E35iM56AcFJRpiMB97lAVzklU7OvBZ47gIKdeGOE6JEpy4A==, tarball: file:projects/arm-quantum.tgz}
+    resolution: {integrity: sha512-xP2rvmm8No35qr4926zgbYxvhcFeFL3BgRtsIfqZwdkfPePOLN6PvKxKkW3iLCVf6pBNIlnTAl3tgPU2YIrdVw==, tarball: file:projects/arm-quantum.tgz}
     name: '@rush-temp/arm-quantum'
     version: 0.0.0
     dependencies:
@@ -16741,7 +17200,7 @@ packages:
     dev: false
 
   file:projects/arm-qumulo.tgz:
-    resolution: {integrity: sha512-gkQBQdvUZvcpuBS+1Zu6LG9FqyENUb2A6s6x0AkRuT7b1lLUUPuZ0TfDDgAcZhiVuKcxjMyFoFlJlnBoZ03DDA==, tarball: file:projects/arm-qumulo.tgz}
+    resolution: {integrity: sha512-GvNjuh1gLELFmbPB8immc9DHDkscOFYjKiDw5bjiiCztDErU30r2bRlAWG+t3HBIKP8A3vxRjE4E3Fg3TfqzpA==, tarball: file:projects/arm-qumulo.tgz}
     name: '@rush-temp/arm-qumulo'
     version: 0.0.0
     dependencies:
@@ -16766,7 +17225,7 @@ packages:
     dev: false
 
   file:projects/arm-quota.tgz:
-    resolution: {integrity: sha512-rlHMGNJI6N6fWUpjueTqbJeCE0o/xvRBSap3ud+KF60WuB91RfXJpwr4QMUokX6L2LPGi06JqfMW3He6njLzew==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-QwVcR8rDpStg5HMZe6SQwRH3M0urFftPsuruvM7/q+bgn7x5tPEoWgbTc6YJ56xoVJjF2hd9uJ507cU2/O0fGQ==, tarball: file:projects/arm-quota.tgz}
     name: '@rush-temp/arm-quota'
     version: 0.0.0
     dependencies:
@@ -16790,7 +17249,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices-siterecovery.tgz:
-    resolution: {integrity: sha512-4iW72DoOxavk74kVk2PCtoP1U0GzT1FlLoj0k1NOSA6e0xzaKg3SSkh5C/yMgMjlT7sfMBaCVhTOqX/5sKvXHQ==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
+    resolution: {integrity: sha512-0hx1uOBiPzzBNSJ2mIHTNsFnPBA3HladFZodOhjx2sRN/QMc1aNvhKCXtXh64lXRpJiA4LCi8AmwyYvl5gIPxA==, tarball: file:projects/arm-recoveryservices-siterecovery.tgz}
     name: '@rush-temp/arm-recoveryservices-siterecovery'
     version: 0.0.0
     dependencies:
@@ -16814,7 +17273,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservices.tgz:
-    resolution: {integrity: sha512-lgLpygYuQNiWsXLb0oIP1YCn5/wsTRbxUq6iN7JkQGzd29OyxFnAeWiNYHBbyW+QAhMdKEJGpfkXrJV/jgCEpg==, tarball: file:projects/arm-recoveryservices.tgz}
+    resolution: {integrity: sha512-mFPSyWQdG/j7vrWW7eEtuA4Pff4ufi72b0cr4wd+l0ROsOw6X6/wyBWdKFp8/0H/UQbEVVk/w1I+Cnv/nxHZzg==, tarball: file:projects/arm-recoveryservices.tgz}
     name: '@rush-temp/arm-recoveryservices'
     version: 0.0.0
     dependencies:
@@ -16839,7 +17298,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesbackup.tgz:
-    resolution: {integrity: sha512-gW0f2oYvsf0kaL+RT1NcdGM2nfBZ/FzIL4xboPh017jp2aVe5qUnnF3tnZc8aasyYg/H9bhmNj9O35LOGnfHFw==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
+    resolution: {integrity: sha512-MZ5RS6gwDn+feDzZKMctYEU+vnH8GB/kyiQ0vLkTFGM7mnWmh+rP4EWGu3YaSnmATVQs7bb7nT89q9M9oOqRLQ==, tarball: file:projects/arm-recoveryservicesbackup.tgz}
     name: '@rush-temp/arm-recoveryservicesbackup'
     version: 0.0.0
     dependencies:
@@ -16865,7 +17324,7 @@ packages:
     dev: false
 
   file:projects/arm-recoveryservicesdatareplication.tgz:
-    resolution: {integrity: sha512-lG+WGs2eLnEsIqRLHdwaihdLu83oNVJUgtkaqIO5aKekXqAPSObNnmHhoyQGoWztDIqeec3Vjk12jr0FChQMlQ==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
+    resolution: {integrity: sha512-otqaBB9Hci0Krid3rS4PcAnlfGgVzMxgLFVZr7/StCAQGJCyFfq3jiZtsy1giz9HKVY5RFgO2FlsZ6FPPK1B7w==, tarball: file:projects/arm-recoveryservicesdatareplication.tgz}
     name: '@rush-temp/arm-recoveryservicesdatareplication'
     version: 0.0.0
     dependencies:
@@ -16889,7 +17348,7 @@ packages:
     dev: false
 
   file:projects/arm-redhatopenshift.tgz:
-    resolution: {integrity: sha512-K6hkhLbZXBF2SANkgCVMS6/f6GEqGUl6kGU92k9USJ63AUfNtoZu2dyI+u556VnHYNF0SBYMrosJIyOFC0vyOA==, tarball: file:projects/arm-redhatopenshift.tgz}
+    resolution: {integrity: sha512-NmOqVjAgBMCZWoIbPZ7Z4WqM2GGzeZoPj1h1eQ+c1PTGX5C/Vnh+oB4BulBI0XX8vWbXb5zcL3/IoyfR56+tEg==, tarball: file:projects/arm-redhatopenshift.tgz}
     name: '@rush-temp/arm-redhatopenshift'
     version: 0.0.0
     dependencies:
@@ -16914,7 +17373,7 @@ packages:
     dev: false
 
   file:projects/arm-rediscache.tgz:
-    resolution: {integrity: sha512-q2BqBmysFUw8yUK7gtk6mXoLczZ88MXDFSqvbxjX/USnp7PFnhdQfXSxW4/Bd+fRBRoyiDDtPXv3FMeFottffg==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-gVzDiXeSc1iYKiwyIMsEld1Un4DuhH+nYKQh25P259Igq4qBmvqYqdXw74vPZsn3EOB9dXNhTR44wwYRD8Fi3A==, tarball: file:projects/arm-rediscache.tgz}
     name: '@rush-temp/arm-rediscache'
     version: 0.0.0
     dependencies:
@@ -16940,7 +17399,7 @@ packages:
     dev: false
 
   file:projects/arm-redisenterprisecache.tgz:
-    resolution: {integrity: sha512-zKdrPHasAWMJefAzX0hwQDoypjoDBoLQius14b7zfdqWqAws/nZl8V7eNAbD0x0Eip1rOtNFWwBKjSptui13Cg==, tarball: file:projects/arm-redisenterprisecache.tgz}
+    resolution: {integrity: sha512-JfS42Yn+K/TLq+Se+akqb8q88bzshj4Dl+vYYe5OJ2r5UpKFk4NZ8OjWQOp3SWwXkmTX1CEnTzfCHGHecZjJ6A==, tarball: file:projects/arm-redisenterprisecache.tgz}
     name: '@rush-temp/arm-redisenterprisecache'
     version: 0.0.0
     dependencies:
@@ -16965,7 +17424,7 @@ packages:
     dev: false
 
   file:projects/arm-relay.tgz:
-    resolution: {integrity: sha512-zjdoKVlP06pBh7maxYaa0+NaM3AD+X4dip47R9H6hkb7YImNBC5AoBhKzW7UJBvb489QnSWumyJhI/GNEaIJ6Q==, tarball: file:projects/arm-relay.tgz}
+    resolution: {integrity: sha512-fVj2S3CG8JMLbyVeSpP9DM4J8mmbSDnwwY9nch0LZD0vFE1O2kL4it2TxG9zhyfRt7iBL402ruIXTtfJEkRMIw==, tarball: file:projects/arm-relay.tgz}
     name: '@rush-temp/arm-relay'
     version: 0.0.0
     dependencies:
@@ -16989,7 +17448,7 @@ packages:
     dev: false
 
   file:projects/arm-reservations.tgz:
-    resolution: {integrity: sha512-IEQQoTn399joXXR+ZFzMsCJHfv61mMQ+Zgldh+qUHLJAs3amgfzDt4POa0A4qsxvvvXLLfvEnayuMWhbtvRKNA==, tarball: file:projects/arm-reservations.tgz}
+    resolution: {integrity: sha512-FdacME3yzURAAsuBjnRnJ2KAGTQEW9NHv7QcZV8Rys9PZBVbYBrmiKyU6HNit+q/m3AHwvZRawoaUZK6S8OjyA==, tarball: file:projects/arm-reservations.tgz}
     name: '@rush-temp/arm-reservations'
     version: 0.0.0
     dependencies:
@@ -17013,7 +17472,7 @@ packages:
     dev: false
 
   file:projects/arm-resourceconnector.tgz:
-    resolution: {integrity: sha512-gVNTkNakQYeSiFWvcThCmRH9Fwmxd1LGBdGl134vMs4kHxmz7DDR7ZVC+jgJuadi7vedvTxsXTaYfSOnE3OL0w==, tarball: file:projects/arm-resourceconnector.tgz}
+    resolution: {integrity: sha512-SsCFyn3kbEnN4qdIGW2ESx249VZIbZ3GMkghseba2+qEaUXLZ3lo14P9Mrx0QdVoNMXA1jbI72xcFEI7o7+pAw==, tarball: file:projects/arm-resourceconnector.tgz}
     name: '@rush-temp/arm-resourceconnector'
     version: 0.0.0
     dependencies:
@@ -17037,7 +17496,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcegraph.tgz:
-    resolution: {integrity: sha512-95DLp75+EmKmDIJ5fxydbpyIEcw4HUaD7z6RqO9P+I5YITh6KDuf3cgLJOembdxEh0+29TZljRebHFvFeLRAsQ==, tarball: file:projects/arm-resourcegraph.tgz}
+    resolution: {integrity: sha512-F8fk/VAAZaqgEQAuPe1bdfy8TAUiRc4cJ4DU8MHzJ6LjMJsMHHWbSxZCHb/T5eRaFmq16kYpBrz3BabbMEgWKw==, tarball: file:projects/arm-resourcegraph.tgz}
     name: '@rush-temp/arm-resourcegraph'
     version: 0.0.0
     dependencies:
@@ -17058,7 +17517,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcehealth.tgz:
-    resolution: {integrity: sha512-A44WC+/iAuB5Rkomr+TXqOPlKz4Lg2izwkvV40/zXYnvmr0TcI4o/1USxHCE3S4r3ii+ERL7vDAaNSDQxsnLxw==, tarball: file:projects/arm-resourcehealth.tgz}
+    resolution: {integrity: sha512-UhCMvtSAp/l2zKS+Rv7Og9a9wvBQUMxFL86znccK3jUeIQzF9ILLb6X+TIgr0lyfNiPrOwQvkARxRia20dB0Ag==, tarball: file:projects/arm-resourcehealth.tgz}
     name: '@rush-temp/arm-resourcehealth'
     version: 0.0.0
     dependencies:
@@ -17080,7 +17539,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcemover.tgz:
-    resolution: {integrity: sha512-mCWMnix6GWzh0UWHO1kw4rxYQ6BWnOl8/gmHELpYjwnYYQPTF3OD33LqMBXkFL3mB+0yCaR+WDn8DySvj+9cWw==, tarball: file:projects/arm-resourcemover.tgz}
+    resolution: {integrity: sha512-O/bxTp+7wN3wjYJy4DfZ9pU6DND+7twrWXkyrkkeAr0dqTdPcrOgniuktWaswDMHW/m/6x13EIWT6/1y3iy5zg==, tarball: file:projects/arm-resourcemover.tgz}
     name: '@rush-temp/arm-resourcemover'
     version: 0.0.0
     dependencies:
@@ -17104,7 +17563,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-GsvM5ubTDTD9W5Y+9PH77+4CtQQdBRiMKKhm7bxguxhDM01Q6kO9PcJ4oMs7oUrUfZJoUoDmP6886WuD17Nmvg==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-UoOYFBNGwHCyrGsG5qxIjIfA3wj3s/JOS1Ju1+xcbTCu/59IVcCPB6fhl+CjcP4HO/PfNOrd90qMfEjJtN3qHA==, tarball: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-resources-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -17128,7 +17587,7 @@ packages:
     dev: false
 
   file:projects/arm-resources-subscriptions.tgz:
-    resolution: {integrity: sha512-cqybu86uZL4mJDivZvteI5/lLFjqfYhUMwS3qolJQI90GpgUHfsiPl25cl+X9ZlUhiCxVlq9cKeOIiMVTI0qPQ==, tarball: file:projects/arm-resources-subscriptions.tgz}
+    resolution: {integrity: sha512-fo2nYy2zMtCOQjVp+jsJGyI4B0bPQgn57FkRNTVVqr16pdgg+FrvVDm17cFgeFEMYASGEWqe1v1emir/dq3M8Q==, tarball: file:projects/arm-resources-subscriptions.tgz}
     name: '@rush-temp/arm-resources-subscriptions'
     version: 0.0.0
     dependencies:
@@ -17150,7 +17609,7 @@ packages:
     dev: false
 
   file:projects/arm-resources.tgz:
-    resolution: {integrity: sha512-sWIm9mEHRsGcc+wo9dqWYbswxuyKGkayy/wOIjLYa/DNhcABjmq8eE2+Fbh8NNWXJZBtZsHbSn2q979ovQ/eQg==, tarball: file:projects/arm-resources.tgz}
+    resolution: {integrity: sha512-9SaLTPWntG2Av77FA6Ohmq5HCZ9pOaHDMqclNbBhVlaeJPIx0lIpf8bUPW7QRcvhbOL4h3bF7VbqnjhvSiYgJQ==, tarball: file:projects/arm-resources.tgz}
     name: '@rush-temp/arm-resources'
     version: 0.0.0
     dependencies:
@@ -17174,7 +17633,7 @@ packages:
     dev: false
 
   file:projects/arm-resourcesdeploymentstacks.tgz:
-    resolution: {integrity: sha512-OgMbGs90q3on+HVJBZb1uvw0dcpzRV5snWAO+T7vKW6MUCiJsK6fVj596SjYRO1ETEREGJYR1yrtSlC1tokw5w==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
+    resolution: {integrity: sha512-IYldBVZbFp7xV8JQiXRgK1oaUbS8VsjmRbN6q2Kh6ZICwr+YFupzopghf5QuT0I8P3DfjYQEBVRgdp9ere4pyQ==, tarball: file:projects/arm-resourcesdeploymentstacks.tgz}
     name: '@rush-temp/arm-resourcesdeploymentstacks'
     version: 0.0.0
     dependencies:
@@ -17199,7 +17658,7 @@ packages:
     dev: false
 
   file:projects/arm-scvmm.tgz:
-    resolution: {integrity: sha512-UQMZ7x1BNShAgeN3fc+cUpRwqQqTlKoK5G6PWR+h3c3jiavdo3SN7m2cwC+LYJo5KB5lMG3dwOGSGQm4xXGgmg==, tarball: file:projects/arm-scvmm.tgz}
+    resolution: {integrity: sha512-5QuIAfV5de8N9O7oWO1LuaMAfJp0ZEJ8YMZqvVSxQoF5xem3M4ywrfBsVn+uxzWCcdAONhn3//f8LLHIqn+HxA==, tarball: file:projects/arm-scvmm.tgz}
     name: '@rush-temp/arm-scvmm'
     version: 0.0.0
     dependencies:
@@ -17224,7 +17683,7 @@ packages:
     dev: false
 
   file:projects/arm-search.tgz:
-    resolution: {integrity: sha512-laFT9XV2gnBwg3mMoqkRdaBs6G9liSaXkBbwpGqEG6O2DMrstlPOMKY0fqvJIo/o/yRmgwHUVgW5iFOlJQhtuA==, tarball: file:projects/arm-search.tgz}
+    resolution: {integrity: sha512-3l9pmizwE1fezhBvKUrskPoNCto/ps7FuFBG5wYCXQwJI9kfBI1iLCzmQ05UdB8SgJ+fzsv3VSRIi191eTlNpA==, tarball: file:projects/arm-search.tgz}
     name: '@rush-temp/arm-search'
     version: 0.0.0
     dependencies:
@@ -17249,7 +17708,7 @@ packages:
     dev: false
 
   file:projects/arm-security.tgz:
-    resolution: {integrity: sha512-cUASP7knxLuGWkTUT9hxpQgeCN7KkmFMoEIw9rcP6u0yMH+jm7Nll9sZNQ10KltQ0WjnXuc8C1W0pb2MYIwoKQ==, tarball: file:projects/arm-security.tgz}
+    resolution: {integrity: sha512-22RGqRcyYaPFitd+dsTw1zG2oCNEXRqrIvmv+CDwszHmlfjPBWWUsKVBrI+x67GNo+RSnu0Ix+/utJ+Pp0XI2Q==, tarball: file:projects/arm-security.tgz}
     name: '@rush-temp/arm-security'
     version: 0.0.0
     dependencies:
@@ -17274,7 +17733,7 @@ packages:
     dev: false
 
   file:projects/arm-securitydevops.tgz:
-    resolution: {integrity: sha512-r0Q95hT96ppOC2O2daRPM5qBWgAvscwa6HM69ardJLUU+Iw+Qro/Wyg1Xp/83qlsNBVr5UHr773GVR8Rp74O7g==, tarball: file:projects/arm-securitydevops.tgz}
+    resolution: {integrity: sha512-gpCSYI06lsT/HaShrnO8fHwrF+l1semd11AyT0xWNqGoruqnmwpMSOqiRQ08/Oetko0HPrpNU/CkH3AanIOhZQ==, tarball: file:projects/arm-securitydevops.tgz}
     name: '@rush-temp/arm-securitydevops'
     version: 0.0.0
     dependencies:
@@ -17298,7 +17757,7 @@ packages:
     dev: false
 
   file:projects/arm-securityinsight.tgz:
-    resolution: {integrity: sha512-8PipCR6TGEbjgqOXZF9ysgMNaIrQwliLl8qOlTD8ye9lezctgxJsVe8p253a1wd5mihnXOiA5LD82Aq25b3pYQ==, tarball: file:projects/arm-securityinsight.tgz}
+    resolution: {integrity: sha512-SCF2L5Bbrd8uJoNqDeLWxaxyWS7rllwa3PHSUuab0nU9p+A6J4FKHcFEI8UXnhmQ6G+a5p+h+hUS/3YkbdS16w==, tarball: file:projects/arm-securityinsight.tgz}
     name: '@rush-temp/arm-securityinsight'
     version: 0.0.0
     dependencies:
@@ -17322,7 +17781,7 @@ packages:
     dev: false
 
   file:projects/arm-selfhelp.tgz:
-    resolution: {integrity: sha512-UpY64n9KYojIZzT/CSg9+hCC6bcPifRxTIMWVkVeRSjVXt3fmitgJDHmooxHgnV5alcqtLeGaUc5U3qmeJ/Raw==, tarball: file:projects/arm-selfhelp.tgz}
+    resolution: {integrity: sha512-sdkDyBIc+NQnCGkGTfO2MTgDQpfE7v3bALPUx0C6s3YB/7MF6KgNDtFphCTeWZyapjbDAAbapQdPHITnuVmrvw==, tarball: file:projects/arm-selfhelp.tgz}
     name: '@rush-temp/arm-selfhelp'
     version: 0.0.0
     dependencies:
@@ -17347,7 +17806,7 @@ packages:
     dev: false
 
   file:projects/arm-serialconsole.tgz:
-    resolution: {integrity: sha512-qgmZGTZx06sXqIQVYxCwCA8EMHlhJ2BVtY26Cww+r1IKRjScIch/CVDzc4NNmIPfPOJ4LIjCg/MVOdghP37R0A==, tarball: file:projects/arm-serialconsole.tgz}
+    resolution: {integrity: sha512-KNi7Imam0REjFlsy5/dOG6Rf+Xj2ADIR69R9+deTYcmDaKjIYRWJTihvJJwihQ1Bp71o0LG5xVpevAFV5Kyz2w==, tarball: file:projects/arm-serialconsole.tgz}
     name: '@rush-temp/arm-serialconsole'
     version: 0.0.0
     dependencies:
@@ -17368,7 +17827,7 @@ packages:
     dev: false
 
   file:projects/arm-servicebus.tgz:
-    resolution: {integrity: sha512-MZRsSrmWUt1V9tRHYVQmnaWIao0C1ois82uUktrL+vteL7IuXc1Oo6NVuQfJcJMYWGgnuV8M7+330nm/Ixr7Wg==, tarball: file:projects/arm-servicebus.tgz}
+    resolution: {integrity: sha512-UBM3OmJoLdiNW+CE5VlkfMvsZyf3Yymoy12am9Zj2M6SE/Ou9HLga1niwDwyMpqhIOBFFbkE1gmknWLtTT+dCQ==, tarball: file:projects/arm-servicebus.tgz}
     name: '@rush-temp/arm-servicebus'
     version: 0.0.0
     dependencies:
@@ -17392,7 +17851,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric-1.tgz:
-    resolution: {integrity: sha512-qwu7r0tH/8h7Li6Ecz1V2fqmMimIakqA55jkHsg0SkiBlSo4CrjMPqF/YBd2a47L5zNdunrf8CreRGUq+/GvmQ==, tarball: file:projects/arm-servicefabric-1.tgz}
+    resolution: {integrity: sha512-551u8qKrGsDjHpKeh7BvAzoOfD1cPXE1n4w4euuKHMAAeU3nwMF61mT6mE0TtBm7X9xVwNIXYsb+oyUYxLTP+A==, tarball: file:projects/arm-servicefabric-1.tgz}
     name: '@rush-temp/arm-servicefabric-1'
     version: 0.0.0
     dependencies:
@@ -17416,7 +17875,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabric.tgz:
-    resolution: {integrity: sha512-x69+FIWBgiSxd9By3q2iZv5EkGuHY2Vnof4rjodYDYjVZor83Ibxia7WgdKM5iPUt4ytr99rbxTTq5HLZX321g==, tarball: file:projects/arm-servicefabric.tgz}
+    resolution: {integrity: sha512-PuvzLvVHXgAKhfDiamIXBvU+LsmLTiwm+MDLnepvBJEOJsT6uaZz0tTfAeFqI5jn6XIPc7VDBMN+43gmLcoVGQ==, tarball: file:projects/arm-servicefabric.tgz}
     name: '@rush-temp/arm-servicefabric'
     version: 0.0.0
     dependencies:
@@ -17458,7 +17917,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmanagedclusters.tgz:
-    resolution: {integrity: sha512-NVkHG9bhgK7vghzXmslXYnJyvINPuvVsKjbioxLdGraV8ixmtY0k0sq/+yov94G+GdY/hqkSdErnqsNJ+YbZiA==, tarball: file:projects/arm-servicefabricmanagedclusters.tgz}
+    resolution: {integrity: sha512-s+VwW/qetGIfyzvygIg+QcMNcQvb0lt5tJJu7MBZX814nim+a2BUzCBhzso6BahF1P7/Qf3qhiV2TnPTrspSLA==, tarball: file:projects/arm-servicefabricmanagedclusters.tgz}
     name: '@rush-temp/arm-servicefabricmanagedclusters'
     version: 0.0.0
     dependencies:
@@ -17482,7 +17941,7 @@ packages:
     dev: false
 
   file:projects/arm-servicefabricmesh.tgz:
-    resolution: {integrity: sha512-xlyV500hV6rEzy8QU/ylGzvgCVEBgmE7VS83ssrFMxjbNfaFtjSjQD8UdzURGNTw0hZDKWFsll7hlA2mVKhMlg==, tarball: file:projects/arm-servicefabricmesh.tgz}
+    resolution: {integrity: sha512-vDe3T+CXmMlrjwSMbADy5OgiCuzj8jDMwDnWJM3zI2ZMi7H/YOW4Ch9zhWYXhq5rifswkgnjugKB7NpAwwe6wA==, tarball: file:projects/arm-servicefabricmesh.tgz}
     name: '@rush-temp/arm-servicefabricmesh'
     version: 0.0.0
     dependencies:
@@ -17504,7 +17963,7 @@ packages:
     dev: false
 
   file:projects/arm-servicelinker.tgz:
-    resolution: {integrity: sha512-jmXF2OF6KCD7sfW5UNWw4gmW4rD9SxIY46xeOM5khuin+7CmC2bYJ9e0cM79GJQrD32FbwxMyvtyaIn6e/WO+Q==, tarball: file:projects/arm-servicelinker.tgz}
+    resolution: {integrity: sha512-+GxSXuJJ3lQkjP/cZtBJ2SCGX1SpOp+34TniJldvvoGIECYqpZGJ2S6mPEv0G4GO395uV+0xoKtm3wuJpy7FFg==, tarball: file:projects/arm-servicelinker.tgz}
     name: '@rush-temp/arm-servicelinker'
     version: 0.0.0
     dependencies:
@@ -17528,7 +17987,7 @@ packages:
     dev: false
 
   file:projects/arm-servicemap.tgz:
-    resolution: {integrity: sha512-12aJeaZhKsZhTKRobLmaZhhg4ysZzncivjjVP9ejVqHQoktU8ji0WwrAgII/ppBZy+lb4K0FUVdOh6VuRxoulQ==, tarball: file:projects/arm-servicemap.tgz}
+    resolution: {integrity: sha512-1sN3SNdWdptwboQvJX3hPiCB9slVQo5R5TogHOdopiFbWLLM0ODoxmpbuqlkVavTgLZwDBx91sF2Kulq1C9GMg==, tarball: file:projects/arm-servicemap.tgz}
     name: '@rush-temp/arm-servicemap'
     version: 0.0.0
     dependencies:
@@ -17550,7 +18009,7 @@ packages:
     dev: false
 
   file:projects/arm-servicenetworking.tgz:
-    resolution: {integrity: sha512-yhDiaZYqT8gMsKz+BAgksjFo8d5Yt9H3ahlR3VaI6NznjKjpLeb1kPJ8wmuMNqtNRMB2+tFG0zmTtKw0EUH4Ow==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-ox+4FNOWOCMOuQlKNXLXDy5Hb7FZlA+phMuMtJzA1h3pCnnQtzPatCQIwHJHZfPLoS/2XWjdmGQ0LsF4k5BKjA==, tarball: file:projects/arm-servicenetworking.tgz}
     name: '@rush-temp/arm-servicenetworking'
     version: 0.0.0
     dependencies:
@@ -17574,7 +18033,7 @@ packages:
     dev: false
 
   file:projects/arm-signalr.tgz:
-    resolution: {integrity: sha512-RTKGBRpfUwdBauU/aUXKy4QR1R7HI/XFMEzFqeu7/ENsbrkiaAdIu6RBcKMeJyg3kxXw1YaDiePqchdYLhUwkA==, tarball: file:projects/arm-signalr.tgz}
+    resolution: {integrity: sha512-zZDgBmlxTPQ8AS5R+nXtKHAbOGUN10SI07btmhtnhOdQog3lj4UUxH5rucN2BkzqwNLRfcbB8OQXDUhB0G2xlw==, tarball: file:projects/arm-signalr.tgz}
     name: '@rush-temp/arm-signalr'
     version: 0.0.0
     dependencies:
@@ -17598,7 +18057,7 @@ packages:
     dev: false
 
   file:projects/arm-sphere.tgz:
-    resolution: {integrity: sha512-iOkmNmwy56v6t0Jbv5ZTezSz7bkTTlo0ycEeM9CnwsIzm6wyfteURgDE0uZCLUxAVZp3ZrKXqGZr4/eHsKDRhQ==, tarball: file:projects/arm-sphere.tgz}
+    resolution: {integrity: sha512-/NWEeRrYisE057V3i3CRB9SCV/aDquLguCGA0NZYHlFDAgehbzi8bQpRTS26dMsdqoF5P0T596jHoSwhvsh0zA==, tarball: file:projects/arm-sphere.tgz}
     name: '@rush-temp/arm-sphere'
     version: 0.0.0
     dependencies:
@@ -17622,7 +18081,7 @@ packages:
     dev: false
 
   file:projects/arm-springappdiscovery.tgz:
-    resolution: {integrity: sha512-rPt33X6YK+sPes36+8n1wQG9qthpBp3UO1UiW9i9TggIUr/uDWHJxE2eWNRBtYTemlJ6N2YyIKMePMchlVocCQ==, tarball: file:projects/arm-springappdiscovery.tgz}
+    resolution: {integrity: sha512-B+LXkZt9OAaOMzzEmaud84skPXo+bnqamRbwBd1O/0pTURgKIXm6OYZHNvGvjLUOiP1s9MO6gHeFV3GUXkYumg==, tarball: file:projects/arm-springappdiscovery.tgz}
     name: '@rush-temp/arm-springappdiscovery'
     version: 0.0.0
     dependencies:
@@ -17646,7 +18105,7 @@ packages:
     dev: false
 
   file:projects/arm-sql.tgz:
-    resolution: {integrity: sha512-HSdUnotViQAJ6HCBOsWT/edtoKneqOfmjyRLswdTSDpaPXfjI3mkEHWuphVHIlbXlIA19ACcW5u6Hk7TDJP1mA==, tarball: file:projects/arm-sql.tgz}
+    resolution: {integrity: sha512-nX4WUS036DUuBzWexVmsVgSwDiK07oocvftAGOHtBygitFig9uDDTxAjObRdoKqq8HRy3Yhoy6q1mmAGPTvQ3Q==, tarball: file:projects/arm-sql.tgz}
     name: '@rush-temp/arm-sql'
     version: 0.0.0
     dependencies:
@@ -17670,7 +18129,7 @@ packages:
     dev: false
 
   file:projects/arm-sqlvirtualmachine.tgz:
-    resolution: {integrity: sha512-RGEMf7+s4K/bBhnm6IiiVTmE9h2oAVC2KeX7VgKG7moiZ2TKn+wXKCh72xqevcpw48ddjNHI+Cb4Mg6I/NTX1A==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
+    resolution: {integrity: sha512-Fx7d+VKqiPPxPJHVvS4ysPmiDR+Ml5wRBEOyStJg5ZsWT2C3i6mXJICye+eVhL+9mdbRNEXYnriApZFkHz20Qg==, tarball: file:projects/arm-sqlvirtualmachine.tgz}
     name: '@rush-temp/arm-sqlvirtualmachine'
     version: 0.0.0
     dependencies:
@@ -17694,20 +18153,20 @@ packages:
     dev: false
 
   file:projects/arm-standbypool.tgz:
-    resolution: {integrity: sha512-lBp+YGTwo3+S+0zRPNL42SjK4lLENcKqTdRrqbJfiiLvwu92k6wmM2YWr5xZXHh5arGKmz2FkNZuo5nFlRdKOA==, tarball: file:projects/arm-standbypool.tgz}
+    resolution: {integrity: sha512-TRu+ru5GU+60uJPhfo5CRgT3MwVhbZRCcQrbGdWyXmy3/5aNX2f50K2glNDJOtl1wWtjnR0fOEGC+QipO6Qr/A==, tarball: file:projects/arm-standbypool.tgz}
     name: '@rush-temp/arm-standbypool'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -17725,13 +18184,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-storage-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-CxXRxo0GQSOu+gwyJZ4jkmAK8RyS8J0aGR4z5xCxL+Jjay4x5KZqZdp6sm/a3TDbvZsvyJWlLvwhznNx4GYd9w==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-JYBCbbiEHKfpUH+ye9I856wYODg9mtlNNpB4iTopZpBl8M30hTiMu1a8uNd7rBgZfAJJO5q7sCaj+VFODSkmKw==, tarball: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-storage-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -17754,7 +18215,7 @@ packages:
     dev: false
 
   file:projects/arm-storage.tgz:
-    resolution: {integrity: sha512-7JaMM+XbnS5mlPjhHW0lN9MC1+MfQWGHxHowEAzrDGKMQq0S59yl1ARyzZenuxCksPB4fUGFkCMF2x0dWdoiXw==, tarball: file:projects/arm-storage.tgz}
+    resolution: {integrity: sha512-ijcggoXU0gVKEw/dCRDrCbrAom1AUkm6ge52rwL9ynWvBCANEjvtZmt3tdImgGcQfqXxywlYvIaWzHRTai1AeA==, tarball: file:projects/arm-storage.tgz}
     name: '@rush-temp/arm-storage'
     version: 0.0.0
     dependencies:
@@ -17778,7 +18239,7 @@ packages:
     dev: false
 
   file:projects/arm-storageactions.tgz:
-    resolution: {integrity: sha512-J2A+Z0Xz5BkQdWKwkX7vvJKcis5s/P/2jTfK9FpQxQaz8xDnNBitsB4WoYnMqNtRZGh6D6l1xZfo6EKDyzFs9w==, tarball: file:projects/arm-storageactions.tgz}
+    resolution: {integrity: sha512-537soJljGx38U8w0cfmf7vST8xUfZBCdYwMqhp3dhnSp9juXo+RcVvmvT5ZmJsadYfuEj9x0UkegNEXeK1l89A==, tarball: file:projects/arm-storageactions.tgz}
     name: '@rush-temp/arm-storageactions'
     version: 0.0.0
     dependencies:
@@ -17802,7 +18263,7 @@ packages:
     dev: false
 
   file:projects/arm-storagecache.tgz:
-    resolution: {integrity: sha512-54w0drdqLOZ5H2ctjYw/08CF3Gk0HP23mJbhTG+xtXZqz8ixEXAlzqLk1qH+3SuBbP7kON/Q1TNPcyDjH7E7wg==, tarball: file:projects/arm-storagecache.tgz}
+    resolution: {integrity: sha512-4cejEJSFx/QoW6lORh/r+xN3HlIIyUlHu0vlE2G0kYnr+ZsKei7kvo3nOx6De69VF81T3PVSzYLBoSsYSs/l6g==, tarball: file:projects/arm-storagecache.tgz}
     name: '@rush-temp/arm-storagecache'
     version: 0.0.0
     dependencies:
@@ -17827,7 +18288,7 @@ packages:
     dev: false
 
   file:projects/arm-storageimportexport.tgz:
-    resolution: {integrity: sha512-l6/Ao3ypthPFWaYa5RXUWFZfQjVCA3yqqvPTucngqWIwLqdir9AZiSnoKhId64vpoRrSRZYh1rsLWPzS1UdBAg==, tarball: file:projects/arm-storageimportexport.tgz}
+    resolution: {integrity: sha512-qyWLxVQOBIj1WfG8BNPF1WoBjkMVenKKCdRUQAOw0C+DA65fx0Hw2ZepGqHn3yy28y3Nj09S0C0jVdJFVXAGVw==, tarball: file:projects/arm-storageimportexport.tgz}
     name: '@rush-temp/arm-storageimportexport'
     version: 0.0.0
     dependencies:
@@ -17849,7 +18310,7 @@ packages:
     dev: false
 
   file:projects/arm-storagemover.tgz:
-    resolution: {integrity: sha512-Ov0RLvOUkqcZP/Xy3Pjd1pKhCsMqr+V17vQSiNmUppWdXGgwKYp3SfkhvlxF5pwkotJl0pYBizQQpPullPOauw==, tarball: file:projects/arm-storagemover.tgz}
+    resolution: {integrity: sha512-hYnhwBpSFhKZ50heEnQFUyMGRQkA7nVCTjaEG5HgwgEJJLkzYrbfY5SpcdF8q5PpDZazPceop77JDnQhV0AcJA==, tarball: file:projects/arm-storagemover.tgz}
     name: '@rush-temp/arm-storagemover'
     version: 0.0.0
     dependencies:
@@ -17874,7 +18335,7 @@ packages:
     dev: false
 
   file:projects/arm-storagesync.tgz:
-    resolution: {integrity: sha512-fKD6uofi9+UqrnP9CXLuy4Gtwzg9qZpaWToXmrqZumPplzkMBRexrY7UexQrqyctQG5KhIA0Ivg9uhALersfQg==, tarball: file:projects/arm-storagesync.tgz}
+    resolution: {integrity: sha512-rp7JC71tjCqNcYNkgfFK0onLFZRIyjb8qqHAvQe3+bhWah5XlGJ1wTfNwIZ7V9tyDCyqOUVjwT24+Svnovpsqg==, tarball: file:projects/arm-storagesync.tgz}
     name: '@rush-temp/arm-storagesync'
     version: 0.0.0
     dependencies:
@@ -17897,7 +18358,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple1200series.tgz:
-    resolution: {integrity: sha512-vuWBVlLqpb0kUW+dLvCoWwZnDDiqxbnm0w7zEXC/vksb+SxmG7upDIYKdpLct+t4Ah4u+Dg2mUqNvtkuAHshEg==, tarball: file:projects/arm-storsimple1200series.tgz}
+    resolution: {integrity: sha512-bsP222a4WKLHWCiXijBj6F4CkqYqsCIqYA56HRtHjNQDdpR3Y63XaIsuiN9uPQSPqLi2iH36tXnPwQkkR+ZvRg==, tarball: file:projects/arm-storsimple1200series.tgz}
     name: '@rush-temp/arm-storsimple1200series'
     version: 0.0.0
     dependencies:
@@ -17920,7 +18381,7 @@ packages:
     dev: false
 
   file:projects/arm-storsimple8000series.tgz:
-    resolution: {integrity: sha512-YCCPLoSrFl+scyWtwdTi+rJeCKMLLgXpoV6TYtOus05mLEdkqzmeOYkVUi41rMzD4jgznDnZeuceDfrf7tsT6Q==, tarball: file:projects/arm-storsimple8000series.tgz}
+    resolution: {integrity: sha512-3esxxDnWEhg3CR5AlgIj7/ovC46rvf7AuoUC7RVuA2YDb9XL3ftSkksclfUHEV7ayNYzH+t4/H8MJJhSIKOOYQ==, tarball: file:projects/arm-storsimple8000series.tgz}
     name: '@rush-temp/arm-storsimple8000series'
     version: 0.0.0
     dependencies:
@@ -17943,7 +18404,7 @@ packages:
     dev: false
 
   file:projects/arm-streamanalytics.tgz:
-    resolution: {integrity: sha512-x2r4yR4EZaXI4cuc2PE0ZFEDlBd7t+wSyYUGLOIxjTV5A8UWdh6GjvciEmhHE9G98RM82qOOoD4wVpIUfhM+XQ==, tarball: file:projects/arm-streamanalytics.tgz}
+    resolution: {integrity: sha512-1zbkRv+E450Mnoo80LZzplB3/9zskaWACPQ1wV7bh0nB50V9shpYSDpdJB6hnL85Mk15QKItEPswky0kAOxJFQ==, tarball: file:projects/arm-streamanalytics.tgz}
     name: '@rush-temp/arm-streamanalytics'
     version: 0.0.0
     dependencies:
@@ -17967,7 +18428,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz:
-    resolution: {integrity: sha512-s9QF9sX/pfctdiDj6d1OSl4qAPwVQCb3LnbUeB02hiC7/89Dtd6DU5//ocx9WwdgDyWmr8VYgwb3Yx0Go0XbYg==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
+    resolution: {integrity: sha512-IGzxlsqe1b7MsSol4Mw/mTRfZ/lfoWKkX8OkAK7Eja//4AojorsRdg1EayRT35hmB2hjGP+1PQ9Afua9MLn2vQ==, tarball: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz}
     name: '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid'
     version: 0.0.0
     dependencies:
@@ -17989,7 +18450,7 @@ packages:
     dev: false
 
   file:projects/arm-subscriptions.tgz:
-    resolution: {integrity: sha512-faGQJwN+3MUpsDxOtTp6V64CC2s+yX/vquKSiUiKR1IMNAMEsrDmmJ5ewdR1g9mrr34q96xnAxdblGkC6EPrMg==, tarball: file:projects/arm-subscriptions.tgz}
+    resolution: {integrity: sha512-a3ZpAORqlQ3kp1uagU9RKBxhr5g7DNTv+kzaSZgrHxz1xJdiYERONGj3dSoYBnp7+YDycH97l7p7SzUSgCPZLw==, tarball: file:projects/arm-subscriptions.tgz}
     name: '@rush-temp/arm-subscriptions'
     version: 0.0.0
     dependencies:
@@ -18012,7 +18473,7 @@ packages:
     dev: false
 
   file:projects/arm-support.tgz:
-    resolution: {integrity: sha512-FGO/xCFCsXYIpkdWZlXY7paU3Z8ZReLTwReVmAQUftQKEcDfb3gHBY6WBtgEXHjc5b70hvRA3GlNrMcX2XDTIQ==, tarball: file:projects/arm-support.tgz}
+    resolution: {integrity: sha512-YzUEqqEV0TZiTK+VBY4xmOkuPlofcoGe4S0CS9vq64d7iKkIDPULaeKIKq+mt6Kz1xz22Cg1ewknHqUm0Ah3tw==, tarball: file:projects/arm-support.tgz}
     name: '@rush-temp/arm-support'
     version: 0.0.0
     dependencies:
@@ -18036,7 +18497,7 @@ packages:
     dev: false
 
   file:projects/arm-synapse.tgz:
-    resolution: {integrity: sha512-S5WnuTQi2aWK6q5toiunog3uKzjMhwq0Y3CQ1JAtlJyGa3oIEO760qFTIhycvbhVuiRcmUui5mQGgLV6ChZcHA==, tarball: file:projects/arm-synapse.tgz}
+    resolution: {integrity: sha512-9XXkgLi1fyOaWAnyoycbOg0jTN55keB2SGb0q2HwC54PZBwhjmrzHalrLQXJ/w9pmJ0l7pzmAbPcwIWpTzNDnA==, tarball: file:projects/arm-synapse.tgz}
     name: '@rush-temp/arm-synapse'
     version: 0.0.0
     dependencies:
@@ -18060,7 +18521,7 @@ packages:
     dev: false
 
   file:projects/arm-templatespecs.tgz:
-    resolution: {integrity: sha512-OIPrZZVFbxQnyAWw2pOb2LxWdAVbjUpHeSL0jlFzQtmxLFPvPsfKYYzuff9JBT52JzLpdSdzrx8yJD6vVEsoWA==, tarball: file:projects/arm-templatespecs.tgz}
+    resolution: {integrity: sha512-a/mg5GZD7U9ALAU0iG+huEmfo9yWN+YQ9tQ4fuSsRQjL7jy4evJJ7De1fmSnq4i1JWSk8tPjrsdDXHXd1AEmAw==, tarball: file:projects/arm-templatespecs.tgz}
     name: '@rush-temp/arm-templatespecs'
     version: 0.0.0
     dependencies:
@@ -18081,21 +18542,21 @@ packages:
     dev: false
 
   file:projects/arm-terraform.tgz:
-    resolution: {integrity: sha512-N33mFCaqI2ZhFQmBD9XUJCLTiWbuU1ezZsBV0/gRiWFzzt+zBTwgEt/x/HE39Tc7q2JbCnzqB+ms5PjyIHxzsw==, tarball: file:projects/arm-terraform.tgz}
+    resolution: {integrity: sha512-wGQluePhtJ6cC9WCWLV5bohph2voPDr1C6Ph+RQ1xg7vSCDiefmaV7eHGYTXPglHpddsVWz6LcrYVYRM4VAnuA==, tarball: file:projects/arm-terraform.tgz}
     name: '@rush-temp/arm-terraform'
     version: 0.0.0
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@18.19.66)
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tshy: 2.0.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18113,13 +18574,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-timeseriesinsights.tgz:
-    resolution: {integrity: sha512-M5JNlYjuksfmjRYhRoQQBgymivooZF50jpe2EptMZQNRfn19ukQ2DilgCzx2EdJPHoT6IuVUo1D5DkbL7ebV3w==, tarball: file:projects/arm-timeseriesinsights.tgz}
+    resolution: {integrity: sha512-JXLU0oVkEvQKbf8ZmXfaHSHBj2zCzAnZLxMzEN2+cTiNbKPA5SKR88KyICp1eFsB/2Idmp07Wd2UxfI16SdKCA==, tarball: file:projects/arm-timeseriesinsights.tgz}
     name: '@rush-temp/arm-timeseriesinsights'
     version: 0.0.0
     dependencies:
@@ -18143,7 +18606,7 @@ packages:
     dev: false
 
   file:projects/arm-trafficmanager.tgz:
-    resolution: {integrity: sha512-2JiKgZ434r2fSRoVYkvEymSssKsgnskylDniZmFRBcS0YjK+DNT0kW5TxFfgVDpgtKduwemmp/1Nmzx134Q3Jw==, tarball: file:projects/arm-trafficmanager.tgz}
+    resolution: {integrity: sha512-/PRwMIPgOWg/cPd7c/1ObTfRbd8dehfDNlKVdcaxAtHS1V8W6OoxHb8/dmnquStUhJhjUj3wNOX2DjhzFfxM1g==, tarball: file:projects/arm-trafficmanager.tgz}
     name: '@rush-temp/arm-trafficmanager'
     version: 0.0.0
     dependencies:
@@ -18165,19 +18628,19 @@ packages:
     dev: false
 
   file:projects/arm-trustedsigning.tgz:
-    resolution: {integrity: sha512-wGwPeLkUdS8uFAHYhPGRjtS5hsI+ChbmQHSs8C9H4EDrel45yFDkNKazb3Njff0LPlTQFDggKVitNaWAANJEwg==, tarball: file:projects/arm-trustedsigning.tgz}
+    resolution: {integrity: sha512-etdSnfmFDKm8A6kcedUjfu6EtxlhBNClWo0eGsV+1iQDcbo0PHqzJIEj7abIVO9ub3ZLUed/dSU8jo12pXttCw==, tarball: file:projects/arm-trustedsigning.tgz}
     name: '@rush-temp/arm-trustedsigning'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18195,13 +18658,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/arm-visualstudio.tgz:
-    resolution: {integrity: sha512-UiQjCfvL9Ny3F2040HaEfUQPTcWHQE3GbKEZd8n+VZ2dt6SoYpgyeUfTql79t26fFgY+/01mvA63JF1z4CLZVg==, tarball: file:projects/arm-visualstudio.tgz}
+    resolution: {integrity: sha512-zqlmLRh22Y7e6FGsMwbtIS8FZrDeVn+L1jK2r0YNgyB33Mm49p8xQYQLd01lJ2mQD8GBEeDZtGqpnO+c0U/jsQ==, tarball: file:projects/arm-visualstudio.tgz}
     name: '@rush-temp/arm-visualstudio'
     version: 0.0.0
     dependencies:
@@ -18224,7 +18689,7 @@ packages:
     dev: false
 
   file:projects/arm-vmwarecloudsimple.tgz:
-    resolution: {integrity: sha512-tELhHvn9pmZyfjuO6fXJCIrxRu0e2/FEOQ5pePkVBXrj6sjV/rCibw8kdoj66wrR9txTW6x9s1UdDBM52Pl36A==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
+    resolution: {integrity: sha512-519dZgfrTEhJDgF0iBZQP5she2Ge6DGI6O56olqv4Xb7cXj7kEPoSKv0OiAY2EtQ16lwV1CP3FNRH7rv149foQ==, tarball: file:projects/arm-vmwarecloudsimple.tgz}
     name: '@rush-temp/arm-vmwarecloudsimple'
     version: 0.0.0
     dependencies:
@@ -18248,7 +18713,7 @@ packages:
     dev: false
 
   file:projects/arm-voiceservices.tgz:
-    resolution: {integrity: sha512-VqgW59CBLAxfPUL7PGHgPFG6b7h1O/UuqT+7hg3QSh/c/buwzdJmfne8rBcdcUInmYspTBDmIGQzZYjqdPEAJA==, tarball: file:projects/arm-voiceservices.tgz}
+    resolution: {integrity: sha512-Ja9w17hq6zolGGTzQDxMBq0UViaU+d5U/nU17l9EtDRjKtyDQx7S1jWGEhf7MK9ksN82/VHEHdOtei62BDFwqA==, tarball: file:projects/arm-voiceservices.tgz}
     name: '@rush-temp/arm-voiceservices'
     version: 0.0.0
     dependencies:
@@ -18272,7 +18737,7 @@ packages:
     dev: false
 
   file:projects/arm-webpubsub.tgz:
-    resolution: {integrity: sha512-34fMxJ6RStuhR6500e+VWhueRdW4MOCzh6ukjZI19rg8bYvg0CkNulAdKUqJw2AOFzfz1LDSge4lSZqczzI5Kw==, tarball: file:projects/arm-webpubsub.tgz}
+    resolution: {integrity: sha512-DlZqyuLTvulHioCw+zSb+bimBYGGpgpYc9Y0aHz5mTpPNQtHmAeLdHDDzIp4u7vt+ah6CKsrs74Y4S1s8bd9pA==, tarball: file:projects/arm-webpubsub.tgz}
     name: '@rush-temp/arm-webpubsub'
     version: 0.0.0
     dependencies:
@@ -18296,7 +18761,7 @@ packages:
     dev: false
 
   file:projects/arm-webservices.tgz:
-    resolution: {integrity: sha512-zsL2ZwYn8PD8COnolYhDSDCebonahH9gCw4/ozxJFrJRLATcZnziCKJ3a6qs6G3+HofjbPX/y9OvxLI27YpBow==, tarball: file:projects/arm-webservices.tgz}
+    resolution: {integrity: sha512-LIJNmyEGe+OB7McLX0jFAUNDVmIe6W0rLByBZiNmkK0u1HzHUdyvP33nqBujOiMdVsgOR+VNASHeF6waofU8AQ==, tarball: file:projects/arm-webservices.tgz}
     name: '@rush-temp/arm-webservices'
     version: 0.0.0
     dependencies:
@@ -18319,7 +18784,7 @@ packages:
     dev: false
 
   file:projects/arm-workloads.tgz:
-    resolution: {integrity: sha512-RWQfpgvMRTCHIhZM0bD9lyj2R7hVQCEvLJ2F0TmuGSYTQZ5E3qw6NHUkYoISxj8rVxnB/xnyRJTFPLYuhIeNfg==, tarball: file:projects/arm-workloads.tgz}
+    resolution: {integrity: sha512-bhcUrcO2tgLY3/Nszt+6BYUCBKrcV0TaHgX0Ubua/gVKJ2/W/vzt9sw5918N68903xdFc9mE4Lw6h2VrR7Jolg==, tarball: file:projects/arm-workloads.tgz}
     name: '@rush-temp/arm-workloads'
     version: 0.0.0
     dependencies:
@@ -18343,7 +18808,7 @@ packages:
     dev: false
 
   file:projects/arm-workloadssapvirtualinstance.tgz:
-    resolution: {integrity: sha512-jzDm+jPkBcBG4bAIvtw3t8ZxD1hvQPvdI/zVSbkYM0PQeuuJtnqcdKF8uk21zXZBZxlSfXzmURvcpXQym3SFzw==, tarball: file:projects/arm-workloadssapvirtualinstance.tgz}
+    resolution: {integrity: sha512-eyOhOcNMcsU0ohneNptCBDacB50eSW1bgBKS26nf5srS7ENKaP6dh1BGnHw6i42rgrr0feRLwm4gghf9+y1qIw==, tarball: file:projects/arm-workloadssapvirtualinstance.tgz}
     name: '@rush-temp/arm-workloadssapvirtualinstance'
     version: 0.0.0
     dependencies:
@@ -18367,7 +18832,7 @@ packages:
     dev: false
 
   file:projects/arm-workspaces.tgz:
-    resolution: {integrity: sha512-2Lzj4dGvzsZjC0mpObJ5KeQjUbUrmcm8tYz0hdZzC+7gVvVSEUOfYY+IlMS0xTwAklcMLaB0GPjg7fY57xY7sw==, tarball: file:projects/arm-workspaces.tgz}
+    resolution: {integrity: sha512-VQ9EFNtyw83LHupHAG1GSIeqLvDebfSwEnH2ob4TGVg7SRb1XPKv6JWSQUgDvbNn5DwLShRJ9XIY72BeFTvFXQ==, tarball: file:projects/arm-workspaces.tgz}
     name: '@rush-temp/arm-workspaces'
     version: 0.0.0
     dependencies:
@@ -18388,13 +18853,13 @@ packages:
     dev: false
 
   file:projects/attestation.tgz:
-    resolution: {integrity: sha512-3sCMDoIZh5Y23js3HfWFMKzahYChBEc/+kaUas0+0FJ06UcWuof3jLf7hXnADbxp+J8/RCnvDqy/0xDmOcZkPA==, tarball: file:projects/attestation.tgz}
+    resolution: {integrity: sha512-74eSGY7/wm/4Ay71VPnKfniH76OEERoJ9HI41DV8WKWhxU8ejyK/bUEKBd558iH0Mt65I7mcqnjeCYgG1+X/HQ==, tarball: file:projects/attestation.tgz}
     name: '@rush-temp/attestation'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       buffer: 6.0.3
       dotenv: 16.4.5
       eslint: 9.15.0
@@ -18405,7 +18870,7 @@ packages:
       tslib: 2.8.1
       typescript: 5.6.3
       util: 0.12.5
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18423,13 +18888,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/batch.tgz:
-    resolution: {integrity: sha512-5aWGICBLDXaS8dyz90IUuG+KysKDtOr7RkVjdYzfxCimiWRMgPYdRmvP+k7Dkm5xkp16VRTIG8kTnJFVUBSMHw==, tarball: file:projects/batch.tgz}
+    resolution: {integrity: sha512-qiMmMExnnsDsvMzxPnlKVaj7Z3hio25vELd7XcIG7lt7BSYg/JQjsZWySdiwTtLIQXyS7Sviiw7KYdChyglqAQ==, tarball: file:projects/batch.tgz}
     name: '@rush-temp/batch'
     version: 0.0.0
     dependencies:
@@ -18443,7 +18910,7 @@ packages:
       loupe: 3.1.2
       moment: 2.30.1
       playwright: 1.49.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 1.6.0(@types/node@18.19.66)(@vitest/browser@1.6.0)
@@ -18466,20 +18933,20 @@ packages:
     dev: false
 
   file:projects/communication-alpha-ids.tgz:
-    resolution: {integrity: sha512-JoRTIDlwHZDPs7keNqgIU0MrximNBp+fJgAIZoRfwav8szwZz08PtN2HvqjTP1BZ8bFcnOkdlWJhZwvcHiPBsA==, tarball: file:projects/communication-alpha-ids.tgz}
+    resolution: {integrity: sha512-M4SNcUJRBHnM/IMZ9eqN50/Hoo+iXh+Op5mYDrTGT61PMKA2CMHA+5Ceo8jg9vovtQ268Qxlq12RBJDhz1rkJw==, tarball: file:projects/communication-alpha-ids.tgz}
     name: '@rush-temp/communication-alpha-ids'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18497,20 +18964,22 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-call-automation.tgz:
-    resolution: {integrity: sha512-j9rSk+SzAA5RTLrNqnlSWmfabKPVUE/iu7X3ckI3iQyYIgHYjn1Ek+zXQaN0DYMThl2chTjnq389qCuy1OeT4Q==, tarball: file:projects/communication-call-automation.tgz}
+    resolution: {integrity: sha512-P3uKFNCI/an58RK9PK62mNAgN0B7sOFwCq/tuvTHUIxwVh5VYhdrV4PZif8Q4lnqDJzuDTqZBwYsRWMlR5AbFg==, tarball: file:projects/communication-call-automation.tgz}
     name: '@rush-temp/communication-call-automation'
     version: 0.0.0
     dependencies:
       '@azure/communication-phone-numbers': 1.2.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
@@ -18518,7 +18987,7 @@ packages:
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18536,27 +19005,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-chat.tgz:
-    resolution: {integrity: sha512-b8v2dH6bvbYnjZtQtKl6ReggBc4gkDHx66jdrHCgqW4yEpxfFsQAqHDQgZftlGhJCUe5eKKRJ6vqBEwhTOGWDA==, tarball: file:projects/communication-chat.tgz}
+    resolution: {integrity: sha512-9tvFUZGtEvlmposRiYeruEUJ7cyZ1OOrKXpkxTOI86IDNZ7LTfKv7E9sphbHPRXTTRbFm3sHSrx/LSkrbnq9Kw==, tarball: file:projects/communication-chat.tgz}
     name: '@rush-temp/communication-chat'
     version: 0.0.0
     dependencies:
       '@azure/communication-signaling': 1.0.0-beta.29
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18574,19 +19045,21 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-common.tgz:
-    resolution: {integrity: sha512-XzWEZCKhE4dx4TzQbLDgRWi+8qjzn8gojvk/pDAUuWUcG7nhg1H2rB67Ygmtys2qgIrTh1mB5wDyPwvVLDzjcA==, tarball: file:projects/communication-common.tgz}
+    resolution: {integrity: sha512-Mu1umPtnnXCvErc4uLWw32kLF5ozZhRzt+WIafeBN5RGZTpt/Yv3Ta4krP664XY5quz+d6Iew39Iyi7gjeMRhQ==, tarball: file:projects/communication-common.tgz}
     name: '@rush-temp/communication-common'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       events: 3.3.0
       inherits: 2.0.4
@@ -18596,7 +19069,7 @@ packages:
       tslib: 2.8.1
       typescript: 5.6.3
       util: 0.12.5
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18614,26 +19087,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-email.tgz:
-    resolution: {integrity: sha512-QhLsLLokYOq6xNcg5alwSd7zmjUr5iul+3/p1yq7jzXk2vDsxGU32Wq5S1ALu5jX+eTLPpxjm8WPdCFc37UtIg==, tarball: file:projects/communication-email.tgz}
+    resolution: {integrity: sha512-V4BFQmP2+fvb9CVxQrEcn70zCbvwxiBNRV2OsgVdw3SSVf+mIenItX89mN3w7gzNjmwqd2Jhp7t8gdjPy9ta/Q==, tarball: file:projects/communication-email.tgz}
     name: '@rush-temp/communication-email'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18651,28 +19126,30 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-identity.tgz:
-    resolution: {integrity: sha512-cHCdd2LiWjg4jftWNnziaCV9uNSMfkhoUDFlKBymYkvmj4dbrgoobwpuPOkqJ4zoB9r86aiRDNP/E0YmMF2RFw==, tarball: file:projects/communication-identity.tgz}
+    resolution: {integrity: sha512-Z8Eg6dCgwG6evdIyKD35fSnB48ETzDqi7pcaPzlnzzc84AK0YUOXpNgFmwTBcP6taol9EKZ1I52KP3v3S4aamA==, tarball: file:projects/communication-identity.tgz}
     name: '@rush-temp/communication-identity'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/msal-node': 2.16.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18690,20 +19167,22 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-job-router-1.tgz:
-    resolution: {integrity: sha512-7NGs1l8E3JJ5oW9FXr+0jZnJyJkaCWcNqd/iA2rE1PqlEPv1bJ1GkPY+vh6cmDoZUSodOmWK4kn7Un4S5nsinw==, tarball: file:projects/communication-job-router-1.tgz}
+    resolution: {integrity: sha512-dGcc+4RttS5kdqpFWCQuF2hCkJXTx6byhARDgaVaxP+iOQPomI1wh6F86QWWE0ptaG2r86+zwQj3yF1UFfSMpg==, tarball: file:projects/communication-job-router-1.tgz}
     name: '@rush-temp/communication-job-router-1'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
       '@types/uuid': 8.3.4
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
@@ -18713,7 +19192,7 @@ packages:
       typescript: 5.6.3
       util: 0.12.5
       uuid: 8.3.2
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18731,26 +19210,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-job-router.tgz:
-    resolution: {integrity: sha512-2asWr03USbfs287ufZkj8sgX94e8AIkX8BU9mVvBxqPp+5NwM8F2I2OeKa/ZRb9z7dcawliux8IwyB2kNGIEAg==, tarball: file:projects/communication-job-router.tgz}
+    resolution: {integrity: sha512-HSFJ4meVsYj5Zjw1MNCPCvAbx+D4toSi2HoycCplbDJ+2AubIyqJAjM78sqTvQzShd5rU3PlTWGt3FbzAPBNOQ==, tarball: file:projects/communication-job-router.tgz}
     name: '@rush-temp/communication-job-router'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18768,19 +19249,21 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-messages.tgz:
-    resolution: {integrity: sha512-IcDGaDqJ1GhWIIajWNiyS4FUnZB3JEvDYXG7mopGzk4wgpUfOhVoVrJuz07pg3unKTn48Oqlm4EOWFmAm0wbag==, tarball: file:projects/communication-messages.tgz}
+    resolution: {integrity: sha512-Yp2g4smW9WDm9rdu+riPV92/0EaPcfKBre/FcPS9uNr7Y4rZQ0wHpoD8mpQUb0WfsLWMcNWwxmm30CxLUnAhlg==, tarball: file:projects/communication-messages.tgz}
     name: '@rush-temp/communication-messages'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
@@ -18788,7 +19271,7 @@ packages:
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18806,27 +19289,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-phone-numbers.tgz:
-    resolution: {integrity: sha512-24JG0UquvqCfpD2fHYVg31EE7Zu+1LadlqbxK1oIhPj3dnaQ152m8T++HHMAkFzfbNdaH/1yqWjLTpBVotKMXA==, tarball: file:projects/communication-phone-numbers.tgz}
+    resolution: {integrity: sha512-iR0/kmBPDoBpvjLCev+e/k/M3E6BD8C20nDuS4lj/FSuBbMK0LirSNPmkiEBe9OqVVtj+lLRCumze68CHqqi9Q==, tarball: file:projects/communication-phone-numbers.tgz}
     name: '@rush-temp/communication-phone-numbers'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18844,27 +19329,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-recipient-verification.tgz:
-    resolution: {integrity: sha512-cpVMuIbO+tSFbjQSjDB1yOL3QgqBKppbLvWuYCe2JoY10LBIu+a5SWMTSk9DbjlN+DfUCQ8gQN01zbizH0BBhw==, tarball: file:projects/communication-recipient-verification.tgz}
+    resolution: {integrity: sha512-+6+f4oOSNtuLyuk1ZFDhhmui3IRFwXQK2gGcZEHNLkg58CRscZZMkSCOWaEYAI4Zuh1pq5kIRHm3v1x7x45CVg==, tarball: file:projects/communication-recipient-verification.tgz}
     name: '@rush-temp/communication-recipient-verification'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18882,25 +19369,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-rooms.tgz:
-    resolution: {integrity: sha512-F/7ZgMfumTgdSJXk4iLzYs3cbwxW08iZlD3OjjDYAqkYG/qodpxjdwjDxneSeXLPaIDUwYBnz9S7LTTzvSGtcA==, tarball: file:projects/communication-rooms.tgz}
+    resolution: {integrity: sha512-LUP3Ckn6iZfh9M/S3/ESlDo7vnKqJLHQUuKh4ILK/mMVLzUFAb3Fxz9XvfJh1sChOWZUnQ4F1uQGFsDZ5plt9Q==, tarball: file:projects/communication-rooms.tgz}
     name: '@rush-temp/communication-rooms'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18918,27 +19407,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-short-codes.tgz:
-    resolution: {integrity: sha512-4Bh0DOycDYo2hEz+Yj2Z1IJ+BrRhHj3PLWrEPEBRS61LJqNcFHxyROmdSniFzPFMccdLftvLeekkq34WbBcMuw==, tarball: file:projects/communication-short-codes.tgz}
+    resolution: {integrity: sha512-HMAnhBzDN4Ml8j+L0zIp4mIgqhXkP7j9M6lpxfJoNJrrP5jwtgz1100R68YXdpsCaf/s8aIdWa8xIYTXhNQOFQ==, tarball: file:projects/communication-short-codes.tgz}
     name: '@rush-temp/communication-short-codes'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18956,26 +19447,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-sms.tgz:
-    resolution: {integrity: sha512-dmscPn+No1b2ix4Mc9o8yZR34qSg/0GaILdZES+WE1tBsYeSqo8yWKJo3/bTOSNBRR5oIdHe+XafVl1sWObFdw==, tarball: file:projects/communication-sms.tgz}
+    resolution: {integrity: sha512-4+dfIAfcloRDAIpDv3GJkFMTlld6VrK8XpnbyLtMwUWlEZdK1jdAEIMYyzATAzyDR47kJap6Tx2HjtymfbNW0A==, tarball: file:projects/communication-sms.tgz}
     name: '@rush-temp/communication-sms'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -18993,21 +19486,23 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-tiering.tgz:
-    resolution: {integrity: sha512-rz1BR/nFh76ye4xr8Y7ma9rk7L5MdY/OvQzCHdccWUqJtna7thL+3dBEzfugUV3+3x25rHJ6QTwpj6VFz8P6Pg==, tarball: file:projects/communication-tiering.tgz}
+    resolution: {integrity: sha512-35UiszClNr2G1r4sCMqb9CMNZY+ECxzG0rp06Ppq3ZhDMDjwq7mtU/P0cKGde0OzvoEr7df6GMawcAxV0bGU7w==, tarball: file:projects/communication-tiering.tgz}
     name: '@rush-temp/communication-tiering'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
       '@types/uuid': 8.3.4
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
@@ -19016,7 +19511,7 @@ packages:
       tslib: 2.8.1
       typescript: 5.6.3
       uuid: 8.3.2
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19034,27 +19529,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/communication-toll-free-verification.tgz:
-    resolution: {integrity: sha512-mh4iB2h+E3K7dWs6knXVxNVb98YvNIrrSZobhGiQoRb9Wy6RGmX45o28nQyHVm7yk7nQV+DTtBu4N3aTIQtKUQ==, tarball: file:projects/communication-toll-free-verification.tgz}
+    resolution: {integrity: sha512-g3Kvt/HZzF6s8/p5Tw5opYtEux+ai2cN0Krcsei//onaUr5hbGvoXPbqiHrnuF4hlcx4sx6lebkLeducyPJs5A==, tarball: file:projects/communication-toll-free-verification.tgz}
     name: '@rush-temp/communication-toll-free-verification'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       inherits: 2.0.4
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19072,23 +19569,25 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/confidential-ledger.tgz:
-    resolution: {integrity: sha512-kz/gO0p1kTIesYPMsgME5Tc8BCXl3x6DQgBG9NDcR586apYrge1buEHANawGmE/uh44YKSsT5PjHgRCBIkz1Wg==, tarball: file:projects/confidential-ledger.tgz}
+    resolution: {integrity: sha512-Ce1lXxrB208ujBLjzT43aqatT+8uuHGsUpWUXQIyLpR5v+2k4CeO/1HZCdO2VDvdJ/zywUCXbYbUy1SUmvaOiA==, tarball: file:projects/confidential-ledger.tgz}
     name: '@rush-temp/confidential-ledger'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -19105,10 +19604,12 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   file:projects/container-registry.tgz:
-    resolution: {integrity: sha512-OqITO/TMWza3AeETuc9wVLLfZgTD3CWl58tQ+NejouMEUalv/t+TkNEaUlubfdN6v43Xc3n2CeB5VmIni8UnsA==, tarball: file:projects/container-registry.tgz}
+    resolution: {integrity: sha512-odCaf5FtNnW8WLfxsxC7Y2CD3eEYfT6w5CS4t35p1bRmUayNJRastmIkeUQ2CmE8MnoByZ9Z9VTUTc8CrGmeZQ==, tarball: file:projects/container-registry.tgz}
     name: '@rush-temp/container-registry'
     version: 0.0.0
     dependencies:
@@ -19148,7 +19649,7 @@ packages:
     dev: false
 
   file:projects/core-amqp.tgz:
-    resolution: {integrity: sha512-/2vGGrll/08qao8LtbTxEkN2iv7PM0QIEuIz2P4GAWeSYDsFC/WA4vqLv9rJuIYnPPBjVmsDtcoDYdAOOOx0Rg==, tarball: file:projects/core-amqp.tgz}
+    resolution: {integrity: sha512-OqYlWfHg+Zkbpb1I+oahq9hz9mpnLRHFiKrefyh9ZzVCmf9sqJMkSfcngHRMrv8MQ91WT2q5mBeOSXbpok4nXg==, tarball: file:projects/core-amqp.tgz}
     name: '@rush-temp/core-amqp'
     version: 0.0.0
     dependencies:
@@ -19156,8 +19657,8 @@ packages:
       '@types/debug': 4.1.12
       '@types/node': 18.19.66
       '@types/ws': 8.5.13
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       buffer: 6.0.3
       debug: 4.3.7(supports-color@8.1.1)
       eslint: 9.15.0
@@ -19168,7 +19669,7 @@ packages:
       rhea-promise: 3.0.3
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -19188,24 +19689,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-auth.tgz:
-    resolution: {integrity: sha512-2/zRN82mg2u9wY05YBvFovr4UtjJufNuslCMWFz6Izeb714PJ5ui/rKBkNSCGqF2rN/wYdRYEyjBoVPt3xvZ6A==, tarball: file:projects/core-auth.tgz}
+    resolution: {integrity: sha512-MaXn3CmICoRKYb6TlDHt4JSkdankNR0RKlPQREJgp4/pn34yUErfcdFoM4jgSJyhC0hBTkp+wI2EpW13sdaY+Q==, tarball: file:projects/core-auth.tgz}
     name: '@rush-temp/core-auth'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19223,24 +19726,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-client-1.tgz:
-    resolution: {integrity: sha512-5aveSHwePaeXSLXGtJoqNzrczR+H2982g41Q/hfAyR93MS0wuXC3j2nigqFb9Hsg7X89yd8Hp5yRiLzXCxDCnw==, tarball: file:projects/core-client-1.tgz}
+    resolution: {integrity: sha512-6fM/CI4P/T1qNhmpILLbTtrpZzIFFlCQKb115H5P+h6B+kdzSElrlMKDbzJob7af9IW0Nn32O3s8xSJ8Xpcr5A==, tarball: file:projects/core-client-1.tgz}
     name: '@rush-temp/core-client-1'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19258,24 +19763,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-client.tgz:
-    resolution: {integrity: sha512-5dh3EbYk/fk+XEee8QohXAIYVGiBlZ83HMxNbPM5PloKBPU1KR/XpxzE9meoCCZI/YXYde7y0XtJt0WrrMD0EA==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-u7s2Av91jtn4L9njaGPymA61ZZDdvq73QwrvtY/Lyr7EumdaPmkG171AI5yShiie9IKTRP78iC63oURDmV4ImQ==, tarball: file:projects/core-client.tgz}
     name: '@rush-temp/core-client'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19293,23 +19800,25 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-http-compat.tgz:
-    resolution: {integrity: sha512-qOdiUTJ9rDmwQJmnitpCp0NINREdG5D9EwIQ3kOT+YtiOVwhPGdLW43TN5dSE7ked8JBpt9A2WDDqHu44ZZQnA==, tarball: file:projects/core-http-compat.tgz}
+    resolution: {integrity: sha512-i+RZVJKfzFIlNthnzi7ungSEb+5zoz+LBgNT4gMk+C10fiiiD0wP8skMCFKDcqyMrmNpunKjWfeXmAoWLjnNtg==, tarball: file:projects/core-http-compat.tgz}
     name: '@rush-temp/core-http-compat'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19327,24 +19836,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-lro.tgz:
-    resolution: {integrity: sha512-cBsvf63Tx1YzHui0z45RnZ7cf1YO8mmMjWHAVKamM1qkgYjqAHlkuy8tHg58bX2UA2fD6zResUWrLFTeVcaGXw==, tarball: file:projects/core-lro.tgz}
+    resolution: {integrity: sha512-hsNRfrobAHPTGtTtsqKf5Jy11ZZHVH8jgrzs2clCVlcoxW9JDA0Gp5vfRMNzbGBj1EbRN+hjNFCf+Xay4qlq/A==, tarball: file:projects/core-lro.tgz}
     name: '@rush-temp/core-lro'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19362,24 +19873,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-paging.tgz:
-    resolution: {integrity: sha512-px6mk9CbnVeYyrkPiQyEzTxWYSljX8H0ErfmgqMztDUixkf5di4gATajF862TC9HZqhvu823m7TPYr6ZrcE6wg==, tarball: file:projects/core-paging.tgz}
+    resolution: {integrity: sha512-2DpFIroXl/UjB1NkN6Np5mmsgv5G1/ZaZfeZVGzqYq2t6h2C6T5aOVJ4abyZPh8i1XyIboPyYZStWqYXjFPl0A==, tarball: file:projects/core-paging.tgz}
     name: '@rush-temp/core-paging'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19397,26 +19910,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-cLY3mP8nNh39e2Z+HOapFC46okrP5yUhdCp11L7uTalzKw78YSdgczo/nDgeuEBQBbplEasTcPrqYsVSpwqpxQ==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-lv3dskT2vmbMXclpQpqWOjvLa7yovuhbU2MANf27MN0yIVJaWl6W7Hu6zGkleufK1DCs1d2vCDH1WvdV5lQsLg==, tarball: file:projects/core-rest-pipeline.tgz}
     name: '@rush-temp/core-rest-pipeline'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19434,20 +19949,22 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-sse.tgz:
-    resolution: {integrity: sha512-rxq/J1ftJ2e0MkPDv49RFsVQcu/68yCe6/h0R6+SdIkKBnhbYY12SkHzwOEOLFtemwLv+mh2SAqE6KHTYwJ8Lg==, tarball: file:projects/core-sse.tgz}
+    resolution: {integrity: sha512-oiaLxZQvVVIB8DzYF+6OH4b0tyigA/Z1NdoaX4s7ddaUGSJomgXxjDI1npBgPIE286Qa05pTkTYfo+ZhKRQ5lg==, tarball: file:projects/core-sse.tgz}
     name: '@rush-temp/core-sse'
     version: 0.0.0
     dependencies:
       '@types/express': 4.17.21
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       express: 4.21.1
@@ -19455,7 +19972,7 @@ packages:
       tslib: 2.8.1
       tsx: 4.19.2
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)(tsx@4.19.2)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19476,21 +19993,22 @@ packages:
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-tracing.tgz:
-    resolution: {integrity: sha512-4CmZFhCjzOgxIJxUQ3TtpCqlzz9WqVC40ObRj+7A819dmf7ZjHwkMWCY5uK1oa/HgCzDTJr9BAhWsJuAy8RXHg==, tarball: file:projects/core-tracing.tgz}
+    resolution: {integrity: sha512-q9zCna8DNovRlNCwCPyHMPrRxUqsM0Nuv8qxNt8e3KfHsmU99ailPZ8NA6AcqJQ7iwnwMR/w0qrX/UacmLmeOQ==, tarball: file:projects/core-tracing.tgz}
     name: '@rush-temp/core-tracing'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19508,24 +20026,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-util.tgz:
-    resolution: {integrity: sha512-ITGwI/UWm/wik2GMJMHcshniArRh9zY4RAh4cC8Qm3YPUmBDVYDnWaczz5varWczO6/3yNNeqFGCb7p4KQM/LA==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-mvpma+gu4veXzj77c5KWYUb5NGh3sucUxgW9zDniGL9wNNez3YV31nR1TRGih41GyFHIWF3bFVF3OMRt0d5wpQ==, tarball: file:projects/core-util.tgz}
     name: '@rush-temp/core-util'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19543,26 +20063,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/core-xml.tgz:
-    resolution: {integrity: sha512-GzkUuDtgvIBn354F3Fu1kg5qhh4tWLUptqtoMQVtyTsiaXx74vGD1L+cPqPg/mgowEwD1MsT+0BjKoAtm56RIQ==, tarball: file:projects/core-xml.tgz}
+    resolution: {integrity: sha512-sPxEPV0S+cNFOnaZ3PL5h8iWbKYeLerETSMsFiA/kBy/64MEJ9MO/CeqxDUt0E0pM9sSfQ+xSy1A0nzwO5XE7Q==, tarball: file:projects/core-xml.tgz}
     name: '@rush-temp/core-xml'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
       '@types/trusted-types': 2.0.7
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       fast-xml-parser: 4.5.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19580,13 +20102,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/cosmos.tgz:
-    resolution: {integrity: sha512-l5rV9Yu/fjvbShmu02iwVLOdLChhvsru7Ke7u8yG6uoPVQJK8Ruto5Y6gWeWaNiJ57yHruwQ+8iOiJj+fHuGuQ==, tarball: file:projects/cosmos.tgz}
+    resolution: {integrity: sha512-vqaUmjnQv6/AcvB8qItTtVZU67aCXR9vGQ6ZYw02Flauf9FKiHFxPQxDGXua5iDItLKGkR0smPDC0vc/xcsorA==, tarball: file:projects/cosmos.tgz}
     name: '@rush-temp/cosmos'
     version: 0.0.0
     dependencies:
@@ -19624,18 +20148,18 @@ packages:
     dev: false
 
   file:projects/create-microsoft-playwright-testing.tgz:
-    resolution: {integrity: sha512-B9WGzCSNUgX+6tno77dWcNkHz6R11S8AQnwV09k6RxLFfWIY1WGRtctRBlLOLUh28jjMNZILl5n+Q/pnl4t6xA==, tarball: file:projects/create-microsoft-playwright-testing.tgz}
+    resolution: {integrity: sha512-CMqmyZX7Kyeruq9KV9tc9MR1gxPLxCISQp1ybOHvZkJjWgwaKoGxqdgZduify4YxO3UafYY8Qh2iU6NN323+lw==, tarball: file:projects/create-microsoft-playwright-testing.tgz}
     name: '@rush-temp/create-microsoft-playwright-testing'
     version: 0.0.0
     dependencies:
       '@types/node': 20.17.8
       '@types/prompts': 2.4.9
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       prompts: 2.4.2
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@20.17.8)
+      vitest: 2.1.6(@types/node@20.17.8)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -19652,10 +20176,12 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   file:projects/data-tables.tgz:
-    resolution: {integrity: sha512-xODK4A1N6ov1xlxMr1oXEnY990Di6baXNlSEnh7YRKMICl2TPAYZIkTxuyDA79UHJnQJtbfbgFSc0TsSfYnmJg==, tarball: file:projects/data-tables.tgz}
+    resolution: {integrity: sha512-5+9UGIhTp4cFRK6s8Dp0D/Y0Ggu0Ixe/2CpbHaTnJ7yKyW4P8zQh87Px0mOfND1hr/VDyO40FUPK9KdQb47fjw==, tarball: file:projects/data-tables.tgz}
     name: '@rush-temp/data-tables'
     version: 0.0.0
     dependencies:
@@ -19696,7 +20222,7 @@ packages:
     dev: false
 
   file:projects/defender-easm.tgz:
-    resolution: {integrity: sha512-MLAU13wRdZyx1md95NqJXLQx7CVsNC90D0xQb1VaqHNDEcElaggArHAFWeVDcdfnw5Wlt+TFa1RcfEOuyY/Bgw==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-3tSB3ZTpzCFwRfBbww1kDesnenKVMWFJReitQ2L16ZIggHktX9ZoKxoxECMp88hf/a5mu0cQLP7od7ZhRgdV1Q==, tarball: file:projects/defender-easm.tgz}
     name: '@rush-temp/defender-easm'
     version: 0.0.0
     dependencies:
@@ -19739,7 +20265,7 @@ packages:
     dev: false
 
   file:projects/dev-tool.tgz:
-    resolution: {integrity: sha512-XCBnKpGSW22BE7usDIwYyn3OCoVLKK7sItBOUvWEvQhqXgJcMP6zEL6NpUmN8WkCpuO2ZIfxEdfJamIhpb3XQg==, tarball: file:projects/dev-tool.tgz}
+    resolution: {integrity: sha512-gAmWkc3vUpW43oagZR+CnjMaNV3IVxhAto3tbPuOMfBLr5FRTvgd+d+gU58jJW5TjKnEm2T3VmRxENY9nD5hWw==, tarball: file:projects/dev-tool.tgz}
     name: '@rush-temp/dev-tool'
     version: 0.0.0
     dependencies:
@@ -19763,7 +20289,7 @@ packages:
       '@types/minimist': 1.2.5
       '@types/node': 18.19.66
       '@types/semver': 7.5.8
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       builtin-modules: 3.3.0
       chalk: 4.1.2
@@ -19777,7 +20303,7 @@ packages:
       fs-extra: 11.2.0
       minimist: 1.2.8
       mkdirp: 3.0.1
-      prettier: 3.4.0
+      prettier: 3.4.1
       rimraf: 5.0.10
       rollup: 4.27.4
       rollup-plugin-polyfill-node: 0.13.0(rollup@4.27.4)
@@ -19792,7 +20318,7 @@ packages:
       typescript: 5.6.3
       typescript-eslint: 8.15.0(eslint@9.15.0)(typescript@5.6.3)
       uglify-js: 3.19.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(tsx@4.19.2)(yaml@2.6.1)
       yaml: 2.6.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -19815,20 +20341,20 @@ packages:
     dev: false
 
   file:projects/developer-devcenter.tgz:
-    resolution: {integrity: sha512-Udy5L39qvC1bAYmkcYQ62Pj7frKtq+q6xGml9ppF+yBSMoew6HHzZVHqMi3kExEbqZX4uPABBG5nEbPdd/qDYA==, tarball: file:projects/developer-devcenter.tgz}
+    resolution: {integrity: sha512-dYdMYevys48DPPWwjE4SbgQQ4YQAkAGAhCI30Oey7XfVWPNqvNU6YFMmJVnFwytW9QBv3vi2cGZ5TtzNOskLZg==, tarball: file:projects/developer-devcenter.tgz}
     name: '@rush-temp/developer-devcenter'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 3.0.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19846,13 +20372,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/digital-twins-core.tgz:
-    resolution: {integrity: sha512-nKRSIQm5cqW1j4RbzNJUFNN91ChO4tzpWvV5CiBvWS6XteK20Y+ogMxj66r6/3GmKiaxKMKLTFbXZaYXpjXc1A==, tarball: file:projects/digital-twins-core.tgz}
+    resolution: {integrity: sha512-gXa2pxVpc+HJ3mtsoIG7ghlA7Of8ro9x6U3E1zwsuHLBwcyBGdLb69AjZdMhd+kAwl9cyTVv0Yerjrxywioghw==, tarball: file:projects/digital-twins-core.tgz}
     name: '@rush-temp/digital-twins-core'
     version: 0.0.0
     dependencies:
@@ -19895,7 +20423,7 @@ packages:
     dev: false
 
   file:projects/eslint-plugin-azure-sdk.tgz:
-    resolution: {integrity: sha512-wjvMu2Em7IHf1Yac5e1uw0wP8BXisiTMVkLDqorysR2GqhLy8Bp1hIUw5f3noPL5CDWVMrNHOacCnIuf/soE8w==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
+    resolution: {integrity: sha512-jwjKuwVTFJPPPv88Us338ifijLZjIbfbRQQswWKe2RdwapQIPTkAus2sJfZXrS/1zpfXx+APM4FKIBJfVu8jgw==, tarball: file:projects/eslint-plugin-azure-sdk.tgz}
     name: '@rush-temp/eslint-plugin-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -19921,7 +20449,7 @@ packages:
       eslint-plugin-promise: 6.6.0(eslint@9.15.0)
       eslint-plugin-tsdoc: 0.2.17
       glob: 10.4.5
-      prettier: 3.4.0
+      prettier: 3.4.1
       rimraf: 5.0.10
       source-map-support: 0.5.21
       tslib: 2.8.1
@@ -19946,7 +20474,7 @@ packages:
     dev: false
 
   file:projects/event-hubs.tgz:
-    resolution: {integrity: sha512-j9YciF9vtRTK7EMgIG5h9jMcJ/v8iPNtlelLJCMP3pDfQ9wlL+C/hH9S9V861470ISevdwBCuYIAEGru8Lbsiw==, tarball: file:projects/event-hubs.tgz}
+    resolution: {integrity: sha512-OrnW9HtSOMn0TRrdBWQB20xfJ1o2MK1+cuGZBdA34aKF9oh+j/OBmCHyxEEuwqomLmFH7263RqEvlKISMZvM9g==, tarball: file:projects/event-hubs.tgz}
     name: '@rush-temp/event-hubs'
     version: 0.0.0
     dependencies:
@@ -19955,8 +20483,8 @@ packages:
       '@types/debug': 4.1.12
       '@types/node': 18.19.66
       '@types/ws': 7.4.7
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       buffer: 6.0.3
       chai: 5.1.2
       chai-as-promised: 8.0.1(chai@5.1.2)
@@ -19973,7 +20501,7 @@ packages:
       tslib: 2.8.1
       tsx: 4.19.2
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)(tsx@4.19.2)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -19996,10 +20524,11 @@ packages:
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/eventgrid-namespaces.tgz:
-    resolution: {integrity: sha512-Wd58Mi30gLxzNV/3UQRMv8/cQAtIuZ42VA26P+B9zOLq0yVN336r1POexl2IqHfQ4YzHfI6gh0my7v1jB4v/BA==, tarball: file:projects/eventgrid-namespaces.tgz}
+    resolution: {integrity: sha512-tIjcfIo0WstYPSVLemK/6CQZG53Bxi+66Y70pc2ebZ6+Orjk9cod8li6GaGSHwCX3wd4hWJ0d80nIw+7tBFIHw==, tarball: file:projects/eventgrid-namespaces.tgz}
     name: '@rush-temp/eventgrid-namespaces'
     version: 0.0.0
     dependencies:
@@ -20044,7 +20573,7 @@ packages:
     dev: false
 
   file:projects/eventgrid-system-events.tgz:
-    resolution: {integrity: sha512-Tw1HTrvyfyTsDkGoctasSt5CUXyDQcjYSpYZcU9Vpqw47tUDeMP1Vr5dOMMsJ53Y3VzHCXlALCDDxHP3lk6zXw==, tarball: file:projects/eventgrid-system-events.tgz}
+    resolution: {integrity: sha512-BG5/u9aaFv62K7q8271pQFN6IypwCqsnMP2UzzVp1CyRcTvYDaK+q9MB2kQKkchw8DzhsOb3JxhnSD6ft+TRXg==, tarball: file:projects/eventgrid-system-events.tgz}
     name: '@rush-temp/eventgrid-system-events'
     version: 0.0.0
     dependencies:
@@ -20089,7 +20618,7 @@ packages:
     dev: false
 
   file:projects/eventgrid.tgz:
-    resolution: {integrity: sha512-/TNBsgSdupaAAeAhkkutA9OWjS+w5lX5OBmIiHqeEMfaH1j4ZZ2TeykFw9KFRFVA6fsaNxWCJeJ1fRvz2ovkYQ==, tarball: file:projects/eventgrid.tgz}
+    resolution: {integrity: sha512-2wX990zto4al8gUtJr9nhuUaV8VJ1/qrGjMUNMC5ZNfHGKG0/wVBUu+3I/KVOV53q5jUSArz0jVvdrdnu975xw==, tarball: file:projects/eventgrid.tgz}
     name: '@rush-temp/eventgrid'
     version: 0.0.0
     dependencies:
@@ -20131,7 +20660,7 @@ packages:
     dev: false
 
   file:projects/eventhubs-checkpointstore-blob.tgz(chai@4.3.10):
-    resolution: {integrity: sha512-QIMCv2kTVX8O/o5j/9cm9cj3M1Yu68nIK2z4ubzIx+w0ZJ4Sby3hc2F+UFe5oj59UyA29uZLX6sfITm7+SuKgQ==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
+    resolution: {integrity: sha512-fAlgQyS4WoXlCQiMfoHerr1HbZG8q4bAkuJwnSjUkSkH1JPeGoX0CuHaQVqv7YFqPjn4R3M0nvxLBaILlZTnJw==, tarball: file:projects/eventhubs-checkpointstore-blob.tgz}
     id: file:projects/eventhubs-checkpointstore-blob.tgz
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     version: 0.0.0
@@ -20140,8 +20669,8 @@ packages:
       '@types/chai-as-promised': 7.1.8
       '@types/debug': 4.1.12
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       buffer: 6.0.3
       chai-as-promised: 8.0.1(chai@4.3.10)
       debug: 4.3.7(supports-color@8.1.1)
@@ -20153,7 +20682,7 @@ packages:
       tslib: 2.8.1
       tsx: 4.19.2
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)(tsx@4.19.2)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20176,10 +20705,11 @@ packages:
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/eventhubs-checkpointstore-table.tgz(chai@4.3.10):
-    resolution: {integrity: sha512-shPBb4XPKzwZkYDOvEn5AqC4nSdal0o+RW0dFDOE1FAdPmN5uyouad+Na48MtP3aHiDL9ObtRPeh5xkX905SIw==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
+    resolution: {integrity: sha512-1pE9xN7CYQeQJs0qqojrTYhUWCTn2/SNab5NAdJnto45T7nws40Ky+QXrpyDUJWZ6RhfX8fbFCjpgC8gsOUZeA==, tarball: file:projects/eventhubs-checkpointstore-table.tgz}
     id: file:projects/eventhubs-checkpointstore-table.tgz
     name: '@rush-temp/eventhubs-checkpointstore-table'
     version: 0.0.0
@@ -20188,8 +20718,8 @@ packages:
       '@types/chai-as-promised': 7.1.8
       '@types/debug': 4.1.12
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       buffer: 6.0.3
       chai-as-promised: 8.0.1(chai@4.3.10)
       debug: 4.3.7(supports-color@8.1.1)
@@ -20200,7 +20730,7 @@ packages:
       stream: 0.0.3
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20220,13 +20750,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/functions-authentication-events.tgz:
-    resolution: {integrity: sha512-oFukFmJk2iIPQauvOB5HqP7CTjE7CbaLyi+szryLRSCDHcBc+mphI5f+q1Jk4GXWgXjQJXDhmJHUZog2FRn8HQ==, tarball: file:projects/functions-authentication-events.tgz}
+    resolution: {integrity: sha512-CgCgnl3kr2zaJNMhN5QkT7ToqOXE7MUltb+k7z9FKzD/ezlcuzzskGHZfP04GgPcPC5FcP5iDoqP/JpqUL0s2A==, tarball: file:projects/functions-authentication-events.tgz}
     name: '@rush-temp/functions-authentication-events'
     version: 0.0.0
     dependencies:
@@ -20268,20 +20800,20 @@ packages:
     dev: false
 
   file:projects/health-deidentification.tgz:
-    resolution: {integrity: sha512-6LdN/I3/IT+r5A4w8Ac5rRXYnfUzCGhSyEhSq0zB1vEsyX0oOz5viCnGYYqmiyOOfGvgqaMBOk4KwrCCeMcTOA==, tarball: file:projects/health-deidentification.tgz}
+    resolution: {integrity: sha512-mkAo3loCilNcP1RMyye891o2wlceeG10uXyEp+yA6v6DGFjEeDATNcG1oPc13C9HJrHtnMOT363SzdPZaMjfZA==, tarball: file:projects/health-deidentification.tgz}
     name: '@rush-temp/health-deidentification'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       loupe: 3.1.2
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20299,27 +20831,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/health-insights-cancerprofiling.tgz:
-    resolution: {integrity: sha512-VbNwjG9FeYaNHVZ5ccHivYA5aMTBQaj9e/3S1qhujNHdW79W4w9R989l0SMtitK7WXcC7OfQunMVVA/v5BKPeA==, tarball: file:projects/health-insights-cancerprofiling.tgz}
+    resolution: {integrity: sha512-ItQOoWA9pHcbXPag2OUTMtwsVc7DtKRTDVj90TztPuJwC4+2KkKVSeLRe33E9/wlu7RAgHFAvhnnLMKoXLauGA==, tarball: file:projects/health-insights-cancerprofiling.tgz}
     name: '@rush-temp/health-insights-cancerprofiling'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20337,27 +20871,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/health-insights-clinicalmatching.tgz:
-    resolution: {integrity: sha512-gPS26NLHskZBUrKuYf6hZouvsKGu6G09W2sGxPEnaCTj5KGmZN/aL9K9WOchcwTcY5HBQM98VwV3EEhTeNYiag==, tarball: file:projects/health-insights-clinicalmatching.tgz}
+    resolution: {integrity: sha512-lvlsNudRLygY96kepx6kBKv3D+jtu/0DcXksdvXt5udedjrMDFf+Fb/UAwLLkh7NO7YZeQf9ykSd5LzTXBdDdg==, tarball: file:projects/health-insights-clinicalmatching.tgz}
     name: '@rush-temp/health-insights-clinicalmatching'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20375,27 +20911,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/health-insights-radiologyinsights.tgz:
-    resolution: {integrity: sha512-IC51lwhRQqr8r5PP7rrUwlrQXDDWlI0DbP2GE8H2prk+A9IauQB7CIHrjosRCtJINIMMaQJXa2roHF5GVtbv0w==, tarball: file:projects/health-insights-radiologyinsights.tgz}
+    resolution: {integrity: sha512-i6f3uHmWMSdQuyzgxccApXM++5NuXDOdL5LcKdYOcCfs4dTnbDxJQv8jXGAj0uTpmxK5WlFCuONp1/hmOCQt3g==, tarball: file:projects/health-insights-radiologyinsights.tgz}
     name: '@rush-temp/health-insights-radiologyinsights'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20413,27 +20951,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/identity-broker.tgz:
-    resolution: {integrity: sha512-vq3L3DyNQvVXqYonnD5vweOxzUQrulNdo7115ZCAV7e1y7Q0GfwvwC5k5LyeCY0F5TT3iQuUwHBDIE15/EMYpg==, tarball: file:projects/identity-broker.tgz}
+    resolution: {integrity: sha512-jxsXZKFYsNTKWg92RTKJSSXCo6LweRc9wCmHUKqi9I1/bXKH+HfDAQIU/PU8jS2N/hKRhbJU/FFEYLHt8MZowA==, tarball: file:projects/identity-broker.tgz}
     name: '@rush-temp/identity-broker'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/msal-node': 2.15.0
-      '@azure/msal-node-extensions': 1.3.0
+      '@azure/msal-node': 2.16.2
+      '@azure/msal-node-extensions': 1.5.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20451,19 +20991,21 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/identity-cache-persistence.tgz:
-    resolution: {integrity: sha512-0thxM8DrK7tB2vOmAf2w7m99QKSRMHuwlc7ALykcHGiEAbCN9JEbVdT+b0sEGjqna89Vl5KQJtjRRktLnFPDCw==, tarball: file:projects/identity-cache-persistence.tgz}
+    resolution: {integrity: sha512-m4FV+2itMbtVaJIwNsRRhkt69/BR/DHBhTo8zw5+nGZB6pm6/flJ6Mx75tTvJKbKdCBJGw3ku5pwG7M1iq6R/Q==, tarball: file:projects/identity-cache-persistence.tgz}
     name: '@rush-temp/identity-cache-persistence'
     version: 0.0.0
     dependencies:
       '@azure-tools/test-recorder': 3.5.2
-      '@azure/msal-node': 2.15.0
-      '@azure/msal-node-extensions': 1.3.0
+      '@azure/msal-node': 2.16.2
+      '@azure/msal-node-extensions': 1.5.0
       '@types/jws': 3.2.10
       '@types/mocha': 10.0.10
       '@types/node': 18.19.66
@@ -20490,7 +21032,7 @@ packages:
     dev: false
 
   file:projects/identity-vscode.tgz:
-    resolution: {integrity: sha512-7wFwOEU77YA+6eg2Xs7S8xD4eXOUfUcPc4Ic8g2JDQ1COfG1Sh6MiADCcnB8jFbjLrTLGUr/XsqI0eu9oOX/bA==, tarball: file:projects/identity-vscode.tgz}
+    resolution: {integrity: sha512-1pmJAZOLrjGBP8zx++96pBq+vyajPEoTfAW/+qtd6fwzoUrIos0ka2VOpVMzqh82pl08sG/LWbqzjXKHJLwMNw==, tarball: file:projects/identity-vscode.tgz}
     name: '@rush-temp/identity-vscode'
     version: 0.0.0
     dependencies:
@@ -20522,20 +21064,20 @@ packages:
     dev: false
 
   file:projects/identity.tgz:
-    resolution: {integrity: sha512-P0HbQwwg1mF2aczzbJ5iXPm+nf8N/iWXqAupzCtVBFQ+VC1OrVIQhL987fdKgpl/3c2LD4KdEm0rf9IoqO9/lQ==, tarball: file:projects/identity.tgz}
+    resolution: {integrity: sha512-RMsM6Q4q0FFSeNIuAZv7DilPSSCtM+NAN1mPJcYQsF51982xOWvtNeeSNldwDfG1tNx0ee6RRH6M1wWh0VXVvQ==, tarball: file:projects/identity.tgz}
     name: '@rush-temp/identity'
     version: 0.0.0
     dependencies:
       '@azure/keyvault-keys': 4.9.0
-      '@azure/msal-browser': 3.26.1
-      '@azure/msal-node': 2.15.0
+      '@azure/msal-browser': 3.27.0
+      '@azure/msal-node': 2.16.2
       '@types/jsonwebtoken': 9.0.7
       '@types/jws': 3.2.10
       '@types/ms': 0.7.34
       '@types/node': 18.19.66
       '@types/stoppable': 1.1.3
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       events: 3.3.0
@@ -20549,7 +21091,7 @@ packages:
       tslib: 2.8.1
       typescript: 5.6.3
       util: 0.12.5
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20567,13 +21109,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/iot-device-update.tgz:
-    resolution: {integrity: sha512-j+/7pjRuxaNdX1fkGEa6LLEMmGp6LDV6z5RimV7GRnBRVlrYBgK3bfd4YdqYdNrg5Z4aksGwIcU+dt4Q+/yzRg==, tarball: file:projects/iot-device-update.tgz}
+    resolution: {integrity: sha512-PFeo/YnmOhvjNuisJzkoD0lsoY9qEfzbU8c+XPsCqQDwsT+SDTmg2qc3BxnC0+OZTY4xjlRndrkPisBcIx70gA==, tarball: file:projects/iot-device-update.tgz}
     name: '@rush-temp/iot-device-update'
     version: 0.0.0
     dependencies:
@@ -20616,19 +21160,19 @@ packages:
     dev: false
 
   file:projects/iot-modelsrepository.tgz:
-    resolution: {integrity: sha512-hJMVERfcQNl1arQVH2kNoM2in/mmJ4z6kwm2udCgcU8OnrJoJUVCFELh1hBxKpbIFkwb3DJLs8Racg2WNo8dBw==, tarball: file:projects/iot-modelsrepository.tgz}
+    resolution: {integrity: sha512-NjV3eBHtbskfVkp8MCjNm+HsfuIOHk5Ar4qsB1SU8V/FXgd7zY45UZJ93/FVe30vMkqA5azc92vouft2on/E6Q==, tarball: file:projects/iot-modelsrepository.tgz}
     name: '@rush-temp/iot-modelsrepository'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       events: 3.3.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20646,26 +21190,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/keyvault-admin.tgz:
-    resolution: {integrity: sha512-4T4Drp4Ho5XDjqmusRaUkqzfMRXIP5g2wNH4/yQLP+IKrwX6cIRBA7VjIXn9iYFikcw8+Dyove8130WKf6KnAQ==, tarball: file:projects/keyvault-admin.tgz}
+    resolution: {integrity: sha512-SmFpcLDjU01YLFcWaokPpeufk1j+Tl6/d5BFTA3tf8ODxbIP0veHEN8ZUFDdA91GoiWS0P8CmjJjoWc3uULK7w==, tarball: file:projects/keyvault-admin.tgz}
     name: '@rush-temp/keyvault-admin'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20683,26 +21229,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/keyvault-certificates.tgz:
-    resolution: {integrity: sha512-hHHFZjEUX2s1FPN5WTYcqoT1hqSFS7iJnQvqh6nFyknX+Z9pOUl5+gU6gaxGxwYiLV3yPo+wYN4+w/S9K9x7DQ==, tarball: file:projects/keyvault-certificates.tgz}
+    resolution: {integrity: sha512-BzOVbb1bEBGAVwmpqEW+F1mjHXqinv7c32iOFnOAXKMan0YNFIbMNpFnwh2UHqX4V+OrBkgs56+w/g5FVjS6eQ==, tarball: file:projects/keyvault-certificates.tgz}
     name: '@rush-temp/keyvault-certificates'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20720,24 +21268,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/keyvault-common.tgz:
-    resolution: {integrity: sha512-rTXsqvFYag+m2JKDGB2LuWRhQ/I87lcBSEe2rR5XXBCv/nqLjTZn273dRDGiLm+fTb/c03Vy3higYqgStuCNZg==, tarball: file:projects/keyvault-common.tgz}
+    resolution: {integrity: sha512-AaNYahcED4uWLxyFBz1klGaMhES44moirxn4G3RdaOJM0QSWD0HdkIfrgGkoPyBp4k1VIXiFcW9jqQTKLAZgxQ==, tarball: file:projects/keyvault-common.tgz}
     name: '@rush-temp/keyvault-common'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20755,27 +21305,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/keyvault-keys.tgz:
-    resolution: {integrity: sha512-Y2UfpOV8HfTmUGL1uYR7FJM2bNyeTyMQ2pD0+9u/uHIuZmuIgfX3aYMtn0ZmIaspNXDDnzUEDahvgKZbJsd0Pw==, tarball: file:projects/keyvault-keys.tgz}
+    resolution: {integrity: sha512-uaGv6yMXEPNLJSoqNWPj0/fRACbZZk7HVk7VTGbqjNWouJJjTm0GlaGyiHHeyUG2i/+JCubFgD5OPDeqGWsBmQ==, tarball: file:projects/keyvault-keys.tgz}
     name: '@rush-temp/keyvault-keys'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dayjs: 1.11.13
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20793,25 +21345,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/keyvault-secrets.tgz:
-    resolution: {integrity: sha512-XdGtBXoiBvpODd8UhGwxazB7/nQiYZxp2/mMGE/pwVKyi64zTVMa7FZKGnJolBlWvycaJJ8Qxql3Eg3c9EvDOg==, tarball: file:projects/keyvault-secrets.tgz}
+    resolution: {integrity: sha512-ortAK5U+6zao147VOhIYkWTwnLtfKnGEhv4Q1ysdRkHSCBZHnY5JNP6ZIhn33lC9J4mu72EVL0EpviPym5pNTg==, tarball: file:projects/keyvault-secrets.tgz}
     name: '@rush-temp/keyvault-secrets'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -20828,24 +21382,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   file:projects/load-testing.tgz:
-    resolution: {integrity: sha512-mWVb1m4MgOwmwvtCgw+GpN4BwujiAzXpm+2lWJdLgtH4EFCwkLQWaefkaSqlyXMEXqCy/lPJYAS4hXrIP7DkEg==, tarball: file:projects/load-testing.tgz}
+    resolution: {integrity: sha512-Z/QG10wcp5gZv8JUANBYVEJ0hYX8RS4QztuaOFoTSAzLiIdq1orqtXAU/O8dfJe5TzITjsdy/YRoTpyQUAFgPg==, tarball: file:projects/load-testing.tgz}
     name: '@rush-temp/load-testing'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20863,25 +21419,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-8fQDOieFeyQCxjSYMdXHCt7P4sZA75rTVR5Vsc0zD4g+x5k/PW2ZXILXlHiVNhoSmN1A7tBoQZILI0z0Bo7rBg==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-FM2KtW/4yaJi62BL3l9zyep3ImhUqCI5w9JT2zGrapJJgkCzOv4by4ukNU8k1ZDTXzT9FxuMt9XE/s+q9dx7Yw==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20899,25 +21457,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/maps-common.tgz:
-    resolution: {integrity: sha512-7IIkOs3sUOtOgIdp3Ub14NUBdqW6KtzCuwnnyFt7gxK9Fq2vUpn/77XOOZ/pnh7agJHiMZj+Y/0nYmcmCKYu+A==, tarball: file:projects/maps-common.tgz}
+    resolution: {integrity: sha512-APLUTjFnFqSCgrrCBVk4nDL6k07wMlMeHZCCFGz1rkR6IYIdHugUC482lpUPsmrkYb7NmI3KA6juzP/IRDsHOg==, tarball: file:projects/maps-common.tgz}
     name: '@rush-temp/maps-common'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20935,27 +21495,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/maps-geolocation.tgz:
-    resolution: {integrity: sha512-pmNHm5WCIRn8MxaO6SWedBhcV/fSxsZ1SAVnA/n0XaDm9ra21chQXMxzznlSNAWOFv4hxt0LYczZnfsHOlgo2g==, tarball: file:projects/maps-geolocation.tgz}
+    resolution: {integrity: sha512-TFJ+NgJ7vFZ7BSJkkwuykpRFo8Nq+wYpSx3m33PiApN8sNcdlM8fb47TbNpju+oEknHV9RsUaqO3rvxJiOTMLg==, tarball: file:projects/maps-geolocation.tgz}
     name: '@rush-temp/maps-geolocation'
     version: 0.0.0
     dependencies:
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20973,27 +21535,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/maps-render.tgz:
-    resolution: {integrity: sha512-QAN/KrCWpGIXIWoapOwdtSefJ5ZjzaWvD/yy7sWXZyzFSPftL11l12oXJcE+iBy5409gXNlMuH9ZKj6DgA/tGA==, tarball: file:projects/maps-render.tgz}
+    resolution: {integrity: sha512-orzj7rlshl7UDDVMDX26HapJOJumUcdmyQMfMfsOBY4tTcHlkfVl1E9kqoZgtbQuMCDmKhGpGLc62EMESeA4pQ==, tarball: file:projects/maps-render.tgz}
     name: '@rush-temp/maps-render'
     version: 0.0.0
     dependencies:
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21011,28 +21575,30 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/maps-route.tgz:
-    resolution: {integrity: sha512-5+w6/ULXCxZtXZhoJ5l7+MKUKaQIx49viOcfYMVGjQw0vi0Tq59nx9Qrl6qWos6BC1kILM5uINp8W47dBpCNWA==, tarball: file:projects/maps-route.tgz}
+    resolution: {integrity: sha512-YZi0GdL4JhTadOTlX1anuv/W2vimmTyvU7n1ORdJH4RtevP3qSAx8+w6nacgI5Y/XY70bJApKljBCC0cE4OdTA==, tarball: file:projects/maps-route.tgz}
     name: '@rush-temp/maps-route'
     version: 0.0.0
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21050,28 +21616,30 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/maps-search.tgz:
-    resolution: {integrity: sha512-3L9N9SrTi+SdvxB/8TQWgZDIuBtS6ODj8qc+QNqdc5XyToQop38/Hh6GV+xVt+W28umT3ZufBQbz9dA5McL/6w==, tarball: file:projects/maps-search.tgz}
+    resolution: {integrity: sha512-OgjgbEL/irDpw71WTiGSMZT3FEmVYMw/ehUAGm7qUY1cozsH7K5HI6c2h2RC9LIQL8ithTD/5lrm7OPthxFxfw==, tarball: file:projects/maps-search.tgz}
     name: '@rush-temp/maps-search'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21089,13 +21657,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/microsoft-playwright-testing.tgz:
-    resolution: {integrity: sha512-LOfcpsGhkCQlf/ONHLHqjTVgWCasb0ImH6OcRwRpzkO4ybQbiAi4eQvnD2CVwpoa3crRHI9hebbLeSvBsBKAVA==, tarball: file:projects/microsoft-playwright-testing.tgz}
+    resolution: {integrity: sha512-v7f81MeQnLjoFiJl9bZdDKBjsOiprSe3T/ZGpJDWb6364W3Xv/Bgg+HY80C2UQTumsNSOMuds1uTVWKhmfIPoQ==, tarball: file:projects/microsoft-playwright-testing.tgz}
     name: '@rush-temp/microsoft-playwright-testing'
     version: 0.0.0
     dependencies:
@@ -21115,7 +21685,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-authentication.tgz:
-    resolution: {integrity: sha512-hIZoFTkE8J6rHj93GQHuFB05PUPHWq+LiWgFIacamW2tTo1Ej1Q1+04Y4RUdZiaUTEPrrWgVM2hKKclbLO2pTA==, tarball: file:projects/mixed-reality-authentication.tgz}
+    resolution: {integrity: sha512-g1iEPkbDqLPEmr9rP27uURDLvWp9nHUhX9Gdw4ui8LflQi4s6XxggamYC01nyAYjpY10Xt9/vOm2aFG6c0/X7Q==, tarball: file:projects/mixed-reality-authentication.tgz}
     name: '@rush-temp/mixed-reality-authentication'
     version: 0.0.0
     dependencies:
@@ -21156,7 +21726,7 @@ packages:
     dev: false
 
   file:projects/mixed-reality-remote-rendering.tgz:
-    resolution: {integrity: sha512-LR01bnuhUjLmqWd+4Ti/9Dywdu8VzgOZEi8mjK9OX0DQeXH9BItASAMtCrmzSwffCdEORSMg8jbFXb1wAjFO/w==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
+    resolution: {integrity: sha512-5AGul9NjObclTg3c6o27eWsMc325aSAfTsm52DzHlE/FwEFJvvgogTZveoRdrg3tdX9JZ412NPi2of5ZuQT+mQ==, tarball: file:projects/mixed-reality-remote-rendering.tgz}
     name: '@rush-temp/mixed-reality-remote-rendering'
     version: 0.0.0
     dependencies:
@@ -21200,19 +21770,19 @@ packages:
     dev: false
 
   file:projects/mock-hub.tgz:
-    resolution: {integrity: sha512-XQS2MMS5Q1hRiH/QR6+Swm4E+0t/Gx5x8pQLGO/tmsyxmD/YrRmVUrSweu8BTNRTnBvHj+eHR0Src+iPlYdZLg==, tarball: file:projects/mock-hub.tgz}
+    resolution: {integrity: sha512-HM29hTOMGgvBnyY4hiFX+PjNDyI7UBDrmkviCuYCp8USUCb5ILUhIggVpJKrZ3gvKPslySsua5h/TEe00FFG2w==, tarball: file:projects/mock-hub.tgz}
     name: '@rush-temp/mock-hub'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       rhea: 3.0.3
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -21229,24 +21799,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
     dev: false
 
   file:projects/monitor-ingestion.tgz:
-    resolution: {integrity: sha512-pllRWLfOMD+ngWvcILVdzLi1f1XtozTseyFDESOKh67IT3MbSBExuav0w6vQOk2H5E88cpYU8mh0c/kFn2/Iwg==, tarball: file:projects/monitor-ingestion.tgz}
+    resolution: {integrity: sha512-S9cn6iJynScspi51A6UlyWP+hAKBcLfj8GUWZELiBf47/bnQocs+6FLdghH+wnd0rFXc7wL9JS36J9UgwGNIlA==, tarball: file:projects/monitor-ingestion.tgz}
     name: '@rush-temp/monitor-ingestion'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
       '@types/pako': 2.0.3
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       pako: 2.1.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21264,13 +21836,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/monitor-opentelemetry-exporter.tgz:
-    resolution: {integrity: sha512-0VIQPgToKmqe3LLOimazhF7mNr9QLYfopAFLP/2is/l8UOKnEhmj3McflVLq5viuYv0fAI2Xp2P8UH+48x8CsA==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
+    resolution: {integrity: sha512-sx401G9cVpYtfnHJ7TkX//x/jkYIGwzPzh4pE3oIeaSN2aGwX7YoyUTqF9RzmJul7uHk2f9CbGsZhMhW9de/XQ==, tarball: file:projects/monitor-opentelemetry-exporter.tgz}
     name: '@rush-temp/monitor-opentelemetry-exporter'
     version: 0.0.0
     dependencies:
@@ -21286,15 +21860,15 @@ packages:
       '@opentelemetry/sdk-trace-node': 1.28.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       nock: 13.5.6
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21312,13 +21886,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-SqkTFQ9XDW6780y/y4kwohv9eV+fi/f4jqDjPwOW1Y0+Uz1gQLssjbSPaTnRDiTa9i+tJLLUiTE/VeV9BCtDUA==, tarball: file:projects/monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-EulrPsbct992rAKyqBuW8wDgu/zn2SMgO9e43X4kjxqihkxRIcKiqZknhMVXPK9G3TlLM1SzhgrUdpa7m22WPg==, tarball: file:projects/monitor-opentelemetry.tgz}
     name: '@rush-temp/monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -21364,7 +21940,7 @@ packages:
     dev: false
 
   file:projects/monitor-query.tgz:
-    resolution: {integrity: sha512-9g40nZJQraBhs00SI0bhtABIQoOPM7dM9BoyQexZKVcVfcK4IuUbXeiKkIuIzoTi29aosXakOmRDUQqBDQBDPA==, tarball: file:projects/monitor-query.tgz}
+    resolution: {integrity: sha512-eshGHARttGQDBtjUCP+oglqlsp+rTrLhUfSRCaSjbVle3oX0xQYsEYdiebCRgGRceaWGTBwSmVCpqIJcS2BLXA==, tarball: file:projects/monitor-query.tgz}
     name: '@rush-temp/monitor-query'
     version: 0.0.0
     dependencies:
@@ -21372,14 +21948,14 @@ packages:
       '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.28.0(@opentelemetry/api@1.9.0)
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21397,26 +21973,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/notification-hubs.tgz:
-    resolution: {integrity: sha512-g1pwLcMuOaTjljwQ9fIY6KM/uZTSTiZReOl36Q5kftxvBjt7gBY0/x0Hjse6TNq/SsgJQNkAgjR5K+grm5Oo0Q==, tarball: file:projects/notification-hubs.tgz}
+    resolution: {integrity: sha512-taB2ayKr9Jta1CJqRgHw1SDyihI8nvONNs7aIEcrVrUp2IWpctD1MJTX6QL4vTQksN67TCUhTQhiJOSspAIQgg==, tarball: file:projects/notification-hubs.tgz}
     name: '@rush-temp/notification-hubs'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       tsx: 4.19.2
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)(tsx@4.19.2)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21437,23 +22015,24 @@ packages:
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/openai.tgz:
-    resolution: {integrity: sha512-HbvC8ZldtA4WQ2pLFQaqYn7GBJbve7a4L/FlCFInJL8qXMDqC0B0by+XFQRFwJNyhR16BUE4OzqLtmr0RZHi0A==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-Ayz/zG30ZSe0jXkIRjdOoksLPbt9U6yytg/B2tmfKFE5Y5549i5gtnjVoXfns7zZ7E508ipjBYue0RGZ/Gg7/g==, tarball: file:projects/openai.tgz}
     name: '@rush-temp/openai'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       openai: 4.73.1
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21472,14 +22051,16 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
       - zod
     dev: false
 
   file:projects/opentelemetry-instrumentation-azure-sdk.tgz:
-    resolution: {integrity: sha512-j4jZQSrXrI310NB0Z7+SkHC52HmR4ezkGFRtaKwIj1lvDbi7qqjgzrEEqVm1ueHl0ipaNmZ1vZJyIqWoZCqZow==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
+    resolution: {integrity: sha512-z8t0kAu3PLvUiWxDt9lyeOXvRnuY2oE/ZvwcP/NOo9y0v6vM2wFIapQdaRr4m+LRIVv4DJzqA2NBvFtoxgkKOw==, tarball: file:projects/opentelemetry-instrumentation-azure-sdk.tgz}
     name: '@rush-temp/opentelemetry-instrumentation-azure-sdk'
     version: 0.0.0
     dependencies:
@@ -21489,14 +22070,14 @@ packages:
       '@opentelemetry/sdk-trace-base': 1.28.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.28.0(@opentelemetry/api@1.9.0)
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -21514,13 +22095,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/perf-ai-form-recognizer.tgz:
-    resolution: {integrity: sha512-DvSsfDIsOdgKWVvDZ5g+TkyaXikP7Siklw/UqDH/V8eNvz3wQvvcSgg+WOSLrpoW2eq+bx1ZZUIFdvJOdNSwig==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-cTyhKZXoRWbHXC4v2prsvpDW6Cgcn6srcHCkU3aYBpI8jQYiqUHFB3gDMz8q+EUMs7SbLQTL1lGTx8Yzo/loyw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     name: '@rush-temp/perf-ai-form-recognizer'
     version: 0.0.0
     dependencies:
@@ -21538,7 +22121,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-language-text.tgz:
-    resolution: {integrity: sha512-YLzvAF50r4GeP+YOEtkC2jc7m1NsfuDk7I6RCU8Qp9tlnxEukxP2VoVt+Yn9tbpRuNGZBe1HFoIdUQcS0cLB2g==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-TtVg1DBaP0qrel4o28y9lRQraF1FuyJuGHn1rLtwcAdWSsGIejjRqmG7P6AvPyTQPCIC2adAsaxF9uA34nGsCA==, tarball: file:projects/perf-ai-language-text.tgz}
     name: '@rush-temp/perf-ai-language-text'
     version: 0.0.0
     dependencies:
@@ -21556,7 +22139,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-metrics-advisor.tgz:
-    resolution: {integrity: sha512-6JSVuIfIFvRVwSXA5O5uLyr0gPb5j2Spu6AFzoHNcoMtfCl/94mWPmgofhG9qGsIOybTyAVS0jkD1nlxcsQWkQ==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
+    resolution: {integrity: sha512-YMrhfBkWnQzZdNJB5Xx1OFygnkpEqfu+Nt9hU2/inNn7e2yNXegWL8aD+qxqFaS4FfC9vwb8r3SEQS7skhmkxw==, tarball: file:projects/perf-ai-metrics-advisor.tgz}
     name: '@rush-temp/perf-ai-metrics-advisor'
     version: 0.0.0
     dependencies:
@@ -21574,7 +22157,7 @@ packages:
     dev: false
 
   file:projects/perf-ai-text-analytics.tgz:
-    resolution: {integrity: sha512-HEeXcquBy4/HxCQDiHYIh56U/wSyFktEifaFi6u5aWjQHA0YVCZ2mL4n2UNp8/B+G7Z4Di2gAsinuyXdk04VFQ==, tarball: file:projects/perf-ai-text-analytics.tgz}
+    resolution: {integrity: sha512-CBC42SNPhF0ZSXY0fHOOqUV4VBVYSv8sHJeK0jkP2RGzT4MbSBvUoHb48BTqnSN4+w/gQoeDorXxmrZhTYaZSA==, tarball: file:projects/perf-ai-text-analytics.tgz}
     name: '@rush-temp/perf-ai-text-analytics'
     version: 0.0.0
     dependencies:
@@ -21592,7 +22175,7 @@ packages:
     dev: false
 
   file:projects/perf-app-configuration.tgz:
-    resolution: {integrity: sha512-t0U7XU8cZUm77KBnp/BVMSVcyhgtm5UpiGF5jTLZLLo1TG9hAvbz30aaykK4OIZE4erQ5o3KoRrsr0tznaiBPQ==, tarball: file:projects/perf-app-configuration.tgz}
+    resolution: {integrity: sha512-RtWIGVKy2avGBMAgWY1dUG12GYFIupEf42Vkjnf2Zt6GbD7Cv881uZkW07gTQdqG2zsaG82Pi/b37otJB894TQ==, tarball: file:projects/perf-app-configuration.tgz}
     name: '@rush-temp/perf-app-configuration'
     version: 0.0.0
     dependencies:
@@ -21611,7 +22194,7 @@ packages:
     dev: false
 
   file:projects/perf-container-registry.tgz:
-    resolution: {integrity: sha512-GsW1EvTmOLWMlaJa7m9yf/xvgplmqpkQ4EuIXhNpuZWayCCAdqlRnKQ4CgpyywNCweKEpgptqNCB6/4DVCVuZw==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-OBYQY6CUxR5bqhFSfcx8XX8cIFmPiqW/ZoNnZExUqdWL4aqOhTFe1/geKhKiJyXwSWDGtnibDHtPcRGvFnLKsw==, tarball: file:projects/perf-container-registry.tgz}
     name: '@rush-temp/perf-container-registry'
     version: 0.0.0
     dependencies:
@@ -21629,7 +22212,7 @@ packages:
     dev: false
 
   file:projects/perf-core-rest-pipeline.tgz:
-    resolution: {integrity: sha512-WJIHg5Hr69UC7K4ql6duSdxP7zODNxAdZONrboVKZE6gb22g/N1t2GrmINbtFccG44tLe5KU0eI5wyBXc0uK1w==, tarball: file:projects/perf-core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-nizgC9U+XOKMAlchzjql1GRdMaN1VbQXaSeuumy3RyVSL/3d1Yx6iNTwaANk+lF9JVuGWlS4zdogtJK9I0Yt8g==, tarball: file:projects/perf-core-rest-pipeline.tgz}
     name: '@rush-temp/perf-core-rest-pipeline'
     version: 0.0.0
     dependencies:
@@ -21651,7 +22234,7 @@ packages:
     dev: false
 
   file:projects/perf-data-tables.tgz:
-    resolution: {integrity: sha512-7WuM+VxSyy1vUPKLLasOhvvBLoDVj0py2ePQ60WqxGXGY2bPAdzm+hnyi7BCFcCTT0IsxHxwjRfUarne98jGlw==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-v4UT4kIiJxejwF+WwAtGbCZS3+Tu2M5jLQ/AY9UrH7RLIYtsIJ8oewA3wpp2XOo6CFxImMRuwJ1HZ7AdBANxPw==, tarball: file:projects/perf-data-tables.tgz}
     name: '@rush-temp/perf-data-tables'
     version: 0.0.0
     dependencies:
@@ -21669,7 +22252,7 @@ packages:
     dev: false
 
   file:projects/perf-event-hubs.tgz:
-    resolution: {integrity: sha512-YYgBzab8fIXup4kV38KXDPi1tKF4AJuwnHiQQrrNmX+MNQDnpiWlDvf4I3qiXirF0UQMrc8icbrNtsmAt7r6cg==, tarball: file:projects/perf-event-hubs.tgz}
+    resolution: {integrity: sha512-SUlN7HcwnQoSS5G0X6/UNFREufFCI7RbCrVeFTOW7fMsN7owpJ82TPgThGBSif/vkm8sku0WJeWOAYCd+PxtBg==, tarball: file:projects/perf-event-hubs.tgz}
     name: '@rush-temp/perf-event-hubs'
     version: 0.0.0
     dependencies:
@@ -21690,7 +22273,7 @@ packages:
     dev: false
 
   file:projects/perf-eventgrid.tgz:
-    resolution: {integrity: sha512-ZYkjk1Pz46OB0szqPrpg0Ymo7rNaSbRqu9gIfv9ntX3li6ol/f8HhNenejnokCbHjCi+bb1mN2pD/2WdRUdF8w==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-7wp/TNaLs6N+9bemI3V27bX/PBnTBNipK7WxjckekVjf4yqouS8nCcfdIuZoK3+6fSN0sK9+1YIfN3UDQGIlJA==, tarball: file:projects/perf-eventgrid.tgz}
     name: '@rush-temp/perf-eventgrid'
     version: 0.0.0
     dependencies:
@@ -21708,7 +22291,7 @@ packages:
     dev: false
 
   file:projects/perf-identity.tgz:
-    resolution: {integrity: sha512-A7aeJKxdmV27Fkdz2zrFh/3n3U/WQ/ay+4X+o13PrT1AeqXPALD6tt4wdLT0QW3ymM2D2WGFgW9M3oLVhP00qw==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-jAHLo6XmcTxovCF1WIyVFREPaDTUbpkDwlbgaY1pccYUdukJi/19CgjFH5Hv+cjLXZiOCsFWxtJCPS+KNAa5Lw==, tarball: file:projects/perf-identity.tgz}
     name: '@rush-temp/perf-identity'
     version: 0.0.0
     dependencies:
@@ -21727,7 +22310,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-certificates.tgz:
-    resolution: {integrity: sha512-vzsSPptQv8Y3pbBGjHRmJPRzTuJuP+usNSwZVZYDSs4t3OG4MK3576QV9oH4MtUCfE10kC9ECq4t+d4z6yJUow==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-Uq63ZSw9Z8GCVcwWntIzDnWF3aU3A+EV0l+0Ahf8nQ1lHzolfDOoYxpMYIh+Xa2BI+fUPGpDSi2xGWwpmYjXYg==, tarball: file:projects/perf-keyvault-certificates.tgz}
     name: '@rush-temp/perf-keyvault-certificates'
     version: 0.0.0
     dependencies:
@@ -21747,7 +22330,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-keys.tgz:
-    resolution: {integrity: sha512-GytYZta0ioUfmiPAcQuo7jpRdiy64l+82lMDnj6y66FdrlvD5lfSTPxSH6XdrYJkKOjm2O8XHLZB5nYaX/0zGw==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-JpKgox7B249DS8b1n49F+j2h8KmzlrtyfKv/1IYHlN1DM6J0ZZB99tdGEMZxAPybo0k2tfEwvwesOX+VDchVIA==, tarball: file:projects/perf-keyvault-keys.tgz}
     name: '@rush-temp/perf-keyvault-keys'
     version: 0.0.0
     dependencies:
@@ -21767,7 +22350,7 @@ packages:
     dev: false
 
   file:projects/perf-keyvault-secrets.tgz:
-    resolution: {integrity: sha512-MqZSqQo/G6QZYa4vNiEpCukkUwCRo4mzVUHawlp1nqAmvlrrXoLumGyF48rJBVJh1sUEXFxw3koVBm+5asCNZw==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-8WV8IzHgx9J5tK17jNzqfM1BQSoIMs7lvCYupXWt0Uw7+Zy4DB2eXxdZ+a6zNYybAmfnRvbpl4a5ppaCHu482g==, tarball: file:projects/perf-keyvault-secrets.tgz}
     name: '@rush-temp/perf-keyvault-secrets'
     version: 0.0.0
     dependencies:
@@ -21787,7 +22370,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-ingestion.tgz:
-    resolution: {integrity: sha512-7Th0T7Nf0UNrvJPsjjNs/3KqkzRMWElB/HvNsNalfRxqHobWS/uIdXRo1zoLIZFh6dAKXlK5pyhboxzSczyeYQ==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-RQKOZEZIZAyn3h9KfczkYYQvGeOz8GS+6zl6YAKZHeUphki9fds8yD2eSwRxwC1MLCo6V7AyJLzdHyTbfA4TXw==, tarball: file:projects/perf-monitor-ingestion.tgz}
     name: '@rush-temp/perf-monitor-ingestion'
     version: 0.0.0
     dependencies:
@@ -21805,7 +22388,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-opentelemetry.tgz:
-    resolution: {integrity: sha512-/pYMxuI2HSlzyv5V+fT9y3NLkd1hfjwON1q0588fSZ8mAR8gdupjauyfWGxVsc4gXWKvp1IvxAV6KgYdA3v2wg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-skDSgg6y+DZRYGsT+68ObU2JS+/FEnA3cHwwE2KwsE/JWM06Ifj29z9DEIzUV06gucLKbUXW0GREDZ9w/lKxIg==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     name: '@rush-temp/perf-monitor-opentelemetry'
     version: 0.0.0
     dependencies:
@@ -21823,7 +22406,7 @@ packages:
     dev: false
 
   file:projects/perf-monitor-query.tgz:
-    resolution: {integrity: sha512-iSZgFDWsrLX/w4PpblJltsGErNQ9rACL1nLhGiHv+uKXQ0dXxiuvx05G760OECb5ngfpcMRBmpPG3rvk0EgCXw==, tarball: file:projects/perf-monitor-query.tgz}
+    resolution: {integrity: sha512-XblTYpNwX8UpFLWmopD84Q3LCniA4/ii06wM6cngfTdQHdmDaP23TrlVQ/rn6B815lmskF3E0SwbO3PfPf75rg==, tarball: file:projects/perf-monitor-query.tgz}
     name: '@rush-temp/perf-monitor-query'
     version: 0.0.0
     dependencies:
@@ -21841,7 +22424,7 @@ packages:
     dev: false
 
   file:projects/perf-schema-registry-avro.tgz:
-    resolution: {integrity: sha512-QtAa+7ijpuBTTP6lmfJ/sFlMH8ihneNRqOmmObNiTwa3dDYAaymQ881zsh6p4pFDsboP6c+MJleulyBbz313xw==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-MTed684VKWlukSvp216Ye0MaQ0UTJGxKge4yIn2b4esRmbOSoNzkyuB2eg8DKcLDlXR9qxe6e65d2R6mEkIRCw==, tarball: file:projects/perf-schema-registry-avro.tgz}
     name: '@rush-temp/perf-schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -21860,7 +22443,7 @@ packages:
     dev: false
 
   file:projects/perf-search-documents.tgz:
-    resolution: {integrity: sha512-PgsOy3Mk2G3ZV5qUzYhHPwIqGUZsn4zG2TXigxDet5P4x0DF1pSSHGYmnL/hab2HWAvQ3psoecV7gZrZn+fYIg==, tarball: file:projects/perf-search-documents.tgz}
+    resolution: {integrity: sha512-ghZqi+iLYdZhWkD40qlEv7kDtL6HvgjBcwN2S9WIXwpY6FwF9P+Irb/64XMtflQ14C7pqpNrLV5ifWooZt38wA==, tarball: file:projects/perf-search-documents.tgz}
     name: '@rush-temp/perf-search-documents'
     version: 0.0.0
     dependencies:
@@ -21879,7 +22462,7 @@ packages:
     dev: false
 
   file:projects/perf-service-bus.tgz:
-    resolution: {integrity: sha512-Ay1DLnWGeLRoiit4z+1K1c501P9VpGPcs4t7LGkqa59H7CO/+ccoTfx6TFBP8EQE9tacQd7/nB1j7ABgHs7CzQ==, tarball: file:projects/perf-service-bus.tgz}
+    resolution: {integrity: sha512-jDWlTpb5h3NcUsJ20JxR3AsIb7OyogzYS9jVCtaQL9NK0rNEBXeE/BOGVsPF6TTE8IkRRaNrOeaJc+BNBUhdqw==, tarball: file:projects/perf-service-bus.tgz}
     name: '@rush-temp/perf-service-bus'
     version: 0.0.0
     dependencies:
@@ -21899,7 +22482,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-blob.tgz:
-    resolution: {integrity: sha512-gC/6yI3RAsLz8yW4HuwmY/hZJdfQ4WpTasQrnaGM2o0ADvshX7BbTMziACBVC1IJ+SZS0f25nzWdMrf1cKEPUA==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-33Nj4h6RqwWDx8jf+Vq66/bhi54qjnawbcaiXHMK1A5/yW4gk4iHcHw4GDCBg/12dqD16LTEroCRTFJXyn5SGg==, tarball: file:projects/perf-storage-blob.tgz}
     name: '@rush-temp/perf-storage-blob'
     version: 0.0.0
     dependencies:
@@ -21917,7 +22500,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-datalake.tgz:
-    resolution: {integrity: sha512-/Ci5NG7Th6jCRFjxNQnQIN066A0l8K8hkuTPVCvaChixw0hduEm6MN1HeVT+Qmwkko8uVFlLNu1s7HgLwy8rLw==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-zzWjtoU44sAp+e2yWE2rDR8F7+rV/EYV3BUIDRuv6ANU8rrVeP14xCDbWQp+xFOpXeDksYJxrdLr57nhOVW/cw==, tarball: file:projects/perf-storage-file-datalake.tgz}
     name: '@rush-temp/perf-storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -21935,7 +22518,7 @@ packages:
     dev: false
 
   file:projects/perf-storage-file-share.tgz:
-    resolution: {integrity: sha512-PA4GNlP5egvK17bRRWDzOrPQgQ87ZxFP+UzUQxy/Wa1NwuHJdBlcsa8P3do4HTkD0UpSzTyeNQ5P7X2etFM+8A==, tarball: file:projects/perf-storage-file-share.tgz}
+    resolution: {integrity: sha512-joX/kMUoaaZUQ7137XqjPPXfYJeQEkgCGd0gmTGH+fTCcNbfDCRPfmsHhbu4ZCZ/qRGpXuv37yJ2/D6LNkMGTw==, tarball: file:projects/perf-storage-file-share.tgz}
     name: '@rush-temp/perf-storage-file-share'
     version: 0.0.0
     dependencies:
@@ -21953,7 +22536,7 @@ packages:
     dev: false
 
   file:projects/perf-template.tgz:
-    resolution: {integrity: sha512-i6UEyKvgmn6FvOtrhdZkwnXMGsvbMgShf5YRJPf65eSnu8HDC3xx0eo0Cx86HwcjLohRuNa4GorVT7+b5h1BHA==, tarball: file:projects/perf-template.tgz}
+    resolution: {integrity: sha512-bQvxQNhEM65xWC4AfnQokPhqL2nbSFyldK6fWxT3qjS3coulvjc+Hi4lKo8XTE2eDiE+TsmqPigQvsmo0xwljw==, tarball: file:projects/perf-template.tgz}
     name: '@rush-temp/perf-template'
     version: 0.0.0
     dependencies:
@@ -21970,19 +22553,19 @@ packages:
     dev: false
 
   file:projects/purview-administration.tgz:
-    resolution: {integrity: sha512-sgg4tkB4l9zyjfabBh9sUFhifmfGF+ntAIAb2e9vsDSCi1ttSW6dQHrKx5IFCKwz3b0Cl0DaeRMwS8j4e8hecQ==, tarball: file:projects/purview-administration.tgz}
+    resolution: {integrity: sha512-j+3CMetOBfzDxe/xxnYIibrdqYaMwncZBl5HB8Kk84TG6+2ZxSk9RvatfdLHKOUtcE2t7PK1pwsFOXZv4icSKw==, tarball: file:projects/purview-administration.tgz}
     name: '@rush-temp/purview-administration'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22000,26 +22583,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/purview-catalog.tgz:
-    resolution: {integrity: sha512-P4T1DLaTzNfhCfRSS/tZTK6wVBW2sBDaf9tAw6qOqvlz3ZPkJ5vTGehSROpmF8eDPloYnN7IaDtM/Pdi3d2d/w==, tarball: file:projects/purview-catalog.tgz}
+    resolution: {integrity: sha512-mnB2oPdP/+t7o19g+5GugsAd4if9mxG4B8KvcN6IG3b5tvt7CwCDRcmpKHj0E5GHFIsqFB9Vw2WRoMUp64Ue5A==, tarball: file:projects/purview-catalog.tgz}
     name: '@rush-temp/purview-catalog'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22037,26 +22622,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/purview-datamap.tgz:
-    resolution: {integrity: sha512-7oiGt2hH9ZkCV8TyJRw6R4MvjW1O2ULh5uJ+cg3GIx4BKR1bcZYk73h9m4k56lwo15yDon0raH0UmjfoNb7Rng==, tarball: file:projects/purview-datamap.tgz}
+    resolution: {integrity: sha512-k3e8YcgnHqd9qdCQ7lMkduheJhA4ba3cu/C4AW7hhg5FEHBNuamzt1BVMneYlSsHLJdDYSQVvG9yetn1u/Sc5A==, tarball: file:projects/purview-datamap.tgz}
     name: '@rush-temp/purview-datamap'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22074,25 +22661,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/purview-scanning.tgz:
-    resolution: {integrity: sha512-4060O8WtwjIXcuZEqtihG9mNZBUsaY5vEBCXdX/KgZdDyAdxaz+ly58sFqmPVhQrrsFcEAoiK3eM3d1aT02/LQ==, tarball: file:projects/purview-scanning.tgz}
+    resolution: {integrity: sha512-YdDedn5HsEfVK4qu0/BSByU0m1+BrqNQluuNYuULJE/pgeC9S30uPNb0OYBvHNNictyI1ll+0vnx/W2zIiKC4w==, tarball: file:projects/purview-scanning.tgz}
     name: '@rush-temp/purview-scanning'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22110,27 +22699,29 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/purview-sharing.tgz:
-    resolution: {integrity: sha512-7I95FPCB1deMsV/SaCRhORc5RRUsCrw5eHZLOvt2Ij5fF2cIOCv6nvAi0qlzyOwxZsbMSh21qJenVxLx25gVIQ==, tarball: file:projects/purview-sharing.tgz}
+    resolution: {integrity: sha512-zZioDKoU7H0kep5tD3hqpcjjXNa17H3ey77hhtpbCmI0sXm1Q67a17CIfHRm5EPvTcTSuNa3ddgPREZm6kmFvQ==, tarball: file:projects/purview-sharing.tgz}
     name: '@rush-temp/purview-sharing'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22148,26 +22739,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/purview-workflow.tgz:
-    resolution: {integrity: sha512-cdYtC2hiHpniV2a3lK+YjL72OLtV5ekUtCffOgqU4O0DlyPAPhVKzEP5PU3jzfgsGtwzPwcL4r9AJFIUQIMB+w==, tarball: file:projects/purview-workflow.tgz}
+    resolution: {integrity: sha512-9L0yOH/Dz6doUb4AxTPMG0+FfLy47wfgTZWJACWmnZAvuJfkIVm5a0JMu5TfLStUHbhAq7xQJse/mivGMxO1aw==, tarball: file:projects/purview-workflow.tgz}
     name: '@rush-temp/purview-workflow'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       autorest: 3.7.1
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22185,13 +22778,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/quantum-jobs.tgz:
-    resolution: {integrity: sha512-1klhp8mezs4wRSJHc86lzMqH4vCtP8AEgdnPWyyQ54FhWw8xpHjBXDxNffumdJDlI+ZpOawvsczRsqMR7Wgw+w==, tarball: file:projects/quantum-jobs.tgz}
+    resolution: {integrity: sha512-7B8Bb25hm4hSEIhDV700Ku1MzPtuENAvr7GV8h19CI8QUU5+nR5qXv3I8MEpyYRrAroRcJGW1knmm4PEn9mB8Q==, tarball: file:projects/quantum-jobs.tgz}
     name: '@rush-temp/quantum-jobs'
     version: 0.0.0
     dependencies:
@@ -22233,7 +22828,7 @@ packages:
     dev: false
 
   file:projects/schema-registry-avro.tgz:
-    resolution: {integrity: sha512-xy7wUN0smV928ueXcqOM9xeP9JACYQr3NXHdCj4AuZTzkIsCJQc2/AgerhqBiVKlreiJxX899IO2MZ1+gt8MXA==, tarball: file:projects/schema-registry-avro.tgz}
+    resolution: {integrity: sha512-0n5gdhm/RMY6kiOQSzcVJVKEut9ODGXUm/OAGjNCJLNfjO4iMJmH5KYwCVudNAW2ZwjS06vzS8Bt9z7aIxH8Lg==, tarball: file:projects/schema-registry-avro.tgz}
     name: '@rush-temp/schema-registry-avro'
     version: 0.0.0
     dependencies:
@@ -22241,8 +22836,8 @@ packages:
       '@rollup/plugin-inject': 5.0.5(rollup@4.27.4)
       '@types/node': 18.19.66
       '@types/uuid': 8.3.4
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       avsc: 5.7.7
       buffer: 6.0.3
       dotenv: 16.4.5
@@ -22254,7 +22849,7 @@ packages:
       tslib: 2.8.1
       typescript: 5.6.3
       uuid: 8.3.2
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22273,13 +22868,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/schema-registry-json.tgz:
-    resolution: {integrity: sha512-J/R0tUT5fzAYXoYtTWaKf37oo5dSMJhebBHhfdnMMAxkKfO78DVwIMadUE91wv2CZ4p56zPefORTsWErHNPNww==, tarball: file:projects/schema-registry-json.tgz}
+    resolution: {integrity: sha512-rRpzaub7jS8Xhz85nNGAiUenxE4P0R7WVau0m7MFd37i0VFk9o/yJftx9LWuoNFH1tKB3YENeajfvFOWPM4lkg==, tarball: file:projects/schema-registry-json.tgz}
     name: '@rush-temp/schema-registry-json'
     version: 0.0.0
     dependencies:
@@ -22319,7 +22916,7 @@ packages:
     dev: false
 
   file:projects/schema-registry.tgz:
-    resolution: {integrity: sha512-cV1YfaW7G3fU0JPawhjZA5suunxV4Sc9ROHcGzFYcBG2MkVqltpKmLXGYPPwwTUEV7n+YV7p0HNnSL7B5qC/UQ==, tarball: file:projects/schema-registry.tgz}
+    resolution: {integrity: sha512-orH2bHzNpvyQrfb+haytdJko4CMjXy3yrJ5BsYvvBSYnCuu7BJ3D/y/Vix76NwTcurAK4h1XKHUhwZ9bPWoqbQ==, tarball: file:projects/schema-registry.tgz}
     name: '@rush-temp/schema-registry'
     version: 0.0.0
     dependencies:
@@ -22356,7 +22953,7 @@ packages:
     dev: false
 
   file:projects/search-documents.tgz:
-    resolution: {integrity: sha512-8YCD+t6qJKJwWqQ/Naao8ExK2lQjxDtpDL4YUmK6k312+QN7zwxzDkRYEcnIjm3F2EvcGcY3yUiMbDIIl9QCkQ==, tarball: file:projects/search-documents.tgz}
+    resolution: {integrity: sha512-rEg/TlfkfcG87IEUOSZJTTJWLAmU5+Exho5dokXkfk2tjdlnpbrHu5HnM0etnw3rVbiv/8ImhaPGle+oyKBa9g==, tarball: file:projects/search-documents.tgz}
     name: '@rush-temp/search-documents'
     version: 0.0.0
     dependencies:
@@ -22401,7 +22998,7 @@ packages:
     dev: false
 
   file:projects/service-bus.tgz:
-    resolution: {integrity: sha512-h3VAF/BwJEz++gcPcaKJXOaKdeNCi+ivQjg7ElYyGw4ZHr79xMK5XC1d5pM9/v0PzYZYyVC3EH626OaUDdyIMA==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-2V+Dl7dAdqR4n+dDiIMILmgBKvjDtYzXMxDuiWCUi9QjImQ7UxndlIwbC4tunW4fA+OKBVnwAiuHUTsdktGpZQ==, tarball: file:projects/service-bus.tgz}
     name: '@rush-temp/service-bus'
     version: 0.0.0
     dependencies:
@@ -22412,8 +23009,8 @@ packages:
       '@types/node': 18.19.66
       '@types/uuid': 8.3.4
       '@types/ws': 7.4.7
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       buffer: 6.0.3
       chai: 5.1.2
       chai-as-promised: 8.0.1(chai@5.1.2)
@@ -22432,7 +23029,7 @@ packages:
       tslib: 2.8.1
       typescript: 5.6.3
       uuid: 8.3.2
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -22452,13 +23049,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/storage-blob-changefeed.tgz:
-    resolution: {integrity: sha512-rChvDY+jZ3y66M9WZpo3RXw66M63Ke4wdaRyCgyYQ/xEWQv8SVzha5u/cAf/eEDzo+dqdz7Nit8voOAWS5Fo4A==, tarball: file:projects/storage-blob-changefeed.tgz}
+    resolution: {integrity: sha512-bULvcE/VTPlwc5GWXxojuVCofjNdpQvnmq3Co9aL9XJw15F0wNW7yA0yoGRy8izkXVQjQtJp9ZRcmOOgL4l8YQ==, tarball: file:projects/storage-blob-changefeed.tgz}
     name: '@rush-temp/storage-blob-changefeed'
     version: 0.0.0
     dependencies:
@@ -22505,7 +23104,7 @@ packages:
     dev: false
 
   file:projects/storage-blob.tgz:
-    resolution: {integrity: sha512-GM0+E284qr6AcJ08tcb2AcizAP6optptQOXpMpJxJVBsoFuYUVyghZtk6mEE992MJV8SRc+guWscppusRF6JfA==, tarball: file:projects/storage-blob.tgz}
+    resolution: {integrity: sha512-oLGMdM7gSsKoTbbEmt9jbScObB3IO9ICgGcrUUN/Dx+o6ZwwTAb2wd6tGo5Ns7uq0Lu8Qx9RuQWX+N2jGz7icQ==, tarball: file:projects/storage-blob.tgz}
     name: '@rush-temp/storage-blob'
     version: 0.0.0
     dependencies:
@@ -22549,7 +23148,7 @@ packages:
     dev: false
 
   file:projects/storage-file-datalake.tgz:
-    resolution: {integrity: sha512-yAoj31VtAud8gXiyicLgx/40rpFcpXg61eD88ARTkePcL6gGyqNAM8gtIaKA2/8rvHqSUpZWWvwL3ZDicjj1qA==, tarball: file:projects/storage-file-datalake.tgz}
+    resolution: {integrity: sha512-qnrzYzdwp8sDluJS2FGE14ygvhsOseWw+Oruam2HPo09a/JzsWw6xPYcPDJ37eUYWTsAH+kHO2JKZiIoscVgJQ==, tarball: file:projects/storage-file-datalake.tgz}
     name: '@rush-temp/storage-file-datalake'
     version: 0.0.0
     dependencies:
@@ -22596,7 +23195,7 @@ packages:
     dev: false
 
   file:projects/storage-file-share.tgz:
-    resolution: {integrity: sha512-3wsuOatFgt/+CNvfmLQqXyj27WiDouP9EBW18/ylo2g+6qsjma4e/vERPG7bHqjaP9aroE4o/s3/9SEZN/1mBQ==, tarball: file:projects/storage-file-share.tgz}
+    resolution: {integrity: sha512-tkDuRyvVAFOV0sqgeisI05ts58x4E8TQbKorV1M/pwbWZXgLonpqNf4sU2Lb+w7ss9RuKTLFx4ElswFiqm4dmA==, tarball: file:projects/storage-file-share.tgz}
     name: '@rush-temp/storage-file-share'
     version: 0.0.0
     dependencies:
@@ -22641,7 +23240,7 @@ packages:
     dev: false
 
   file:projects/storage-internal-avro.tgz:
-    resolution: {integrity: sha512-2/b7G0Iiufhu4j2foCdmSudSu8K2sJQXezR2aT5k/yaBAXNmwyWv0GRGIj2yTJwr6mevb4SzZxG7P5sSxboBbw==, tarball: file:projects/storage-internal-avro.tgz}
+    resolution: {integrity: sha512-eTS8oUEngebyT6/7uUb/l8Vmuu7fNx7+gaSpVnsk7ioC9fdbSTTY08Gp0QbrL0ZnvWg3oUOsXx9DOf74jDpq6A==, tarball: file:projects/storage-internal-avro.tgz}
     name: '@rush-temp/storage-internal-avro'
     version: 0.0.0
     dependencies:
@@ -22681,7 +23280,7 @@ packages:
     dev: false
 
   file:projects/storage-queue.tgz:
-    resolution: {integrity: sha512-Bzntrsw6BeXydXyVg8GShcAqGlhTyIk41mXoir+ySY1FhNavDbHmfapDnw7zICn3OOLhL5fCeNRupxB174Giow==, tarball: file:projects/storage-queue.tgz}
+    resolution: {integrity: sha512-4pGMIXB8Zyvla6U5Hu1+YP2WwtQnLVF0KbjrQbNIc3S/nC7Ag9tXY5mLgZ+TY7kRBPBfmBPjsDysdsWvs+s/DQ==, tarball: file:projects/storage-queue.tgz}
     name: '@rush-temp/storage-queue'
     version: 0.0.0
     dependencies:
@@ -22723,19 +23322,19 @@ packages:
     dev: false
 
   file:projects/synapse-access-control-1.tgz:
-    resolution: {integrity: sha512-PsDI9ixsWoG5tbuoB6Wd2BVZZvqY2rHjdfrUQu8RK+vGxCFhm9sYPNZ/u7SCk7Twm/eZCi7FtlHClXTiWhKSAg==, tarball: file:projects/synapse-access-control-1.tgz}
+    resolution: {integrity: sha512-jwQQkrdlzEyy2KAFo5COAaGuwS9vFWHhXfio9NZ3jvpt5fGfzlcAD+C9GJod9tMwnIfyuA3AIce5AaOJcer6sw==, tarball: file:projects/synapse-access-control-1.tgz}
     name: '@rush-temp/synapse-access-control-1'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22753,25 +23352,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/synapse-access-control.tgz:
-    resolution: {integrity: sha512-9xdlw5x0quMLB/SC77TKuY4c9igb2+HFgbGAKlE/RoEe0xa9azz9mACQzrzEipqEkmcETcTuIyvGXzJHEi6KXw==, tarball: file:projects/synapse-access-control.tgz}
+    resolution: {integrity: sha512-1WZ4zXdyR/RmWwiDq8XOkD0xVlSEWhqdGFpw/+yxlzDpsW40rmnCCjV5Of1f6df99sk1M/715KJ+f9aOf/YmMw==, tarball: file:projects/synapse-access-control.tgz}
     name: '@rush-temp/synapse-access-control'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22789,26 +23390,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/synapse-artifacts.tgz:
-    resolution: {integrity: sha512-5rjggfXNlltSIRafPLODuubz9l0qMTDLyDbF9fMNGQxiCs+CQ9CHFxYu26bL3bC8FkqKbFzi9TntWrWX1F/TYw==, tarball: file:projects/synapse-artifacts.tgz}
+    resolution: {integrity: sha512-MIJR2z9SwBdhVn7v3Zw6oLiMiiOWAnk2R7DOc8/ZtMFCtDhX4KO6PydNq1bmUgNYu/aTlWnip7pVh+B+y9TYUg==, tarball: file:projects/synapse-artifacts.tgz}
     name: '@rush-temp/synapse-artifacts'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22826,25 +23429,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/synapse-managed-private-endpoints.tgz:
-    resolution: {integrity: sha512-Zpd22jZb08NobyWIJwBybVo2rLF1jcIPtcPosR7Gtuv286aRX2tdD1ki14DasDmhtox1Ey6EiUkx9gtq9+W5sw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
+    resolution: {integrity: sha512-ZoLslET5C3sOKmaRs7yCMWgZhfTj3z1iZB/aI/Jf55JfYqiPc7Nawbz5ihDXfHLaIfyxnq7QWR858WQcSBLDLw==, tarball: file:projects/synapse-managed-private-endpoints.tgz}
     name: '@rush-temp/synapse-managed-private-endpoints'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22862,24 +23467,26 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/synapse-monitoring.tgz:
-    resolution: {integrity: sha512-I5BQzGL2nrC0KkDbMwt6You5P/21te8gmwJkGNLZWeVLEQ2L8eZoRCwIbx8cDd45uTn6qLM6gKqRylQLnOBm0g==, tarball: file:projects/synapse-monitoring.tgz}
+    resolution: {integrity: sha512-ienvK6gmlhtKslEkpgBiakEpVUmpvmYCeX1D57sy5qRXIMhHLm7bpKa3YwG1NZ9s4xzyoxoRWWl4Ap/YttOiZA==, tarball: file:projects/synapse-monitoring.tgz}
     name: '@rush-temp/synapse-monitoring'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22897,25 +23504,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/synapse-spark.tgz:
-    resolution: {integrity: sha512-7VuuV5NynayhACA7upeM3teS3wfatr9zrVsViPOWaY9D2pg63KDr3duw0olTfwdDyIzFvraUWChLH1YGesC9Wg==, tarball: file:projects/synapse-spark.tgz}
+    resolution: {integrity: sha512-qL/b8QCGrkaen/Mm5iyXQkiUyQ4UUqAij2xog3EGUbYXYaZ4OlYLgHsw1DmGXA7rOTTvSyOS5yn3QYaxSbwRuA==, tarball: file:projects/synapse-spark.tgz}
     name: '@rush-temp/synapse-spark'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22933,25 +23542,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/template-dpg.tgz:
-    resolution: {integrity: sha512-UJwkAC81L049EHeAKs0ou6XCuvhFYRC0eddCEuuTg5a9/y65Jm/zVZQm9WieV/cIgQVUcQSH6zz/4Fg7jqnvvg==, tarball: file:projects/template-dpg.tgz}
+    resolution: {integrity: sha512-i2Xh8ocFWhPQBbry5QrVsk2bD4j/eppBmNt4MoVwqYjAkShcMADTX8ATRgcapVy6Gx0u6NLtlqPlFbZZ4s8YtA==, tarball: file:projects/template-dpg.tgz}
     name: '@rush-temp/template-dpg'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22969,20 +23580,22 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/template.tgz:
-    resolution: {integrity: sha512-Vc/FTk71GLJxhhRPmo2aqP4uc1wpf6iqgin1Gq6gouqJdvmeZwC46SoYt+oh9jiqGjz6BiIR5sieK8l4KlHQuQ==, tarball: file:projects/template.tgz}
+    resolution: {integrity: sha512-OVDJ/eRlYCho7hzfpAFRr+p9r1FZdwiakBbAUu8ASH9FZOF1X5KdYTF8/peKVlZxJ9cA7FCAqQ3bhceG3j2goA==, tarball: file:projects/template.tgz}
     name: '@rush-temp/template'
     version: 0.0.0
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       loupe: 3.1.2
@@ -22990,7 +23603,7 @@ packages:
       source-map-support: 0.5.21
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -23008,13 +23621,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/test-credential.tgz:
-    resolution: {integrity: sha512-bYrr6dFuCJWhb76ZIYcsr5Yp56E+ucLdJB8EntpuQev3rYZ9RmUOO8tLmLBpeEaaXX9Ze9qdX8cir9e8oasSbw==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-h1MdybqbEsoFGbrsQlEf8HD7EBUItgDZQFoKaTiegMYa5PAzjePI0NtZ2xry1iW8paybZewrSVk9qMICp6jn4A==, tarball: file:projects/test-credential.tgz}
     name: '@rush-temp/test-credential'
     version: 0.0.0
     dependencies:
@@ -23031,7 +23646,7 @@ packages:
     dev: false
 
   file:projects/test-perf.tgz:
-    resolution: {integrity: sha512-m/fCLIeioBtXTbl1LcjJ3YJxPnmN2PYQPz5maCbrexdkaJRUg1MRMofioLLXf8xjZ0jlWmY9y6doSkO49Q+fXg==, tarball: file:projects/test-perf.tgz}
+    resolution: {integrity: sha512-gpsDs+aHU61dcBTC2nBYNyPWX28FOxTLeVmwI1FrEWSCf1x0YMoPMWORUBSxoMo3mIceCQZJE5Qlj1/1JbKO2g==, tarball: file:projects/test-perf.tgz}
     name: '@rush-temp/test-perf'
     version: 0.0.0
     dependencies:
@@ -23059,20 +23674,20 @@ packages:
     dev: false
 
   file:projects/test-recorder.tgz:
-    resolution: {integrity: sha512-ca93qy0WlC+uOB/l2f8zrE6nmV6Cz8dUIsfMylW/L+rQF95T6ulPyMUV3He8s9tRsFYdNe+eIWrXqVdAzuToXA==, tarball: file:projects/test-recorder.tgz}
+    resolution: {integrity: sha512-vvaAuUJnpcqhw8EiumLe4TpV0URXcmFWc4Gw8AyS6Lit8DFewwmDYLZExMo9ZcKJeLOVM+ACmEGtXKQE43eXTw==, tarball: file:projects/test-recorder.tgz}
     name: '@rush-temp/test-recorder'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       concurrently: 8.2.2
       eslint: 9.15.0
       express: 4.21.1
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -23090,26 +23705,28 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/test-utils-vitest.tgz:
-    resolution: {integrity: sha512-TZ0JoLUcj0z4c6zQUSR7Cgz8M970PDDbhCOC05+N4KI16GR3HtYrkPm/YNsLOJZ934ZypPeQccL3rkQ7W+mmXQ==, tarball: file:projects/test-utils-vitest.tgz}
+    resolution: {integrity: sha512-952rKf8yqlmZqR2uUTjx/aWDG05V7KTViTcEpA0WhExzvj9R7ZCXYXkhFLixWh960ilD4u5GzG4lBwt7GK89wQ==, tarball: file:projects/test-utils-vitest.tgz}
     name: '@rush-temp/test-utils-vitest'
     version: 0.0.0
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
-      '@vitest/expect': 2.1.5
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
+      '@vitest/expect': 2.1.6
       eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -23127,13 +23744,15 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/test-utils.tgz:
-    resolution: {integrity: sha512-wZSudXx+6doapn71XFuSN01fZqsuPPPUkLws2cNTB4La+YL2sEoT4I3/2NU9xg9A2kwMBj4VSJzPCUQW8nzAxA==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-wMdLEaPcon+2xUCVn7CFP6SIaXNy/MF17CB/o2IB6xH51aYIrFVHEpBCSrAo/vfYioEOYsGTTbxvvUYBpzWsIg==, tarball: file:projects/test-utils.tgz}
     name: '@rush-temp/test-utils'
     version: 0.0.0
     dependencies:
@@ -23168,13 +23787,13 @@ packages:
     dev: false
 
   file:projects/ts-http-runtime.tgz:
-    resolution: {integrity: sha512-npn/z1hHJ0qqSXSxNecWqYSM2b0ZnXjWKMBKVEObMM+kxrWugOdvQNUmEmsD/r9bnHsIYmMg/u+qaOmh/GOyTA==, tarball: file:projects/ts-http-runtime.tgz}
+    resolution: {integrity: sha512-EAAc+igauKUvBNRizFx41IENCDdZjVLtXqckUvWXRoceiH9szZ2jHtiMjllAeCKph0+mO1sJeY7uhptPvJWejQ==, tarball: file:projects/ts-http-runtime.tgz}
     name: '@rush-temp/ts-http-runtime'
     version: 0.0.0
     dependencies:
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       eslint: 9.15.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
@@ -23182,7 +23801,7 @@ packages:
       tslib: 2.8.1
       tsx: 4.19.2
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)(tsx@4.19.2)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -23203,17 +23822,18 @@ packages:
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/vite-plugin-browser-test-map.tgz:
-    resolution: {integrity: sha512-NqjZZaCCOu5mcDAfo7eTwmmIK4nm9wUKPZK5iEqsCAmnI4QumQswsL3NQQ6DvsMVjxO5rLd91f8TYfxi7TcKLw==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
+    resolution: {integrity: sha512-O/3r/M+vH+IGZCiSs6thRnBlppHkcaOFPxz5+3dNVhr0e8vda/JcdX6IxCmIyLWMK7zAVJ6VWBDbQJkaGlrBWQ==, tarball: file:projects/vite-plugin-browser-test-map.tgz}
     name: '@rush-temp/vite-plugin-browser-test-map'
     version: 0.0.0
     dependencies:
       '@eslint/js': 9.15.0
       '@types/node': 18.19.66
       eslint: 9.15.0
-      prettier: 3.4.0
+      prettier: 3.4.1
       rimraf: 5.0.10
       tslib: 2.8.1
       typescript: 5.6.3
@@ -23224,13 +23844,13 @@ packages:
     dev: false
 
   file:projects/web-pubsub-client-protobuf.tgz:
-    resolution: {integrity: sha512-9sgZsAR3tTAtbiZnoxbIh4r3Flno3WJ8SdQrlTCIHtyP9/8GIspGVUgBGrOOrmQLW+dzdusqNEJp/eqY87lfBg==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-OtPNgCqLj1fgACqD40aQmZdFhby6AJVeArfK55IsgvdickEEjVlbUjk9Qp8/XfE+D20oaxafJjrTaJuYYsBwBQ==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     name: '@rush-temp/web-pubsub-client-protobuf'
     version: 0.0.0
     dependencies:
       '@azure/web-pubsub-client': 1.0.0-beta.2
       '@types/node': 18.19.66
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       cpy-cli: 5.0.0
       dotenv: 16.4.5
       eslint: 9.15.0
@@ -23240,7 +23860,7 @@ packages:
       protobufjs-cli: 1.1.3(protobufjs@7.4.0)
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -23258,11 +23878,13 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
+      - yaml
     dev: false
 
   file:projects/web-pubsub-client.tgz:
-    resolution: {integrity: sha512-FHqP4W6QpMWigQ7+hjxfb44bM2fSiYx2KtnjvFgrafi5fYxefEN5jIZa/8sm0w1n5P9EUL6b7qi84ennhGMAhw==, tarball: file:projects/web-pubsub-client.tgz}
+    resolution: {integrity: sha512-Tuit8/jpECGW1dO3eteSJhnP9syhS7ANDzWDRPWNzAB/iTy/+jOF0WZJdwzVSswe4vDSd7fcEhdjPHRt9+wtMw==, tarball: file:projects/web-pubsub-client.tgz}
     name: '@rush-temp/web-pubsub-client'
     version: 0.0.0
     dependencies:
@@ -23313,7 +23935,7 @@ packages:
     dev: false
 
   file:projects/web-pubsub-express.tgz:
-    resolution: {integrity: sha512-1XC45faVaVx/yNzemEnwMgV+KwZPv44GgD0hA9Nclx5gNyjOTDSbqd7YpWpft/ioItN5J3MJSXfH0WieAXZmJw==, tarball: file:projects/web-pubsub-express.tgz}
+    resolution: {integrity: sha512-dY8s2jexRmK/DVpuvuFSt4QpAr5uwUJy2qCJ35v/3J6F9BN11RVjsiFHt8/oF0UJnJFJXZWMBz5QdFnmATXRbg==, tarball: file:projects/web-pubsub-express.tgz}
     name: '@rush-temp/web-pubsub-express'
     version: 0.0.0
     dependencies:
@@ -23321,14 +23943,14 @@ packages:
       '@types/express-serve-static-core': 4.19.6
       '@types/jsonwebtoken': 9.0.7
       '@types/node': 18.19.66
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       express: 4.21.1
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -23347,28 +23969,30 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false
 
   file:projects/web-pubsub.tgz:
-    resolution: {integrity: sha512-9qOQ3T6D4CiqL/mRmdEK6fl05ZmfXc+F76zy6eQMct15j6XqFy3GODZmdOPpW6BqOrOPbwRvTULlGTR+BcScsA==, tarball: file:projects/web-pubsub.tgz}
+    resolution: {integrity: sha512-o5k5QfafV6B0ytwOEUw+xXF6BtNoGvF7eA+RlAyX5GxDSuCK8yNa7XU6Z4KTTWCqidWXrkjZYwlyySlZxF4GOw==, tarball: file:projects/web-pubsub.tgz}
     name: '@rush-temp/web-pubsub'
     version: 0.0.0
     dependencies:
       '@types/jsonwebtoken': 9.0.7
       '@types/node': 18.19.66
       '@types/ws': 8.5.13
-      '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
-      '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
+      '@vitest/browser': 2.1.6(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.6)
+      '@vitest/coverage-istanbul': 2.1.6(vitest@2.1.6)
       dotenv: 16.4.5
       eslint: 9.15.0
       jsonwebtoken: 9.0.2
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
-      vitest: 2.1.5(@types/node@18.19.66)(@vitest/browser@2.1.5)
+      vitest: 2.1.6(@types/node@18.19.66)(@vitest/browser@2.1.6)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -23387,7 +24011,9 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - utf-8-validate
       - vite
       - webdriverio
+      - yaml
     dev: false

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_f8cb6e70bf"
+  "Tag": "js/identity/identity_9c942f1d35"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_9c942f1d35"
+  "Tag": "js/identity/identity_ac8467354c"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_41bcaec991"
+  "Tag": "js/identity/identity_f8cb6e70bf"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_41668ddcf2"
+  "Tag": "js/identity/identity_0847ca7372"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_ac8467354c"
+  "Tag": "js/identity/identity_41668ddcf2"
 }

--- a/sdk/identity/identity/assets.json
+++ b/sdk/identity/identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/identity/identity",
-  "Tag": "js/identity/identity_0847ca7372"
+  "Tag": "js/identity/identity_9dc037e376"
 }

--- a/sdk/identity/identity/test/internal/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/deviceCodeCredential.spec.ts
@@ -43,7 +43,7 @@ describe("DeviceCodeCredential (internal)", function () {
       recorder.configureClientOptions({
         tenantId: env.AZURE_TENANT_ID,
         clientId: env.AZURE_CLIENT_ID,
-      })
+      }),
     );
 
     await credential.getToken(scope);
@@ -66,7 +66,7 @@ describe("DeviceCodeCredential (internal)", function () {
       recorder.configureClientOptions({
         tenantId: env.AZURE_TENANT_ID,
         clientId: env.AZURE_CLIENT_ID,
-      })
+      }),
     );
 
     await credential.getToken(scope, { tenantId: env.AZURE_TENANT_ID });

--- a/sdk/identity/identity/test/internal/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/deviceCodeCredential.spec.ts
@@ -7,7 +7,7 @@ import type { Recorder } from "@azure-tools/test-recorder";
 import { env, isLiveMode } from "@azure-tools/test-recorder";
 import { DeviceCodeCredential } from "../../../src/index.js";
 import { PublicClientApplication } from "@azure/msal-node";
-import { describe, it, assert, expect, vi, beforeEach, afterEach, MockInstance } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, MockInstance } from "vitest";
 
 describe("DeviceCodeCredential (internal)", function () {
   let cleanup: MsalTestCleanup;
@@ -32,7 +32,7 @@ describe("DeviceCodeCredential (internal)", function () {
     await cleanup();
   });
 
-  const scope = "https://vault.azure.net/.default";
+  const scope = "https://graph.microsoft.com/.default";
 
   it("Authenticates silently after the initial request", async function (ctx) {
     // These tests should not run live because this credential requires user interaction.
@@ -43,7 +43,7 @@ describe("DeviceCodeCredential (internal)", function () {
       recorder.configureClientOptions({
         tenantId: env.AZURE_TENANT_ID,
         clientId: env.AZURE_CLIENT_ID,
-      }),
+      })
     );
 
     await credential.getToken(scope);
@@ -66,7 +66,7 @@ describe("DeviceCodeCredential (internal)", function () {
       recorder.configureClientOptions({
         tenantId: env.AZURE_TENANT_ID,
         clientId: env.AZURE_CLIENT_ID,
-      }),
+      })
     );
 
     await credential.getToken(scope, { tenantId: env.AZURE_TENANT_ID });

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -196,7 +196,7 @@ export async function msalNodeTestSetup(
           },
         ],
       },
-      ["record", "playback"]
+      ["record", "playback"],
     );
 
     return {

--- a/sdk/identity/identity/test/node/msalNodeTestSetup.ts
+++ b/sdk/identity/identity/test/node/msalNodeTestSetup.ts
@@ -102,6 +102,13 @@ export async function msalNodeTestSetup(
     // Playback sanitizers
     await recorder.addSanitizers(
       {
+        uriSanitizers: [
+          {
+            regex: true,
+            target: `client-request-id=[a-zA-Z0-9-]+`,
+            value: `client-request-id=${playbackValues.correlationId}`,
+          },
+        ],
         bodySanitizers: [
           {
             regex: true,
@@ -189,7 +196,7 @@ export async function msalNodeTestSetup(
           },
         ],
       },
-      ["record", "playback"],
+      ["record", "playback"]
     );
 
     return {


### PR DESCRIPTION
With the recent upgrades to msal node (2.15 to 2.16) and msal common (14.15 to 14.16), the request uri used by msal has now been updated to include the client-request-id as a query parameter in the request uri. I have manually updated recordings of the tests to reflect the change, in order to fix the breaking recorded tests after upgrading dependecy on msal.
Unable to re-record the tests to auto-generate the recordings, due to tenant restrictions, hence manually updated the recordings.

Also unpinning the msal dependency that were pinned in this PR - https://github.com/Azure/azure-sdk-for-js/pull/31819/
