### PR TITLE
[EngSys] upgrade dev dependency `eslint` version to v9

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2439,16 +2439,6 @@ packages:
     dev: false
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.1(eslint@8.57.1):
-    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-    dev: false
-
   /@eslint-community/eslint-utils@4.4.1(eslint@9.15.0):
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2492,23 +2482,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: false
 
-  /@eslint/eslintrc@2.1.4:
-    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.7(supports-color@8.1.1)
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@eslint/eslintrc@3.2.0:
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2524,11 +2497,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@eslint/js@8.57.1:
-    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
   /@eslint/js@9.15.0:
@@ -2585,26 +2553,9 @@ packages:
       '@humanwhocodes/retry': 0.3.1
     dev: false
 
-  /@humanwhocodes/config-array@0.13.0:
-    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@8.1.1)
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-    dev: false
-
-  /@humanwhocodes/object-schema@2.0.3:
-    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
-    deprecated: Use @eslint/object-schema instead
     dev: false
 
   /@humanwhocodes/retry@0.3.1:
@@ -4332,10 +4283,6 @@ packages:
       eslint-visitor-keys: 4.2.0
     dev: false
 
-  /@ungap/structured-clone@1.2.0:
-    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
-    dev: false
-
   /@vitest/browser@1.6.0(playwright@1.49.0)(vitest@1.6.0):
     resolution: {integrity: sha512-3Wpp9h1hf++rRVPvoXevkdHybLhJVn7MwIMKMIh08tVaoDMmT6fnNhbP222Z48V9PptpYeA5zvH9Ct/ZcaAzmQ==}
     peerDependencies:
@@ -5813,13 +5760,6 @@ packages:
       path-type: 4.0.0
     dev: false
 
-  /doctrine@3.0.0:
-    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      esutils: 2.0.3
-    dev: false
-
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: false
@@ -6167,14 +6107,6 @@ packages:
       '@microsoft/tsdoc-config': 0.16.2
     dev: false
 
-  /eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-    dev: false
-
   /eslint-scope@8.2.0:
     resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -6191,54 +6123,6 @@ packages:
   /eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: false
-
-  /eslint@8.57.1:
-    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@8.1.1)
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /eslint@9.15.0:
@@ -6568,13 +6452,6 @@ packages:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
     dev: false
 
-  /file-entry-cache@6.0.1:
-    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      flat-cache: 3.2.0
-    dev: false
-
   /file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -6653,15 +6530,6 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: false
-
-  /flat-cache@3.2.0:
-    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      flatted: 3.3.2
-      keyv: 4.5.4
-      rimraf: 3.0.2
     dev: false
 
   /flat-cache@4.0.1:
@@ -6937,13 +6805,6 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: false
-
-  /globals@13.24.0:
-    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.20.2
     dev: false
 
   /globals@14.0.0:
@@ -7366,11 +7227,6 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: false
-
-  /is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
     dev: false
 
   /is-plain-obj@1.1.0:
@@ -10412,10 +10268,6 @@ packages:
     resolution: {integrity: sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==}
     dev: false
 
-  /text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-    dev: false
-
   /thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -10731,11 +10583,6 @@ packages:
   /type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
-    dev: false
-
-  /type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
     dev: false
 
   /type-fest@0.21.3:
@@ -12230,7 +12077,7 @@ packages:
     dev: false
 
   file:projects/ai-vision-face.tgz:
-    resolution: {integrity: sha512-ffejZRSIsy9IatYOLMHRiNiN41hBEDAvzSJSsCPu2DNp2xhHiKVhpn1v97MJwbV/SoLQM9ugMnbZO4bPXt5LZw==, tarball: file:projects/ai-vision-face.tgz}
+    resolution: {integrity: sha512-ktM3Ox3D54Pau2C1Ggi84dOAExqiKEoH0JI9PoVUmaT0UssSCuhz9Til/3cA+2MlIJ2+BYTbFuuh6QjyafFhlA==, tarball: file:projects/ai-vision-face.tgz}
     name: '@rush-temp/ai-vision-face'
     version: 0.0.0
     dependencies:
@@ -13399,7 +13246,7 @@ packages:
     dev: false
 
   file:projects/arm-computefleet.tgz:
