### PR TITLE
Enable perf-tests package discovery

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -104,21 +104,6 @@ function Get-javascript-AdditionalValidationPackagesFromPackageSet {
   return $uniqueResultSet
 }
 
-# function Get-AllPackageInfoFromRepo ([string]$ServiceDirectory = $null) {
-#   $pkgPropsResult = @()
-
-#   if ([string]::IsNullOrEmpty($ServiceDirectory)) {
-#     foreach ($dir in (Get-ChildItem (Join-Path $RepoRoot "sdk") -Directory)) {
-#       $pkgPropsResult += Get-PkgPropsForEntireService -serviceDirectoryPath $dir.FullName
-#     }
-#   }
-#   else {
-#     $pkgPropsResult = Get-PkgPropsForEntireService -serviceDirectoryPath (Join-Path $RepoRoot "sdk" $ServiceDirectory)
-#   }
-
-#   return $pkgPropsResult
-# }
-
 function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory) {
   $projectPath = (Join-Path $pkgPath "package.json")
   $packageProps = @()

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -104,36 +104,70 @@ function Get-javascript-AdditionalValidationPackagesFromPackageSet {
   return $uniqueResultSet
 }
 
+# function Get-AllPackageInfoFromRepo ([string]$ServiceDirectory = $null) {
+#   $pkgPropsResult = @()
+
+#   if ([string]::IsNullOrEmpty($ServiceDirectory)) {
+#     foreach ($dir in (Get-ChildItem (Join-Path $RepoRoot "sdk") -Directory)) {
+#       $pkgPropsResult += Get-PkgPropsForEntireService -serviceDirectoryPath $dir.FullName
+#     }
+#   }
+#   else {
+#     $pkgPropsResult = Get-PkgPropsForEntireService -serviceDirectoryPath (Join-Path $RepoRoot "sdk" $ServiceDirectory)
+#   }
+
+#   return $pkgPropsResult
+# }
 
 function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory) {
-  $projectPath = Join-Path $pkgPath "package.json"
-  if (Test-Path $projectPath) {
-    $projectJson = Get-Content $projectPath | ConvertFrom-Json
-    $jsStylePkgName = $projectJson.name.Replace("@", "").Replace("/", "-")
+  $projectPath = (Join-Path $pkgPath "package.json")
+  $packageProps = @()
 
-    $pkgProp = [PackageProps]::new($projectJson.name, $projectJson.version, $pkgPath, $serviceDirectory)
-    if ($projectJson.psobject.properties.name -contains 'sdk-type') {
-      $pkgProp.SdkType = $projectJson.psobject.properties['sdk-type'].value
-    }
-    else {
-      $pkgProp.SdkType = "unknown"
-    }
-    $pkgProp.IsNewSdk = ($pkgProp.SdkType -eq "client") -or ($pkgProp.SdkType -eq "mgmt")
-    $pkgProp.ArtifactName = $jsStylePkgName
-
-
-    if ($ReducedDependencyLookup.ContainsKey($pkgProp.ServiceDirectory)) {
-      $pkgProp.AdditionalValidationPackages = $ReducedDependencyLookup[$pkgProp.ServiceDirectory]
+  if (-not (Test-Path $projectPath) -and $pkgPath.Contains("perf-test")) {
+    $subdirectories = Get-ChildItem -Path $pkgPath -Directory | Where-Object {
+      return Test-Path -Path (Join-Path $_.FullName "package.json")
     }
 
-    # the constructor for the package properties object attempts to initialize CI artifacts on instantiation
-    # of the class. however, due to the fact that we set the ArtifactName _after_ the constructor is called,
-    # we need to call it again here to ensure the CI artifacts are properly initialized
-    $pkgProp.InitializeCIArtifacts()
-
-    return $pkgProp
+    # Filter subdirectories to those containing a `package.json`
+    $projectPaths = $subdirectories | ForEach-Object {
+      return Join-Path $_.FullName "package.json"
+    }
   }
-  return $null
+  else {
+    $projectPaths = @($projectPath)
+  }
+
+  foreach ($projectPath in $projectPaths) {
+    if (Test-Path $projectPath) {
+      $projectJson = Get-Content $projectPath | ConvertFrom-Json
+
+      $jsStylePkgName = $projectJson.name.Replace("@", "").Replace("/", "-")
+
+      $pkgProp = [PackageProps]::new($projectJson.name, $projectJson.version, $pkgPath, $serviceDirectory)
+      if ($projectJson.psobject.properties.name -contains 'sdk-type') {
+        $pkgProp.SdkType = $projectJson.psobject.properties['sdk-type'].value
+      }
+      else {
+        $pkgProp.SdkType = "unknown"
+      }
+      $pkgProp.IsNewSdk = ($pkgProp.SdkType -eq "client") -or ($pkgProp.SdkType -eq "mgmt")
+      $pkgProp.ArtifactName = $jsStylePkgName
+
+
+      if ($ReducedDependencyLookup.ContainsKey($pkgProp.ServiceDirectory)) {
+        $pkgProp.AdditionalValidationPackages = $ReducedDependencyLookup[$pkgProp.ServiceDirectory]
+      }
+
+      # the constructor for the package properties object attempts to initialize CI artifacts on instantiation
+      # of the class. however, due to the fact that we set the ArtifactName _after_ the constructor is called,
+      # we need to call it again here to ensure the CI artifacts are properly initialized
+      $pkgProp.InitializeCIArtifacts()
+
+      $packageProps += $pkgProp
+    }
+  }
+
+  return $packageProps
 }
 
 # Returns the npm publish status of a package id and version.


### PR DESCRIPTION
Right now, we search:

`sdk/<servicedirectory>/<folder>/package.json`

This PR simply adds:

`sdk/<servicedirectory>/<folder>/perf-tests/<folder>/package.json`

Of course, an alternative is to use the equivalent of a `glob` under the service directory folder, where we _exclude_ certain folders from the globbing. Reason I didn't go with that is that I feel like the error case for that will be much more common than the one for this solution. Namely that every time we add a auto-generated folder structure that may contain a `package.json` under it, we'll need to add that folder to the `exclude` list. I have a strong feeling that's why this has been left as-is.

That being said, I'm entirely ok with going to the other methodology. Will post a comment with the total comparison of detected packages in the repo.

@ckairen Thoughts?
