### PR TITLE
[identity] Bump vitest hook/test timeout

### DIFF
--- a/sdk/identity/identity/vitest.browser.config.ts
+++ b/sdk/identity/identity/vitest.browser.config.ts
@@ -10,6 +10,8 @@ export default mergeConfig(
     test: {
       include: ["dist-test/browser/test/**/*.spec.js"],
       exclude: ["dist-test/browser/test/snippets.spec.js"],
+      hookTimeout: 500000,
+      testTimeout: 500000,
     },
   }),
 );

--- a/sdk/identity/identity/vitest.config.ts
+++ b/sdk/identity/identity/vitest.config.ts
@@ -14,6 +14,8 @@ export default mergeConfig(
         "test/snippets.spec.ts",
         "test/integration/**/*.spec.ts",
       ],
+      hookTimeout: 500000,
+      testTimeout: 500000,
     },
   }),
 );

--- a/sdk/identity/identity/vitest.managed-identity.config.ts
+++ b/sdk/identity/identity/vitest.managed-identity.config.ts
@@ -9,6 +9,8 @@ export default mergeConfig(
   defineConfig({
     test: {
       include: ["test/integration/**/*.spec.ts"],
+      hookTimeout: 500000,
+      testTimeout: 500000,
     },
   }),
 );


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Bumps the `hookTimeout` and `testTimeout` for @azure/identity tests.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
