### PR TITLE
Avoid multiple artifact upload errors during retry

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -29,12 +29,6 @@ steps:
       ServiceDirectory: "template"
       TestPipeline: ${{ parameters.TestPipeline }}
 
-  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-    parameters:
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'package-diffs'
-      SbomEnabled: false
-
   - template: /eng/common/pipelines/templates/steps/verify-readmes.yml
     parameters:
       PackagePropertiesFolder: $(Build.ArtifactStagingDirectory)/PackageInfo
@@ -112,6 +106,12 @@ steps:
     parameters:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)'
       ArtifactName: 'reports'
+      SbomEnabled: false
+
+  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: 'package-diffs'
       SbomEnabled: false
 
   - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml


### PR DESCRIPTION
[Mariana hit this situation](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4363935&view=logs&j=36df4387-3551-57fa-098c-b43a23930261&t=8d5dfa63-dbe9-55f5-dc41-53a9f3f32393). 

The issue here is that I believe the failed step which _should_ have caused the artifact name to add the `FailedAttemptN` suffix was AFTER the artifact upload. That means during the analyze phase the order was:

- static analyze 1 (succeeded)
- static analyze 2 (succeeded)
- publish artifact 
- static analyze 3 (failed)

And if a failure occurs in `static analyze 3` step above, we will attempt to publish the same artifact name twice. That causes it's own error, and is what we're seeing on the linked build.