-    resolution: {integrity: sha512-6/T4PDvH2k2L4yVEAs/wyfYf8xhVHNvXNMlMFbDM+VxiLN37O2HI+uqTa6AGqx7qcPzRjyBZfTPAcUK8HI7G0A==, tarball: file:projects/arm-computefleet.tgz}
+    resolution: {integrity: sha512-KNacYssZkHv1/lsUIsCMJ1wsVZw6ssf4feH9W6Pmnz8R/K0rHDiF7E7ambEa+euPWPT6kHal7J9fjxAA1rOIWg==, tarball: file:projects/arm-computefleet.tgz}
     name: '@rush-temp/arm-computefleet'
     version: 0.0.0
     dependencies:
@@ -13407,7 +13254,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
@@ -13417,6 +13264,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -13434,7 +13282,7 @@ packages:
     dev: false
 
   file:projects/arm-computeschedule.tgz:
-    resolution: {integrity: sha512-GgVAVrMUsXbo7MWQG9Ioi4dWOg1pNvhetLZpUXa92AyTgIK8WHuL3EqGpGjTy9HO1YYRC6v/YBho1KKF33vgUw==, tarball: file:projects/arm-computeschedule.tgz}
+    resolution: {integrity: sha512-LikjGLDhppCKtO9/RI42l+TovuXgyFifllzgtNrGC3+mkan99xV0Vw/2jCqTL0v+HrFXKsPwrHzvtaWrGfJ14g==, tarball: file:projects/arm-computeschedule.tgz}
     name: '@rush-temp/arm-computeschedule'
     version: 0.0.0
     dependencies:
@@ -13442,7 +13290,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       prettier: 3.3.3
       tslib: 2.8.1
@@ -13453,6 +13301,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -13519,7 +13368,7 @@ packages:
     dev: false
 
   file:projects/arm-connectedcache.tgz:
-    resolution: {integrity: sha512-z09VpU8HdMfm7XwTPPUYSVW3NaaMfTQwjVUggbtWe+xm7gPo5L3zB13SjvVaduyXorZg5roXzeT2At0W6Vkkqg==, tarball: file:projects/arm-connectedcache.tgz}
+    resolution: {integrity: sha512-br4EU3We4o4ri3cAJhHvkAh/yEeu924X37t899KkKtNmqgI2vP6YX09aWowD9KalMEKuxsXOJtVKuX8IfIa2gQ==, tarball: file:projects/arm-connectedcache.tgz}
     name: '@rush-temp/arm-connectedcache'
     version: 0.0.0
     dependencies:
@@ -13528,7 +13377,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tshy: 2.0.1
       tslib: 2.8.1
@@ -13539,6 +13388,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -13626,7 +13476,7 @@ packages:
     dev: false
 
   file:projects/arm-containerorchestratorruntime.tgz:
-    resolution: {integrity: sha512-5SpApVxYGPizH4rRvkMlLK55bj9rkVVfoG5w5mBeB2uZX+mCY9g0g5j4gKf1g4rmbZ3HQgORWuE8TxmdLTdNHg==, tarball: file:projects/arm-containerorchestratorruntime.tgz}
+    resolution: {integrity: sha512-jYkdD3JE46i6HXD5rnOW9rRu6d7u3bSM/OFtK8BXKUM/OHVIDZL5zJjAb5wE669ZO02Pp6D9+sNPrMXgapIZpw==, tarball: file:projects/arm-containerorchestratorruntime.tgz}
     name: '@rush-temp/arm-containerorchestratorruntime'
     version: 0.0.0
     dependencies:
@@ -13634,7 +13484,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
@@ -13644,6 +13494,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -14561,7 +14412,7 @@ packages:
     dev: false
 
   file:projects/arm-edgezones.tgz:
-    resolution: {integrity: sha512-Jf+4E9zw4Qw8zPT3t4EaV92PrxNit/MF/ufz4OyLSIiBJQMEcISTvHLRrAPQEqmMG+NXRaO+mgG3XAzOCnYe2Q==, tarball: file:projects/arm-edgezones.tgz}
+    resolution: {integrity: sha512-7Lx+GC3XiUXQHYTMYyxOJZ1oNmYQO17cc4GvuXpm6dv7siGj5rCidZiebA53JEWr/TspcctIeGnG8AHLAVsBYw==, tarball: file:projects/arm-edgezones.tgz}
     name: '@rush-temp/arm-edgezones'
     version: 0.0.0
     dependencies:
@@ -14570,7 +14421,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tshy: 2.0.1
       tslib: 2.8.1
