### PR TITLE
[dev-tool] Add source fixups for Communication packages

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/index.ts
+++ b/common/tools/dev-tool/src/commands/admin/index.ts
@@ -9,5 +9,6 @@ export default subCommand(commandInfo, {
   "create-migration": () => import("./create-migration"),
   "stage-migrations": () => import("./stage-migrations"),
   "migrate-package": () => import("./migrate-package"),
+  "migrate-source": () => import("./migrate-source"),
   list: () => import("./list"),
 });

--- a/common/tools/dev-tool/src/commands/admin/migrate-source.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-source.ts
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License
+
+import { leafCommand, makeCommandInfo } from "../../framework/command";
+import { Project, SourceFile } from "ts-morph";
+import { createPrinter } from "../../util/printer";
+import { resolveRoot } from "../../util/resolveProject";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import stripJsonComments from "strip-json-comments";
+import { existsSync, lstatSync } from "node:fs";
+
+const log = createPrinter("migrate-package");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _rushJson: any = undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getRushJson(): Promise<any> {
+  if (_rushJson) return _rushJson;
+
+  const rushJsonText = await readFile(resolve(__dirname, "../../../../../../rush.json"), "utf-8");
+
+  return (_rushJson = JSON.parse(stripJsonComments(rushJsonText)));
+}
+
+/**
+ * The shape of a rush.json `projects` entry.
+ */
+export interface RushJsonProject {
+  /**
+   * The name of the package.
+   */
+  packageName: string;
+  /**
+   * The path to the project, relative to the monorepo root.
+   */
+  projectFolder: string;
+
+  /**
+   * The version policy name.
+   */
+  versionPolicyName: string;
+}
+
+export const commandInfo = makeCommandInfo(
+  "migrate-source",
+  "migrates a package to the latest source code standards",
+  {
+    "package-name": {
+      description: "The name of the package to migrate",
+      kind: "string",
+    },
+  },
+);
+
+export default leafCommand(commandInfo, async ({ "package-name": packageName }) => {
+  const root = await resolveRoot();
+
+  const rushJson = await getRushJson();
+  const projects = rushJson.projects;
+
+  const project = projects.find((p: RushJsonProject) => p.packageName === packageName);
+  if (!project) {
+    log.error(`Package ${packageName} not found in rush.json`);
+    return false;
+  }
+
+  const projectFolder = resolve(root, project.projectFolder);
+  const projectFile = resolve(projectFolder, "tsconfig.json");
+
+  const projectFileContents = await readFile(projectFile, "utf-8");
+  const projectFileJSON = JSON.parse(projectFileContents);
+  const module = projectFileJSON.compilerOptions.module;
+  const moduleResolution = projectFileJSON.compilerOptions.moduleResolution;
+
+  if (module !== "NodeNext" || moduleResolution !== "NodeNext") {
+    log.info("Package does not use NodeNext module resolution. Skipping.");
+    return true;
+  }
+
+  const tsProject = new Project({ tsConfigFilePath: projectFile });
+  for (const sourceFile of tsProject.getSourceFiles()) {
+    fixSourceFile(sourceFile);
+    await sourceFile.save();
+  }
+
+  return true;
+});
+
+function fixSourceFile(sourceFile: SourceFile): void {
+  // Iterate over all the import declarations
+  for (const importExportDeclaration of sourceFile.getImportDeclarations()) {
+    let moduleSpecifier = importExportDeclaration.getModuleSpecifierValue();
+    moduleSpecifier = fixDeclaration(sourceFile, moduleSpecifier);
+    importExportDeclaration.setModuleSpecifier(moduleSpecifier);
+  }
+
+  // iterate over all the export declarations
+  for (const exportDeclaration of sourceFile.getExportDeclarations()) {
+    let moduleSpecifier = exportDeclaration.getModuleSpecifierValue();
+    if (moduleSpecifier) {
+      moduleSpecifier = fixDeclaration(sourceFile, moduleSpecifier);
+      exportDeclaration.setModuleSpecifier(moduleSpecifier);
+    }
+  }
+}
+
+function fixDeclaration(sourceFile: SourceFile, moduleSpecifier: string): string {
+  if (moduleSpecifier.startsWith(".") || moduleSpecifier.startsWith("..")) {
+    if (!moduleSpecifier.endsWith(".js")) {
+      // If the module specifier ends with "/", add "index.js", otherwise add ".js"
+      if (moduleSpecifier.endsWith("/")) {
+        moduleSpecifier += "index.js";
+      } else {
+        // Check if the module specifier is a directory
+        const path = resolve(sourceFile.getDirectoryPath(), moduleSpecifier);
+        if (existsSync(path) && lstatSync(path).isDirectory()) {
+          moduleSpecifier += "/index.js";
+        } else {
+          moduleSpecifier += ".js";
+        }
+      }
+    }
+  }
+  // Fix the node module declaration as well
+  return fixNodeDeclaration(moduleSpecifier);
+}
+
+function fixNodeDeclaration(moduleSpecifier: string): string {
+  const nodeModules = [
+    "assert",
+    "child_process",
+    "crypto",
+    "fs",
+    "fs/promises",
+    "http",
+    "https",
+    "net",
+    "os",
+    "path",
+    "process",
+    "stream",
+    "tls",
+    "util",
+  ];
+
+  if (nodeModules.includes(moduleSpecifier)) {
+    moduleSpecifier = `node:${moduleSpecifier}`;
+  }
+
+  return moduleSpecifier;
+}

