### PR TITLE
[dev-tool] avoid resolving rush projects in migrate-source

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-source.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-source.ts
@@ -10,7 +10,7 @@ import { resolve } from "node:path";
 import stripJsonComments from "strip-json-comments";
 import { existsSync, lstatSync } from "node:fs";
 
-const log = createPrinter("migrate-package");
+const log = createPrinter("migrate-source");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _rushJson: any = undefined;
@@ -56,25 +56,29 @@ export const commandInfo = makeCommandInfo(
 );
 
 export default leafCommand(commandInfo, async ({ "package-name": packageName }) => {
-  const root = await resolveRoot();
-
-  const rushJson = await getRushJson();
-  const projects = rushJson.projects;
+  let projectFolder: string;
 
   if (!packageName) {
+    projectFolder = process.cwd();
     const info = await resolveProject(process.cwd());
     packageName = info.packageJson.name;
-  }
+  } else {
+    const root = await resolveRoot();
 
-  const project = projects.find((p: RushJsonProject) => p.packageName === packageName);
-  if (!project) {
-    log.error(`Package ${packageName} not found in rush.json`);
-    return false;
+    const rushJson = await getRushJson();
+    const projects = rushJson.projects;
+
+    const project = projects.find((p: RushJsonProject) => p.packageName === packageName);
+    if (!project) {
+      log.error(`Package ${packageName} not found in rush.json`);
+      return false;
+    }
+
+    projectFolder = resolve(root, project.projectFolder);
   }
 
   log.info(`Migrating package ${packageName}`);
 
-  const projectFolder = resolve(root, project.projectFolder);
   const projectFile = resolve(projectFolder, "tsconfig.json");
 
   const projectFileContents = await readFile(projectFile, "utf-8");


### PR DESCRIPTION
When falling back to current package