### PR TITLE
[identity] Fix build warnings

### DIFF
--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -15,44 +15,14 @@ import type { ClientCertificateCredentialOptions } from "./clientCertificateCred
 import { credentialLogger } from "../util/logging.js";
 import { readFile } from "node:fs/promises";
 import { tracingClient } from "../util/tracing.js";
+import type {
+  ClientCertificateCredentialPEMConfiguration,
+  ClientCertificatePEMCertificate,
+  ClientCertificatePEMCertificatePath,
+} from "./clientCertificateCredentialModels.js";
 
 const credentialName = "ClientCertificateCredential";
 const logger = credentialLogger(credentialName);
-
-/**
- * Required configuration options for the {@link ClientCertificateCredential}, with the string contents of a PEM certificate
- */
-export interface ClientCertificatePEMCertificate {
-  /**
-   * The PEM-encoded public/private key certificate on the filesystem.
-   */
-  certificate: string;
-
-  /**
-   * The password for the certificate file.
-   */
-  certificatePassword?: string;
-}
-/**
- * Required configuration options for the {@link ClientCertificateCredential}, with the path to a PEM certificate.
- */
-export interface ClientCertificatePEMCertificatePath {
-  /**
-   * The path to the PEM-encoded public/private key certificate on the filesystem.
-   */
-  certificatePath: string;
-
-  /**
-   * The password for the certificate file.
-   */
-  certificatePassword?: string;
-}
-/**
- * Required configuration options for the {@link ClientCertificateCredential}, with either the string contents of a PEM certificate, or the path to a PEM certificate.
- */
-export type ClientCertificateCredentialPEMConfiguration =
-  | ClientCertificatePEMCertificate
-  | ClientCertificatePEMCertificatePath;
 
 /**
  * Enables authentication to Microsoft Entra ID using a PEM-encoded
@@ -140,12 +110,10 @@ export class ClientCertificateCredential implements TokenCredential {
           }
         : certificatePathOrConfiguration),
     };
-    const certificate: string | undefined = (
-      this.certificateConfiguration as ClientCertificatePEMCertificate
-    ).certificate;
-    const certificatePath: string | undefined = (
-      this.certificateConfiguration as ClientCertificatePEMCertificatePath
-    ).certificatePath;
+    const certificate = (this.certificateConfiguration as ClientCertificatePEMCertificate)
+      .certificate;
+    const certificatePath = (this.certificateConfiguration as ClientCertificatePEMCertificatePath)
+      .certificatePath;
     if (!this.certificateConfiguration || !(certificate || certificatePath)) {
       throw new Error(
         `${credentialName}: Provide either a PEM certificate in string form, or the path to that certificate in the filesystem. To troubleshoot, visit https://aka.ms/azsdk/js/identity/serviceprincipalauthentication/troubleshoot.`,
@@ -227,12 +195,9 @@ export async function parseCertificate(
   certificateConfiguration: ClientCertificateCredentialPEMConfiguration,
   sendCertificateChain: boolean,
 ): Promise<Omit<CertificateParts, "privateKey"> & { certificateContents: string }> {
-  const certificate: string | undefined = (
-    certificateConfiguration as ClientCertificatePEMCertificate
-  ).certificate;
-  const certificatePath: string | undefined = (
-    certificateConfiguration as ClientCertificatePEMCertificatePath
-  ).certificatePath;
+  const certificate = (certificateConfiguration as ClientCertificatePEMCertificate).certificate;
+  const certificatePath = (certificateConfiguration as ClientCertificatePEMCertificatePath)
+    .certificatePath;
   const certificateContents = certificate || (await readFile(certificatePath!, "utf8"));
   const x5c = sendCertificateChain ? certificateContents : undefined;
 

--- a/sdk/identity/identity/src/credentials/clientCertificateCredentialModels.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredentialModels.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Required configuration options for the {@link ClientCertificateCredential}, with the string contents of a PEM certificate
+ */
+export interface ClientCertificatePEMCertificate {
+  /**
+   * The PEM-encoded public/private key certificate on the filesystem.
+   */
+  certificate: string;
+
+  /**
+   * The password for the certificate file.
+   */
+  certificatePassword?: string;
+}
+/**
+ * Required configuration options for the {@link ClientCertificateCredential}, with the path to a PEM certificate.
+ */
+export interface ClientCertificatePEMCertificatePath {
+  /**
+   * The path to the PEM-encoded public/private key certificate on the filesystem.
+   */
+  certificatePath: string;
+
+  /**
+   * The password for the certificate file.
+   */
+  certificatePassword?: string;
+}
+/**
+ * Required configuration options for the {@link ClientCertificateCredential}, with either the string contents of a PEM certificate, or the path to a PEM certificate.
+ */
+export type ClientCertificateCredentialPEMConfiguration =
+  | ClientCertificatePEMCertificate
+  | ClientCertificatePEMCertificatePath;

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -9,7 +9,7 @@ import type {
 import type {
   ManagedIdentityCredentialClientIdOptions,
   ManagedIdentityCredentialResourceIdOptions,
-} from "./managedIdentityCredential/index.js";
+} from "./managedIdentityCredential/options.js";
 import { ManagedIdentityCredential } from "./managedIdentityCredential/index.js";
 
 import { AzureCliCredential } from "./azureCliCredential.js";

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -17,46 +17,13 @@ import { imdsMsi } from "./imdsMsi.js";
 import { tokenExchangeMsi } from "./tokenExchangeMsi.js";
 import { mapScopesToResource } from "./utils.js";
 import type { MsalToken, ValidMsalToken } from "../../msal/types.js";