--- a/sdk/communication/communication-alpha-ids/package.json
+++ b/sdk/communication/communication-alpha-ids/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-alpha-ids && rushx format",
+    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-alpha-ids/package.json
+++ b/sdk/communication/communication-alpha-ids/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && rushx format",
+    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-alpha-ids && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -9,7 +9,7 @@
   "browser": "./dist/browser/index.js",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-call-automation && rushx format",
+    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:node": "dev-tool run build-package && dev-tool run bundle",
     "build:samples": "dev-tool samples publish --force",
@@ -19,7 +19,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-call-automation && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -9,7 +9,7 @@
   "browser": "./dist/browser/index.js",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest ./swagger/README.md && rushx format",
+    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-call-automation && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:node": "dev-tool run build-package && dev-tool run bundle",
     "build:samples": "dev-tool samples publish --force",
@@ -19,7 +19,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-call-automation && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-chat && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-chat && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-email && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-email && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -19,7 +19,7 @@
     "execute:ts-samples": "dev-tool samples run dist-samples/typescript/dist/dist-samples/typescript/src/",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-identity && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -19,7 +19,7 @@
     "execute:ts-samples": "dev-tool samples run dist-samples/typescript/dist/dist-samples/typescript/src/",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-identity && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-job-router/package.json
+++ b/sdk/communication/communication-job-router/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-job-router && rushx format",
+    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle && dev-tool run vendored cross-env ONLY_BROWSER=true ",
     "build:node": "dev-tool run build-package && dev-tool run bundle && dev-tool run vendored cross-env ONLY_NODE=true ",
     "build:samples": "dev-tool samples publish -f",

--- a/sdk/communication/communication-job-router/package.json
+++ b/sdk/communication/communication-job-router/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest ./swagger/README.md && rushx format",
+    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-job-router && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle && dev-tool run vendored cross-env ONLY_BROWSER=true ",
     "build:node": "dev-tool run build-package && dev-tool run bundle && dev-tool run vendored cross-env ONLY_NODE=true ",
     "build:samples": "dev-tool samples publish -f",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-phone-numbers && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-phone-numbers && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-recipient-verification/package.json
+++ b/sdk/communication/communication-recipient-verification/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-recipient-verification && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-recipient-verification/package.json
+++ b/sdk/communication/communication-recipient-verification/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-recipient-verification && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-rooms/package.json
+++ b/sdk/communication/communication-rooms/package.json
@@ -70,7 +70,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript --disable-async-iterators ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-rooms && rushx format",
+    "generate:client": "autorest --typescript --disable-async-iterators ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-rooms/package.json
+++ b/sdk/communication/communication-rooms/package.json
@@ -70,7 +70,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript --disable-async-iterators ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript --disable-async-iterators ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-rooms && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest",

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-short-codes && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-short-codes && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -18,7 +18,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-sms && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "dev-tool run test:browser",
     "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -18,7 +18,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure/communication-sms && rushx format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "dev-tool run test:browser",
     "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",

--- a/sdk/communication/communication-tiering/package.json
+++ b/sdk/communication/communication-tiering/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-tiering && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-tiering/package.json
+++ b/sdk/communication/communication-tiering/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-tiering && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-toll-free-verification/package.json
+++ b/sdk/communication/communication-toll-free-verification/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && rushx format",
+    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-toll-free-verification && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-toll-free-verification/package.json
+++ b/sdk/communication/communication-toll-free-verification/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source --package-name=@azure-tools/communication-toll-free-verification && rushx format",
+    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source && rushx format",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool
- @azure-tools/communication-alpha-ids
- @azure/communication-call-automation
- @azure/communication-chat
- @azure/communication-email
- @azure/communication-identity
- @azure/communication-job-router
- @azure/communication-phone-numbers
- @azure-tools/communication-recipient-verification
- @azure/communication-rooms
- @azure-tools/communication-short-codes
- @azure/communication-sms
- @azure-tools/communication-tiering
- @azure-tools/communication-toll-free-verification

### Issues associated with this PR

### Describe the problem that is addressed by this PR

This adds a source fixup tool which fixes the imports for generated code from autorest using NodeNext TypeScript resolution.  This is used so that the code will compile after being generated via autorest to be compliant with our ESM builds.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- #31889

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
