### PR TITLE
[data-tables] Appease release check

### DIFF
--- a/sdk/tables/data-tables/swagger/README.md
+++ b/sdk/tables/data-tables/swagger/README.md
@@ -14,7 +14,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/4a8cd09ab6963b6dd36088aafca81975d32ee561/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/table.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cosmos-db/data-plane/Microsoft.Tables/preview/2019-02-02/table.json
 add-credentials: false
 override-client-name: GeneratedClient
 use-extension:


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/data-tables`

### Describe the problem that is addressed by this PR

Nothing is actually changing here except the release automation now complains if the commit used isn't referencing main. The input file is the same.