### PR TITLE
[dev-tool] Enable test-proxy Debug log-level

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testBrowser.ts
+++ b/common/tools/dev-tool/src/commands/run/testBrowser.ts
@@ -15,6 +15,11 @@ export const commandInfo = makeCommandInfo(
       kind: "boolean",
       default: true,
     },
+    "test-proxy-debug": {
+      description: "Runs the test-proxy with debug logs enabled (Logging__LogLevel__Default=Debug); generates testProxyOutput.log",
+      kind: "boolean",
+      default: false
+    }
   },
 );
 
@@ -25,6 +30,8 @@ export default leafCommand(commandInfo, async (options) => {
 
   const stopRelay =
     options["relay-server"] && (await shouldStartRelay()) ? startRelayServer() : undefined;
+
+  if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
 
   try {
     const result = await runTestsWithProxyTool({

--- a/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeJSInput.ts
@@ -17,6 +17,11 @@ export const commandInfo = makeCommandInfo(
       default: true,
       description: "whether to run with test-proxy",
     },
+    "test-proxy-debug": {
+      description: "Runs the test-proxy with debug logs enabled (Logging__LogLevel__Default=Debug); generates testProxyOutput.log",
+      kind: "boolean",
+      default: false
+    }
   },
 );
 
@@ -36,6 +41,7 @@ export default leafCommand(commandInfo, async (options) => {
   };
 
   if (options["test-proxy"]) {
+    if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
     return runTestsWithProxyTool(command);
   }
 

--- a/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTSInput.ts
@@ -18,6 +18,11 @@ export const commandInfo = makeCommandInfo(
       default: true,
       description: "whether to enable launching test-proxy",
     },
+    "test-proxy-debug": {
+      description: "Runs the test-proxy with debug logs enabled (Logging__LogLevel__Default=Debug); generates testProxyOutput.log",
+      kind: "boolean",
+      default: false
+    }
   },
 );
 
@@ -38,11 +43,12 @@ export default leafCommand(commandInfo, async (options) => {
     command: isModuleProj
       ? `mocha --loader=ts-node/esm ${defaultMochaArgs} ${mochaArgs}`
       : // eslint-disable-next-line no-useless-escape
-        `${CROSS_ENV_PATH} TS_NODE_COMPILER_OPTIONS="{\\\"module\\\":\\\"commonjs\\\"}" mocha -r ts-node/register ${defaultMochaArgs} ${mochaArgs}`,
+      `${CROSS_ENV_PATH} TS_NODE_COMPILER_OPTIONS="{\\\"module\\\":\\\"commonjs\\\"}" mocha -r ts-node/register ${defaultMochaArgs} ${mochaArgs}`,
     name: "node-tests",
   };
 
   if (options["test-proxy"]) {
+    if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
     return runTestsWithProxyTool(command);
   }
 

--- a/common/tools/dev-tool/src/commands/run/testNodeTsxTS.ts
+++ b/common/tools/dev-tool/src/commands/run/testNodeTsxTS.ts
@@ -16,6 +16,11 @@ export const commandInfo = makeCommandInfo(
       default: true,
       description: "whether to enable launching test-proxy",
     },
+    "test-proxy-debug": {
+      description: "Runs the test-proxy with debug logs enabled (Logging__LogLevel__Default=Debug); generates testProxyOutput.log",
+      kind: "boolean",
+      default: false
+    }
   },
 );
 
@@ -35,6 +40,7 @@ export default leafCommand(commandInfo, async (options) => {
   };
 
   if (options["test-proxy"]) {
+    if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
     return runTestsWithProxyTool(command);
   }
 

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -32,6 +32,11 @@ export const commandInfo = makeCommandInfo(
       kind: "boolean",
       default: true,
     },
+    "test-proxy-debug": {
+      description: "Runs the test-proxy with debug logs enabled (Logging__LogLevel__Default=Debug); generates testProxyOutput.log",
+      kind: "boolean",
+      default: false
+    }
   },
 );
 
@@ -79,6 +84,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   try {
     if (options["test-proxy"]) {
+      if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
       return await runTestsWithProxyTool(command);
     }
 

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -172,7 +172,7 @@ function runCommand(executable: string, argv: string[], options: SpawnOptions = 
 }
 
 export async function runTestProxyCommand(argv: string[]): Promise<void> {
-  const result = runCommand(await getTestProxyExecutable(), argv, { stdio: "inherit" }).result;
+  const result = runCommand(await getTestProxyExecutable(), argv, { stdio: "inherit", env: { ...process.env } }).result;
   if (await fs.pathExists("assets.json")) {
     await linkRecordingsDirectory();
   }
@@ -287,8 +287,7 @@ export async function isProxyToolActive(): Promise<boolean> {
     }
 
     log.info(
-      `Proxy tool seems to be active at http://localhost:${
-        process.env.TEST_PROXY_HTTP_PORT ?? 5000
+      `Proxy tool seems to be active at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000
       }\n`,
     );
     return true;


### PR DESCRIPTION
## What's going on?

- Invocation of `test-proxy` in the `child_process` will now support environment variables
  - injects the current environment variables into the child's environment 
- Added a new flag `"test-proxy-debug"` to all the test commands, which enables debug logging for the test-proxy
  - sets the environment variable `Logging__LogLevel__Default` to `"Debug"`
- Simply setting the environment variable `Logging__LogLevel__Default` to `"Debug"` will have the same effect as passing `test-proxy-debug` flag to the test commands.

Related to https://github.com/Azure/azure-sdk-tools/pull/9164