### PR TITLE
Addressing `private` package docs copy failure during pr - Extending PR Timeout on `Build`/`Analyze`

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -30,7 +30,7 @@ jobs:
   - job: "Build"
 
     ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
-      TimeOutInMinutes: 240
+      timeoutInMinutes: 240
 
     pool:
       name: $(LINUXPOOL)
@@ -55,7 +55,7 @@ jobs:
   - job: "Analyze"
 
     ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
-      TimeOutInMinutes: 240
+      timeoutInMinutes: 240
 
     pool:
       name: $(LINUXPOOL)

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -29,6 +29,9 @@ parameters:
 jobs:
   - job: "Build"
 
+    ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
+      TimeOutInMinutes: 240
+
     pool:
       name: $(LINUXPOOL)
       image: $(LINUXVMIMAGE)
@@ -50,6 +53,9 @@ jobs:
           IncludeRelease: ${{ parameters.IncludeRelease }}
 
   - job: "Analyze"
+
+    ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
+      TimeOutInMinutes: 240
 
     pool:
       name: $(LINUXPOOL)

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -89,11 +89,20 @@ steps:
       foreach ($artifact in $artifacts)
       {
         $artifactDetails = Get-Content -Raw $(Build.ArtifactStagingDirectory)/PackageInfo/$artifact.json | ConvertFrom-Json
+        $packageJson = Join-Path $(Build.SourcesDirectory) $artifactDetails.DirectoryPath "package.json"
 
         Write-Host "Copying $artifact artifacts to $(Build.ArtifactStagingDirectory)/$artifact"
         New-Item -Type Directory -Force -Name $artifact -Path $(Build.ArtifactStagingDirectory) > $null
         Copy-Item sdk/$($artifactDetails.ServiceDirectory)/**/$artifact-[0-9]*.[0-9]*.[0-9]*.tgz $(Build.ArtifactStagingDirectory)/$artifact
-        Copy-Item sdk/$($artifactDetails.ServiceDirectory)/**/browser/$artifact-[0-9]*.[0-9]*.[0-9]*.zip $(Build.ArtifactStagingDirectory)/$artifact
+
+        # we can only copy docs if they exist, and they will never exist for packages marked as private
+        if ((Get-Content $packageJson -Raw | ConvertFrom-Json).private -ne $true)
+        {
+          Copy-Item sdk/$($artifactDetails.ServiceDirectory)/**/browser/$artifact-[0-9]*.[0-9]*.[0-9]*.zip $(Build.ArtifactStagingDirectory)/$artifact
+        }
+        else {
+          Write-Host "Skipping documentation for private package $artifact"
+        }
 
         if ($${{ parameters.IncludeRelease }} -eq $true -and $artifactDetails.ArtifactDetails.skipPublishDocMs -ne $true)
         {


### PR DESCRIPTION
See title.

- @ckairen When @jeremymeng hits a large cross-cutting PR, we need to allow for a "couple" more minutes for the build and analyze steps to complete.
- This is also addressing the PR build failure that @deyaaeldeen is facing over in #32097 