+import type {
+  ManagedIdentityCredentialClientIdOptions,
+  ManagedIdentityCredentialObjectIdOptions,
+  ManagedIdentityCredentialResourceIdOptions,
+} from "./options.js";
 
 const logger = credentialLogger("ManagedIdentityCredential");
-
-/**
- * Options to send on the {@link ManagedIdentityCredential} constructor.
- * This variation supports `clientId` and not `resourceId`, since only one of both is supported.
- */
-export interface ManagedIdentityCredentialClientIdOptions extends TokenCredentialOptions {
-  /**
-   * The client ID of the user - assigned identity, or app registration(when working with AKS pod - identity).
-   */
-  clientId?: string;
-}
-
-/**
- * Options to send on the {@link ManagedIdentityCredential} constructor.
- * This variation supports `resourceId` and not `clientId`, since only one of both is supported.
- */
-export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredentialOptions {
-  /**
-   * Allows specifying a custom resource Id.
-   * In scenarios such as when user assigned identities are created using an ARM template,
-   * where the resource Id of the identity is known but the client Id can't be known ahead of time,
-   * this parameter allows programs to use these user assigned identities
-   * without having to first determine the client Id of the created identity.
-   */
-  resourceId: string;
-}
-
-/**
- * Options to send on the {@link ManagedIdentityCredential} constructor.
- * This variation supports `objectId` as a constructor argument.
- */
-export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
-  /**
-   * Allows specifying the object ID of the underlying service principal used to authenticate a user-assigned managed identity.
-   * This is an alternative to providing a client ID or resource ID and is not required for system-assigned managed identities.
-   */
-  objectId: string;
-}
 
 /**
  * Attempts authentication using a managed identity available at the deployment environment.

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/options.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/options.ts
@@ -3,7 +3,6 @@
 
 import type { TokenCredentialOptions } from "../../tokenCredentialOptions.js";
 
-
 /**
  * Options to send on the {@link ManagedIdentityCredential} constructor.
  * This variation supports `clientId` and not `resourceId`, since only one of both is supported.

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/options.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/options.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { TokenCredentialOptions } from "../../tokenCredentialOptions.js";
+
+
+/**
+ * Options to send on the {@link ManagedIdentityCredential} constructor.
+ * This variation supports `clientId` and not `resourceId`, since only one of both is supported.
+ */
+export interface ManagedIdentityCredentialClientIdOptions extends TokenCredentialOptions {
+  /**
+   * The client ID of the user - assigned identity, or app registration(when working with AKS pod - identity).
+   */
+  clientId?: string;
+}
+
+/**
+ * Options to send on the {@link ManagedIdentityCredential} constructor.
+ * This variation supports `resourceId` and not `clientId`, since only one of both is supported.
+ */
+export interface ManagedIdentityCredentialResourceIdOptions extends TokenCredentialOptions {
+  /**
+   * Allows specifying a custom resource Id.
+   * In scenarios such as when user assigned identities are created using an ARM template,
+   * where the resource Id of the identity is known but the client Id can't be known ahead of time,
+   * this parameter allows programs to use these user assigned identities
+   * without having to first determine the client Id of the created identity.
+   */
+  resourceId: string;
+}
+
+/**
+ * Options to send on the {@link ManagedIdentityCredential} constructor.
+ * This variation supports `objectId` as a constructor argument.
+ */
+export interface ManagedIdentityCredentialObjectIdOptions extends TokenCredentialOptions {
+  /**
+   * Allows specifying the object ID of the underlying service principal used to authenticate a user-assigned managed identity.
+   * This is an alternative to providing a client ID or resource ID and is not required for system-assigned managed identities.
+   */
+  objectId: string;
+}

--- a/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
+++ b/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
@@ -17,7 +17,7 @@ import {
 } from "../util/tenantIdUtils.js";
 
 import type { CertificateParts } from "../msal/types.js";