@@ -14581,6 +14432,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -14766,7 +14618,7 @@ packages:
     dev: false
 
   file:projects/arm-fabric.tgz:
-    resolution: {integrity: sha512-SFH1vDEKPQWOWsgrtk66s3+ZPKzVKFLD1961AAe/XLzHP6vNizf6JyCAOpS3Xh4/os4CeocBa9vT+CgA9UQBZg==, tarball: file:projects/arm-fabric.tgz}
+    resolution: {integrity: sha512-ICWVjR6hU0iagAV8KUf4dINj8JVMdphqd+y6bJH97q45JuzNuOdSFTw4XA/cI7bZn6OuanDSpwQN0JIFlgZZnw==, tarball: file:projects/arm-fabric.tgz}
     name: '@rush-temp/arm-fabric'
     version: 0.0.0
     dependencies:
@@ -14774,7 +14626,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       prettier: 3.3.3
       tslib: 2.8.1
@@ -14785,6 +14637,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -15363,7 +15216,7 @@ packages:
     dev: false
 
   file:projects/arm-iotoperations.tgz:
-    resolution: {integrity: sha512-t5QJr31o81EF3dX5/7stmGinUIk/yNXXkq27iowhAgZIPcKV27V9MxHmvsmnvBnZR5kPndkRaqnJl+gDavTCFw==, tarball: file:projects/arm-iotoperations.tgz}
+    resolution: {integrity: sha512-cSjFFCKmI/3TAVPk7BHWbSTCBg6JOVJ3jvJURbPxmeiIaab+SIvBHRH2d5N/sT1ktQirW+wr1aF410IqvfDEKw==, tarball: file:projects/arm-iotoperations.tgz}
     name: '@rush-temp/arm-iotoperations'
     version: 0.0.0
     dependencies:
@@ -15371,7 +15224,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
@@ -15381,6 +15234,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -16022,7 +15876,7 @@ packages:
     dev: false
 
   file:projects/arm-mongocluster.tgz:
-    resolution: {integrity: sha512-0cIKdDqo8SucLoVDs7HobYbgm2dX7HXlQ7WaCHLrPLrLmKVvfOGAs7TjYERvORqKlIUs/tIzAtp9oM1zOPaN3A==, tarball: file:projects/arm-mongocluster.tgz}
+    resolution: {integrity: sha512-uHXY8aiy59HNsKOlADr+OcpDG8TihgYdOW4ZXH1ap6Lc+nlMFoMVFYFbM2O0w40S2Me9pQaUbHOe+/94MCjoWQ==, tarball: file:projects/arm-mongocluster.tgz}
     name: '@rush-temp/arm-mongocluster'
     version: 0.0.0
     dependencies:
@@ -16030,7 +15884,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       prettier: 3.3.3
       tslib: 2.8.1
@@ -16041,6 +15895,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -17830,7 +17685,7 @@ packages:
     dev: false
 
   file:projects/arm-standbypool.tgz:
-    resolution: {integrity: sha512-d2xnd2nJyWATOqT3IDONbjSerCpYzZzzoD96MrMUpOEwjbePLcyjJw8ft9YyO2QHK7OOUG0WuN9rqv6eCQLxIQ==, tarball: file:projects/arm-standbypool.tgz}
+    resolution: {integrity: sha512-lBp+YGTwo3+S+0zRPNL42SjK4lLENcKqTdRrqbJfiiLvwu92k6wmM2YWr5xZXHh5arGKmz2FkNZuo5nFlRdKOA==, tarball: file:projects/arm-standbypool.tgz}
     name: '@rush-temp/arm-standbypool'
     version: 0.0.0
     dependencies:
@@ -17838,7 +17693,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       prettier: 3.3.3
       tslib: 2.8.1
@@ -17849,6 +17704,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -18216,7 +18072,7 @@ packages:
     dev: false
 
   file:projects/arm-terraform.tgz:
-    resolution: {integrity: sha512-Emfl2nYOlyHvEUQn52bjceznQXcHvOFvn3kEHtbNb5RCyIICzcWSEjQNAD5rDhVA/zEfsmAhFpfS3H8ua3Wk6Q==, tarball: file:projects/arm-terraform.tgz}
+    resolution: {integrity: sha512-N33mFCaqI2ZhFQmBD9XUJCLTiWbuU1ezZsBV0/gRiWFzzt+zBTwgEt/x/HE39Tc7q2JbCnzqB+ms5PjyIHxzsw==, tarball: file:projects/arm-terraform.tgz}
     name: '@rush-temp/arm-terraform'
     version: 0.0.0
     dependencies:
