### PR TITLE
feat(core-amqp): Add support for specifying the Port in the connection string

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Support for specifying the Port in the connection string for AMQP-based libraries such as `@azure/service-bus` and `@azure/event-hubs` [PR #32091](https://github.com/Azure/azure-sdk-for-js/pull/32091)
+  e.g. `Endpoint=host;Port=1234`
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -36,6 +39,7 @@
 ## 4.3.0 (2024-05-20)
 
 ### Breaking Changes
+
 - Moved to ESM core with builds for ESM, CommonJS, React-Native and Browser.
 - Moved unit tests from mocha to vitest.
 
@@ -79,7 +83,7 @@
 
 ### Features Added
 
-- Changed `TokenProvider` to use native crypto libraries.  This changes the signature from `getToken` from being sync to async.
+- Changed `TokenProvider` to use native crypto libraries. This changes the signature from `getToken` from being sync to async.
 
 ### Breaking Changes
 

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -110,9 +110,10 @@ export const ConnectionConfig = {
 
     const parsedCS = parseConnectionString<{
       Endpoint: string;
-      SharedAccessKeyName: string;
-      SharedAccessKey: string;
       EntityPath?: string;
+      Port?: string;
+      SharedAccessKey: string;
+      SharedAccessKeyName: string;
       UseDevelopmentEmulator?: string;
     }>(connectionString);
     if (!parsedCS.Endpoint) {
@@ -133,6 +134,11 @@ export const ConnectionConfig = {
     if (path || parsedCS.EntityPath) {
       result.entityPath = path || parsedCS.EntityPath;
     }
+
+    if (parsedCS["Port"] !== undefined && parsedCS["Port"] !== "") {
+      result.port = Number.parseInt(parsedCS["Port"]);
+    }
+
     return result;
   },
 
@@ -157,6 +163,10 @@ export const ConnectionConfig = {
       throw new TypeError("Missing 'host' in configuration");
     }
     config.host = String(config.host);
+
+    if (config.port !== undefined && !(config.port >= 0 && config.port <= 65535)) {
+      throw new TypeError("Invalid 'port' in configuration");
+    }
 
     if (options.isEntityPathRequired && !config.entityPath) {
       throw new TypeError("Missing 'entityPath' in configuration");

--- a/sdk/core/core-amqp/test/config.spec.ts
+++ b/sdk/core/core-amqp/test/config.spec.ts
@@ -88,10 +88,10 @@ describe("ConnectionConfig", function () {
 
     it("Parses the connection string for the development emulator", async function () {
       const config = ConnectionConfig.create(
-        "Endpoint=sb://localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+        "Endpoint=sb://localhost;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
       );
-      assert.equal(config.endpoint, "sb://localhost:6765/");
-      assert.equal(config.host, "localhost:6765");
+      assert.equal(config.endpoint, "sb://localhost/");
+      assert.equal(config.host, "localhost");
       assert.isTrue(config.useDevelopmentEmulator);
     });
 
@@ -224,11 +224,11 @@ describe("ConnectionConfig", function () {
     describe("Development Emulator Validation", function () {
       it("Accepts localhost", async function () {
         const connectionString =
-          "Endpoint=sb://localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
+          "Endpoint=sb://localhost;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "localhost:6765/",
-          host: "sb://localhost:6765/",
+          endpoint: "localhost/",
+          host: "sb://localhost/",
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -238,11 +238,11 @@ describe("ConnectionConfig", function () {
 
       it("Accepts 127.0.0.1", async function () {
         const connectionString =
-          "Endpoint=sb://127.0.0.1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
+          "Endpoint=sb://127.0.0.1;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "127.0.0.1:6765/",
-          host: "sb://127.0.0.1:6765",
+          endpoint: "127.0.0.1/",
+          host: "sb://127.0.0.1",
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -280,11 +280,11 @@ describe("ConnectionConfig", function () {
 
       it("Accepts localhost with missing scheme", async function () {
         const connectionString =
-          "Endpoint=localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
+          "Endpoint=localhost;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "localhost:6765/",
-          host: "localhost:6765/",
+          endpoint: "localhost/",
+          host: "localhost/",
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,


### PR DESCRIPTION
### Packages impacted by this PR
- `core-amqp`, and as a consequence all packages that depend upon that library, including:
- `eventhub`
- `servicebus`
- and possibly more.

### Issues associated with this PR
None that I could find.

### Describe the problem that is addressed by this PR
Before this it was impossible to run multiple AMQP-based service emulators on the same host with different port mappings, e.g. by running each emulator in a Docker container with the internal 5672 port mapped to an arbitrary host port. Now with the ability to specify the port we can create such a set up.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
I could have placed the port in the `Endpoint` entry, e.g. `Endpoint=sb://localhost:5681;`, but looking across the limited Microsoft documentation I have access to I found that [other implementations of the connection string format use a separate `Port` entry](https://learn.microsoft.com/en-us/azure/azure-signalr/concept-connection-string) e.g. `Endpoint=sb://localhost;Port=5681;` so I went with that pattern.

The existing tests attempted to demonstrate using the colon syntax, but the placing the port in the host field of the Node Socket `connect` function isn't valid and was the result of what was here before. Simply placing the port in the standard location for a connection string solves the problem.  Could more code be added to support colon syntax? Yes,  but not my goal here.

### Are there test cases added in this PR?
Yes! :D 

### Provide a list of related PRs _(if any)_
None that I'm aware of, even after searching.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