-import type { ClientCertificatePEMCertificatePath } from "./clientCertificateCredential.js";
+import type { ClientCertificatePEMCertificatePath } from "./clientCertificateCredentialModels.js";
 import type { CredentialPersistenceOptions } from "./credentialPersistenceOptions.js";
 import { CredentialUnavailableError } from "../errors.js";
 import type { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialOptions.js";

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -51,12 +51,12 @@ export {
 export { EnvironmentCredential } from "./credentials/environmentCredential.js";
 export { EnvironmentCredentialOptions } from "./credentials/environmentCredentialOptions.js";
 
+export { ClientCertificateCredential } from "./credentials/clientCertificateCredential.js";
 export {
-  ClientCertificateCredential,
   ClientCertificateCredentialPEMConfiguration,
   ClientCertificatePEMCertificatePath,
   ClientCertificatePEMCertificate,
-} from "./credentials/clientCertificateCredential.js";
+} from "./credentials/clientCertificateCredentialModels.js";
 export { ClientCertificateCredentialOptions } from "./credentials/clientCertificateCredentialOptions.js";
 export { ClientAssertionCredential } from "./credentials/clientAssertionCredential.js";
 export { ClientAssertionCredentialOptions } from "./credentials/clientAssertionCredentialOptions.js";
@@ -71,12 +71,12 @@ export {
   InteractiveBrowserCredentialInBrowserOptions,
   BrowserLoginStyle,
 } from "./credentials/interactiveBrowserCredentialOptions.js";
+export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential/index.js";
 export {
-  ManagedIdentityCredential,
   ManagedIdentityCredentialClientIdOptions,
   ManagedIdentityCredentialResourceIdOptions,
   ManagedIdentityCredentialObjectIdOptions,
-} from "./credentials/managedIdentityCredential/index.js";
+} from "./credentials/managedIdentityCredential/options.js";
 export { DeviceCodeCredential } from "./credentials/deviceCodeCredential.js";
 export {
   DeviceCodePromptCallback,

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -3,5 +3,8 @@
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.samples.json" },
     { "path": "./tsconfig.test.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/32227

### Describe the problem that is addressed by this PR
The API extractor is showing the following warnings:
```
2024-12-14T01:02:41.6475182Z Warning: /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/https://github.com/Azure+msal-node@2.16.2/node_modules/@azure/msal-node/dist/config/Configuration.d.ts:4:8 - (TS1192) Module '"http"' has no default export.
2024-12-14T01:02:41.6475819Z Warning: /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/https://github.com/Azure+msal-node@2.16.2/node_modules/@azure/msal-node/dist/config/Configuration.d.ts:5:8 - (TS1192) Module '"https"' has no default export.
2024-12-14T01:02:41.6476323Z Warning: dist/browser/index.d.ts:20:39 - (TS2305) Module '"./credentials/clientCertificateCredential.js"' has no exported member 'ClientCertificateCredentialPEMConfiguration'.
2024-12-14T01:02:41.6476804Z Warning: dist/browser/index.d.ts:20:84 - (TS2305) Module '"./credentials/clientCertificateCredential.js"' has no exported member 'ClientCertificatePEMCertificatePath'.
2024-12-14T01:02:41.6477272Z Warning: dist/browser/index.d.ts:20:121 - (TS2305) Module '"./credentials/clientCertificateCredential.js"' has no exported member 'ClientCertificatePEMCertificate'.
2024-12-14T01:02:41.6477755Z Warning: dist/browser/index.d.ts:31:37 - (TS2305) Module '"./credentials/managedIdentityCredential/index.js"' has no exported member 'ManagedIdentityCredentialClientIdOptions'.
2024-12-14T01:02:41.6478237Z Warning: dist/browser/index.d.ts:31:79 - (TS2305) Module '"./credentials/managedIdentityCredential/index.js"' has no exported member 'ManagedIdentityCredentialResourceIdOptions'.
2024-12-14T01:02:41.6478731Z Warning: dist/browser/index.d.ts:31:123 - (TS2305) Module '"./credentials/managedIdentityCredential/index.js"' has no exported member 'ManagedIdentityCredentialObjectIdOptions'.
```

It doesn't seem to be smart enough to notice that `esModuleInterop` is enabled in `tsconfig.src.json` which is referenced in `tsconfig.json` so this PR enables it explicitly there.

Also for the "no exported member" issues, this PR reorganizes exports in such a way that they are exported from the browser build too.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Alternatively, we could configure the API extractor to use the `tsconfig.src.json` instead:

```json
{
  "compiler": {
    "tsconfigFilePath": "./tsconfig.src.json"
  },
}
```

However, it uses an older version of TS (v5.4) which doesn't know about `${configDir}` reference in the include paths, a relatively new feature.

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
