### PR TITLE
Adding new test recorder to --to restricted packages

### DIFF
--- a/eng/tools/rush-runner/index.js
+++ b/eng/tools/rush-runner/index.js
@@ -118,6 +118,7 @@ const restrictedToPackages = [
   "@azure-tools/test-recorder",
   "@azure-tools/test-credential",
   "@azure-tools/test-utils",
+  "@azure-tools/test-utils-vitest"
 ];
 
 /**


### PR DESCRIPTION
So we don't blow up the unit test invocation during builds, as is visible over in #32133

FYI @deyaaeldeen 