### PR TITLE
[generate-doc] Discover tsconfig.src.json

### DIFF
--- a/eng/tools/generate-doc/index.ts
+++ b/eng/tools/generate-doc/index.ts
@@ -27,16 +27,22 @@ async function runTypeDoc({ outputFolder, cwd }: { outputFolder: string; cwd: st
   }
   console.log(`entrypoints: ${JSON.stringify(entryPoints)}`);
 
-  const app = await TypeDocApplication.bootstrap({
-    entryPoints,
-    excludeInternal: true,
-    excludePrivate: true,
-    skipErrorChecking: true,
-    theme: "azureSdk",
-  }, [
-    new TSConfigReader(),
-    new TypeDocReader(),
-  ]);
+  const srcTsconfigPath = path.join(cwd, "tsconfig.src.json");
+  const tsconfig = (await fileExists(srcTsconfigPath))
+    ? srcTsconfigPath
+    : path.join(cwd, "tsconfig.json");
+
+  const app = await TypeDocApplication.bootstrap(
+    {
+      entryPoints,
+      excludeInternal: true,
+      excludePrivate: true,
+      skipErrorChecking: true,
+      theme: "azureSdk",
+      tsconfig,
+    },
+    [new TSConfigReader(), new TypeDocReader()],
+  );
 
   loadTheme(app);
 

--- a/eng/tools/generate-doc/package-lock.json
+++ b/eng/tools/generate-doc/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/node": "^18.0.0",
         "@types/yargs": "^17.0.32",
+        "prettier": "^3.4.2",
         "typescript": "~5.6.2"
       }
     },
@@ -534,6 +535,22 @@
         "emoji-regex-xs": "^1.0.0",
         "regex": "^5.0.0",
         "regex-recursion": "^4.2.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/property-information": {

--- a/eng/tools/generate-doc/package.json
+++ b/eng/tools/generate-doc/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "generate-doc": "node index.js"
+    "generate-doc": "node dist/index.js",
+    "format": "prettier --write \"index.ts\""
   },
   "author": "",
   "license": "MIT",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "@types/node": "^18.0.0",
     "@types/yargs": "^17.0.32",
+    "prettier": "^3.4.2",
     "typescript": "~5.6.2"
   }
 }


### PR DESCRIPTION
Passes `tsconfig.src.json` if available to TypeDoc. Otherwise, defaults to `tsconfig.json`.