### PR TITLE
[dev-tool] Fix source fixups per tsconfig changes

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-source.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-source.ts
@@ -81,18 +81,15 @@ export default leafCommand(commandInfo, async ({ "package-name": packageName }) 
 
   const projectFile = resolve(projectFolder, "tsconfig.json");
 
-  const projectFileContents = await readFile(projectFile, "utf-8");
-  const projectFileJSON = JSON.parse(projectFileContents);
-  const module = projectFileJSON.compilerOptions.module;
-  const moduleResolution = projectFileJSON.compilerOptions.moduleResolution;
-
-  if (module !== "NodeNext" || moduleResolution !== "NodeNext") {
-    log.info("Package does not use NodeNext module resolution. Skipping.");
-    return true;
-  }
+  const skipPatterns = [/^vitest.*\.config\.ts$/];
 
   const tsProject = new Project({ tsConfigFilePath: projectFile });
   for (const sourceFile of tsProject.getSourceFiles()) {
+    // Skip config files
+    if (skipPatterns.some((pattern) => pattern.test(sourceFile.getBaseName()))) {
+      continue;
+    }
+
     fixSourceFile(sourceFile);
     await sourceFile.save();
   }


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Fixes the source migration to not look for the `NodeNext` but to make the migration.  Also fixes the idempotency of the migration for config files.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
