### PR TITLE
[ConfidentialLedger] Generate SDK based on preview-2024-01-26 spec

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.2
+
+- User List endpoint
+
 ## 1.0.1 (Unreleased)
 
 ### Features Added
@@ -11,6 +15,7 @@
 ### Other Changes
 
 ## 1.0.0 (2022-07-18)
+
 - Pageable collections and consortium endpoints
 - Renaming ledgerUri to ledgerEndpoint
 - postLedgerEntry changed to createLedgerEntry

--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.1.0-beta.1 (Unreleased)
 
 ### Features Added
 
 - User List endpoint
-
-## 1.0.1 (Unreleased)
-
-### Features Added
 
 ### Breaking Changes
 

--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.0.2
+## 1.0.2 (2024-11-27)
+
+### Features
 
 - User List endpoint
 

--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 1.0.2 (2024-11-27)
+## 1.0.2 (Unreleased)
 
-### Features
+### Features Added
 
 - User List endpoint
 

--- a/sdk/confidentialledger/confidential-ledger-rest/assets.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/confidentialledger/confidential-ledger-rest",
-  "Tag": "js/confidentialledger/confidential-ledger-rest_73e943cd0e"
+  "Tag": "js/confidentialledger/confidential-ledger-rest_cf1638c72c"
 }

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
-  "version": "1.0.2",
+  "version": "1.1.0-beta.1",
   "keywords": [
     "node",
     "azure",

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "node",
     "azure",

--- a/sdk/confidentialledger/confidential-ledger-rest/review/confidential-ledger.api.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/review/confidential-ledger.api.md
@@ -15,6 +15,19 @@ import { StreamableMethod } from '@azure-rest/core-client';
 import type { TokenCredential } from '@azure/core-auth';
 
 // @public
+export interface ApplicationClaimOutput {
+    digest?: ClaimDigestOutput;
+    kind: "LedgerEntry" | "ClaimDigest";
+    ledgerEntry?: LedgerEntryClaimOutput;
+}
+
+// @public
+export interface ClaimDigestOutput {
+    protocol: "LedgerEntryV1";
+    value?: string;
+}
+
+// @public
 export interface CollectionOutput {
     // (undocumented)
     collectionId: string;
@@ -404,6 +417,9 @@ export function isUnexpected(response: GetTransactionStatus200Response | GetTran
 export function isUnexpected(response: GetCurrentLedgerEntry200Response | GetCurrentLedgerEntryDefaultResponse): response is GetCurrentLedgerEntryDefaultResponse;
 
 // @public (undocumented)
+export function isUnexpected(response: ListUsers200Response | ListUsersDefaultResponse): response is ListUsersDefaultResponse;
+
+// @public (undocumented)
 export function isUnexpected(response: DeleteUser204Response | DeleteUserDefaultResponse): response is DeleteUserDefaultResponse;
 
 // @public (undocumented)
@@ -415,6 +431,14 @@ export function isUnexpected(response: CreateOrUpdateUser200Response | CreateOrU
 // @public
 export interface LedgerEntry {
     contents: string;
+}
+
+// @public
+export interface LedgerEntryClaimOutput {
+    collectionId?: string;
+    contents?: string;
+    protocol: "LedgerEntryV1";
+    secretKey?: string;
 }
 
 // @public
@@ -545,6 +569,30 @@ export interface ListLedgerEntriesQueryParamProperties {
     toTransactionId?: string;
 }
 
+// @public (undocumented)
+export interface ListUsers {
+    get(options?: ListUsersParameters): StreamableMethod<ListUsers200Response | ListUsersDefaultResponse>;
+}
+
+// @public
+export interface ListUsers200Response extends HttpResponse {
+    // (undocumented)
+    body: PagedUsersOutput;
+    // (undocumented)
+    status: "200";
+}
+
+// @public
+export interface ListUsersDefaultResponse extends HttpResponse {
+    // (undocumented)
+    body: ConfidentialLedgerErrorOutput;
+    // (undocumented)
+    status: string;
+}
+
+// @public (undocumented)
+export type ListUsersParameters = RequestParameters;
+
 // @public
 export interface PagedCollectionsOutput {
     // (undocumented)
@@ -557,6 +605,13 @@ export interface PagedLedgerEntriesOutput {
     entries: Array<LedgerEntryOutput>;
     nextLink?: string;
     state: "Loading" | "Ready";
+}
+
+// @public
+export interface PagedUsersOutput {
+    // (undocumented)
+    ledgerUsers?: Array<LedgerUserOutput>;
+    nextLink?: string;
 }
 
 // @public
@@ -578,6 +633,10 @@ export type PaginateReturn<TResult> = TResult extends {
 } | {
     body: {
         entries?: infer TPage;
+    };
+} | {
+    body: {
+        ledgerUsers?: infer TPage;
     };
 } ? GetArrayType<TPage> : Array<unknown>;
 
@@ -635,11 +694,13 @@ export interface Routes {
     (path: "/app/transactions/{transactionId}/receipt", transactionId: string): GetReceipt;
     (path: "/app/transactions/{transactionId}/status", transactionId: string): GetTransactionStatus;
     (path: "/app/transactions/current"): GetCurrentLedgerEntry;
+    (path: "/app/users"): ListUsers;
     (path: "/app/users/{userId}", userId: string): DeleteUser;
 }
 
 // @public
 export interface TransactionReceiptOutput {
+    applicationClaims?: Array<ApplicationClaimOutput>;
     // (undocumented)
     receipt?: ReceiptContentsOutput;
     state: "Loading" | "Ready";

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/clientDefinitions.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/clientDefinitions.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   GetConstitutionParameters,
@@ -12,10 +12,11 @@ import {
   GetReceiptParameters,
   GetTransactionStatusParameters,
   GetCurrentLedgerEntryParameters,
+  ListUsersParameters,
   DeleteUserParameters,
   GetUserParameters,
   CreateOrUpdateUserParameters
-} from "./parameters.js";
+} from "./parameters";
 import {
   GetConstitution200Response,
   GetConstitutionDefaultResponse,
@@ -37,13 +38,15 @@ import {
   GetTransactionStatusDefaultResponse,
   GetCurrentLedgerEntry200Response,
   GetCurrentLedgerEntryDefaultResponse,
+  ListUsers200Response,
+  ListUsersDefaultResponse,
   DeleteUser204Response,
   DeleteUserDefaultResponse,
   GetUser200Response,
   GetUserDefaultResponse,
   CreateOrUpdateUser200Response,
   CreateOrUpdateUserDefaultResponse
-} from "./responses.js";
+} from "./responses";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
 export interface GetConstitution {
@@ -131,6 +134,13 @@ export interface GetCurrentLedgerEntry {
   >;
 }
 
+export interface ListUsers {
+  /** All users' object IDs and roles will be returned. */
+  get(
+    options?: ListUsersParameters
+  ): StreamableMethod<ListUsers200Response | ListUsersDefaultResponse>;
+}
+
 export interface DeleteUser {
   /** Deletes a user from the Confidential Ledger. */
   delete(
@@ -176,6 +186,8 @@ export interface Routes {
   ): GetTransactionStatus;
   /** Resource for '/app/transactions/current' has methods for the following verbs: get */
   (path: "/app/transactions/current"): GetCurrentLedgerEntry;
+  /** Resource for '/app/users' has methods for the following verbs: get */
+  (path: "/app/users"): ListUsers;
   /** Resource for '/app/users/\{userId\}' has methods for the following verbs: delete, get, patch */
   (path: "/app/users/{userId}", userId: string): DeleteUser;
 }

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/clientDefinitions.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/clientDefinitions.ts
@@ -16,7 +16,7 @@ import {
   DeleteUserParameters,
   GetUserParameters,
   CreateOrUpdateUserParameters
-} from "./parameters";
+} from "./parameters.js";
 import {
   GetConstitution200Response,
   GetConstitutionDefaultResponse,
@@ -46,7 +46,7 @@ import {
   GetUserDefaultResponse,
   CreateOrUpdateUser200Response,
   CreateOrUpdateUserDefaultResponse
-} from "./responses";
+} from "./responses.js";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
 export interface GetConstitution {

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { getClient, ClientOptions } from "@azure-rest/core-client";
-import { logger } from "./logger.js";
+import { logger } from "./logger";
 import { TokenCredential } from "@azure/core-auth";
-import { ConfidentialLedgerClient } from "./clientDefinitions.js";
+import { ConfidentialLedgerClient } from "./clientDefinitions";
 
 /**
  * Initialize a new instance of `ConfidentialLedgerClient`
- * @param ledgerEndpoint - The Confidential Ledger URL, for example https://contoso.confidentialledger.azure.com
+ * @param endpoint - The Confidential Ledger URL, for example https://contoso.confidentialledger.azure.com
  * @param credentials - uniquely identify client credential
  * @param options - the parameter for all optional parameters
  */
 export default function createClient(
-  ledgerEndpoint: string,
+  endpoint: string,
   credentials: TokenCredential,
   options: ClientOptions = {}
 ): ConfidentialLedgerClient {
-  const baseUrl = options.baseUrl ?? `${ledgerEndpoint}`;
-  options.apiVersion = options.apiVersion ?? "2022-05-13";
+  const baseUrl = options.baseUrl ?? `${endpoint}`;
+  options.apiVersion = options.apiVersion ?? "2024-01-26-preview";
   options = {
     ...options,
     credentials: {

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
@@ -28,7 +28,7 @@ export default function createClient(
     }
   };
 
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.0.2`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.1.0-beta.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
@@ -28,7 +28,7 @@ export default function createClient(
     }
   };
 
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.0.1`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.0.2`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/confidentialLedger.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import { getClient, ClientOptions } from "@azure-rest/core-client";
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 import { TokenCredential } from "@azure/core-auth";
-import { ConfidentialLedgerClient } from "./clientDefinitions";
+import { ConfidentialLedgerClient } from "./clientDefinitions.js";
 
 /**
  * Initialize a new instance of `ConfidentialLedgerClient`

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/index.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/index.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import ConfidentialLedger from "./confidentialLedger";
+import ConfidentialLedger from "./confidentialLedger.js";
 
-export * from "./confidentialLedger";
-export * from "./parameters";
-export * from "./responses";
-export * from "./clientDefinitions";
-export * from "./isUnexpected";
-export * from "./models";
-export * from "./outputModels";
-export * from "./paginateHelper";
+export * from "./confidentialLedger.js";
+export * from "./parameters.js";
+export * from "./responses.js";
+export * from "./clientDefinitions.js";
+export * from "./isUnexpected.js";
+export * from "./models.js";
+export * from "./outputModels.js";
+export * from "./paginateHelper.js";
 
 export default ConfidentialLedger;

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/index.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/index.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
-import ConfidentialLedger from "./confidentialLedger.js";
+import ConfidentialLedger from "./confidentialLedger";
 
-export * from "./confidentialLedger.js";
-export * from "./parameters.js";
-export * from "./responses.js";
-export * from "./clientDefinitions.js";
-export * from "./isUnexpected.js";
-export * from "./models.js";
-export * from "./outputModels.js";
-export * from "./paginateHelper.js";
+export * from "./confidentialLedger";
+export * from "./parameters";
+export * from "./responses";
+export * from "./clientDefinitions";
+export * from "./isUnexpected";
+export * from "./models";
+export * from "./outputModels";
+export * from "./paginateHelper";
 
 export default ConfidentialLedger;

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/isUnexpected.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/isUnexpected.ts
@@ -30,7 +30,7 @@ import {
   GetUserDefaultResponse,
   CreateOrUpdateUser200Response,
   CreateOrUpdateUserDefaultResponse
-} from "./responses";
+} from "./responses.js";
 
 const responseMap: Record<string, string[]> = {
   "GET /app/governance/constitution": ["200"],

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/isUnexpected.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/isUnexpected.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   GetConstitution200Response,
@@ -22,13 +22,15 @@ import {
   GetTransactionStatusDefaultResponse,
   GetCurrentLedgerEntry200Response,
   GetCurrentLedgerEntryDefaultResponse,
+  ListUsers200Response,
+  ListUsersDefaultResponse,
   DeleteUser204Response,
   DeleteUserDefaultResponse,
   GetUser200Response,
   GetUserDefaultResponse,
   CreateOrUpdateUser200Response,
   CreateOrUpdateUserDefaultResponse
-} from "./responses.js";
+} from "./responses";
 
 const responseMap: Record<string, string[]> = {
   "GET /app/governance/constitution": ["200"],
@@ -41,6 +43,7 @@ const responseMap: Record<string, string[]> = {
   "GET /app/transactions/{transactionId}/receipt": ["200"],
   "GET /app/transactions/{transactionId}/status": ["200"],
   "GET /app/transactions/current": ["200"],
+  "GET /app/users": ["200"],
   "DELETE /app/users/{userId}": ["204"],
   "GET /app/users/{userId}": ["200"],
   "PATCH /app/users/{userId}": ["200"]
@@ -83,6 +86,9 @@ export function isUnexpected(
     | GetCurrentLedgerEntryDefaultResponse
 ): response is GetCurrentLedgerEntryDefaultResponse;
 export function isUnexpected(
+  response: ListUsers200Response | ListUsersDefaultResponse
+): response is ListUsersDefaultResponse;
+export function isUnexpected(
   response: DeleteUser204Response | DeleteUserDefaultResponse
 ): response is DeleteUserDefaultResponse;
 export function isUnexpected(
@@ -113,6 +119,8 @@ export function isUnexpected(
     | GetTransactionStatusDefaultResponse
     | GetCurrentLedgerEntry200Response
     | GetCurrentLedgerEntryDefaultResponse
+    | ListUsers200Response
+    | ListUsersDefaultResponse
     | DeleteUser204Response
     | DeleteUserDefaultResponse
     | GetUser200Response
@@ -130,6 +138,7 @@ export function isUnexpected(
   | GetReceiptDefaultResponse
   | GetTransactionStatusDefaultResponse
   | GetCurrentLedgerEntryDefaultResponse
+  | ListUsersDefaultResponse
   | DeleteUserDefaultResponse
   | GetUserDefaultResponse
   | CreateOrUpdateUserDefaultResponse {

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/logger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/logger.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { createClientLogger } from "@azure/logger";
 export const logger = createClientLogger("confidential-ledger");

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/models.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/models.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /** An entry in the ledger. */
 export interface LedgerEntry {

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/outputModels.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/outputModels.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /** The governance script for the application. */
 export interface ConstitutionOutput {
@@ -104,11 +104,43 @@ export interface LedgerQueryResultOutput {
 
 /** A receipt certifying the transaction at the specified id. */
 export interface TransactionReceiptOutput {
+  /** List of application claims. */
+  applicationClaims?: Array<ApplicationClaimOutput>;
   receipt?: ReceiptContentsOutput;
   /** State of a ledger query. */
   state: "Loading" | "Ready";
   /** A unique identifier for the state of the ledger. If returned as part of a LedgerEntry, it indicates the state from which the entry was read. */
   transactionId: string;
+}
+
+/** A claim of a ledger application. */
+export interface ApplicationClaimOutput {
+  /** An application claim in digested form. */
+  digest?: ClaimDigestOutput;
+  /** Represents the kind of an application claim. */
+  kind: "LedgerEntry" | "ClaimDigest";
+  /** An application claim derived from ledger entry data. */
+  ledgerEntry?: LedgerEntryClaimOutput;
+}
+
+/** An application claim in digested form. */
+export interface ClaimDigestOutput {
+  /** The digest of the application claim, in hexadecimal form. */
+  value?: string;
+  /** Represents the protocol to be used to compute the digest of a claim from the given claim data. */
+  protocol: "LedgerEntryV1";
+}
+
+/** An application claim derived from ledger entry data. */
+export interface LedgerEntryClaimOutput {
+  /** Identifier of a collection. */
+  collectionId?: string;
+  /** Contents of a ledger entry. */
+  contents?: string;
+  /** Base64-encoded secret key. */
+  secretKey?: string;
+  /** Represents the protocol to be used to compute the digest of a claim from the given claim data. */
+  protocol: "LedgerEntryV1";
 }
 
 export interface ReceiptContentsOutput {
@@ -139,6 +171,13 @@ export interface TransactionStatusOutput {
   state: "Committed" | "Pending";
   /** A unique identifier for the state of the ledger. If returned as part of a LedgerEntry, it indicates the state from which the entry was read. */
   transactionId: string;
+}
+
+/** Paginated users returned in response to a query. */
+export interface PagedUsersOutput {
+  ledgerUsers?: Array<LedgerUserOutput>;
+  /** Path from which to retrieve the next page of results. */
+  nextLink?: string;
 }
 
 /** Details about a Confidential Ledger user. */

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/paginateHelper.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/paginateHelper.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   getPagedAsyncIterator,
@@ -57,6 +57,9 @@ export type PaginateReturn<TResult> = TResult extends
     }
   | {
       body: { entries?: infer TPage };
+    }
+  | {
+      body: { ledgerUsers?: infer TPage };
     }
   ? GetArrayType<TPage>
   : Array<unknown>;
@@ -173,7 +176,13 @@ function getPaginationProperties(initialResponse: PathUncheckedResponse) {
   const nextLinkNames = new Set(["nextLink", "@nextLink"]);
 
   // Build a set with the passed custom set of itemNames
-  const itemNames = new Set(["value", "members", "collections", "entries"]);
+  const itemNames = new Set([
+    "value",
+    "members",
+    "collections",
+    "entries",
+    "ledgerUsers"
+  ]);
 
   let nextLinkName: string | undefined;
   let itemName: string | undefined;

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/parameters.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/parameters.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { RequestParameters } from "@azure-rest/core-client";
-import { LedgerEntry, LedgerUser } from "./models";
+import { LedgerEntry, LedgerUser } from "./models.js";
 
 export type GetConstitutionParameters = RequestParameters;
 export type ListConsortiumMembersParameters = RequestParameters;

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/parameters.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/parameters.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { RequestParameters } from "@azure-rest/core-client";
-import { LedgerEntry, LedgerUser } from "./models.js";
+import { LedgerEntry, LedgerUser } from "./models";
 
 export type GetConstitutionParameters = RequestParameters;
 export type ListConsortiumMembersParameters = RequestParameters;
@@ -74,6 +74,7 @@ export interface GetCurrentLedgerEntryQueryParam {
 
 export type GetCurrentLedgerEntryParameters = GetCurrentLedgerEntryQueryParam &
   RequestParameters;
+export type ListUsersParameters = RequestParameters;
 export type DeleteUserParameters = RequestParameters;
 export type GetUserParameters = RequestParameters;
 /** Details about a Confidential Ledger user. */

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/responses.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/responses.ts
@@ -17,7 +17,7 @@ import {
   LedgerEntryOutput,
   PagedUsersOutput,
   LedgerUserOutput
-} from "./outputModels";
+} from "./outputModels.js";
 
 /** The constitution is a script that assesses and applies proposals from consortium members. */
 export interface GetConstitution200Response extends HttpResponse {

--- a/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/responses.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/generated/src/responses.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { RawHttpHeaders } from "@azure/core-rest-pipeline";
 import { HttpResponse } from "@azure-rest/core-client";
@@ -15,8 +15,9 @@ import {
   TransactionReceiptOutput,
   TransactionStatusOutput,
   LedgerEntryOutput,
+  PagedUsersOutput,
   LedgerUserOutput
-} from "./outputModels.js";
+} from "./outputModels";
 
 /** The constitution is a script that assesses and applies proposals from consortium members. */
 export interface GetConstitution200Response extends HttpResponse {
@@ -140,6 +141,18 @@ export interface GetCurrentLedgerEntry200Response extends HttpResponse {
 
 /** A collection id may optionally be specified. */
 export interface GetCurrentLedgerEntryDefaultResponse extends HttpResponse {
+  status: string;
+  body: ConfidentialLedgerErrorOutput;
+}
+
+/** All users' object IDs and roles will be returned. */
+export interface ListUsers200Response extends HttpResponse {
+  status: "200";
+  body: PagedUsersOutput;
+}
+
+/** All users' object IDs and roles will be returned. */
+export interface ListUsersDefaultResponse extends HttpResponse {
   status: string;
   body: ConfidentialLedgerErrorOutput;
 }

--- a/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
@@ -11,7 +11,7 @@ description: The ConfidentialLedgerClient writes and retrieves ledger entries ag
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
-input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/stable/2022-05-13/confidentialledger.json
+input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/2024-01-26-preview/confidentialledger.json
 package-version: 1.0.1
 hide-clients: true
 rest-level-client: true

--- a/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/2024-01-26-preview/confidentialledger.json
-package-version: 1.0.2
+package-version: 1.1.0-beta.1
 hide-clients: true
 rest-level-client: true
 security: "AADToken"

--- a/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
@@ -12,7 +12,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/2024-01-26-preview/confidentialledger.json
-package-version: 1.0.1
+package-version: 1.0.2
 hide-clients: true
 rest-level-client: true
 security: "AADToken"

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/usersEndpoint.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/usersEndpoint.spec.ts
@@ -33,4 +33,19 @@ describe("Get user", () => {
 
     assert.equal(result.body.userId, userId);
   });
+
+  it("should list all user data", { skip: !env.AZURE_CLIENT_OID }, async () => {
+    // If using a test app, it needs to be the oid.
+    const userId = env.AZURE_CLIENT_OID;
+    const result = await client.path("/app/users").get();
+    assert.equal(result.status, "200");
+
+    if (isUnexpected(result)) {
+      throw result.body;
+    }
+
+    assert.equal(result.body.ledgerUsers?.length, 1);
+    assert.isNotNull(result.body.ledgerUsers);
+    assert.equal(result.body.ledgerUsers![0].userId, userId);
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure-rest/confidential-ledger

### Issues associated with this PR
Add a single API - the ability to *list* users from the "app/users" endpoint. Please see the [doc](https://microsoft-my.sharepoint-df.com/:w:/g/personal/tachou_microsoft_com1/EVUirfTSrlhJslGy0i_eCOgBP_wb0gDTlBZOBynm5wWoCw?e=oaZcv4) here. 

### Describe the problem that is addressed by this PR
Customers can `GET` details of a user from the `app/users/{userId}` endpoint, but needed to know the `userId` beforehand.  The API was amended in `preview-2024-01-26` to include the ability to list all users from the `app/users` endpoint.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
[Spec API Change](https://github.com/Azure/azure-rest-api-specs/pull/27564)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_


### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
