### PR TITLE
[Monitor OpenTelemetry] Fix Setting Cloud Resource Attributes in AKS Scenarios on Standard Metrics

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix incorrectly setting the cloud role name and role instance to undefined on standard metrics in AKS environments.
+
 ### Other Changes
 
 ## 1.8.0 (2024-10-23)

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -29,8 +29,6 @@ import type {
 } from "../../generated";
 import { KnownCollectionConfigurationErrorType, KnownTelemetryType } from "../../generated";
 import {
-  getCloudRole,
-  getCloudRoleInstance,
   getLogDocument,
   getSdkVersion,
   getSpanData,
@@ -70,6 +68,7 @@ import {
 } from "./filtering/quickpulseErrors";
 import { SEMATTRS_EXCEPTION_TYPE } from "@opentelemetry/semantic-conventions";
 import { getPhysicalMemory, getProcessorTimeNormalized } from "../utils";
+import { getCloudRole, getCloudRoleInstance } from "../utils";
 
 const POST_INTERVAL = 1000;
 const MAX_POST_WAIT_TIME = 20000;

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -3,7 +3,6 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 
-import * as os from "os";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import type { LogRecord } from "@opentelemetry/sdk-logs";
 import type {
@@ -34,16 +33,6 @@ import {
   SEMATTRS_NET_PEER_NAME,
   SEMATTRS_NET_PEER_PORT,
   SEMATTRS_RPC_GRPC_STATUS_CODE,
-  SEMRESATTRS_K8S_CRONJOB_NAME,
-  SEMRESATTRS_K8S_DAEMONSET_NAME,
-  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
-  SEMRESATTRS_K8S_JOB_NAME,
-  SEMRESATTRS_K8S_POD_NAME,
-  SEMRESATTRS_K8S_REPLICASET_NAME,
-  SEMRESATTRS_K8S_STATEFULSET_NAME,
-  SEMRESATTRS_SERVICE_INSTANCE_ID,
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_SERVICE_NAMESPACE,
   SEMRESATTRS_TELEMETRY_SDK_VERSION,
   SEMATTRS_EXCEPTION_STACKTRACE,
   SEMATTRS_DB_SYSTEM,
@@ -65,7 +54,6 @@ import {
   AZURE_MONITOR_PREFIX,
   AttachTypePrefix,
 } from "../../types";
-import type { Resource } from "@opentelemetry/resources";
 import type { RequestData, DependencyData, ExceptionData, TraceData, TelemetryData } from "./types";
 import {
   QuickPulseMetricNames,
@@ -97,71 +85,6 @@ export function setSdkPrefix(): void {
     process.env[AZURE_MONITOR_PREFIX] =
       `${getResourceProvider()}${getOsPrefix()}${prefixAttachType}_`;
   }
-}
-
-export function getCloudRole(resource: Resource): string {
-  let cloudRole = "";
-  // Service attributes
-  const serviceName = resource.attributes[SEMRESATTRS_SERVICE_NAME];
-  const serviceNamespace = resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE];
-  if (serviceName) {
-    // Custom Service name provided by customer is highest precedence
-    if (!String(serviceName).startsWith("unknown_service")) {
-      if (serviceNamespace) {
-        return `${serviceNamespace}.${serviceName}`;
-      } else {
-        return String(serviceName);
-      }
-    } else {
-      // Service attributes will be only used if K8S attributes are not present
-      if (serviceNamespace) {
-        cloudRole = `${serviceNamespace}.${serviceName}`;
-      } else {
-        cloudRole = String(serviceName);
-      }
-    }
-  }
-  // Kubernetes attributes should take precedence
-  const kubernetesDeploymentName = resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME];
-  if (kubernetesDeploymentName) {
-    return String(kubernetesDeploymentName);
-  }
-  const kuberneteReplicasetName = resource.attributes[SEMRESATTRS_K8S_REPLICASET_NAME];
-  if (kuberneteReplicasetName) {
-    return String(kuberneteReplicasetName);
-  }
-  const kubernetesStatefulSetName = resource.attributes[SEMRESATTRS_K8S_STATEFULSET_NAME];
-  if (kubernetesStatefulSetName) {
-    return String(kubernetesStatefulSetName);
-  }
-  const kubernetesJobName = resource.attributes[SEMRESATTRS_K8S_JOB_NAME];
-  if (kubernetesJobName) {
-    return String(kubernetesJobName);
-  }
-  const kubernetesCronjobName = resource.attributes[SEMRESATTRS_K8S_CRONJOB_NAME];
-  if (kubernetesCronjobName) {
-    return String(kubernetesCronjobName);
-  }
-  const kubernetesDaemonsetName = resource.attributes[SEMRESATTRS_K8S_DAEMONSET_NAME];
-  if (kubernetesDaemonsetName) {
-    return String(kubernetesDaemonsetName);
-  }
-  return cloudRole;
-}
-
-export function getCloudRoleInstance(resource: Resource): string {
-  // Kubernetes attributes should take precedence
-  const kubernetesPodName = resource.attributes[SEMRESATTRS_K8S_POD_NAME];
-  if (kubernetesPodName) {
-    return String(kubernetesPodName);
-  }
-  // Service attributes
-  const serviceInstanceId = resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID];
-  if (serviceInstanceId) {
-    return String(serviceInstanceId);
-  }
-  // Default
-  return os && os.hostname();
 }
 
 export function resourceMetricsToQuickpulseDataPoint(

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
@@ -5,9 +5,6 @@ import type { Attributes } from "@opentelemetry/api";
 import { SpanStatusCode } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import {
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_SERVICE_NAMESPACE,
-  SEMRESATTRS_SERVICE_INSTANCE_ID,
   SEMATTRS_PEER_SERVICE,
   SEMATTRS_NET_PEER_NAME,
   SEMATTRS_NET_HOST_PORT,
@@ -24,6 +21,16 @@ import {
   DBSYSTEMVALUES_OTHER_SQL,
   DBSYSTEMVALUES_HSQLDB,
   DBSYSTEMVALUES_H2,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_REPLICASET_NAME,
+  SEMRESATTRS_K8S_STATEFULSET_NAME,
+  SEMRESATTRS_K8S_JOB_NAME,
+  SEMRESATTRS_K8S_CRONJOB_NAME,
+  SEMRESATTRS_K8S_DAEMONSET_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
 } from "@opentelemetry/semantic-conventions";
 import type {
   MetricDependencyDimensions,
@@ -80,18 +87,8 @@ export function getBaseDimensions(resource: Resource): StandardMetricBaseDimensi
   const dimensions: StandardMetricBaseDimensions = {};
   dimensions.IsAutocollected = "True";
   if (resource) {
-    const spanResourceAttributes = resource.attributes;
-    const serviceName = spanResourceAttributes[SEMRESATTRS_SERVICE_NAME];
-    const serviceNamespace = spanResourceAttributes[SEMRESATTRS_SERVICE_NAMESPACE];
-    if (serviceName) {
-      if (serviceNamespace) {
-        dimensions.cloudRoleName = `${serviceNamespace}.${serviceName}`;
-      } else {
-        dimensions.cloudRoleName = String(serviceName);
-      }
-    }
-    const serviceInstanceId = spanResourceAttributes[SEMRESATTRS_SERVICE_INSTANCE_ID];
-    dimensions.cloudRoleInstance = String(serviceInstanceId);
+    dimensions.cloudRoleName = getCloudRole(resource);
+    dimensions.cloudRoleInstance = getCloudRoleInstance(resource);
   }
   return dimensions;
 }
@@ -195,4 +192,80 @@ export function getProcessorTimeNormalized(
   numCpus = numCpus === 0 ? 1 : numCpus;
 
   return (usageDifMs / elapsedTimeMs / numCpus) * 100;
+}
+
+/**
+ * Gets the cloud role name based on the resource attributes
+ * @param resource Resource object from OpenTelemetry
+ * @returns cloud role name
+ * @internal
+ */
+export function getCloudRole(resource: Resource): string {
+  let cloudRole = "";
+  // Service attributes
+  const serviceName = resource.attributes[SEMRESATTRS_SERVICE_NAME];
+  const serviceNamespace = resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE];
+  if (serviceName) {
+    // Custom Service name provided by customer is highest precedence
+    if (!String(serviceName).startsWith("unknown_service")) {
+      if (serviceNamespace) {
+        return `${serviceNamespace}.${serviceName}`;
+      } else {
+        return String(serviceName);
+      }
+    } else {
+      // Service attributes will be only used if K8S attributes are not present
+      if (serviceNamespace) {
+        cloudRole = `${serviceNamespace}.${serviceName}`;
+      } else {
+        cloudRole = String(serviceName);
+      }
+    }
+  }
+  // Kubernetes attributes should take precedence
+  const kubernetesDeploymentName = resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME];
+  if (kubernetesDeploymentName) {
+    return String(kubernetesDeploymentName);
+  }
+  const kuberneteReplicasetName = resource.attributes[SEMRESATTRS_K8S_REPLICASET_NAME];
+  if (kuberneteReplicasetName) {
+    return String(kuberneteReplicasetName);
+  }
+  const kubernetesStatefulSetName = resource.attributes[SEMRESATTRS_K8S_STATEFULSET_NAME];
+  if (kubernetesStatefulSetName) {
+    return String(kubernetesStatefulSetName);
+  }
+  const kubernetesJobName = resource.attributes[SEMRESATTRS_K8S_JOB_NAME];
+  if (kubernetesJobName) {
+    return String(kubernetesJobName);
+  }
+  const kubernetesCronjobName = resource.attributes[SEMRESATTRS_K8S_CRONJOB_NAME];
+  if (kubernetesCronjobName) {
+    return String(kubernetesCronjobName);
+  }
+  const kubernetesDaemonsetName = resource.attributes[SEMRESATTRS_K8S_DAEMONSET_NAME];
+  if (kubernetesDaemonsetName) {
+    return String(kubernetesDaemonsetName);
+  }
+  return cloudRole;
+}
+
+/**
+ * Gets the cloud role instance based on the resource attributes
+ * @param resource Resource object from OpenTelemetry
+ * @returns cloud role instance
+ */
+export function getCloudRoleInstance(resource: Resource): string {
+  // Kubernetes attributes should take precedence
+  const kubernetesPodName = resource.attributes[SEMRESATTRS_K8S_POD_NAME];
+  if (kubernetesPodName) {
+    return String(kubernetesPodName);
+  }
+  // Service attributes
+  const serviceInstanceId = resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID];
+  if (serviceInstanceId) {
+    return String(serviceInstanceId);
+  }
+  // Default
+  return os && os.hostname();
 }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/utils.ts
