### PR TITLE
[core] Handle 4xx and 5xx in tracing policy

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where tracing spans were incorrectly marked as successful. [PR #32018](https://github.com/Azure/azure-sdk-for-js/pull/32018)
+
 ### Other Changes
 
 ## 1.18.1 (2024-11-26)

--- a/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/tracingPolicy.ts
@@ -159,9 +159,14 @@ function tryProcessResponse(span: TracingSpan, response: PipelineResponse): void
     if (serviceRequestId) {
       span.setAttribute("serviceRequestId", serviceRequestId);
     }
-    span.setStatus({
-      status: "success",
-    });
+    // Per semantic conventions, only set the status to error if the status code is 4xx or 5xx.
+    // Otherwise, the status MUST remain unset.
+    // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+    if (response.status >= 400) {
+      span.setStatus({
+        status: "error",
+      });
+    }
     span.end();
   } catch (e: any) {
     logger.warning(`Skipping tracing span processing due to an error: ${getErrorMessage(e)}`);

--- a/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/tracingPolicy.spec.ts
@@ -269,14 +269,16 @@ describe("tracingPolicy", function () {
           },
         });
 
-        const policy = tracingPolicy();
-        const next = vi.fn<SendRequest>();
-        next.mockResolvedValue({
+        const response = {
           headers: createHttpHeaders(),
           request: request,
           status: statusCode,
           bodyAsText: JSON.stringify({}),
-        });
+        };
+
+        const policy = tracingPolicy();
+        const next = vi.fn<SendRequest>();
+        next.mockResolvedValue(response);
 
         await policy.sendRequest(request, next);
         const createdSpan = activeInstrumenter.lastSpanCreated;

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -1874,7 +1874,7 @@ index a40d4ab..0000000
 -  };
 -}
 diff --git a/src/policies/tracingPolicy.ts b/src/policies/tracingPolicy.ts
-index 5e69548..34fad89 100644
+index 4f54b0d..4131837 100644
 --- a/src/policies/tracingPolicy.ts
 +++ b/src/policies/tracingPolicy.ts
 @@ -1,18 +1,14 @@

--- a/sdk/core/ts-http-runtime/src/policies/tracingPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/tracingPolicy.ts
@@ -155,9 +155,14 @@ function tryProcessResponse(span: TracingSpan, response: PipelineResponse): void
     if (serviceRequestId) {
       span.setAttribute("serviceRequestId", serviceRequestId);
     }
-    span.setStatus({
-      status: "success",
-    });
+    // Per semantic conventions, only set the status to error if the status code is 4xx or 5xx.
+    // Otherwise, the status MUST remain unset.
+    // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+    if (response.status >= 400) {
+      span.setStatus({
+        status: "error",
+      });
+    }
     span.end();
   } catch (e: any) {
     logger.warning(`Skipping tracing span processing due to an error: ${getErrorMessage(e)}`);

--- a/sdk/core/ts-http-runtime/test/tracingPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/tracingPolicy.spec.ts
@@ -232,6 +232,58 @@ describe("tracingPolicy", function () {
     assert.exists(createdSpan);
   });
 
+  describe("HTTP status codes", () => {
+    const data = [
+      {
+        statusCode: 100,
+        expectedSpanStatus: undefined,
+      },
+      {
+        statusCode: 201,
+        expectedSpanStatus: undefined,
+      },
+      {
+        statusCode: 302,
+        expectedSpanStatus: undefined,
+      },
+      {
+        statusCode: 400,
+        expectedSpanStatus: "error",
+      },
+      {
+        statusCode: 500,
+        expectedSpanStatus: "error",
+      },
+    ];
+
+    for (const { statusCode, expectedSpanStatus } of data) {
+      it(`will set the span status to ${expectedSpanStatus} for a status code of ${statusCode}`, async () => {
+        const request = createPipelineRequest({
+          url: "https://bing.com",
+          tracingOptions: {
+            tracingContext: noopTracingContext,
+          },
+        });
+
+        const response = {
+          headers: createHttpHeaders(),
+          request: request,
+          status: statusCode,
+          bodyAsText: JSON.stringify({}),
+        };
+
+        const policy = tracingPolicy();
+        const next = vi.fn<SendRequest>();
+        next.mockResolvedValue(response);
+
+        await policy.sendRequest(request, next);
+        const createdSpan = activeInstrumenter.lastSpanCreated;
+        assert.exists(createdSpan);
+        assert.equal(createdSpan?.status?.status, expectedSpanStatus);
+      });
+    }
+  });
+
   describe("span errors", () => {
     it("will not fail the request when creating a span throws", async () => {
       vi.spyOn(activeInstrumenter, "startSpan").mockImplementation(() => {


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/core-rest-pipeline
- @typespec/ts-http-runtime 

### Issues associated with this PR

Fixes #31693 

### Describe the problem that is addressed by this PR

According to https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status there are a few things we need to adjust:

| http status | span status |
| ----------- | ----------- |
| 1xx         | unset       |
| 2xx         | unset       |
| 3xx         | unset       |
| 4xx         | error       |
| 5xx         | error       |


Note: We should never mark the HTTP spans as success, leaving them unset instead, per the spec.

The 4xx and 5xx handling is handled in high level clients by the deserialization policy which turns this into an exception.

For RLC we must handle this ourselves within the tracingPolicy


### Checklists
- [x] Added impacted package name to the issue description.
- [x] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
