### PR TITLE
[core] fix js - core build

### DIFF
--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -367,6 +367,8 @@ export type RequestBodyType = NodeJS.ReadableStream | (() => NodeJS.ReadableStre
 // @public
 export class RestError extends Error {
     constructor(message: string, options?: RestErrorOptions);
+    // (undocumented)
+    [x: symbol]: () => string;
     code?: string;
     details?: unknown;
     static readonly PARSE_ERROR: string;

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -2951,7 +2951,7 @@ index 25cf55a..685eaed 100644
  
  /**
 diff --git a/src/util/file.ts b/src/util/file.ts
-index 48d09e6..73d19de 100644
+index 48d09e6..65c0e25 100644
 --- a/src/util/file.ts
 +++ b/src/util/file.ts
 @@ -1,7 +1,7 @@
@@ -2963,16 +2963,6 @@ index 48d09e6..73d19de 100644
  import { isNodeReadableStream } from "./typeGuards.js";
  
  /**
-@@ -42,9 +42,6 @@ const unimplementedMethods = {
-   arrayBuffer: () => {
-     throw new Error("Not implemented");
-   },
--  bytes: () => {
--    throw new Error("Not implemented");
--  },
-   slice: () => {
-     throw new Error("Not implemented");
-   },
 diff --git a/src/util/helpers.ts b/src/util/helpers.ts
 index f6819e8..7272d5d 100644
 --- a/src/util/helpers.ts

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -402,6 +402,8 @@ export interface ResourceMethods<TResponse = PromiseLike<PathUncheckedResponse>>
 // @public
 export class RestError extends Error {
     constructor(message: string, options?: RestErrorOptions);
+    // (undocumented)
+    [x: symbol]: () => string;
     code?: string;
     details?: unknown;
     static readonly PARSE_ERROR: string;

--- a/sdk/core/ts-http-runtime/src/util/file.ts
+++ b/sdk/core/ts-http-runtime/src/util/file.ts
@@ -42,6 +42,9 @@ const unimplementedMethods = {
   arrayBuffer: () => {
     throw new Error("Not implemented");
   },
+  bytes: () => {
+    throw new Error("Not implemented");
+  },
   slice: () => {
     throw new Error("Not implemented");
   },


### PR DESCRIPTION
Document Intelligence bumping its `typescript` dev dependency version to
~5.7.2, and caused some other packages to also use ~5.7.2.  This leads to the
build error in ts-http-runtime, where newer version of lib.dom.d.ts expects
`bytes` property in `File` type.

`bytes` property was added previously in PR
https://github.com/Azure/azure-sdk-for-js/pull/31990, but got removed in PR
https://github.com/Azure/azure-sdk-for-js/pull/31627 maybe due to bad merge?

It also seems to be a pnpm or rush bug that the pnpm-lock.yaml file have
typescript@5.7.2 for other packages that depends on ~5.6.2, for example,
ts-http-runtime:

https://github.com/Azure/azure-sdk-for-js/blob/8a7d4e90ac3795b0494653eb04cebd6bc0f3213d/common/config/rush/pnpm-lock.yaml#L19848

This also results in api.md changes for RestError's `[custom]` logging
method.

While we investigate further into that, this PR should restore
js - core pipeline to green status.