@@ -18225,7 +18081,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tshy: 2.0.1
       tslib: 2.8.1
@@ -18236,6 +18092,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss
@@ -18299,7 +18156,7 @@ packages:
     dev: false
 
   file:projects/arm-trustedsigning.tgz:
-    resolution: {integrity: sha512-/kLL/gGGZ5j6Yohrwb+FrM2goy4TVtPVZsV9xDfifm+kn0cCdhj40K4YBxD0E7+WaCIMaY1CitATyM+lvW+fag==, tarball: file:projects/arm-trustedsigning.tgz}
+    resolution: {integrity: sha512-wGwPeLkUdS8uFAHYhPGRjtS5hsI+ChbmQHSs8C9H4EDrel45yFDkNKazb3Njff0LPlTQFDggKVitNaWAANJEwg==, tarball: file:projects/arm-trustedsigning.tgz}
     name: '@rush-temp/arm-trustedsigning'
     version: 0.0.0
     dependencies:
@@ -18307,7 +18164,7 @@ packages:
       '@vitest/browser': 2.1.5(@types/node@18.19.66)(playwright@1.49.0)(typescript@5.6.3)(vitest@2.1.5)
       '@vitest/coverage-istanbul': 2.1.5(vitest@2.1.5)
       dotenv: 16.4.5
-      eslint: 8.57.1
+      eslint: 9.15.0
       playwright: 1.49.0
       tslib: 2.8.1
       typescript: 5.6.3
@@ -18317,6 +18174,7 @@ packages:
       - '@vitest/ui'
       - bufferutil
       - happy-dom
+      - jiti
       - jsdom
       - less
       - lightningcss

--- a/sdk/computefleet/arm-computefleet/package.json
+++ b/sdk/computefleet/arm-computefleet/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "@vitest/browser": "^2.0.5",

--- a/sdk/computeschedule/arm-computeschedule/package.json
+++ b/sdk/computeschedule/arm-computeschedule/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "prettier": "^3.2.5",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",

--- a/sdk/connectedcache/arm-connectedcache/package.json
+++ b/sdk/connectedcache/arm-connectedcache/package.json
@@ -69,7 +69,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/sdk/edgezones/arm-edgezones/package.json
+++ b/sdk/edgezones/arm-edgezones/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/sdk/fabric/arm-fabric/package.json
+++ b/sdk/fabric/arm-fabric/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "prettier": "^3.2.5",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",

--- a/sdk/face/ai-vision-face-rest/package.json
+++ b/sdk/face/ai-vision-face-rest/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^9.13.0",
+    "eslint": "^9.9.0",
     "prettier": "^3.2.5",
     "typescript": "~5.6.3",
     "tshy": "^1.11.1",

--- a/sdk/iotoperations/arm-iotoperations/package.json
+++ b/sdk/iotoperations/arm-iotoperations/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "@vitest/browser": "^2.0.5",

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "@vitest/browser": "^2.0.5",

--- a/sdk/mongocluster/arm-mongocluster/package.json
+++ b/sdk/mongocluster/arm-mongocluster/package.json
@@ -76,7 +76,7 @@
     "@vitest/browser": "^2.0.5",
     "@vitest/coverage-istanbul": "^2.0.5",
     "dotenv": "^16.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "playwright": "^1.41.2",
     "prettier": "^3.2.5",
     "typescript": "~5.6.2",

--- a/sdk/standbypool/arm-standbypool/package.json
+++ b/sdk/standbypool/arm-standbypool/package.json
@@ -75,7 +75,7 @@
     "@vitest/browser": "^2.0.5",
     "@vitest/coverage-istanbul": "^2.0.5",
     "dotenv": "^16.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "playwright": "^1.41.2",
     "prettier": "^3.2.5",
     "typescript": "~5.6.2",

--- a/sdk/terraform/arm-terraform/package.json
+++ b/sdk/terraform/arm-terraform/package.json
@@ -69,7 +69,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/sdk/trustedsigning/arm-trustedsigning/package.json
+++ b/sdk/trustedsigning/arm-trustedsigning/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "@vitest/browser": "^2.0.5",


### PR DESCRIPTION
Some generated packages still have v8. This PR upgrades them to v9. A separate
PR is submitted to update the code generator.