### PR TITLE
fix(playwrighttesting): Add X-MS-Package-Version header to connect session API

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/constants.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/constants.ts
@@ -57,7 +57,6 @@ export class Constants {
   public static readonly TEST_TYPE = "WebTest";
   public static readonly TEST_SDK_LANGUAGE = "JAVASCRIPT";
   // Placeholder version
-  public static readonly REPORTER_PACKAGE_VERSION = "1.0.0-beta.3";
   public static readonly DEFAULT_DASHBOARD_ENDPOINT = "https://playwright.microsoft.com";
   public static readonly DEFAULT_SERVICE_ENDPOINT =
     "https://{region}.reporting.api.playwright-test.io";

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -102,7 +102,7 @@ const getServiceConfig = (
         ),
         headers: {
           Authorization: `Bearer ${getAccessToken()}`,
-          "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(getReporterVersion())}`,
+          "x-ms-package-version": `@azure/microsoft-playwright-testing/${getReporterVersion()}`,
         },
         timeout: playwrightServiceConfig.timeout,
         exposeNetwork: playwrightServiceConfig.exposeNetwork,
@@ -157,7 +157,7 @@ const getConnectOptions = async (
     options: {
       headers: {
         Authorization: `Bearer ${token}`,
-        "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(getReporterVersion())}`,
+        "x-ms-package-version": `@azure/microsoft-playwright-testing/${getReporterVersion()}`,
       },
       timeout: playwrightServiceConfig.timeout,
       exposeNetwork: playwrightServiceConfig.exposeNetwork,

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -20,7 +20,7 @@ import {
   validatePlaywrightVersion,
   validateServiceUrl,
   exitWithFailureMessage,
-  getReporterVersion,
+  getPackageVersion,
 } from "../utils/utils";
 
 /**
@@ -102,7 +102,7 @@ const getServiceConfig = (
         ),
         headers: {
           Authorization: `Bearer ${getAccessToken()}`,
-          "x-ms-package-version": `@azure/microsoft-playwright-testing/${getReporterVersion()}`,
+          "x-ms-package-version": `@azure/microsoft-playwright-testing/${getPackageVersion()}`,
         },
         timeout: playwrightServiceConfig.timeout,
         exposeNetwork: playwrightServiceConfig.exposeNetwork,
@@ -157,7 +157,7 @@ const getConnectOptions = async (
     options: {
       headers: {
         Authorization: `Bearer ${token}`,
-        "x-ms-package-version": `@azure/microsoft-playwright-testing/${getReporterVersion()}`,
+        "x-ms-package-version": `@azure/microsoft-playwright-testing/${getPackageVersion()}`,
       },
       timeout: playwrightServiceConfig.timeout,
       exposeNetwork: playwrightServiceConfig.exposeNetwork,

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -20,6 +20,7 @@ import {
   validatePlaywrightVersion,
   validateServiceUrl,
   exitWithFailureMessage,
+  getReporterVersion,
 } from "../utils/utils";
 
 /**
@@ -101,6 +102,7 @@ const getServiceConfig = (
         ),
         headers: {
           Authorization: `Bearer ${getAccessToken()}`,
+          "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(getReporterVersion())}`,
         },
         timeout: playwrightServiceConfig.timeout,
         exposeNetwork: playwrightServiceConfig.exposeNetwork,
@@ -155,6 +157,7 @@ const getConnectOptions = async (
     options: {
       headers: {
         Authorization: `Bearer ${token}`,
+        "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(getReporterVersion())}`,
       },
       timeout: playwrightServiceConfig.timeout,
       exposeNetwork: playwrightServiceConfig.exposeNetwork,

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
@@ -31,7 +31,7 @@ import type { CIInfo } from "./cIInfoProvider";
 import { CI_PROVIDERS } from "./cIInfoProvider";
 import { CIInfoProvider } from "./cIInfoProvider";
 import type { StorageUri } from "../model/storageUri";
-import { getReporterVersion } from "./utils";
+import { getPackageVersion } from "./utils";
 class ReporterUtils {
   private envVariables: EnvironmentVariables;
 
@@ -393,7 +393,7 @@ class ReporterUtils {
       },
       testType: Constants.TEST_TYPE,
       testSdkLanguage: Constants.TEST_SDK_LANGUAGE,
-      reporterPackageVersion: getReporterVersion(),
+      reporterPackageVersion: getPackageVersion(),
     };
     return testRunConfig;
   }

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/reporterUtils.ts
@@ -31,7 +31,7 @@ import type { CIInfo } from "./cIInfoProvider";
 import { CI_PROVIDERS } from "./cIInfoProvider";
 import { CIInfoProvider } from "./cIInfoProvider";
 import type { StorageUri } from "../model/storageUri";
-
+import { getReporterVersion } from "./utils";
 class ReporterUtils {
   private envVariables: EnvironmentVariables;
 
@@ -393,7 +393,7 @@ class ReporterUtils {
       },
       testType: Constants.TEST_TYPE,
       testSdkLanguage: Constants.TEST_SDK_LANGUAGE,
-      reporterPackageVersion: Constants.REPORTER_PACKAGE_VERSION,
+      reporterPackageVersion: getReporterVersion(),
     };
     return testRunConfig;
   }

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/utils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/utils.ts
@@ -143,6 +143,12 @@ export const getPlaywrightVersion = (): string => {
   return process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION]!;
 };
 
+export const getReporterVersion = (): string => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const version = require("../../package.json").version;
+  return version;
+};
+
 export const getVersionInfo = (version: string): VersionInfo => {
   const regex = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?/;
   const match = version.match(regex);

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/utils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/utils.ts
@@ -143,12 +143,16 @@ export const getPlaywrightVersion = (): string => {
   return process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION]!;
 };
 
-export const getReporterVersion = (): string => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const version = require("../../package.json").version;
-  return version;
+export const getPackageVersion = (): string => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const version = require("../../package.json").version;
+    return version;
+  } catch (error) {
+    console.error("Error fetching package version:", error);
+    return "unknown version";
+  }
 };
-
 export const getVersionInfo = (version: string): VersionInfo => {
   const regex = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?/;
   const match = version.match(regex);

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
@@ -130,14 +130,17 @@ describe("getServiceConfig", () => {
   it("should return service config with service connect options", () => {
     process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = "token";
     const { getServiceConfig } = require("../../src/core/playwrightService");
-    const config = getServiceConfig(samplePlaywrightConfigInput);
     const playwrightServiceConfig = new PlaywrightServiceConfig();
+    const mockVersion = "1.0.0";
+    sandbox.stub(require("../../package.json"), "version").value(mockVersion);
+    const config = getServiceConfig(samplePlaywrightConfigInput);
     expect(config).to.deep.equal({
       use: {
         connectOptions: {
           wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&runName=${playwrightServiceConfig.runName}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
           headers: {
             Authorization: "Bearer token",
+            "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(mockVersion)}`,
           },
           timeout: playwrightServiceConfig.timeout,
           exposeNetwork: playwrightServiceConfig.exposeNetwork,
@@ -198,7 +201,10 @@ describe("getConnectOptions", () => {
   });
 
   it("should set service connect options with fetched token", async () => {
+    const sandbox = sinon.createSandbox();
     const { getConnectOptions } = require("../../src/core/playwrightService");
+    const mockVersion = "1.0.0";
+    sandbox.stub(require("../../package.json"), "version").value(mockVersion);
     const connectOptions = await getConnectOptions({});
     const playwrightServiceConfig = new PlaywrightServiceConfig();
     expect(connectOptions).to.deep.equal({
@@ -206,12 +212,14 @@ describe("getConnectOptions", () => {
       options: {
         headers: {
           Authorization: "Bearer token",
+          "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(mockVersion)}`,
         },
         timeout: new PlaywrightServiceConfig().timeout,
         exposeNetwork: new PlaywrightServiceConfig().exposeNetwork,
         slowMo: new PlaywrightServiceConfig().slowMo,
       },
     });
+    sandbox.restore();
   });
 
   it("should throw error if token is not set", async () => {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/utils.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/utils.spec.ts
@@ -499,7 +499,7 @@ describe("Service Utils", () => {
     const mockVersion = "1.0.0";
     const packageJson = require("../../package.json");
     sandbox.stub(packageJson, "version").value(mockVersion);
-    const version = utils.getReporterVersion();
+    const version = utils.getPackageVersion();
     expect(version).to.equal(mockVersion);
   });
 });

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/utils.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/utils.spec.ts
@@ -495,4 +495,11 @@ describe("Service Utils", () => {
     const result = populateValuesFromServiceUrl();
     expect(result).to.be.null;
   });
+  it("should return the correct version from package.json", async () => {
+    const mockVersion = "1.0.0";
+    const packageJson = require("../../package.json");
+    sandbox.stub(packageJson, "version").value(mockVersion);
+    const version = utils.getReporterVersion();
+    expect(version).to.equal(mockVersion);
+  });
 });


### PR DESCRIPTION

### Packages impacted by this PR
@azure/microsoft-playwright-testing

### Issues associated with this PR
Added X-MS-Package-Version header to connect session API for language and package version decoding.

### Need to discuss
The getReporterVersion function returns the reporter version, which includes a special character ("."). This caused tests to fail with the error: "Invalid character in header content ["x-ms-package-version"]." Therefore, the characters were escaped.
Since we are passing the header from the package, this needs to be handled by the server. We are encoding it here, but it needs to be decoded on the server side.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
