### PR TITLE
[ServiceBus] fix issue of accepting session with empty string name

### DIFF
--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -260,7 +260,7 @@ export class MessageSession extends LinkEntity<Receiver> {
     this._intermediateLink = link;
 
     const receivedSessionId = link.source?.filter?.[Constants.sessionFilterName];
-    if (!this._providedSessionId && !receivedSessionId) {
+    if (this._providedSessionId === undefined && receivedSessionId === undefined) {
       // When we ask for any sessions (passing option of session-filter: undefined),
       // but don't receive one back, check whether service has sent any error.
       if (
@@ -281,7 +281,10 @@ export class MessageSession extends LinkEntity<Receiver> {
       // Ideally this code path should never be reached as `MessageSession.createReceiver()` should fail instead
       // TODO: https://github.com/Azure/azure-sdk-for-js/issues/9775 to figure out why this code path indeed gets hit.
       errorMessage = `Failed to create a receiver. No unlocked sessions available.`;
-    } else if (this._providedSessionId && receivedSessionId !== this._providedSessionId) {
+    } else if (
+      this._providedSessionId !== undefined &&
+      receivedSessionId !== this._providedSessionId
+    ) {
       // This code path is reached if the session is already locked by another receiver.
       // TODO: Check why the service would not throw an error or just timeout instead of giving a misleading successful receiver
       errorMessage = `Failed to create a receiver for the requested session '${this._providedSessionId}'. It may be locked by another receiver.`;
@@ -321,7 +324,7 @@ export class MessageSession extends LinkEntity<Receiver> {
 
       const receivedSessionId = this.link.source?.filter?.[Constants.sessionFilterName];
 
-      if (!this._providedSessionId) this.sessionId = receivedSessionId;
+      if (this._providedSessionId === undefined) this.sessionId = receivedSessionId;
       this.sessionLockedUntilUtc = convertTicksToDate(
         this.link.properties["com.microsoft:locked-until-utc"],
       );
@@ -347,7 +350,7 @@ export class MessageSession extends LinkEntity<Receiver> {
 
       // Fix the unhelpful error messages for the OperationTimeoutError that comes from `rhea-promise`.
       if ((errObj as MessagingError).code === "OperationTimeoutError") {
-        if (this._providedSessionId) {
+        if (this._providedSessionId !== undefined) {
           errObj.message = `Failed to create a receiver for the requested session '${this._providedSessionId}' within allocated time and retry attempts.`;
         } else {
           errObj.message = "Failed to create a receiver within allocated time and retry attempts.";


### PR DESCRIPTION
We have a check for when asking for any session, i.e., not providing a session id), but not receiving a link having a session id. However, the check is `if (!this._providedSessionId && !receivedSessionId)` which also evaluates to `true` for session id of empty string, which is valid session id.

This PR changes it to check for `undefined` so that session id of empty string doesn't lead to error being thrown.
