### PR TITLE
Install JS API parser using local view of devops feed

### DIFF
--- a/eng/scripts/Generate-APIView-CodeFile.ps1
+++ b/eng/scripts/Generate-APIView-CodeFile.ps1
@@ -1,7 +1,7 @@
 param (
   [Parameter(mandatory = $true)]
   $ArtifactPath,
-  $NpmDevopsFeedRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+  $NpmDevopsFeedRegistry = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js@local/npm/registry/"
 )
 
 Set-StrictMode -Version 3
@@ -12,9 +12,6 @@ if (!(Test-Path -Path $ArtifactPath))
 }
 
 
-npm install "@rushstack/node-core-library@5.9.0"
-npm install "js-tokens@9.0.0"
-npm install "@microsoft/api-extractor-model@7.29.8"
 $apiviewParser = "@azure-tools/ts-genapi@2.0.3"
 Write-Host "Installing $($apiviewParser)"
 npm install $apiviewParser --registry $NpmDevopsFeedRegistry


### PR DESCRIPTION
Install JS API parser and dependencies using local view of Azure DevOps feed for JS packages.