### PR TITLE
[dev-tool] fix migrate-package issues on Windows

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -11,6 +11,7 @@ import { run } from "../../util/run";
 import stripJsonComments from "strip-json-comments";
 import { codemods } from "../../util/admin/migrate-package/codemods";
 import { existsSync } from "node:fs";
+import { isWindows } from "../../util/platform";
 
 const log = createPrinter("migrate-package");
 
@@ -87,7 +88,7 @@ export default leafCommand(commandInfo, async ({ "package-name": packageName, br
   await applyCodemods(projectFolder);
 
   log.info("Formatting files");
-  await run(["rushx", "format"], { cwd: projectFolder });
+  await run(["rushx", "format"], { cwd: projectFolder, shell: isWindows() });
   await commitChanges(projectFolder, "rushx format");
 
   log.info(
@@ -333,6 +334,7 @@ async function addNewPackages(packageJson: any): Promise<void> {
       latestVersion = (
         await run(["npm", "view", newPackage, "version"], {
           captureOutput: true,
+          shell: isWindows(),
         })
       ).output;
     }

--- a/common/tools/dev-tool/src/commands/index.ts
+++ b/common/tools/dev-tool/src/commands/index.ts
@@ -35,7 +35,7 @@ export const baseCommand = async (...args: string[]): Promise<void> => {
   const status = await subCommand(baseCommandInfo, baseCommands)(...args);
 
   if (!status) {
-    log.error("Errors occured. See the output above.");
+    log.error("Errors occurred. See the output above.");
     process.exit(1);
   }
 };

--- a/common/tools/dev-tool/src/commands/run/vendored.ts
+++ b/common/tools/dev-tool/src/commands/run/vendored.ts
@@ -13,14 +13,11 @@ import { makeCommandInfo, subCommand } from "../../framework/command";
 import { CommandOptions } from "../../framework/CommandInfo";
 import { CommandModule } from "../../framework/CommandModule";
 import { createPrinter } from "../../util/printer";
+import { isWindows } from "../../util/platform";
 
 const log = createPrinter("vendored");
 
 const DOT_BIN_PATH = path.resolve(__dirname, "..", "..", "..", "node_modules", ".bin");
-
-function isWindows() {
-  return process.platform === "win32";
-}
 
 /**
  * Wraps a command in an executor that satisfies the dev-tool command interface.

--- a/common/tools/dev-tool/src/util/platform.ts
+++ b/common/tools/dev-tool/src/util/platform.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT License.
+
+export function isWindows() {
+  return process.platform === "win32";
+}


### PR DESCRIPTION
Some CLI scripts (prettier, npm, for example) would cause error on Windows when they are invoked via `spawn()` without `shell: true` options. This PR fixes the issue by applying the same workaround in PR #29414.

Resolves issue https://github.com/Azure/azure-sdk-for-js/issues/32202