@@ -196,9 +196,6 @@ export function getProcessorTimeNormalized(
 
 /**
  * Gets the cloud role name based on the resource attributes
- * @param resource Resource object from OpenTelemetry
- * @returns cloud role name
- * @internal
  */
 export function getCloudRole(resource: Resource): string {
   let cloudRole = "";
@@ -252,8 +249,6 @@ export function getCloudRole(resource: Resource): string {
 
 /**
  * Gets the cloud role instance based on the resource attributes
- * @param resource Resource object from OpenTelemetry
- * @returns cloud role instance
  */
 export function getCloudRoleInstance(resource: Resource): string {
   // Kubernetes attributes should take precedence

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/standardMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/standardMetrics.test.ts
@@ -15,6 +15,8 @@ import {
   SEMRESATTRS_SERVICE_INSTANCE_ID,
   SEMRESATTRS_SERVICE_NAME,
   SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
 } from "@opentelemetry/semantic-conventions";
 import { ExportResultCode } from "@opentelemetry/core";
 import { LoggerProvider, LogRecord } from "@opentelemetry/sdk-logs";
@@ -50,6 +52,32 @@ describe("#StandardMetricsHandler", () => {
   after(() => {
     exportStub.restore();
     autoCollect.shutdown();
+  });
+
+  it("should use AKS attributes to populate common dimensions on standard metrics", async () => {
+    const resource = new Resource({});
+    resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME] = "k8sDeploymentName";
+    resource.attributes[SEMRESATTRS_K8S_POD_NAME] = "k8sPodName";
+    const clientSpan: any = {
+      kind: SpanKind.CLIENT,
+      duration: [123456],
+      attributes: {
+        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+      },
+      status: { code: SpanStatusCode.OK },
+      resource: resource,
+    };
+    clientSpan.attributes[SEMATTRS_PEER_SERVICE] = "testPeerService";
+    autoCollect.recordSpan(clientSpan);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    assert.ok(exportStub.called);
+
+    const resourceMetrics = exportStub.args[0][0];
+    const scopeMetrics = resourceMetrics.scopeMetrics;
+    assert.strictEqual(scopeMetrics.length, 1, "scopeMetrics count");
+    const metrics = scopeMetrics[0].metrics;
+    assert.strictEqual(metrics[0].dataPoints[0].attributes["cloud/roleName"], "k8sDeploymentName");
+    assert.strictEqual(metrics[0].dataPoints[0].attributes["cloud/roleInstance"], "k8sPodName");
   });
 
   it("should observe instruments during collection", async () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
The app map considers attributes taken from both standard metrics cloud resource properties as well as logs. While we correctly set cloud role attributes on logs in the exporter, we do not set these values correctly in AKS environments on standard metrics which leads to incorrect app map application names showing.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
