### PR TITLE
[opentelemetry-instrumentation] Fix min/max tests

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -29,7 +29,7 @@
     "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "echo skipped",
+    "integration-test:node": "dev-tool run test:vitest --no-test-proxy",
     "lint": "eslint package.json api-extractor.json README.md src test",
     "lint:fix": "eslint package.json api-extractor.json README.md src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",


### PR DESCRIPTION
### Packages impacted by this PR

@azure/opentelemetry-instrumentation-azure-sdk

### Issues associated with this PR

Resolves #28188

### Describe the problem that is addressed by this PR

Our min/max tests scripts rely on the integration-test:node contents to
determine whether to use mocha or vitest for min/max tests. Since these were
skipped, this package's min/max tests assumed mocha was still used.

Adding these back fixes the min/max tests and ensures they run correctly and not
skipped.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
