### PR TITLE
[EngSys] move `rush-runner.js` into a dev package

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -333,7 +333,7 @@ jobs:
       # running in this repository" if the previous rush command was killed.
       - pwsh: |
           for ($i=0; $i -lt 30; $i++) {
-            node eng/tools/rush-runner.js unlink
+            node eng/tools/rush-runner/index.js unlink
             if ($lastexitcode -eq 0) {
               break
             }

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -71,7 +71,7 @@ steps:
     displayName: "Install dependencies"
 
   - script: |
-      node eng/tools/rush-runner.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
 
   - template: /eng/pipelines/templates/steps/run-eslint.yml
@@ -79,7 +79,7 @@ steps:
       ServiceDirectories: $(ChangedServices)
 
   - pwsh: |
-      node eng/tools/rush-runner.js check-format $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose
+      node eng/tools/rush-runner/index.js check-format $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose
     displayName: "Check Format in Libraries"
 
   - template: /eng/common/pipelines/templates/steps/verify-changelogs.yml
@@ -95,7 +95,7 @@ steps:
     # Unlink node_modules folders to significantly improve performance of subsequent tasks
     # which need to walk the directory tree (and are hardcoded to follow symlinks).
   - script: |
-      node eng/tools/rush-runner.js unlink
+      node eng/tools/rush-runner/index.js unlink
     displayName: "Unlink dependencies"
 
     # It's important for performance to pass "sdk" as "sourceFolder" rather than as a prefix in "contents".

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -54,7 +54,7 @@ steps:
           echo "##vso[task.setvariable variable=rushBuildCacheCred;issecret=true;]$sasToken"
 
   - pwsh: |
-      node eng/tools/rush-runner.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
     env:
       ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
@@ -62,7 +62,7 @@ steps:
         RUSH_BUILD_CACHE_WRITE_ALLOWED: 1
 
   - script: |
-      node eng/tools/rush-runner.js build:samples "$(ChangedServices)" -packages "$(ArtifactPackageNames)" --verbose
+      node eng/tools/rush-runner/index.js build:samples "$(ChangedServices)" -packages "$(ArtifactPackageNames)" --verbose
     displayName: "Build samples for PR"
 
   - pwsh: |
@@ -70,13 +70,13 @@ steps:
     displayName: "Check api extractor output changes"
 
   - script: |
-      node eng/tools/rush-runner.js pack "$(ChangedServices)" -packages "$(ArtifactPackageNames)" --verbose
+      node eng/tools/rush-runner/index.js pack "$(ChangedServices)" -packages "$(ArtifactPackageNames)" --verbose
     displayName: "Pack libraries"
 
   # Unlink node_modules folders to significantly improve performance of subsequent tasks
   # which need to walk the directory tree (and are hardcoded to follow symlinks).
   - script: |
-      node eng/tools/rush-runner.js unlink
+      node eng/tools/rush-runner/index.js unlink
     displayName: "Unlink dependencies"
 
   - template: ../steps/generate-doc.yml

--- a/eng/pipelines/templates/steps/run-eslint.yml
+++ b/eng/pipelines/templates/steps/run-eslint.yml
@@ -8,5 +8,5 @@ steps:
 
   - pwsh: |
       node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk -t @azure/monitor-opentelemetry-exporter
-      node eng/tools/rush-runner.js lint "${{parameters.ServiceDirectories}}" -p max
+      node eng/tools/rush-runner/index.js lint "${{parameters.ServiceDirectories}}" -p max
     displayName: "Build ESLint Plugin and Lint Libraries"

--- a/eng/pipelines/templates/steps/test-eslint.yml
+++ b/eng/pipelines/templates/steps/test-eslint.yml
@@ -8,7 +8,7 @@ steps:
 
   - pwsh: |
       node common/scripts/install-run-rush.js build -t @azure/eslint-plugin-azure-sdk -t @azure/monitor-opentelemetry-exporter
-      node eng/tools/rush-runner.js lint "${{parameters.ServiceDirectory}}" -p max
+      node eng/tools/rush-runner/index.js lint "${{parameters.ServiceDirectory}}" -p max
     displayName: "Build ESLint Plugin and Lint Libraries"
 
   - pwsh: |

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -25,13 +25,13 @@ steps:
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
-      node eng/tools/rush-runner.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
-      node eng/tools/rush-runner.js build:test $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js build:test $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build test assets"
 
   - template: ../steps/use-node-test-version.yml
@@ -42,14 +42,14 @@ steps:
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
-      node eng/tools/rush-runner.js unit-test:node $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js unit-test:node $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Test libraries"
     condition: and(succeeded(),eq(variables['TestType'], 'node'))
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).
   - script: |
