### PR TITLE
[Monitor OpenTelemetry Exporter] Fix Statsbeat Common Properties

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.28 ()
+
+### Other Changes
+
+- Fix setting statsbeat custom dimensions.
+
 ## 1.0.0-beta.27 (2024-10-23)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -99,6 +99,10 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
       StatsbeatCounter.ATTACH,
     );
 
+    // TODO: Adding this to ensure that the resource provider is set before exporting statsbeat
+    this.isInitialized = true;
+    this.initialize();
+
     this.commonProperties = {
       os: this.os,
       rp: this.resourceProvider,
@@ -112,9 +116,6 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
     this.attachProperties = {
       rpId: this.resourceIdentifier,
     };
-
-    this.isInitialized = true;
-    this.initialize();
   }
 
   private async initialize() {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -98,8 +98,6 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
     this.attachStatsbeatGauge = this.longIntervalStatsbeatMeter.createObservableGauge(
       StatsbeatCounter.ATTACH,
     );
-
-    // TODO: Adding this to ensure that the resource provider is set before exporting statsbeat
     this.isInitialized = true;
     this.initialize();
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -115,6 +115,9 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
       );
     }
 
+    this.isInitialized = true;
+    this.initialize();
+    
     this.commonProperties = {
       os: this.os,
       rp: this.resourceProvider,
@@ -129,9 +132,6 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
       endpoint: this.endpointUrl,
       host: this.host,
     };
-
-    this.isInitialized = true;
-    this.initialize();
   }
 
   public shutdown(): Promise<void> {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -117,7 +117,7 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
 
     this.isInitialized = true;
     this.initialize();
-    
+
     this.commonProperties = {
       os: this.os,
       rp: this.resourceProvider,

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -127,11 +127,18 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         assert.ok(statsbeat["version"]);
       });
 
+      it("should set common properties correctly", () => {
+        const originalEnv = process.env;
+        const newEnv = <{ [id: string]: string }>{};
+        newEnv.WEBSITE_SITE_NAME = "test";
+        process.env = newEnv;
+        const statsbeat = new NetworkStatsbeatMetrics(options);
+        assert.strictEqual(statsbeat["commonProperties"]["rp"], "appsvc");
+        process.env = originalEnv;
+      })
+
       it("should add correct long interval properties to the custom metric", () => {
-        // const exporter = new TestExporter();
-        // const statsbeatMetrics = exporter["sender"]["networkStatsbeatMetrics"];
         const longIntervalStatsbeatMetrics = getInstance(options);
-        // assert.ok(statsbeatMetrics);
         assert.ok(longIntervalStatsbeatMetrics);
         // Represents the bitwise OR of NONE and AADHANDLING features
         assert.strictEqual(longIntervalStatsbeatMetrics["feature"], 3);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -135,7 +135,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const statsbeat = new NetworkStatsbeatMetrics(options);
         assert.strictEqual(statsbeat["commonProperties"]["rp"], "appsvc");
         process.env = originalEnv;
-      })
+      });
 
       it("should add correct long interval properties to the custom metric", () => {
         const longIntervalStatsbeatMetrics = getInstance(options);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Values in the custom properties on both Network and Long Interval stats were not being correctly set and sent.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
