### PR TITLE
[test-utils] Migrate @azure-tools/test-credential to ESM/vitest

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1212,7 +1212,7 @@ importers:
         version: file:projects/template-dpg.tgz(msw@2.6.8(@types/node@22.7.9)(typescript@5.7.2))(vite@5.4.11(@types/node@22.7.9))
       '@rush-temp/test-credential':
         specifier: file:./projects/test-credential.tgz
-        version: file:projects/test-credential.tgz
+        version: file:projects/test-credential.tgz(msw@2.6.8(@types/node@22.7.9)(typescript@5.7.2))(vite@5.4.11(@types/node@22.7.9))
       '@rush-temp/test-perf':
         specifier: file:./projects/test-perf.tgz
         version: file:projects/test-perf.tgz
@@ -3846,11 +3846,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/perf-ai-form-recognizer@file:projects/perf-ai-form-recognizer.tgz':
-    resolution: {integrity: sha512-gkKmxzBKsrY/wyXCcGI4WhO/F0V4SDHGHfWyMe9+vTOsbqVxR54QTrYClJ0JlKmmogFold3Da1pDIJRP9YJvJw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
+    resolution: {integrity: sha512-p6M8KE5r+eju7mdFu51fAPG+Q2ui88B4SKhIU+X1MjAEGxYnvvs5q1Am12FOGPbMDpCpKIQc9GmQhvgdnm9JZw==, tarball: file:projects/perf-ai-form-recognizer.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-ai-language-text@file:projects/perf-ai-language-text.tgz':
-    resolution: {integrity: sha512-YLzvAF50r4GeP+YOEtkC2jc7m1NsfuDk7I6RCU8Qp9tlnxEukxP2VoVt+Yn9tbpRuNGZBe1HFoIdUQcS0cLB2g==, tarball: file:projects/perf-ai-language-text.tgz}
+    resolution: {integrity: sha512-nieSyETytAM0xPUnovc0mrNCOoEu+igHjJ1Ak0yZQdDpJgesfvkWZ2RMK1uu33oIVGC5B/qFHUSEMkCkY/q4tg==, tarball: file:projects/perf-ai-language-text.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-ai-metrics-advisor@file:projects/perf-ai-metrics-advisor.tgz':
@@ -3866,7 +3866,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/perf-container-registry@file:projects/perf-container-registry.tgz':
-    resolution: {integrity: sha512-GsW1EvTmOLWMlaJa7m9yf/xvgplmqpkQ4EuIXhNpuZWayCCAdqlRnKQ4CgpyywNCweKEpgptqNCB6/4DVCVuZw==, tarball: file:projects/perf-container-registry.tgz}
+    resolution: {integrity: sha512-6J3aCs2BR1Fax6SWXRZEFxn8wlkRUoiRVIb8QrbjgHDUYy950dYuomYjISAiG3qptNHs8jvny4Y5tZmheI+Bww==, tarball: file:projects/perf-container-registry.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-core-rest-pipeline@file:projects/perf-core-rest-pipeline.tgz':
@@ -3874,7 +3874,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/perf-data-tables@file:projects/perf-data-tables.tgz':
-    resolution: {integrity: sha512-7WuM+VxSyy1vUPKLLasOhvvBLoDVj0py2ePQ60WqxGXGY2bPAdzm+hnyi7BCFcCTT0IsxHxwjRfUarne98jGlw==, tarball: file:projects/perf-data-tables.tgz}
+    resolution: {integrity: sha512-WO8vtk6tP1pRgwbdzhoFGnqVdi3USclFI9zsdyCYbXnVX97ha83TJDTrtX/h5XyfHqffhCKxmw+FxVcDELbmbQ==, tarball: file:projects/perf-data-tables.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-event-hubs@file:projects/perf-event-hubs.tgz':
@@ -3882,31 +3882,31 @@ packages:
     version: 0.0.0
 
   '@rush-temp/perf-eventgrid@file:projects/perf-eventgrid.tgz':
-    resolution: {integrity: sha512-ZYkjk1Pz46OB0szqPrpg0Ymo7rNaSbRqu9gIfv9ntX3li6ol/f8HhNenejnokCbHjCi+bb1mN2pD/2WdRUdF8w==, tarball: file:projects/perf-eventgrid.tgz}
+    resolution: {integrity: sha512-dt3yEhJhegjfan5c/jJLs7T+Minp/kWPcsRLcm5esNfmjQFBuroYQ1W1Zc6CAJxDojw7AeUVW5X5P1K2Lt15mQ==, tarball: file:projects/perf-eventgrid.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-identity@file:projects/perf-identity.tgz':
-    resolution: {integrity: sha512-A7aeJKxdmV27Fkdz2zrFh/3n3U/WQ/ay+4X+o13PrT1AeqXPALD6tt4wdLT0QW3ymM2D2WGFgW9M3oLVhP00qw==, tarball: file:projects/perf-identity.tgz}
+    resolution: {integrity: sha512-Ky6GozlRP3Wr8LDCvUlndPP0ZhHIo77wy1Cf58/W2brw9NUBLV8aHki070fjpXSFobKJKUGTWpBFbFyRmU1gVg==, tarball: file:projects/perf-identity.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-keyvault-certificates@file:projects/perf-keyvault-certificates.tgz':
-    resolution: {integrity: sha512-vzsSPptQv8Y3pbBGjHRmJPRzTuJuP+usNSwZVZYDSs4t3OG4MK3576QV9oH4MtUCfE10kC9ECq4t+d4z6yJUow==, tarball: file:projects/perf-keyvault-certificates.tgz}
+    resolution: {integrity: sha512-m+XXXPUCWfLR+4RfVNAmbFuaZdzGYWEvk+z4xCQImvCq+F17q5bcO5mnGCwpoDOGbMaTHi53yLK5e2B4mRGgKw==, tarball: file:projects/perf-keyvault-certificates.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-keyvault-keys@file:projects/perf-keyvault-keys.tgz':
-    resolution: {integrity: sha512-GytYZta0ioUfmiPAcQuo7jpRdiy64l+82lMDnj6y66FdrlvD5lfSTPxSH6XdrYJkKOjm2O8XHLZB5nYaX/0zGw==, tarball: file:projects/perf-keyvault-keys.tgz}
+    resolution: {integrity: sha512-7Y3Fs0TxYz6C686H2FYyLAQnpwlTxypIz/YasYJXs62Tv4I6J9r1/EgelJNs0uDTDTVG+UoZvm6i++lohbWkXQ==, tarball: file:projects/perf-keyvault-keys.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-keyvault-secrets@file:projects/perf-keyvault-secrets.tgz':
-    resolution: {integrity: sha512-MqZSqQo/G6QZYa4vNiEpCukkUwCRo4mzVUHawlp1nqAmvlrrXoLumGyF48rJBVJh1sUEXFxw3koVBm+5asCNZw==, tarball: file:projects/perf-keyvault-secrets.tgz}
+    resolution: {integrity: sha512-W82F++lmwp3GlLHRWCpr9q97cnmDOM+CsTOMpXND1ZMki5E4x6kJezFTtrzYYcZeh8+/z8EDCAYKzWMfOFETLw==, tarball: file:projects/perf-keyvault-secrets.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-monitor-ingestion@file:projects/perf-monitor-ingestion.tgz':
-    resolution: {integrity: sha512-7Th0T7Nf0UNrvJPsjjNs/3KqkzRMWElB/HvNsNalfRxqHobWS/uIdXRo1zoLIZFh6dAKXlK5pyhboxzSczyeYQ==, tarball: file:projects/perf-monitor-ingestion.tgz}
+    resolution: {integrity: sha512-OQ69bcFfSdEWvM22k3EJz0mCKje9dTppw0bFA5uf9arJN8cBdLnG6CF+tq1Yrp6cLKR5b/QARyQP8AY6WEo39g==, tarball: file:projects/perf-monitor-ingestion.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-monitor-opentelemetry@file:projects/perf-monitor-opentelemetry.tgz':
-    resolution: {integrity: sha512-sMNiUWBPW0AcKHeMgc9WM7mDbz3LoOlK0SrZRvZ5CZ+stYIu1f5AQQsQScqOF4upL1X5wEtolDa0dwxaVDUGbA==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
+    resolution: {integrity: sha512-xUDDX7s9/9jA+L93I13fMZP90yzlJUNgt+zy0KhCNthiEtzu/GIvPdjGEOyT2k1+Z6yhPAM2o2hQuMF2o+oxqw==, tarball: file:projects/perf-monitor-opentelemetry.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-monitor-query@file:projects/perf-monitor-query.tgz':
@@ -3914,7 +3914,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/perf-schema-registry-avro@file:projects/perf-schema-registry-avro.tgz':
-    resolution: {integrity: sha512-QtAa+7ijpuBTTP6lmfJ/sFlMH8ihneNRqOmmObNiTwa3dDYAaymQ881zsh6p4pFDsboP6c+MJleulyBbz313xw==, tarball: file:projects/perf-schema-registry-avro.tgz}
+    resolution: {integrity: sha512-LfY5zyGD6QV6ne63pKBXb4nZJdlGTFB6HTFXOzfy8jdan73lnd/VEnyAOKV97geKuA5DIfFJQ0MLUUY6ON1vLg==, tarball: file:projects/perf-schema-registry-avro.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-search-documents@file:projects/perf-search-documents.tgz':
@@ -3926,11 +3926,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/perf-storage-blob@file:projects/perf-storage-blob.tgz':
-    resolution: {integrity: sha512-gC/6yI3RAsLz8yW4HuwmY/hZJdfQ4WpTasQrnaGM2o0ADvshX7BbTMziACBVC1IJ+SZS0f25nzWdMrf1cKEPUA==, tarball: file:projects/perf-storage-blob.tgz}
+    resolution: {integrity: sha512-ndiUIY/2sTD1nix+Km5dGfvJTrKRYDCL3/ZJhWfh2pWc1cup85tDdC3hl6hOnT746dWFMpTo1bhatoOOcjeEYA==, tarball: file:projects/perf-storage-blob.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-storage-file-datalake@file:projects/perf-storage-file-datalake.tgz':
-    resolution: {integrity: sha512-/Ci5NG7Th6jCRFjxNQnQIN066A0l8K8hkuTPVCvaChixw0hduEm6MN1HeVT+Qmwkko8uVFlLNu1s7HgLwy8rLw==, tarball: file:projects/perf-storage-file-datalake.tgz}
+    resolution: {integrity: sha512-kKfSIqcwmfwLH0qRThgHMSnjxtBrAApzNIu4wh+0CChWNEXxyxO4EUHHLTpsz5ErMnVWi17tF6IT5tvsw0rMSQ==, tarball: file:projects/perf-storage-file-datalake.tgz}
     version: 0.0.0
 
   '@rush-temp/perf-storage-file-share@file:projects/perf-storage-file-share.tgz':
@@ -4046,7 +4046,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/test-credential@file:projects/test-credential.tgz':
-    resolution: {integrity: sha512-bYrr6dFuCJWhb76ZIYcsr5Yp56E+ucLdJB8EntpuQev3rYZ9RmUOO8tLmLBpeEaaXX9Ze9qdX8cir9e8oasSbw==, tarball: file:projects/test-credential.tgz}
+    resolution: {integrity: sha512-ahmpTdtCcHDXpM5VF1hiTI91ouMI4U3eQwvJja43zmLFmi4AlKOSYwsJysdX4GF9pAduMR54rP64mC1PyK3b8Q==, tarball: file:projects/test-credential.tgz}
     version: 0.0.0
 
   '@rush-temp/test-perf@file:projects/test-perf.tgz':
@@ -18477,12 +18477,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18525,12 +18522,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18554,12 +18548,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18594,75 +18585,53 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
   '@rush-temp/perf-identity@file:projects/perf-identity.tgz':
     dependencies:
       '@types/node': 18.19.68
-      '@types/uuid': 8.3.4
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
   '@rush-temp/perf-keyvault-certificates@file:projects/perf-keyvault-certificates.tgz':
     dependencies:
       '@types/node': 18.19.68
-      '@types/uuid': 8.3.4
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
-      uuid: 8.3.2
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
   '@rush-temp/perf-keyvault-keys@file:projects/perf-keyvault-keys.tgz':
     dependencies:
       '@types/node': 18.19.68
-      '@types/uuid': 8.3.4
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
-      uuid: 8.3.2
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
   '@rush-temp/perf-keyvault-secrets@file:projects/perf-keyvault-secrets.tgz':
     dependencies:
       '@types/node': 18.19.68
-      '@types/uuid': 8.3.4
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
-      uuid: 8.3.2
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18671,12 +18640,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18714,12 +18680,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18751,12 +18714,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -18765,12 +18725,9 @@ snapshots:
       '@types/node': 18.19.68
       dotenv: 16.4.7
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
       - jiti
       - supports-color
 
@@ -19729,18 +19686,36 @@ snapshots:
       - vite
       - webdriverio
 
-  '@rush-temp/test-credential@file:projects/test-credential.tgz':
+  '@rush-temp/test-credential@file:projects/test-credential.tgz(msw@2.6.8(@types/node@22.7.9)(typescript@5.7.2))(vite@5.4.11(@types/node@22.7.9))':
     dependencies:
       '@types/node': 18.19.68
+      '@vitest/browser': 2.1.8(@types/node@18.19.68)(playwright@1.49.1)(typescript@5.6.3)(vite@5.4.11(@types/node@22.7.9))(vitest@2.1.8)
+      '@vitest/coverage-istanbul': 2.1.8(vitest@2.1.8)
       eslint: 9.17.0
-      ts-node: 10.9.2(@types/node@18.19.68)(typescript@5.6.3)
+      playwright: 1.49.1
       tslib: 2.8.1
       typescript: 5.6.3
+      vitest: 2.1.8(@types/node@18.19.68)(@vitest/browser@2.1.8)(msw@2.6.8(@types/node@22.7.9)(typescript@5.7.2))
     transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
+      - '@edge-runtime/vm'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
       - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
       - supports-color
+      - terser
+      - utf-8-validate
+      - vite
+      - webdriverio
 
   '@rush-temp/test-perf@file:projects/test-perf.tgz':
     dependencies:

--- a/sdk/test-utils/test-credential/api-extractor.json
+++ b/sdk/test-utils/test-credential/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "types/latest/src/index.d.ts",
+  "mainEntryPointFilePath": "dist/esm/index.d.ts",
   "docModel": {
     "enabled": true
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/tools-test-credential.d.ts"
+    "publicTrimmedFilePath": "dist/tools-test-credential.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -3,9 +3,9 @@
   "version": "2.1.1",
   "sdk-type": "utility",
   "description": "Test utilities library that provides the test credential",
-  "main": "dist/index.js",
-  "module": "dist-esm/src/index.js",
-  "types": "types/tools-test-credential.d.ts",
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/commonjs/index.d.ts",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -19,9 +19,9 @@
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "echo skipped",
-    "lint": "eslint src test",
-    "lint:fix": "eslint src test --fix --fix-type [problem,suggestion]",
+    "integration-test:node": "dev-tool run test:vitest --esm",
+    "lint": "dev-tool run vendored eslint src test",
+    "lint:fix": "dev-tool run vendored eslint src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
     "test": "npm run clean && npm run build && npm run unit-test",
     "test:browser": "npm run clean && npm run build npm run unit-test:browser",
@@ -52,10 +52,10 @@
   "sideEffects": false,
   "dependencies": {
     "@azure-tools/test-recorder": "^4.0.0",
-    "@azure/core-auth": "^1.3.2",
-    "@azure/core-util": "^1.9.1",
-    "@azure/identity": "^4.4.1",
-    "tslib": "^2.6.2"
+    "@azure/core-auth": "^1.9.0",
+    "@azure/core-util": "^1.11.0",
+    "@azure/identity": "^4.5.0",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "^1.0.0",
@@ -71,6 +71,7 @@
   },
   "type": "module",
   "tshy": {
+    "project": "./tsconfig.src.json",
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
@@ -85,5 +86,26 @@
     ],
     "selfLink": false
   },
-  "browser": "./dist/browser/index.js"
+  "browser": "./dist/browser/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
+      "react-native": {
+        "types": "./dist/react-native/index.d.ts",
+        "default": "./dist/react-native/index.js"
+      },
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  }
 }

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -10,12 +10,12 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && dev-tool run extract-api",
+    "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "build:samples": "echo Skipped.",
     "build:test": "echo not needed",
     "check-format": "dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "dev-tool run vendored rimraf --glob dist dist-* types *.tgz *.log",
-    "extract-api": "tsc -p . && dev-tool run extract-api",
+    "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
@@ -27,14 +27,12 @@
     "test:browser": "npm run clean && npm run build npm run unit-test:browser",
     "test:node": "npm run clean && npm run build && npm run unit-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "unit-test:browser": "echo skipped",
-    "unit-test:node": "echo skipped",
+    "unit-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
+    "unit-test:node": "dev-tool run test:vitest",
     "update-snippets": "echo skipped"
   },
   "files": [
     "dist/",
-    "dist-esm/src/",
-    "types/tools-test-credential.d.ts",
     "README.md",
     "LICENSE"
   ],
@@ -60,11 +58,32 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
+    "@azure-tools/test-utils-vitest": "^1.0.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@types/node": "^18.0.0",
+    "@vitest/browser": "^2.1.8",
+    "@vitest/coverage-istanbul": "^2.1.8",
     "eslint": "^9.9.0",
-    "ts-node": "^10.0.0",
-    "typescript": "~5.6.2"
-  }
+    "playwright": "^1.49.1",
+    "typescript": "~5.6.2",
+    "vitest": "^2.1.8"
+  },
+  "type": "module",
+  "tshy": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "dialects": [
+      "esm",
+      "commonjs"
+    ],
+    "esmDialects": [
+      "browser",
+      "react-native"
+    ],
+    "selfLink": false
+  },
+  "browser": "./dist/browser/index.js"
 }

--- a/sdk/test-utils/test-credential/src/browserRelayCredential.ts
+++ b/sdk/test-utils/test-credential/src/browserRelayCredential.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import type { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
-import type { CreateTestCredentialOptions, DefaultAzureCredentialCombinedOptions } from ".";
+import type { CreateTestCredentialOptions, DefaultAzureCredentialCombinedOptions } from "./index.js";
 
 /**
  * Authentication error thrown when the relay server could not authenticate.

--- a/sdk/test-utils/test-credential/src/browserRelayCredential.ts
+++ b/sdk/test-utils/test-credential/src/browserRelayCredential.ts
@@ -66,8 +66,9 @@ async function getTokenFromRelay(
   scopes: string | string[],
   options: GetTokenOptions = {},
 ): Promise<AccessToken> {
+  const scope = typeof scopes === "string" ? scopes : scopes[0];
   const params = new URLSearchParams({
-    scopes,
+    scopes: scope,
     options: JSON.stringify(options),
   });
 

--- a/sdk/test-utils/test-credential/src/browserRelayCredential.ts
+++ b/sdk/test-utils/test-credential/src/browserRelayCredential.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 import type { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
-import type { CreateTestCredentialOptions, DefaultAzureCredentialCombinedOptions } from "./index.js";
+import type {
+  CreateTestCredentialOptions,
+  DefaultAzureCredentialCombinedOptions,
+} from "./index.js";
 
 /**
  * Authentication error thrown when the relay server could not authenticate.

--- a/sdk/test-utils/test-credential/src/index.ts
+++ b/sdk/test-utils/test-credential/src/index.ts
@@ -13,10 +13,10 @@ import {
   EnvironmentCredential,
 } from "@azure/identity";
 import { isPlaybackMode } from "@azure-tools/test-recorder";
-import { NoOpCredential } from "./noOpCredential";
+import { NoOpCredential } from "./noOpCredential.js";
 import { TokenCredential } from "@azure/core-auth";
 import { isBrowser } from "@azure/core-util";
-import { createBrowserRelayCredential } from "./browserRelayCredential";
+import { createBrowserRelayCredential } from "./browserRelayCredential.js";
 
 /**
  * Alias of the different possible options shapes for the DefaultAzureCredential constructor.

--- a/sdk/test-utils/test-credential/test/browserRelayCredential.spec.ts
+++ b/sdk/test-utils/test-credential/test/browserRelayCredential.spec.ts
@@ -10,7 +10,6 @@ import { describe, it, assert, expect, vi } from "vitest";
 
 describe("browserRelayCredential", () => {
   it("createBrowserRelayCredential creates credential", async () => {
-    // Mock the fetch function.
     const mockCreateCredentialResponse = {
       id: "1",
     };
@@ -81,5 +80,66 @@ describe("browserRelayCredential", () => {
       RelayAuthenticationError,
     );
     expect(localFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("getToken throws error when relay server fails with a 400", async () => {
+    const mockCreateCredentialResponse = {
+      id: "1",
+    };
+
+    const localFetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockCreateCredentialResponse),
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: "Bad request" }),
+        }),
+      );
+
+    vi.stubGlobal("fetch", localFetch);
+
+    const credential = createBrowserRelayCredential();
+
+    await expect(() => credential.getToken("scope1")).rejects.toThrowError(
+      RelayAuthenticationError,
+    );
+    expect(localFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("getToken throws error when relay server fails with a 500", async () => {
+    const mockCreateCredentialResponse = {
+      id: "1",
+    };
+
+    const localFetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockCreateCredentialResponse),
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+        }),
+      );
+
+    vi.stubGlobal("fetch", localFetch);
+
+    const credential = createBrowserRelayCredential();
+
+    await expect(() => credential.getToken("scope1")).rejects.toThrowError(
+      RelayAuthenticationError,
+    );
+    expect(localFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/sdk/test-utils/test-credential/test/browserRelayCredential.spec.ts
+++ b/sdk/test-utils/test-credential/test/browserRelayCredential.spec.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AccessToken } from "@azure/core-auth";
+import { createBrowserRelayCredential } from "../src/browserRelayCredential.js";
+import { describe, it, assert, expect, vi } from "vitest";
+
+describe("browserRelayCredential", () => {
+  it("createBrowserRelayCredential", async () => {
+    // Mock the fetch function.
+    const mockCreateCredentialResponse = {
+      id: "1",
+    };
+
+    const mockAccessTokenResponse: AccessToken = {
+      token: "123",
+      expiresOnTimestamp: Date.now() + 3600 * 1000,
+      tokenType: "Bearer",
+    };
+
+    const localFetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockCreateCredentialResponse),
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockAccessTokenResponse),
+        }),
+      );
+
+    vi.stubGlobal("fetch", localFetch);
+
+    const credential = createBrowserRelayCredential();
+    const token = await credential.getToken("scope1");
+
+    assert.equal(token!.token, "123");
+    assert.equal(token!.tokenType, "Bearer");
+    expect(localFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/sdk/test-utils/test-credential/test/index.spec.ts
+++ b/sdk/test-utils/test-credential/test/index.spec.ts
@@ -1,4 +1,0 @@
-import { describe, it, assert } from "vitest";
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.

--- a/sdk/test-utils/test-credential/test/index.spec.ts
+++ b/sdk/test-utils/test-credential/test/index.spec.ts
@@ -1,2 +1,4 @@
+import { describe, it, assert } from "vitest";
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.

--- a/sdk/test-utils/test-credential/test/noOpCredential.spec.ts
+++ b/sdk/test-utils/test-credential/test/noOpCredential.spec.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import { NoOpCredential } from "../src/noOpCredential.js";
+
+describe("NoOpCredential", () => {
+  it("getToken", async () => {
+    const credential = new NoOpCredential();
+
+    const token = await credential.getToken();
+
+    assert.equal(token.token, "SecretPlaceholder");
+    assert(token.expiresOnTimestamp <= Date.now() + 86400 * 1000);
+  });
+});

--- a/sdk/test-utils/test-credential/tsconfig.browser.config.json
+++ b/sdk/test-utils/test-credential/tsconfig.browser.config.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./.tshy/build.json",
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.mts",
+    "./test/**/*.spec.ts",
+    "./test/**/*.mts"
+  ],
+  "exclude": [
+    "./test/**/node/**/*.ts"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist-test/browser",
+    "rootDir": ".",
+    "skipLibCheck": true
+  }
+}

--- a/sdk/test-utils/test-credential/tsconfig.browser.config.json
+++ b/sdk/test-utils/test-credential/tsconfig.browser.config.json
@@ -1,10 +1,3 @@
 {
-  "extends": "./.tshy/build.json",
-  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts", "./test/**/*.mts"],
-  "exclude": ["./test/**/node/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist-test/browser",
-    "rootDir": ".",
-    "skipLibCheck": true
-  }
+  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
 }

--- a/sdk/test-utils/test-credential/tsconfig.browser.config.json
+++ b/sdk/test-utils/test-credential/tsconfig.browser.config.json
@@ -1,14 +1,7 @@
 {
   "extends": "./.tshy/build.json",
-  "include": [
-    "./src/**/*.ts",
-    "./src/**/*.mts",
-    "./test/**/*.spec.ts",
-    "./test/**/*.mts"
-  ],
-  "exclude": [
-    "./test/**/node/**/*.ts"
-  ],
+  "include": ["./src/**/*.ts", "./src/**/*.mts", "./test/**/*.spec.ts", "./test/**/*.mts"],
+  "exclude": ["./test/**/node/**/*.ts"],
   "compilerOptions": {
     "outDir": "./dist-test/browser",
     "rootDir": ".",

--- a/sdk/test-utils/test-credential/tsconfig.json
+++ b/sdk/test-utils/test-credential/tsconfig.json
@@ -1,17 +1,7 @@
 {
-  "extends": "../../../tsconfig",
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "rootDir": "."
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.mts",
-    "src/**/*.cts",
-    "samples-dev/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.mts",
-    "test/**/*.cts"
+  "references": [
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/sdk/test-utils/test-credential/tsconfig.json
+++ b/sdk/test-utils/test-credential/tsconfig.json
@@ -1,8 +1,17 @@
 {
   "extends": "../../../tsconfig",
   "compilerOptions": {
-    "outDir": "./dist-esm",
-    "declarationDir": "./types/latest"
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "."
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.mts",
+    "src/**/*.cts",
+    "samples-dev/**/*.ts",
+    "test/**/*.ts",
+    "test/**/*.mts",
+    "test/**/*.cts"
+  ]
 }

--- a/sdk/test-utils/test-credential/tsconfig.samples.json
+++ b/sdk/test-utils/test-credential/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.samples.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-tools/test-credential": ["./dist/esm"]
+    }
+  }
+}

--- a/sdk/test-utils/test-credential/tsconfig.src.json
+++ b/sdk/test-utils/test-credential/tsconfig.src.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.lib.json"
+}

--- a/sdk/test-utils/test-credential/tsconfig.test.json
+++ b/sdk/test-utils/test-credential/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"],
+  "compilerOptions": {
+    "lib": ["DOM"]
+  }
+}

--- a/sdk/test-utils/test-credential/vitest.browser.config.ts
+++ b/sdk/test-utils/test-credential/vitest.browser.config.ts
@@ -1,0 +1,17 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "../../../vitest.browser.shared.config.ts";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      include: [
+        "dist-test/browser/test/**/*.spec.js",
+      ],
+    },
+  }),
+);

--- a/sdk/test-utils/test-credential/vitest.config.ts
+++ b/sdk/test-utils/test-credential/vitest.config.ts
@@ -1,0 +1,15 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "../../../vitest.shared.config.ts";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      include: ["test/**/*.spec.ts"],
+    },
+  }),
+);

--- a/sdk/test-utils/test-credential/vitest.config.ts
+++ b/sdk/test-utils/test-credential/vitest.config.ts
@@ -2,14 +2,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
-    test: {
-      include: ["test/**/*.spec.ts"],
-    },
-  }),
-);
+export default viteConfig;

--- a/sdk/test-utils/test-credential/vitest.esm.config.ts
+++ b/sdk/test-utils/test-credential/vitest.esm.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig } from "vitest/config";
+import vitestConfig from "./vitest.config.ts";
+import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
+
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig
+);


### PR DESCRIPTION
### Packages impacted by this PR

- @azure-tools/test-credential

### Issues associated with this PR

- https://github.com/Azure/azure-sdk-for-js/issues/31338

### Describe the problem that is addressed by this PR

Migrates @azure-tools/test-credential to ESM/vitest via automation.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
