### PR TITLE
fix(playwrighttesting): use PlaywrightTestConfig from @playwright/test

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/package.json
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/package.json
@@ -88,6 +88,9 @@
     "sinon": "^17.0.0",
     "typescript": "~5.6.2"
   },
+  "peerDependencies": {
+    "@playwright/test": "^1.43.1"
+  },
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "//sampleConfiguration": {
     "productName": "Microsoft Playwright Testing",

--- a/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
@@ -49,8 +49,8 @@ export type PlaywrightConfig = {
     use?: {
         connectOptions: BrowserConnectOptions;
     };
-    globalSetup?: string | string[];
-    globalTeardown?: string | string[];
+    globalSetup?: string | string[] | any;
+    globalTeardown?: string | string[] | any;
 };
 
 // @public

--- a/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/review/microsoft-playwright-testing.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { PlaywrightTestConfig } from '@playwright/test';
 import type { TokenCredential } from '@azure/identity';
 
 // @public
@@ -33,7 +34,7 @@ export type EndpointOptions = {
 export const getConnectOptions: (options?: Omit<PlaywrightServiceAdditionalOptions, "serviceAuthType">) => Promise<BrowserConnectOptions>;
 
 // @public
-export const getServiceConfig: (config: PlaywrightConfigInput, options?: PlaywrightServiceAdditionalOptions) => PlaywrightConfig;
+export const getServiceConfig: (config: PlaywrightTestConfig, options?: PlaywrightServiceAdditionalOptions) => PlaywrightTestConfig;
 
 // @public
 export interface MPTReporterConfig {
@@ -43,21 +44,6 @@ export interface MPTReporterConfig {
 
 // @public
 export type OsType = (typeof ServiceOS)[keyof typeof ServiceOS];
-
-// @public
-export type PlaywrightConfig = {
-    use?: {
-        connectOptions: BrowserConnectOptions;
-    };
-    globalSetup?: string | string[] | any;
-    globalTeardown?: string | string[] | any;
-};
-
-// @public
-export type PlaywrightConfigInput = {
-    globalSetup?: string | string[];
-    globalTeardown?: string | string[];
-};
 
 // @public
 export type PlaywrightServiceAdditionalOptions = {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
@@ -108,52 +108,6 @@ export type BrowserConnectOptions = EndpointOptions & {
 /**
  * @public
  *
- * Base playwright configuration inputs required for generating the service config.
- */
-export type PlaywrightConfigInput = {
-  /**
-   * @public
-   *
-   * Path to the global setup file. This file will be required and run before all the tests. It must export a single
-   * function that takes a [`TestConfig`] argument.
-   *
-   * Learn more about {@link https://playwright.dev/docs/test-global-setup-teardown | global setup and teardown}.
-   */
-  globalSetup?: string | string[];
-
-  /**
-   * @public
-   *
-   * Path to the global teardown file. This file will be required and run after all the tests. It must export a single
-   * function. See also
-   * {@link https://playwright.dev/docs/api/class-testconfig#test-config-global-teardown | testConfig.globalTeardown}.
-   *
-   * Learn more about {@link https://playwright.dev/docs/test-global-setup-teardown | global setup and teardown}.
-   */
-  globalTeardown?: string | string[];
-};
-
-/**
- * @public
- *
- * Playwright configuration integrated with Microsoft Playwright Testing.
- *
- * @remarks
- *
- * GlobalSetup and globalTeardown wraps around any existing global setup
- * and teardown present in the base playwright configuration and runs it.
- */
-export type PlaywrightConfig = {
-  use?: {
-    connectOptions: BrowserConnectOptions;
-  };
-  globalSetup?: string | string[] | any; // add any since playwright version <1.49 does not support string[]
-  globalTeardown?: string | string[] | any;
-};
-
-/**
- * @public
- *
  * Additional options for the service.
  */
 export type PlaywrightServiceAdditionalOptions = {

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/common/types.ts
@@ -147,8 +147,8 @@ export type PlaywrightConfig = {
   use?: {
     connectOptions: BrowserConnectOptions;
   };
-  globalSetup?: string | string[];
-  globalTeardown?: string | string[];
+  globalSetup?: string | string[] | any; // add any since playwright version <1.49 does not support string[]
+  globalTeardown?: string | string[] | any;
 };
 
 /**

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -5,12 +5,7 @@ import { InternalEnvironmentVariables, ServiceAuth } from "../common/constants";
 import customerConfig from "../common/customerConfig";
 import { PlaywrightServiceConfig } from "../common/playwrightServiceConfig";
 import playwrightServiceEntra from "./playwrightServiceEntra";
-import type {
-  PlaywrightServiceAdditionalOptions,
-  PlaywrightConfig,
-  PlaywrightConfigInput,
-  BrowserConnectOptions,
-} from "../common/types";
+import type { PlaywrightServiceAdditionalOptions, BrowserConnectOptions } from "../common/types";
 import {
   emitReportingUrl,
   fetchOrValidateAccessToken,
@@ -25,6 +20,7 @@ import {
   getVersionInfo,
 } from "../utils/utils";
 import { ServiceErrorMessageConstants } from "../common/messages";
+import type { PlaywrightTestConfig } from "@playwright/test";
 
 /**
  * @public
@@ -57,9 +53,9 @@ import { ServiceErrorMessageConstants } from "../common/messages";
  * ```
  */
 const getServiceConfig = (
-  config: PlaywrightConfigInput,
+  config: PlaywrightTestConfig,
   options?: PlaywrightServiceAdditionalOptions,
-): PlaywrightConfig => {
+): PlaywrightTestConfig => {
   validatePlaywrightVersion();
   validateServiceUrl();
   const playwrightVersionInfo = getVersionInfo(getPlaywrightVersion());

--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/index.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/index.ts
@@ -9,8 +9,6 @@
 
 import { ServiceAuth, ServiceOS, ServiceEnvironmentVariable } from "./common/constants";
 import type {
-  PlaywrightConfig,
-  PlaywrightConfigInput,
   OsType,
   AuthenticationType,
   BrowserConnectOptions,
@@ -27,8 +25,6 @@ export {
   ServiceOS,
   ServiceAuth,
   ServiceEnvironmentVariable,
-  PlaywrightConfig,
-  PlaywrightConfigInput,
   OsType,
   AuthenticationType,
   BrowserConnectOptions,


### PR DESCRIPTION
### Packages impacted by this PR

@azure/microsoft-playwright-testing

### Issues associated with this PR

Playwright version <1.49 does not support string[], thus typescript throws an error if string array is being returned. Using any prevents this error.

```Type 'string | string[] | undefined' is not assignable to type 'string | undefined'.```

### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
