### PR TITLE
[Identity] Fix the resource deployment step for MI tests

### DIFF
--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -3,6 +3,7 @@ trigger: none
 extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
+      Location: westus2
       PreSteps:
       - task: AzureCLI@2
         displayName: Set OIDC variables

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -60,8 +60,6 @@ $env:IDENTITY_SP_CERT_PEM = $pemPath
 
 
 if ($CI) {
-  # Install latest version of the Azure CLI
-  pip install azure-cli
   # The owner is a service principal
   $templateFileParameters['principalUserType'] = 'ServicePrincipal'
   Write-Host "Sleeping for a bit to ensure service principal is ready."

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -60,8 +60,8 @@ $env:IDENTITY_SP_CERT_PEM = $pemPath
 
 
 if ($CI) {
-  # Install this specific version of the Azure CLI to avoid https://github.com/Azure/azure-cli/issues/28358.
-  pip install azure-cli=="2.56.0"
+  # Install latest version of the Azure CLI
+  pip install azure-cli
   # The owner is a service principal
   $templateFileParameters['principalUserType'] = 'ServicePrincipal'
   Write-Host "Sleeping for a bit to ensure service principal is ready."


### PR DESCRIPTION
- The resource deployment script for MI tests has been failing. Fixing this by:
1. Setting the location explicitly to `westus2`
Reason:
We need to deploy vms in the TME tenant, the default region of westus doesnt work. Have to set the Location to westus2, as it has quota for vms/aks. Otherwise we get the error like this :
```
Preflight validation check for resource(s) for container service t32358a8eb2bf4865 in resource group rg-identity-t32358a8eb2bf4865 failed. Message: The VM size of Standard_D2s_v3 is not allowed in your subscription in location 'westus'.
```