### PR TITLE
[communication-rooms] Wait for PatchParticipants Rest API calls to complete before returning 

### DIFF
--- a/sdk/communication/communication-rooms/src/roomsClient.ts
+++ b/sdk/communication/communication-rooms/src/roomsClient.ts
@@ -320,8 +320,8 @@ export class RoomsClient {
     return tracingClient.withSpan(
       "RoomsClient-AddOrUpdateParticipants",
       options,
-      (updatedOptions) => {
-        this.client.participants.update(roomId, {
+      async (updatedOptions) : Promise<void> => {
+        await this.client.participants.update(roomId, {
           ...updatedOptions,
           participants: mapRoomParticipantToRawId(participants),
         });
@@ -341,11 +341,11 @@ export class RoomsClient {
     participantIdentifiers: CommunicationIdentifier[],
     options: RemoveParticipantsOptions = {},
   ): Promise<void> {
-    return tracingClient.withSpan("RoomsClient-RemoveParticipants", options, (updatedOptions) => {
-      this.client.participants.update(roomId, {
-        ...updatedOptions,
-        participants: mapRoomParticipantForRemoval(participantIdentifiers),
-      });
+      return tracingClient.withSpan("RoomsClient-RemoveParticipants", options, async (updatedOptions): Promise<void> => {
+        await this.client.participants.update(roomId, {
+          ...updatedOptions,
+          participants: mapRoomParticipantForRemoval(participantIdentifiers),
+        });
     });
   }
 }

--- a/sdk/communication/communication-rooms/test/public/roomsClient.spec.ts
+++ b/sdk/communication/communication-rooms/test/public/roomsClient.spec.ts
@@ -59,7 +59,7 @@ describe("RoomsClient", () => {
       const createRoomResult = await client.createRoom(options);
       verifyRoomsAttributes(createRoomResult, options);
       roomId = createRoomResult.id;
-      const addParticipantsResult = await client.listParticipants(roomId);
+      const addParticipantsResult = await listParticipants(roomId, client);
       verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 1, 0, 0);
     });
 
@@ -100,7 +100,7 @@ describe("RoomsClient", () => {
 
       verifyRoomsAttributes(createRoomResult, options);
       roomId = createRoomResult.id;
-      const addParticipantsResult = await client.listParticipants(roomId);
+      const addParticipantsResult = await listParticipants(roomId, client);
       verifyRoomsParticipantsAttributes(addParticipantsResult, 0, 0, 0, 0);
     });
 
@@ -156,7 +156,7 @@ describe("RoomsClient", () => {
       verifyRoomsAttributes(createRoomResult, options);
 
       roomId = createRoomResult.id;
-      const addParticipantsResult = await client.listParticipants(roomId);
+      const addParticipantsResult = await listParticipants(roomId, client);
       verifyRoomsParticipantsAttributes(addParticipantsResult, 0, 0, 0, 0);
     });
 
@@ -179,7 +179,7 @@ describe("RoomsClient", () => {
       verifyRoomsAttributes(createRoomResult, options);
 
       roomId = createRoomResult.id;
-      const addParticipantsResult = await client.listParticipants(roomId);
+      const addParticipantsResult = await listParticipants(roomId, client);
       verifyRoomsParticipantsAttributes(addParticipantsResult, 0, 0, 0, 0);
     });
 
@@ -207,7 +207,7 @@ describe("RoomsClient", () => {
       verifyRoomsAttributes(createRoomResult, options);
 
       roomId = createRoomResult.id;
-      const addParticipantsResult = await client.listParticipants(roomId);
+      const addParticipantsResult = await listParticipants(roomId, client);
       verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 1, 0, 0);
     });
 
@@ -229,7 +229,7 @@ describe("RoomsClient", () => {
       const createRoomResult = await client.createRoom(options);
       verifyRoomsAttributes(createRoomResult, options);
       roomId = createRoomResult.id;
-      const addParticipantsResult = await client.listParticipants(roomId);
+      const addParticipantsResult = await listParticipants(roomId, client);
       verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 1, 0, 0);
     });
 
@@ -506,7 +506,7 @@ describe("Participants Operations", () => {
     await client.addOrUpdateParticipants(curRoomId, participants);
     await pause(delayInMs);
 
-    const addParticipantsResult = await client.listParticipants(curRoomId);
+    const addParticipantsResult = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 1, 0, 0);
 
     roomId = curRoomId;
@@ -531,7 +531,7 @@ describe("Participants Operations", () => {
     await client.addOrUpdateParticipants(curRoomId, participants as any);
     await pause(delayInMs);
 
-    const addParticipantsResult = await client.listParticipants(curRoomId);
+    const addParticipantsResult = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 0, 1, 0);
 
     roomId = curRoomId;
@@ -557,7 +557,7 @@ describe("Participants Operations", () => {
     await client.addOrUpdateParticipants(curRoomId, participants);
     await pause(delayInMs);
 
-    const allParticipants = await client.listParticipants(curRoomId);
+    const allParticipants = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(allParticipants, 1, 0, 1, 0);
 
     roomId = curRoomId;
@@ -578,7 +578,7 @@ describe("Participants Operations", () => {
 
     await pause(delayInMs);
 
-    const participants = await client.listParticipants(curRoomId);
+    const participants = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(participants, 0, 0, 0, 0);
 
     roomId = curRoomId;
@@ -608,12 +608,21 @@ describe("Participants Operations", () => {
     await client.removeParticipants(curRoomId, removeParticipants);
     await pause(delayInMs);
 
-    const participants = await client.listParticipants(curRoomId);
+    const participants = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(participants, 0, 0, 0, 0);
 
     roomId = curRoomId;
   });
 });
+
+async function listParticipants(roomId: string, client: RoomsClient) {
+    const roomParticipants = [];
+    const participantsList = await client.listParticipants(roomId);
+    for await (const participant of participantsList) {
+        roomParticipants.push(participant);
+    }
+    return roomParticipants;
+}
 
 async function pause(time: number): Promise<void> {
   if (!isPlaybackMode()) {
@@ -652,7 +661,7 @@ async function verifyRoomsParticipantsAttributes(
 ): Promise<void> {
   // Assert
   assert.isDefined(actualRoomParticipant);
-  assert.isNotEmpty(actualRoomParticipant);
+  //assert.isNotEmpty(actualRoomParticipant);
 
   let count = 0;
   let presenterCount = 0;

--- a/sdk/communication/communication-rooms/test/public/roomsClient.spec.ts
+++ b/sdk/communication/communication-rooms/test/public/roomsClient.spec.ts
@@ -469,7 +469,6 @@ describe("Participants Operations", () => {
   let client: RoomsClient;
   let testUser1: CommunicationUserIdentifier;
   let roomId = "";
-  const delayInMs = 1000;
 
   beforeEach(async (ctx) => {
     ({ client, recorder } = await createRecordedRoomsClient(ctx));
@@ -501,10 +500,8 @@ describe("Participants Operations", () => {
     assert.isDefined(createRoomResult);
     const curRoomId = createRoomResult.id;
 
-    await pause(delayInMs);
     // Patch participants
     await client.addOrUpdateParticipants(curRoomId, participants);
-    await pause(delayInMs);
 
     const addParticipantsResult = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 1, 0, 0);
@@ -526,10 +523,8 @@ describe("Participants Operations", () => {
     assert.isDefined(createRoomResult);
     const curRoomId = createRoomResult.id;
 
-    await pause(delayInMs);
     // Patch Participants
     await client.addOrUpdateParticipants(curRoomId, participants as any);
-    await pause(delayInMs);
 
     const addParticipantsResult = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(addParticipantsResult, 1, 0, 1, 0);
@@ -551,11 +546,8 @@ describe("Participants Operations", () => {
     assert.isDefined(createRoomResult);
     const curRoomId = createRoomResult.id;
 
-    await pause(delayInMs);
-
     // Patch Participants
     await client.addOrUpdateParticipants(curRoomId, participants);
-    await pause(delayInMs);
 
     const allParticipants = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(allParticipants, 1, 0, 1, 0);
@@ -571,12 +563,9 @@ describe("Participants Operations", () => {
     assert.isDefined(createRoomResult);
     const curRoomId = createRoomResult.id;
 
-    await pause(delayInMs);
     // Remove participants
     const participantIdentifiers = [testUser1];
     await client.removeParticipants(curRoomId, participantIdentifiers);
-
-    await pause(delayInMs);
 
     const participants = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(participants, 0, 0, 0, 0);
@@ -601,12 +590,9 @@ describe("Participants Operations", () => {
     assert.isDefined(createRoomResult);
     const curRoomId = createRoomResult.id;
 
-    await pause(delayInMs);
-
     // Remove participants
     const removeParticipants = [testUser1];
     await client.removeParticipants(curRoomId, removeParticipants);
-    await pause(delayInMs);
 
     const participants = await listParticipants(curRoomId, client);
     verifyRoomsParticipantsAttributes(participants, 0, 0, 0, 0);


### PR DESCRIPTION
### Packages impacted by this PR
communication-rooms

### Issues associated with this PR

### Describe the problem that is addressed by this PR
'addOrUpdateParticipants' and 'removeParticipants' methods were missing an await and the methods were returning before the task was getting completed. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
Existing test cases were modified

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
