### PR TITLE
[Search] Fix `SplitTextSkill` missing properties

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Release History
 
+## 12.1.1 (Unreleased)
+
+### Bugs Fixed
+
+- Exposed missing configuration for page-based text splitting in `SplitTextSkill` [#31882](https://github.com/Azure/azure-sdk-for-js/pull/31882) 
+
 ## 12.1.0 (2024-07-24)
 
 ### Features Added
 
-- Added support for text queries against vector fields [#30494](https://github.com/Azure/azure-sdk-for-js/pull/29597) 
+- Added support for text queries against vector fields [#30494](https://github.com/Azure/azure-sdk-for-js/pull/30494) 
   - Create text queries against vector fields with the `VectorizedTextQuery` variant of `VectorQuery`. Such queries are supported by configuring the corresponding index field with a `VectorSearchVectorizer`. This configuration describes a delegate, which the service uses to generate vector embeddings for the query text. 
 - Added `AzureOpenAIEmbeddingSkill` to allow for `SearchIndexer`s to populate embedding fields at index-time.
 - Added index configuration for vector quantization through `VectorSearchCompression`

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -2531,8 +2531,10 @@ export interface SoftDeleteColumnDeletionDetectionPolicy extends BaseDataDeletio
 // @public
 export interface SplitSkill extends BaseSearchIndexerSkill {
     defaultLanguageCode?: SplitSkillLanguage;
+    maximumPagesToTake?: number;
     maxPageLength?: number;
     odatatype: "#Microsoft.Skills.Text.SplitSkill";
+    pageOverlapLength?: number;
     textSplitMode?: TextSplitMode;
 }
 

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -2364,12 +2364,16 @@ export interface SentimentSkill extends BaseSearchIndexerSkill {
 export interface SplitSkill extends BaseSearchIndexerSkill {
   /** Polymorphic discriminator, which specifies the different types this object can be */
   odatatype: "#Microsoft.Skills.Text.SplitSkill";
-  /** A value indicating which language code to use. Default is en. */
+  /** A value indicating which language code to use. Default is `en`. */
   defaultLanguageCode?: SplitSkillLanguage;
   /** A value indicating which split mode to perform. */
   textSplitMode?: TextSplitMode;
   /** The desired maximum page length. Default is 10000. */
   maxPageLength?: number;
+  /** Only applicable when textSplitMode is set to 'pages'. If specified, n+1th chunk will start with this number of characters/tokens from the end of the nth chunk. */
+  pageOverlapLength?: number;
+  /** Only applicable when textSplitMode is set to 'pages'. If specified, the SplitSkill will discontinue splitting after processing the first 'maximumPagesToTake' pages, in order to improve performance when only a few initial pages are needed from each document. */
+  maximumPagesToTake?: number;
 }
 
 /** A skill to translate text from one language to another. */


### PR DESCRIPTION
### Packages impacted by this PR

@azure/search-documents

### Issues associated with this PR

Fixes #31761 

### Describe the problem that is addressed by this PR

Some properties weren't exposed in the 2023-10 release of the Search preview. This is a backport of the fix for the preview SDK.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
