### PR TITLE
[dev-tool] update resolveTsConfig

### DIFF
--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -87,20 +87,20 @@ export default leafCommand(commandInfo, async (options) => {
 
     log.info(`Building for browser testing...`);
     const esmMap = overrides.has("esm") ? overrides.get("esm")!.map : new Map<string, string>();
-    compileForEnvironment("browser", browserConfig, importMap, esmMap);
+    await compileForEnvironment("browser", browserConfig, importMap, esmMap);
   }
 
   return true;
 });
 
-function compileForEnvironment(
+async function compileForEnvironment(
   type: string,
   tsConfig: string,
   importMap: Map<string, string>,
   overrideMap: Map<string, string>,
-): boolean {
+): Promise<boolean> {
   const tsconfigPath = path.join(process.cwd(), tsConfig);
-  const tsConfigJSON = resolveConfig(tsconfigPath);
+  const tsConfigJSON = await resolveConfig(tsconfigPath);
   const outputPath = tsConfigJSON.compilerOptions.outDir;
   if (!existsSync(tsconfigPath)) {
     log.error(`TypeScript config ${tsConfig} does not exist`);

--- a/common/tools/dev-tool/src/util/resolveTsConfig.ts
+++ b/common/tools/dev-tool/src/util/resolveTsConfig.ts
@@ -2,10 +2,15 @@
 // Licensed under the MIT License.
 
 import * as path from "path";
-import * as fs from "fs";
-import ts from "typescript";
+import * as fs from "fs/promises";
+import type { CompilerOptions } from "typescript";
 
-type Config = { compilerOptions: ts.CompilerOptions };
+type Config = {
+  compilerOptions: CompilerOptions;
+  include?: string[];
+  exclude?: string[];
+  files?: string[];
+};
 
 function resolveConfigDir(configPath: string, unresolvedPath: string) {
   return unresolvedPath.replace(/\$\{configDir\}/g, path.dirname(configPath));
@@ -28,12 +33,12 @@ function mergeConfig(config1: Config, config2: Config) {
  * @param configPath - The path to the tsconfig file.
  * @returns A record containing the raw parsed configuration.
  */
-export function resolveConfig(configPath: string) {
-  function helper(configPath: string) {
+export async function resolveConfig(configPath: string) {
+  async function helper(configPath: string) {
     const absolutePath = path.resolve(configPath);
     const configDir = path.dirname(absolutePath);
     const rawConfig = JSON.parse(
-      fs.readFileSync(
+      await fs.readFile(
         !absolutePath.toLowerCase().endsWith(".json") ? `${absolutePath}.json` : absolutePath,
         "utf8",
       ),
@@ -45,16 +50,26 @@ export function resolveConfig(configPath: string) {
       const baseConfigs = Array.isArray(parents) ? parents : [parents];
       for (const baseConfigPath of baseConfigs) {
         const baseConfigAbsolutePath = path.resolve(configDir, baseConfigPath);
-        const baseConfig = helper(baseConfigAbsolutePath);
+        const baseConfig = await helper(baseConfigAbsolutePath);
         resolvedConfig = mergeConfig(resolvedConfig, baseConfig);
       }
     }
     return mergeConfig(resolvedConfig, rest);
   }
-  const resolvedConfig = helper(configPath);
+  const resolvedConfig = await helper(configPath);
   const outDir = resolvedConfig.compilerOptions.outDir;
+  const { include, exclude, files } = resolvedConfig;
   if (outDir) {
     resolvedConfig.compilerOptions.outDir = resolveConfigDir(configPath, outDir);
+  }
+  if (include) {
+    resolvedConfig.include = include.map((p) => resolveConfigDir(configPath, p));
+  }
+  if (exclude) {
+    resolvedConfig.exclude = exclude.map((p) => resolveConfigDir(configPath, p));
+  }
+  if (files) {
+    resolvedConfig.files = files.map((p) => resolveConfigDir(configPath, p));
   }
   return resolvedConfig;
 }

--- a/common/tools/dev-tool/test/resolveTsConfig.spec.ts
+++ b/common/tools/dev-tool/test/resolveTsConfig.spec.ts
@@ -5,10 +5,10 @@ import { describe, it, beforeEach, expect, vi } from "vitest";
 import { vol } from "memfs";
 import { resolveConfig } from "../src/util/resolveTsConfig";
 
-vi.mock("fs", async () => {
+vi.mock("fs/promises", async () => {
   const memfs = await import("memfs");
   return {
-    ...memfs.fs,
+    ...memfs.fs.promises,
   };
 });
 
@@ -17,7 +17,7 @@ describe("resolveConfig", () => {
     vol.reset();
   });
 
-  it("should resolve a simple tsconfig.json", () => {
+  it("should resolve a simple tsconfig.json", async () => {
     const def = {
       compilerOptions: {
         target: "ES6",
@@ -27,11 +27,11 @@ describe("resolveConfig", () => {
       "/project/tsconfig.json": JSON.stringify(def),
     });
 
-    const result = resolveConfig("/project/tsconfig.json");
+    const result = await resolveConfig("/project/tsconfig.json");
     expect(result).toEqual(def);
   });
 
-  it("should resolve tsconfig.json with single extend", () => {
+  it("should resolve tsconfig.json with single extend", async () => {
     vol.fromJSON({
       "/project/tsconfig.base.json": JSON.stringify({
         compilerOptions: {
@@ -47,7 +47,7 @@ describe("resolveConfig", () => {
       }),
     });
 
-    const result = resolveConfig("/project/tsconfig.json");
+    const result = await resolveConfig("/project/tsconfig.json");
     expect(result).toEqual({
       compilerOptions: {
         target: "ES5",
@@ -57,7 +57,7 @@ describe("resolveConfig", () => {
     });
   });
 
-  it("should resolve tsconfig.json with single extend and conflicting option", () => {
+  it("should resolve tsconfig.json with single extend and conflicting option", async () => {
     vol.fromJSON({
       "/project/tsconfig.base.json": JSON.stringify({
         compilerOptions: {
@@ -74,7 +74,7 @@ describe("resolveConfig", () => {
       }),
     });
 
-    const result = resolveConfig("/project/tsconfig.json");
+    const result = await resolveConfig("/project/tsconfig.json");
     expect(result).toEqual({
       compilerOptions: {
         target: "ES5",
@@ -84,7 +84,7 @@ describe("resolveConfig", () => {
     });
   });
 
-  it("should resolve tsconfig.json with multiple extends with conflicting options in parents", () => {
+  it("should resolve tsconfig.json with multiple extends with conflicting options in parents", async () => {
     vol.fromJSON({
       "/project/tsconfig.base1.json": JSON.stringify({
         compilerOptions: {
@@ -105,7 +105,7 @@ describe("resolveConfig", () => {
       }),
     });
 
-    const result = resolveConfig("/project/tsconfig.json");
+    const result = await resolveConfig("/project/tsconfig.json");
     expect(result).toEqual({
       compilerOptions: {
         target: "ES5",


### PR DESCRIPTION
This PR improves the `resolveTsConfig` function to be more complete in case other parts of our tooling may need to use it:

- Updates `resolveTsConfig` to use `fs/promises` and updates the `resolveConfig` function to be asynchronous.
- Resolves references to `${configDir}` in all paths in the configuration file.