### PR TITLE
[maps] Precise Typechecking

### DIFF
--- a/sdk/maps/maps-geolocation-rest/eslint.config.mjs
+++ b/sdk/maps/maps-geolocation-rest/eslint.config.mjs
@@ -3,8 +3,15 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 export default azsdkEslint.config([
   {
     rules: {
-      // Exporting the factory function is a convention for Rest Level Client
-      "@azure/azure-sdk/ts-modules-only-named": "off",
+      "@azure/azure-sdk/ts-modules-only-named": "warn",
+    }
+  },
+  {
+    files: ["**/*.ts", "**/*.cts", "**/*.mts"],
+    languageOptions: {
+      parserOptions: {
+        project: ["./tsconfig.test.json"],
+      },
     },
   },
 ]);

--- a/sdk/maps/maps-geolocation-rest/package.json
+++ b/sdk/maps/maps-geolocation-rest/package.json
@@ -40,7 +40,7 @@
     "generate:client": "autorest --typescript swagger/README.md && npm run format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
-    "integration-test:node": "dev-tool run test:vitest",
+    "integration-test:node": "dev-tool run test:vitest --esm",
     "lint": "eslint package.json api-extractor.json src test",
     "lint:fix": "eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
@@ -115,7 +115,8 @@
       "browser",
       "react-native"
     ],
-    "selfLink": false
+    "selfLink": false,
+    "project": "./tsconfig.src.json"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/maps/maps-geolocation-rest/tsconfig.browser.config.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.browser.config.json
@@ -1,10 +1,3 @@
 {
-  "extends": "./.tshy/build.json",
-  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts", "./test/**/*.mts"],
-  "exclude": ["./test/**/node/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist-test/browser",
-    "rootDir": ".",
-    "skipLibCheck": true
-  }
+  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
 }

--- a/sdk/maps/maps-geolocation-rest/tsconfig.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../tsconfig",
-  "compilerOptions": {
-    "paths": {
-      "@azure-rest/maps-geolocation": ["./src/index"]
-    },
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "rootDir": "."
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "samples-dev/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.mts",
-    "test/**/*.cts"
-  ]
+  "references": [
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ],
+  "files": []
 }

--- a/sdk/maps/maps-geolocation-rest/tsconfig.samples.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.samples.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-rest/maps-geolocation": ["./dist/esm"]
+    }
+  }
+}

--- a/sdk/maps/maps-geolocation-rest/tsconfig.src.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.src.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.lib.json"
+}

--- a/sdk/maps/maps-geolocation-rest/tsconfig.test.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
+}

--- a/sdk/maps/maps-geolocation-rest/vitest.config.ts
+++ b/sdk/maps/maps-geolocation-rest/vitest.config.ts
@@ -11,6 +11,11 @@ export default mergeConfig(
       include: ["test/**/*.spec.ts"],
       hookTimeout: 5000000,
       testTimeout: 5000000,
+      typecheck: {
+        enabled: true,
+        tsconfig: "tsconfig.test.json",
+        include: ["test/**/*.ts", "test/**/*.mts", "test/**/*.cts"],
+      },
     },
   }),
 );

--- a/sdk/maps/maps-geolocation-rest/vitest.esm.config.ts
+++ b/sdk/maps/maps-geolocation-rest/vitest.esm.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig } from "vitest/config";
+import vitestConfig from "./vitest.config.ts";
+import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
+
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig
+);

--- a/sdk/maps/maps-render-rest/eslint.config.mjs
+++ b/sdk/maps/maps-render-rest/eslint.config.mjs
@@ -3,8 +3,15 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 export default azsdkEslint.config([
   {
     rules: {
-      // Exporting the factory function is a convention for Rest Level Client
-      "@azure/azure-sdk/ts-modules-only-named": "off",
+      "@azure/azure-sdk/ts-modules-only-named": "warn",
+    }
+  },
+  {
+    files: ["**/*.ts", "**/*.cts", "**/*.mts"],
+    languageOptions: {
+      parserOptions: {
+        project: ["./tsconfig.test.json"],
+      },
     },
   },
 ]);

--- a/sdk/maps/maps-render-rest/package.json
+++ b/sdk/maps/maps-render-rest/package.json
@@ -43,7 +43,7 @@
     "generate:client": "autorest --typescript swagger/README.md && npm run format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
-    "integration-test:node": "dev-tool run test:vitest",
+    "integration-test:node": "dev-tool run test:vitest --esm",
     "lint": "eslint package.json api-extractor.json src test",
     "lint:fix": "eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
@@ -118,7 +118,8 @@
       "browser",
       "react-native"
     ],
