### PR TITLE
Fix stored `DirectoryPath` for a perf-test package

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -125,10 +125,11 @@ function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory) {
   foreach ($projectPath in $projectPaths) {
     if (Test-Path $projectPath) {
       $projectJson = Get-Content $projectPath | ConvertFrom-Json
+      $projectDirectory = Split-Path $projectPath
 
       $jsStylePkgName = $projectJson.name.Replace("@", "").Replace("/", "-")
 
-      $pkgProp = [PackageProps]::new($projectJson.name, $projectJson.version, $pkgPath, $serviceDirectory)
+      $pkgProp = [PackageProps]::new($projectJson.name, $projectJson.version, $projectDirectory, $serviceDirectory)
       if ($projectJson.psobject.properties.name -contains 'sdk-type') {
         $pkgProp.SdkType = $projectJson.psobject.properties['sdk-type'].value
       }

--- a/sdk/appconfiguration/perf-tests/app-configuration/README.md
+++ b/sdk/appconfiguration/perf-tests/app-configuration/README.md
@@ -4,6 +4,7 @@
 2. Copy the `sample.env` file and name it as `.env`.
 3. Create a App Configuration resource and populate the `.env` file with `APPCONFIG_CONNECTION_STRING` variable.
 4. Run the tests as follows
+5. This is an edited line that will not merge
 
    - list configuration settings
      - `npm run perf-test:node -- ListSettingsTest --warmup 2 --duration 7 --iterations 2 --parallel 2`

--- a/sdk/appconfiguration/perf-tests/app-configuration/README.md
+++ b/sdk/appconfiguration/perf-tests/app-configuration/README.md
@@ -4,7 +4,6 @@
 2. Copy the `sample.env` file and name it as `.env`.
 3. Create a App Configuration resource and populate the `.env` file with `APPCONFIG_CONNECTION_STRING` variable.
 4. Run the tests as follows
-5. This is an edited line that will not merge
 
    - list configuration settings
      - `npm run perf-test:node -- ListSettingsTest --warmup 2 --duration 7 --iterations 2 --parallel 2`


### PR DESCRIPTION
This PR has a touched file in the appconfiguration perf-test package. I will be reverting that prior to merge. I didn't do that with my last PR #32222 which is why this issue slipped through.

EDIT: getting successes across the board reverting the change to the perf-test package.