### PR TITLE
[Identity] update io-redis and node-redis samples to update new password

### DIFF
--- a/sdk/identity/identity/samples/AzureCacheForRedis/ioredis.md
+++ b/sdk/identity/identity/samples/AzureCacheForRedis/ioredis.md
@@ -228,6 +228,7 @@ async function main() {
     id = setTimeout(updateToken, ((accessTokenCache.expiresOnTimestamp- randomTimestamp)) - Date.now());
     if(redis){
       await redis.auth(extractUsernameFromToken(accessToken), accessTokenCache.token);
+      redis.options.password = accessTokenCache.token;
     }
   }
 

--- a/sdk/identity/identity/samples/AzureCacheForRedis/node-redis.md
+++ b/sdk/identity/identity/samples/AzureCacheForRedis/node-redis.md
@@ -233,6 +233,7 @@ async function main() {
         console.log("Auth called...");
         await redisClient.auth({username: extractUsernameFromToken(accessToken),
             password: accessToken.token});
+        redisClient.password = accessToken.token;
     }
   }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
Fixes part 1 of the issue https://github.com/Azure/azure-sdk-for-js/issues/29644

### Describe the problem that is addressed by this PR
- Customer reported that the io-redis password needs to explicitly updated in the token cache sample.
- I executed the same update for node-redis sample.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
- I was under the impression that redis.auth() API updates the password automatically for you, without the need to update explicitly, as per the documentation - 
```
- Dynamic Password Update: If you need to update the password dynamically, you can use the auth method provided by the Redis client libraries. For example:

await client.auth('newpassword');
console.log('Password updated');
This command ensures that your Redis client is authenticated with the correct credentials, allowing secure access to the Redis server.

```
### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
