### PR TITLE
[CODEOWNERS] move health-deidentification to data plane section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -145,6 +145,10 @@
 # PRLabel: %Cognitive - Health Insights
 /sdk/healthinsights/ @tomsft @koen-mertens
 
+# ServiceLabel: %Health Deidentification
+# PRLabel: %Health Deidentification
+/sdk/healthdataaiservices/azure-health-deidentification/ @GrahamMThomas
+
 # PRLabel: %Azure.Identity
 /sdk/identity/ @KarishmaGhiya @minhanh-phan @maorleger @schaabs @Azure/azure-sdk-write-identity
 
@@ -571,10 +575,6 @@ sdk/ai/ai-inference-rest @glharper @dargilco @jhakulin
 
 # PRLabel: %Mgmt
 /sdk/healthcareapis/arm-healthcareapis/ @qiaozha @MaryGao
-
-# ServiceLabel: %Health Deidentification
-# PRLabel: %Health Deidentification
-/sdk/healthdataaiservices/ @GrahamMThomas
 
 # PRLabel: %Mgmt
 /sdk/hybridcompute/arm-hybridcompute/ @qiaozha @MaryGao


### PR DESCRIPTION
It should not be added after the more specific management entry
arm-healthdataaiservices. This PR moves it to the data plane section and also
adds the azure-health-deidentification directory so it matches the labels.