### PR TITLE
Fix copy-paste typo in a link within AppConfig README.md to point to the expected AppConfig EntraID doc

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/README.md
+++ b/sdk/appconfiguration/app-configuration/test/README.md
@@ -34,6 +34,6 @@ The following steps will help you setup the AAD credentials.
 - In the Azure portal, go to your Azure App Configuration and assign the **Owner** role to the registered application.
 - This can be done from `Role assignment` section of `Access control (IAM)` tab (in the left-side-navbar of your Azure App Configuration in the Azure portal)<br>
   _Doing this would allow the registered application manage the resource, i.e., entity creation, deletion, etc.,_<br>
-- For more information on securing your Azure App Configuration: [Learn more](https://docs.microsoft.com/azure/event-hubs/authorize-access-event-hubs)
+- For more information on securing your Azure App Configuration: [Learn more](https://learn.microsoft.com/azure/azure-app-configuration/concept-enable-rbac)
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fappconfiguration%2Fapp-configuration%2Ftest%2FREADME.png)


### PR DESCRIPTION
This was introduced in https://github.com/Azure/azure-sdk-for-js/pull/8398 and seems to have copied from the eventhub doc, accidentally:
https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/eventhub/event-hubs/test/README.md#assign-owner-role-to-the-registered-application

This search for `authorize-access-event-hubs` has two hits:
https://github.com/search?q=repo%3AAzure%2Fazure-sdk-for-js%20authorize-access-event-hubs&type=code