-    "selfLink": false
+    "selfLink": false,
+    "project": "./tsconfig.src.json"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/maps/maps-render-rest/tsconfig.browser.config.json
+++ b/sdk/maps/maps-render-rest/tsconfig.browser.config.json
@@ -1,10 +1,3 @@
 {
-  "extends": "./.tshy/build.json",
-  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts", "./test/**/*.mts"],
-  "exclude": ["./test/**/node/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist-test/browser",
-    "rootDir": ".",
-    "skipLibCheck": true
-  }
+  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
 }

--- a/sdk/maps/maps-render-rest/tsconfig.json
+++ b/sdk/maps/maps-render-rest/tsconfig.json
@@ -1,21 +1,9 @@
 {
   "extends": "../../../tsconfig",
-  "compilerOptions": {
-    "paths": {
-      "@azure-rest/maps-render": ["./src/index"]
-    },
-    "lib": ["DOM"],
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "rootDir": "."
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "samples-dev/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.mts",
-    "test/**/*.cts"
-  ]
+  "references": [
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ],
+  "files": []
 }

--- a/sdk/maps/maps-render-rest/tsconfig.samples.json
+++ b/sdk/maps/maps-render-rest/tsconfig.samples.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.samples.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-rest/maps-render": ["./dist/esm"]
+    },
+    "lib": ["DOM"]
+  }
+}

--- a/sdk/maps/maps-render-rest/tsconfig.src.json
+++ b/sdk/maps/maps-render-rest/tsconfig.src.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.lib.json"
+}

--- a/sdk/maps/maps-render-rest/tsconfig.test.json
+++ b/sdk/maps/maps-render-rest/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
+}

--- a/sdk/maps/maps-render-rest/vitest.config.ts
+++ b/sdk/maps/maps-render-rest/vitest.config.ts
@@ -11,6 +11,11 @@ export default mergeConfig(
       include: ["test/**/*.spec.ts"],
       hookTimeout: 5000000,
       testTimeout: 5000000,
+      typecheck: {
+        enabled: true,
+        tsconfig: "tsconfig.test.json",
+        include: ["test/**/*.ts", "test/**/*.mts", "test/**/*.cts"],
+      },
     },
   }),
 );

--- a/sdk/maps/maps-render-rest/vitest.esm.config.ts
+++ b/sdk/maps/maps-render-rest/vitest.esm.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig } from "vitest/config";
+import vitestConfig from "./vitest.config.ts";
+import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
+
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig
+);

--- a/sdk/maps/maps-route-rest/eslint.config.mjs
+++ b/sdk/maps/maps-route-rest/eslint.config.mjs
@@ -3,8 +3,15 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 export default azsdkEslint.config([
   {
     rules: {
-      // Exporting the factory function is a convention for Rest Level Client
-      "@azure/azure-sdk/ts-modules-only-named": "off",
+      "@azure/azure-sdk/ts-modules-only-named": "warn",
+    }
+  },
+  {
+    files: ["**/*.ts", "**/*.cts", "**/*.mts"],
+    languageOptions: {
+      parserOptions: {
+        project: ["./tsconfig.test.json"],
+      },
     },
   },
 ]);

--- a/sdk/maps/maps-route-rest/package.json
+++ b/sdk/maps/maps-route-rest/package.json
@@ -66,7 +66,7 @@
     "generate:client": "autorest --typescript swagger/README.md && npm run format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "dev-tool run test:browser",
-    "integration-test:node": "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",
+    "integration-test:node": "dev-tool run test:vitest --esm",
     "lint": "eslint package.json api-extractor.json src test",
     "lint:fix": "eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
@@ -122,7 +122,8 @@
       "browser",
       "react-native"
     ],
-    "selfLink": false
+    "selfLink": false,
+    "project": "./tsconfig.src.json"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/maps/maps-route-rest/tsconfig.browser.config.json
+++ b/sdk/maps/maps-route-rest/tsconfig.browser.config.json
@@ -1,10 +1,3 @@
 {
-  "extends": "./.tshy/build.json",
-  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts", "./test/**/*.mts"],
-  "exclude": ["./test/**/node/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist-test/browser",
-    "rootDir": ".",
-    "skipLibCheck": true
-  }
+  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
 }

--- a/sdk/maps/maps-route-rest/tsconfig.json
+++ b/sdk/maps/maps-route-rest/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../tsconfig",
-  "compilerOptions": {
-    "paths": {
-      "@azure-rest/maps-route": ["./src/index"]
-    },
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "rootDir": "."
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "samples-dev/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.mts",
-    "test/**/*.cts"
-  ]
+  "references": [
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ],
+  "files": []
 }

--- a/sdk/maps/maps-route-rest/tsconfig.samples.json
+++ b/sdk/maps/maps-route-rest/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.samples.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-rest/maps-route": ["./dist/esm"]
+    }
+  }
+}

--- a/sdk/maps/maps-route-rest/tsconfig.src.json
+++ b/sdk/maps/maps-route-rest/tsconfig.src.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.lib.json"
+}

--- a/sdk/maps/maps-route-rest/tsconfig.test.json
+++ b/sdk/maps/maps-route-rest/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
+}

