### PR TITLE
Debug configuration for vitest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "test:vitest",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["dev-tool", "run", "test:vitest"],
+      "args": ["--", "--inspect-brk", "--no-file-parallelism", "${input:filename}"],
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "attachSimplePort": 9229,
+      "cwd": "${workspaceFolder}/sdk/${input:package-directory}"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "filename",
+      "type": "promptString",
+      "description": "(Optional) Enter a part of the test file name (e.g. 'foo' will run 'foo.spec.ts', 'notfoo.spec.ts', 'test.foo.spec.ts', etc.)",
+      "default": ""
+    },
+    {
+      "id": "package-directory",
+      "type": "promptString",
+      "description": "Enter the package directory (e.g., 'identity/identity', 'keyvault/keyvault-keys', etc.)"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,8 +10,7 @@
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,
-    "**/.DS_Store": true,
-    "**/node_modules": true
+    "**/.DS_Store": true
   },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,


### PR DESCRIPTION
### Packages impacted by this PR

None

### Issues associated with this PR

None

### Describe the problem that is addressed by this PR

Using the JavaScript Debug Terminal and auto-attaching to every subprocess
results in a long wait time to hit breakpoints when debugging. To improve the
experience, we can include a launch.json configuration that allows running
vitest tests and only attaching to the vitest process itself.

Because we need the test proxy running, using dev-tool is the recommended way to
run tests. This PR adds the proper configuration to support that scenario.

While here I also went ahead and removed `node_modules` from VSCode's exclusion
list so they show up in the file explorer. Happy to revert that but I find it difficult to dig into
dependencies and set breakpoints in node modules when they are hidden.

https://github.com/user-attachments/assets/85e9c69f-c112-4a76-955f-76228ba689e6


