### PR TITLE
Revert "fix(playwrighttesting): Removed runName support from the wsEn…

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -97,6 +97,7 @@ const getServiceConfig = (
       connectOptions: {
         wsEndpoint: getServiceWSEndpoint(
           playwrightServiceConfig.runId,
+          playwrightServiceConfig.runName,
           playwrightServiceConfig.serviceOs,
         ),
         headers: {
@@ -150,6 +151,7 @@ const getConnectOptions = async (
   return {
     wsEndpoint: getServiceWSEndpoint(
       playwrightServiceConfig.runId,
+      playwrightServiceConfig.runName,
       playwrightServiceConfig.serviceOs,
     ),
     options: {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/utils.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/utils/utils.ts
@@ -68,8 +68,8 @@ export const getAndSetRunId = (): string => {
   return runId;
 };
 
-export const getServiceWSEndpoint = (runId: string, os: string): string => {
-  return `${getServiceBaseURL()}?runId=${encodeURIComponent(runId)}&os=${os}&api-version=${API_VERSION}`;
+export const getServiceWSEndpoint = (runId: string, runName: string, os: string): string => {
+  return `${getServiceBaseURL()}?runId=${encodeURIComponent(runId)}&runName=${encodeURIComponent(runName)}&os=${os}&api-version=${API_VERSION}`;
 };
 
 export const validateServiceUrl = (): void => {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
@@ -137,7 +137,7 @@ describe("getServiceConfig", () => {
     expect(config).to.deep.equal({
       use: {
         connectOptions: {
-          wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
+          wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&runName=${playwrightServiceConfig.runName}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
           headers: {
             Authorization: "Bearer token",
             "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(mockVersion)}`,
@@ -208,7 +208,7 @@ describe("getConnectOptions", () => {
     const connectOptions = await getConnectOptions({});
     const playwrightServiceConfig = new PlaywrightServiceConfig();
     expect(connectOptions).to.deep.equal({
-      wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
+      wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&runName=${playwrightServiceConfig.runName}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
       options: {
         headers: {
           Authorization: "Bearer token",

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/utils.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/utils.spec.ts
@@ -75,21 +75,24 @@ describe("Service Utils", () => {
       "wss://eastus.api.playwright.microsoft.com/accounts/1234/browsers";
     const runId = "2021-10-11T07:00:00.000Z";
     const escapeRunId = encodeURIComponent(runId);
+    const runName = "runName";
     const os = "windows";
-    const expected = `wss://eastus.api.playwright.microsoft.com/accounts/1234/browsers?runId=${escapeRunId}&os=${os}&api-version=${API_VERSION}`;
-    expect(getServiceWSEndpoint(runId, os)).to.equal(expected);
+    const expected = `wss://eastus.api.playwright.microsoft.com/accounts/1234/browsers?runId=${escapeRunId}&runName=${runName}&os=${os}&api-version=${API_VERSION}`;
+    expect(getServiceWSEndpoint(runId, runName, os)).to.equal(expected);
 
     delete process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_URL];
   });
 
-  it("should escape special character in runId", () => {
+  it("should escape special character in runName and runId", () => {
     process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_URL] =
       "wss://eastus.api.playwright.microsoft.com/accounts/1234/browsers";
     const runId = "2021-10-11T07:00:00.000Z";
     const escapeRunId = encodeURIComponent(runId);
+    const runName = "run#Name-12/09";
+    const escapeRunName = encodeURIComponent(runName);
     const os = "windows";
-    const expected = `wss://eastus.api.playwright.microsoft.com/accounts/1234/browsers?runId=${escapeRunId}&os=${os}&api-version=${API_VERSION}`;
-    expect(getServiceWSEndpoint(runId, os)).to.equal(expected);
+    const expected = `wss://eastus.api.playwright.microsoft.com/accounts/1234/browsers?runId=${escapeRunId}&runName=${escapeRunName}&os=${os}&api-version=${API_VERSION}`;
+    expect(getServiceWSEndpoint(runId, runName, os)).to.equal(expected);
 
     delete process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_URL];
   });


### PR DESCRIPTION
…dpoint"

This reverts commit 92469c23e44c402a3998412717ad47f2ccec71cf.


### Packages impacted by this PR
@azure/microsoft-playwright-testing


### Issues associated with this PR

### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
