### PR TITLE
fix(playwrighttesting): Add support for multiple global files

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
@@ -49,14 +49,14 @@ export type PlaywrightConfig = {
     use?: {
         connectOptions: BrowserConnectOptions;
     };
-    globalSetup?: string;
-    globalTeardown?: string;
+    globalSetup?: string | string[];
+    globalTeardown?: string | string[];
 };
 
 // @public
 export type PlaywrightConfigInput = {
-    globalSetup?: string;
-    globalTeardown?: string;
+    globalSetup?: string | string[];
+    globalTeardown?: string | string[];
 };
 
 // @public

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/customerConfig.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/customerConfig.ts
@@ -3,8 +3,8 @@
 
 class CustomerConfig {
   private static instance: CustomerConfig;
-  public globalSetup?: string;
-  public globalTeardown?: string;
+  public globalSetup?: string | string[];
+  public globalTeardown?: string | string[];
 
   public static getInstance(): CustomerConfig {
     if (!CustomerConfig.instance) {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/messages.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/messages.ts
@@ -16,6 +16,11 @@ export const ServiceErrorMessageConstants = {
     message:
       "The Playwright version you are using is not supported. See the list of supported versions at https://aka.ms/mpt/supported-versions.",
   },
+  MULTIPLE_SETUP_FILE_PLAYWRIGHT_VERSION_ERROR: {
+    key: "MultipleSetupFilePlaywrightVersionError",
+    message:
+      "The Playwright version you are using does not support multiple setup files. Please update to Playwright version 1.49.0 or higher.",
+  },
   WORKSPACE_MISMATCH_ERROR: {
     key: "InvalidAccessToken",
     message:

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/messages.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/messages.ts
@@ -19,7 +19,7 @@ export const ServiceErrorMessageConstants = {
   MULTIPLE_SETUP_FILE_PLAYWRIGHT_VERSION_ERROR: {
     key: "MultipleSetupFilePlaywrightVersionError",
     message:
-      "The Playwright version you are using does not support multiple setup files. Please update to Playwright version 1.49.0 or higher.",
+      "The Playwright version you are using does not support multiple setup/teardown files. Please update to Playwright version 1.49.0 or higher.",
   },
   WORKSPACE_MISMATCH_ERROR: {
     key: "InvalidAccessToken",

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
@@ -119,7 +119,7 @@ export type PlaywrightConfigInput = {
    *
    * Learn more about {@link https://playwright.dev/docs/test-global-setup-teardown | global setup and teardown}.
    */
-  globalSetup?: string;
+  globalSetup?: string | string[];
 
   /**
    * @public
@@ -130,7 +130,7 @@ export type PlaywrightConfigInput = {
    *
    * Learn more about {@link https://playwright.dev/docs/test-global-setup-teardown | global setup and teardown}.
    */
-  globalTeardown?: string;
+  globalTeardown?: string | string[];
 };
 
 /**
@@ -147,8 +147,8 @@ export type PlaywrightConfig = {
   use?: {
     connectOptions: BrowserConnectOptions;
   };
-  globalSetup?: string;
-  globalTeardown?: string;
+  globalSetup?: string | string[];
+  globalTeardown?: string | string[];
 };
 
 /**

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/global/playwright-service-global-setup.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/global/playwright-service-global-setup.ts
@@ -9,10 +9,10 @@ import customerConfig from "../../common/customerConfig";
 
 const playwrightServiceGlobalSetupWrapper = async (config: FullConfig): Promise<any> => {
   const rootDir = config.configFile ? dirname(config.configFile!) : process.cwd();
-  const customerGlobalSetupFunc = await loadCustomerGlobalFunction(
-    rootDir,
-    customerConfig.globalSetup,
-  );
+  let customerGlobalSetupFunc: any = null;
+  if (customerConfig.globalSetup && typeof customerConfig.globalSetup === "string") {
+    customerGlobalSetupFunc = await loadCustomerGlobalFunction(rootDir, customerConfig.globalSetup);
+  }
 
   await playwrightServiceEntra.globalSetup();
   if (customerGlobalSetupFunc) {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/global/playwright-service-global-teardown.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/global/playwright-service-global-teardown.ts
@@ -9,10 +9,13 @@ import customerConfig from "../../common/customerConfig";
 
 const playwrightServiceGlobalTeardownWrapper = async (config: FullConfig): Promise<void> => {
   const rootDir = config.configFile ? dirname(config.configFile!) : process.cwd();
-  const customerGlobalTeardownFunc = await loadCustomerGlobalFunction(
-    rootDir,
-    customerConfig.globalTeardown,
-  );
+  let customerGlobalTeardownFunc: any = null;
+  if (customerConfig.globalTeardown && typeof customerConfig.globalTeardown === "string") {
+    customerGlobalTeardownFunc = await loadCustomerGlobalFunction(
+      rootDir,
+      customerConfig.globalTeardown,
+    );
+  }
 
   playwrightServiceEntra.globalTeardown();
   if (customerGlobalTeardownFunc) {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -76,7 +76,7 @@ const getServiceConfig = (
   // if global setup/teardown is array -
   // 1. if multiple global file is not supported, throw error
   // 2. append playwright-service global setup/teardown with customer provided global setup/teardown
-  if (config.globalSetup) {
+  if (config && config.globalSetup) {
     if (typeof config.globalSetup === "string") {
       if (isMultipleGlobalFileSupported) {
         customerConfig.globalSetup = [config.globalSetup];
@@ -93,7 +93,7 @@ const getServiceConfig = (
     }
   }
 
-  if (config.globalTeardown) {
+  if (config && config.globalTeardown) {
     if (typeof config.globalTeardown === "string") {
       if (isMultipleGlobalFileSupported) {
         customerConfig.globalTeardown = [config.globalTeardown];
@@ -121,16 +121,18 @@ const getServiceConfig = (
   } else {
     // If multiple global file is supported, append playwright-service global setup/teardown with customer provided global setup/teardown
     if (isMultipleGlobalFileSupported) {
-      globalFunctions.globalSetup = [require.resolve("./global/playwright-service-global-setup")];
-      globalFunctions.globalTeardown = [
-        require.resolve("./global/playwright-service-global-teardown"),
-      ];
+      globalFunctions.globalSetup = [] as string[];
+      globalFunctions.globalTeardown = [] as string[];
       if (customerConfig.globalSetup) {
         globalFunctions.globalSetup.push(...(customerConfig.globalSetup as string[]));
       }
       if (customerConfig.globalTeardown) {
         globalFunctions.globalTeardown.push(...(customerConfig.globalTeardown as string[]));
       }
+      globalFunctions.globalSetup.push(require.resolve("./global/playwright-service-global-setup"));
+      globalFunctions.globalTeardown.push(
+        require.resolve("./global/playwright-service-global-teardown"),
+      );
     } else {
       // If multiple global file is not supported, wrap playwright-service global setup/teardown with customer provided global setup/teardown
       globalFunctions.globalSetup = require.resolve("./global/playwright-service-global-setup");

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
@@ -26,7 +26,7 @@ describe("getServiceConfig", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(console, "error");
-    sandbox.stub(console, "log");
+    // sandbox.stub(console, "log");
     process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_URL] =
       "wss://eastus.playwright.microsoft.com/accounts/1234/browsers";
     process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION] = "1.47.0";
@@ -46,6 +46,125 @@ describe("getServiceConfig", () => {
     expect(() => getServiceConfig(samplePlaywrightConfigInput)).to.throw();
     expect(consoleErrorSpy.calledWith(ServiceErrorMessageConstants.NO_SERVICE_URL_ERROR.message)).to
       .be.true;
+  });
+
+  it("should return service config with service connect options and global setup and teardown as list when playwright version is 1.49.0", () => {
+    process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = "token";
+    process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION] = "1.49.0";
+    const { getServiceConfig } = require("../../src/core/playwrightService");
+
+    const mockVersion = "1.0.0";
+    sandbox.stub(require("../../package.json"), "version").value(mockVersion);
+    const config = getServiceConfig();
+    const playwrightServiceConfig = new PlaywrightServiceConfig();
+    expect(config).to.deep.equal({
+      use: {
+        connectOptions: {
+          wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
+          headers: {
+            Authorization: "Bearer token",
+            "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(mockVersion)}`,
+          },
+          timeout: playwrightServiceConfig.timeout,
+          exposeNetwork: playwrightServiceConfig.exposeNetwork,
+          slowMo: playwrightServiceConfig.slowMo,
+        },
+      },
+      globalSetup: [require.resolve("../../src/core/global/playwright-service-global-setup")],
+      globalTeardown: [require.resolve("../../src/core/global/playwright-service-global-teardown")],
+    });
+  });
+
+  it("should return service config with service connect options and global setup and teardown as list when playwright version is 1.49.0 and input global files are string", () => {
+    process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = "token";
+    process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION] = "1.49.0";
+    const { getServiceConfig } = require("../../src/core/playwrightService");
+
+    const mockVersion = "1.0.0";
+    sandbox.stub(require("../../package.json"), "version").value(mockVersion);
+    const config = getServiceConfig(samplePlaywrightConfigInput);
+    const playwrightServiceConfig = new PlaywrightServiceConfig();
+    const customerConfig = require("../../src/common/customerConfig");
+    expect(customerConfig.default.globalSetup).to.deep.equal(["sample-setup.ts"]);
+    expect(customerConfig.default.globalTeardown).to.deep.equal(["sample-teardown.ts"]);
+    expect(config).to.deep.equal({
+      use: {
+        connectOptions: {
+          wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
+          headers: {
+            Authorization: "Bearer token",
+            "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(mockVersion)}`,
+          },
+          timeout: playwrightServiceConfig.timeout,
+          exposeNetwork: playwrightServiceConfig.exposeNetwork,
+          slowMo: playwrightServiceConfig.slowMo,
+        },
+      },
+      globalSetup: [
+        "sample-setup.ts",
+        require.resolve("../../src/core/global/playwright-service-global-setup"),
+      ],
+      globalTeardown: [
+        "sample-teardown.ts",
+        require.resolve("../../src/core/global/playwright-service-global-teardown"),
+      ],
+    });
+  });
+
+  it("should return service config with service connect options and global setup and teardown as list when playwright version is 1.49.0 and input global files are list", () => {
+    process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = "token";
+    process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION] = "1.49.0";
+    const { getServiceConfig } = require("../../src/core/playwrightService");
+
+    const mockVersion = "1.0.0";
+    sandbox.stub(require("../../package.json"), "version").value(mockVersion);
+    const sampleConfig = {
+      globalSetup: ["sample-setup.ts"],
+      globalTeardown: ["sample-teardown.ts"],
+    };
+    const config = getServiceConfig(sampleConfig);
+    const playwrightServiceConfig = new PlaywrightServiceConfig();
+    const customerConfig = require("../../src/common/customerConfig");
+    expect(customerConfig.default.globalSetup).to.deep.equal(["sample-setup.ts"]);
+    expect(customerConfig.default.globalTeardown).to.deep.equal(["sample-teardown.ts"]);
+    expect(config).to.deep.equal({
+      use: {
+        connectOptions: {
+          wsEndpoint: `wss://eastus.playwright.microsoft.com/accounts/1234/browsers?runId=${playwrightServiceConfig.runId}&os=${playwrightServiceConfig.serviceOs}&api-version=${API_VERSION}`,
+          headers: {
+            Authorization: "Bearer token",
+            "x-ms-package-version": `@azure/microsoft-playwright-testing/${encodeURIComponent(mockVersion)}`,
+          },
+          timeout: playwrightServiceConfig.timeout,
+          exposeNetwork: playwrightServiceConfig.exposeNetwork,
+          slowMo: playwrightServiceConfig.slowMo,
+        },
+      },
+      globalSetup: [
+        "sample-setup.ts",
+        require.resolve("../../src/core/global/playwright-service-global-setup"),
+      ],
+      globalTeardown: [
+        "sample-teardown.ts",
+        require.resolve("../../src/core/global/playwright-service-global-teardown"),
+      ],
+    });
+  });
+
+  it("should throw error when playwright version is 1.48.0 and input global files are list", () => {
+    process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN] = "token";
+    process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION] = "1.48.0";
+    const { getServiceConfig } = require("../../src/core/playwrightService");
+
+    const mockVersion = "1.0.0";
+    sandbox.stub(require("../../package.json"), "version").value(mockVersion);
+    const sampleConfig = {
+      globalSetup: ["sample-setup.ts"],
+      globalTeardown: ["sample-teardown.ts"],
+    };
+    expect(() => getServiceConfig(sampleConfig)).to.throw(
+      ServiceErrorMessageConstants.MULTIPLE_SETUP_FILE_PLAYWRIGHT_VERSION_ERROR.message,
+    );
   });
 
   it("should set customer config global setup and teardown scripts in the config if passed", () => {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/core/playwrightService.spec.ts
@@ -26,7 +26,7 @@ describe("getServiceConfig", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(console, "error");
-    // sandbox.stub(console, "log");
+    sandbox.stub(console, "log");
     process.env[ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_URL] =
       "wss://eastus.playwright.microsoft.com/accounts/1234/browsers";
     process.env[InternalEnvironmentVariables.MPT_PLAYWRIGHT_VERSION] = "1.47.0";


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

Fixes https://github.com/microsoft/playwright-testing-service/issues/151

### Describe the problem that is addressed by this PR

Playwright OSS had introduced support for multiple global setup/teardown files via https://github.com/microsoft/playwright/pull/32955. This SDK did not support array of string as input params and hence threw a TypeError.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_

Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