-      node eng/tools/rush-runner.js unit-test:browser $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js unit-test:browser $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Test libraries"
     condition: and(succeeded(),eq(variables['TestType'], 'browser'))
 
@@ -65,7 +65,7 @@ steps:
   # running in this repository" if the previous rush command was killed.
   - pwsh: |
       for ($i=0; $i -lt 30; $i++) {
-        node eng/tools/rush-runner.js unlink
+        node eng/tools/rush-runner/index.js unlink
         if ($lastexitcode -eq 0) {
           break
         }

--- a/eng/tools/rush-runner/eslint.config.mjs
+++ b/eng/tools/rush-runner/eslint.config.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import eslint from "@eslint/js";
+
+export default [
+  {
+    files: ["./index.js"],
+    rules: eslint.configs.recommended.rules,
+  },
+];

--- a/eng/tools/rush-runner/index.js
+++ b/eng/tools/rush-runner/index.js
@@ -51,7 +51,7 @@ const parseArgs = () => {
   const services = [],
     flags = [];
   const [scriptPath, action, ...givenArgs] = process.argv.slice(1);
-  const baseDir = path.resolve(`${path.dirname(scriptPath)}/../..`);
+  const baseDir = path.resolve(`${path.dirname(scriptPath)}/../../..`);
 
   for (const arg of givenArgs) {
     if (arg === "-packages") {

--- a/eng/tools/rush-runner/package.json
+++ b/eng/tools/rush-runner/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@azure-tools/rush-runner",
+  "type": "module",
+  "prettier": "../../../common/tools/eslint-plugin-azure-sdk/prettier.json",
+  "scripts": {
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore index.js \"test/**/*.js\"",
+    "typecheck": "tsc",
+    "lint": "eslint index.js test",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.9.0",
+    "@types/node": "^18.0.0",
+    "@vitest/coverage-istanbul": "^2.0.5",
+    "eslint": "^9.9.0",
+    "prettier": "3.3.3",
+    "vitest": "^2.0.5",
+    "typescript": "~5.7.2"
+  }
+}

--- a/eng/tools/rush-runner/test/helper.spec.js
+++ b/eng/tools/rush-runner/test/helper.spec.js
@@ -1,0 +1,7 @@
+import { assert, describe, it } from "vitest";
+
+describe("helper", () => {
+  it("should pass", () => {
+    assert(true);
+  });
+});

--- a/eng/tools/rush-runner/tsconfig.json
+++ b/eng/tools/rush-runner/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "target": "Es2021",
+    "skipLibCheck": true
+  },
+  "include": ["index.js", "test/**/*.js"]
+}

--- a/eng/tools/rush-runner/vitest.config.mjs
+++ b/eng/tools/rush-runner/vitest.config.mjs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    testTimeout: 18000,
+    reporters: ["verbose"],
+    watch: false,
+    include: ["test/**/*.spec.js"],
+    coverage: {
+      include: ["index.js"],
+      provider: "istanbul",
+      reporter: ["text", "json", "html"],
+      reportsDirectory: "coverage",
+    },
+  },
+});


### PR DESCRIPTION
so that we can have better local developer experiences with help from compiler, test runner, formatter, and linter etc. when making changes. The code is kept in JavaScript in order for it to be invoked without having to install dev dependencies and build the package.
