### PR TITLE
[EngSys] Update @azure-rest ARM packages to mgmt not client

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -570,9 +570,7 @@
       "projectFolder": "common/tools/dev-tool",
       "versionPolicyName": "utility",
       // Add Identity to decoupledLocalDependencies so that dev-tool uses the package from npm, avoiding a cyclic dependency.
-      "decoupledLocalDependencies": [
-        "@azure/identity"
-      ]
+      "decoupledLocalDependencies": ["@azure/identity"]
     },
     {
       "packageName": "@azure/eventgrid",
@@ -612,9 +610,7 @@
     {
       "packageName": "@azure/identity",
       "projectFolder": "sdk/identity/identity",
-      "decoupledLocalDependencies": [
-        "@azure/keyvault-keys"
-      ],
+      "decoupledLocalDependencies": ["@azure/keyvault-keys"],
       "versionPolicyName": "client"
     },
     {
@@ -985,7 +981,7 @@
     {
       "packageName": "@azure-rest/arm-network",
       "projectFolder": "sdk/network/arm-network-rest",
-      "versionPolicyName": "client"
+      "versionPolicyName": "management"
     },
     {
       "packageName": "@azure/arm-compute",
@@ -995,7 +991,7 @@
     {
       "packageName": "@azure-rest/arm-compute",
       "projectFolder": "sdk/compute/arm-compute-rest",
-      "versionPolicyName": "client"
+      "versionPolicyName": "management"
     },
     {
       "packageName": "@azure/arm-storage",
@@ -1055,7 +1051,7 @@
     {
       "packageName": "@azure-rest/arm-appservice",
       "projectFolder": "sdk/appservice/arm-appservice-rest",
-      "versionPolicyName": "client"
+      "versionPolicyName": "management"
     },
     {
       "packageName": "@azure/arm-resources-subscriptions",
@@ -1155,7 +1151,7 @@
     {
       "packageName": "@azure-rest/arm-containerservice",
       "projectFolder": "sdk/containerservice/arm-containerservice-rest",
-      "versionPolicyName": "client"
+      "versionPolicyName": "management"
     },
     {
       "packageName": "@azure/arm-operations",
@@ -1190,7 +1186,7 @@
     {
       "packageName": "@azure-rest/arm-servicefabric",
       "projectFolder": "sdk/servicefabric/arm-servicefabric-rest",
-      "versionPolicyName": "client"
+      "versionPolicyName": "management"
     },
     {
       "packageName": "@azure/arm-mysql",
@@ -2215,7 +2211,7 @@
     {
       "packageName": "@azure/arm-informaticadatamanagement",
       "projectFolder": "sdk/informatica/arm-informaticadatamanagement",
-      "versionPolicyName": "client"
+      "versionPolicyName": "management"
     },
     {
       "packageName": "@azure/arm-oracledatabase",

--- a/sdk/appservice/arm-appservice-rest/package.json
+++ b/sdk/appservice/arm-appservice-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/arm-appservice",
-  "sdk-type": "client",
+  "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",

--- a/sdk/compute/arm-compute-rest/package.json
+++ b/sdk/compute/arm-compute-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/arm-compute",
-  "sdk-type": "client",
+  "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",

--- a/sdk/containerservice/arm-containerservice-rest/package.json
+++ b/sdk/containerservice/arm-containerservice-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/arm-containerservice",
-  "sdk-type": "client",
+  "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",

--- a/sdk/network/arm-network-rest/assets.json
+++ b/sdk/network/arm-network-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/network/arm-network-rest",
-  "Tag": "js/network/arm-network-rest_473931f3b9"
+  "Tag": "js/network/arm-network-rest_a6b792b701"
 }

--- a/sdk/network/arm-network-rest/assets.json
+++ b/sdk/network/arm-network-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/network/arm-network-rest",
-  "Tag": "js/network/arm-network-rest_a6b792b701"
+  "Tag": "js/network/arm-network-rest_1dbbd4c272"
 }

--- a/sdk/network/arm-network-rest/package.json
+++ b/sdk/network/arm-network-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/arm-network",
-  "sdk-type": "client",
+  "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",

--- a/sdk/network/arm-network-rest/test/public/network_rest_sample.spec.ts
+++ b/sdk/network/arm-network-rest/test/public/network_rest_sample.spec.ts
@@ -35,7 +35,6 @@ import { createTestNetworkManagementClient } from "./utils/recordedClient";
 
 const replaceableVariables: Record<string, string> = {
   SUBSCRIPTION_ID: "azure_subscription_id",
-  RESOURCE_GROUP_NAME: "azure_resource_group",
 };
 
 const recorderOptions: RecorderStartOptions = {

--- a/sdk/network/arm-network-rest/test/public/network_rest_sample.spec.ts
+++ b/sdk/network/arm-network-rest/test/public/network_rest_sample.spec.ts
@@ -244,7 +244,7 @@ describe("Network test", () => {
     for await (const item of pageData) {
       result.push(item);
     }
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 1);
   });
 
   it("subnets list test", async function () {
@@ -426,6 +426,6 @@ describe("Network test", () => {
     for await (const item of pageData) {
       result.push(item);
     }
-    assert.equal(result.length, 1);
+    assert.equal(result.length, 0);
   });
 });

--- a/sdk/network/arm-network-rest/test/public/utils/recordedClient.ts
+++ b/sdk/network/arm-network-rest/test/public/utils/recordedClient.ts
@@ -11,11 +11,7 @@ import createNetworkManagementClient from "../../../src";
 
 const envSetupForPlayback: Record<string, string> = {
   ENDPOINT: "https://endpoint",
-  AZURE_CLIENT_ID: "azure_client_id",
-  AZURE_CLIENT_SECRET: "azure_client_secret",
-  AZURE_TENANT_ID: "88888888-8888-8888-8888-888888888888",
   SUBSCRIPTION_ID: "azure_subscription_id",
-  RESOURCE_GROUP_NAME: "azure_resource_group",
 };
 
 const recorderEnvSetup: RecorderStartOptions = {

--- a/sdk/servicefabric/arm-servicefabric-rest/package.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/arm-servicefabric",
-  "sdk-type": "client",
+  "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",

--- a/sdk/servicefabric/arm-servicefabric-rest/test/public/utils/recordedClient.ts
+++ b/sdk/servicefabric/arm-servicefabric-rest/test/public/utils/recordedClient.ts
@@ -20,6 +20,10 @@ const envSetupForPlayback: Record<string, string> = {
 
 const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback,
+  removeCentralSanitizers: [
+    "AZSDK3493", // .name in the body is not a secret and is listed below in the beforeEach section
+    "AZSDK3430", // .id in the body is not a secret and is listed below in the beforeEach section
+  ],
 };
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR

- @azure-rest/arm-appservice
- @azure-rest/arm-compute
- @azure-rest/arm-containerservice
- @azure-rest/arm-network
- @azure-rest/arm-servicefabric

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Moves the following packages from the `client` to `mgmt` for the `sdk-type` to reflect these are ARM packages and not data-plane packages.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