--- a/sdk/maps/maps-route-rest/vitest.config.ts
+++ b/sdk/maps/maps-route-rest/vitest.config.ts
@@ -11,6 +11,11 @@ export default mergeConfig(
       include: ["test/**/*.spec.ts"],
       hookTimeout: 5000000,
       testTimeout: 5000000,
+      typecheck: {
+        enabled: true,
+        tsconfig: "tsconfig.test.json",
+        include: ["test/**/*.ts", "test/**/*.mts", "test/**/*.cts"],
+      },
     },
   }),
 );

--- a/sdk/maps/maps-route-rest/vitest.esm.config.ts
+++ b/sdk/maps/maps-route-rest/vitest.esm.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig } from "vitest/config";
+import vitestConfig from "./vitest.config.ts";
+import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
+
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig
+);

--- a/sdk/maps/maps-search-rest/eslint.config.mjs
+++ b/sdk/maps/maps-search-rest/eslint.config.mjs
@@ -3,8 +3,15 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 export default azsdkEslint.config([
   {
     rules: {
-      // Exporting the factory function is a convention for Rest Level Client
-      "@azure/azure-sdk/ts-modules-only-named": "off",
+      "@azure/azure-sdk/ts-modules-only-named": "warn",
+    }
+  },
+  {
+    files: ["**/*.ts", "**/*.cts", "**/*.mts"],
+    languageOptions: {
+      parserOptions: {
+        project: ["./tsconfig.test.json"],
+      },
     },
   },
 ]);

--- a/sdk/maps/maps-search-rest/package.json
+++ b/sdk/maps/maps-search-rest/package.json
@@ -43,7 +43,7 @@
     "generate:client": "autorest --typescript swagger/README.md && npm run format",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
-    "integration-test:node": "dev-tool run test:vitest",
+    "integration-test:node": "dev-tool run test:vitest --esm",
     "lint": "eslint package.json api-extractor.json src test",
     "lint:fix": "eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
@@ -120,7 +120,8 @@
       "browser",
       "react-native"
     ],
-    "selfLink": false
+    "selfLink": false,
+    "project": "./tsconfig.src.json"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/maps/maps-search-rest/tsconfig.browser.config.json
+++ b/sdk/maps/maps-search-rest/tsconfig.browser.config.json
@@ -1,10 +1,3 @@
 {
-  "extends": "./.tshy/build.json",
-  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts", "./test/**/*.mts"],
-  "exclude": ["./test/**/node/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist-test/browser",
-    "rootDir": ".",
-    "skipLibCheck": true
-  }
+  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
 }

--- a/sdk/maps/maps-search-rest/tsconfig.json
+++ b/sdk/maps/maps-search-rest/tsconfig.json
@@ -1,20 +1,9 @@
 {
   "extends": "../../../tsconfig",
-  "compilerOptions": {
-    "paths": {
-      "@azure-rest/maps-search": ["./src/index"]
-    },
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "rootDir": "."
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "samples-dev/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.mts",
-    "test/**/*.cts"
-  ]
+  "references": [
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ],
+  "files": []
 }

--- a/sdk/maps/maps-search-rest/tsconfig.samples.json
+++ b/sdk/maps/maps-search-rest/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.samples.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-rest/maps-search": ["./dist/esm"]
+    }
+  }
+}

--- a/sdk/maps/maps-search-rest/tsconfig.src.json
+++ b/sdk/maps/maps-search-rest/tsconfig.src.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.lib.json"
+}

--- a/sdk/maps/maps-search-rest/tsconfig.test.json
+++ b/sdk/maps/maps-search-rest/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
+}

--- a/sdk/maps/maps-search-rest/vitest.config.ts
+++ b/sdk/maps/maps-search-rest/vitest.config.ts
@@ -11,6 +11,11 @@ export default mergeConfig(
       include: ["test/**/*.spec.ts"],
       hookTimeout: 5000000,
       testTimeout: 5000000,
+      typecheck: {
+        enabled: true,
+        tsconfig: "tsconfig.test.json",
+        include: ["test/**/*.ts", "test/**/*.mts", "test/**/*.cts"],
+      },
     },
   }),
 );

--- a/sdk/maps/maps-search-rest/vitest.esm.config.ts
+++ b/sdk/maps/maps-search-rest/vitest.esm.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig } from "vitest/config";
+import vitestConfig from "./vitest.config.ts";
+import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
+
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig
+);


### PR DESCRIPTION
### Packages impacted by this PR
- @azure-rest/maps-render
- @azure-rest/maps-route
- @azure-rest/maps-geolocation
- @azure-rest/maps-search

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
Tests are not being typechecked and linting isn't configured correctly. This PR migrates those libraries to precise typechecking setup introduced in https://github.com/Azure/azure-sdk-for-js/pull/31786

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/31786

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
