### PR TITLE
[EngSys] Fix build pipeline to quote ChangedServices

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -54,7 +54,7 @@ steps:
           echo "##vso[task.setvariable variable=rushBuildCacheCred;issecret=true;]$sasToken"
 
   - pwsh: |
-      node eng/tools/rush-runner/index.js build $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js build "$(ChangedServices)"" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
     env:
       ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -54,7 +54,7 @@ steps:
           echo "##vso[task.setvariable variable=rushBuildCacheCred;issecret=true;]$sasToken"
 
   - pwsh: |
-      node eng/tools/rush-runner/index.js build "$(ChangedServices)"" -packages "$(ArtifactPackageNames)" --verbose -p max
+      node eng/tools/rush-runner/index.js build "$(ChangedServices)" -packages "$(ArtifactPackageNames)" --verbose -p max
     displayName: "Build libraries"
     env:
       ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR

Fixes a bug with the build pipeline where the `ChangedServices` is not properly quoted where in all other locations it is.

```sh
ChangedServices: /mnt/vss/_work/_temp/35cd28fd-3b0a-453b-8cde-112bdf15fc19.ps1:3
Line |
   3 |  node eng/tools/rush-runner/index.js build $(ChangedServices) -package …
     |                                              ~~~~~~~~~~~~~~~
     | The term 'ChangedServices' is not recognized as a name of a cmdlet,
     | function, script file, or executable program. Check the spelling of the
     | name, or if a path was included, verify that the path is correct and try
     | again.

##[error]PowerShell exited with code '1'.
Finishing: Build libraries

```

See https://dev.azure.com/azure-sdk/public/_build/results?buildId=4409811&view=logs&jobId=b70e5e73-bbb6-5567-0939-8415943fadb9&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=c9190431-7417-53a5-3fc1-7c7e026cd79d

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This quotes the ChangedServices in this place where it was quoted in all other locations.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
