### PR TITLE
Added extra hardening security

### DIFF
--- a/sdk/healthdataaiservices/azure-health-deidentification/test-resources.bicep
+++ b/sdk/healthdataaiservices/azure-health-deidentification/test-resources.bicep
@@ -37,6 +37,28 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   kind: 'StorageV2'
   properties: {
     minimumTlsVersion: 'TLS1_2'
+
+    accessTier: 'Hot'
+    supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: false
+    allowCrossTenantReplication: false
+    allowSharedKeyAccess: false
+
+    encryption: {
+      services: {
+        blob: {
+          enabled: true
+          keyType: 'Account'
+        }
+        file: {
+          enabled: true
+          keyType: 'Account'
+        }
+      }
+      requireInfrastructureEncryption: true
+      keySource: 'Microsoft.Storage'
+    }
+
     networkAcls: {
       bypass: 'AzureServices'
       defaultAction: 'Deny'


### PR DESCRIPTION
Created storage was being flagged by security wave.
All tests passing after changes and advisor recommendations all green.

### Packages impacted by this PR
@azure/arm-healthdataaiservices

### Issues associated with this PR
Created storage being flagged by security wave.

Storage should be Identity-Based Access Control, and then apply the AllowSharedKeyAccess = false
https://eng.ms/docs/products/azure-storage/security/standards/identity-based-access

### Describe the problem that is addressed by this PR
Service 360 flag

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Followed recommended settings here and applied same settings used in main service.
https://eng.ms/docs/products/azure-storage/security/standards/identity-based-access

### Are there test cases added in this PR? _(If not, why?)_
No, only storage settings.

### Provide a list of related PRs _(if any)_
Related only where the New-TestResources.ps1 cmd fails without this PR (missing test data).
https://github.com/Azure/azure-sdk-for-js/pull/31921

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
`..\..\..\eng\common\TestResources\New-TestResources.ps1 -ServiceDirectory healthdataaiservices -UserAuth -BaseName demo1 -Subscription a49b70b4-60ee-4422-a7e2-xyz -DeleteAfterHours 8`

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
