### PR TITLE
[dev-tool] fix test and linting

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/create-migration.ts
+++ b/common/tools/dev-tool/src/commands/admin/create-migration.ts
@@ -72,7 +72,6 @@ export default leafCommand(commandInfo, async (options) => {
   let id = options.name ?? (await prompt("Migration Id: "));
   let migrationFile = path.resolve(__dirname, "..", "..", "migrations", ...id.split("/")) + ".ts";
   // Need to check that the id is a simple identifier that only contains alphanumeric characters, underscores, dashes, and slashes.
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     let failed = false;
     if (!/^[a-zA-Z0-9_\-/]+$/.test(id)) {

--- a/common/tools/dev-tool/src/commands/migrate.ts
+++ b/common/tools/dev-tool/src/commands/migrate.ts
@@ -354,7 +354,7 @@ async function runMigrations(pending: Migration[], project: ProjectInfo): Promis
 async function onMigrationSuccess(
   project: ProjectInfo,
   migration: Migration,
-  quiet: boolean = false, // eslint-disable-line @typescript-eslint/no-inferrable-types
+  quiet: boolean = false,
 ): Promise<void> {
   await updateMigrationDate(project, migration);
 
@@ -372,7 +372,7 @@ async function onMigrationSuccess(
 async function onMigrationSkipped(
   project: ProjectInfo,
   migration: Migration,
-  quiet: boolean = false, // eslint-disable-line @typescript-eslint/no-inferrable-types
+  quiet: boolean = false,
 ): Promise<void> {
   await updateMigrationDate(project, migration);
 
@@ -451,10 +451,7 @@ function printMigrationSuspendedWarning(migration: Migration, status: MigrationS
  * @param project - the working project
  * @returns true on success, otherwise false
  */
-async function abortMigration(
-  project: ProjectInfo,
-  quiet: boolean = false, // eslint-disable-line @typescript-eslint/no-inferrable-types
-): Promise<boolean> {
+async function abortMigration(project: ProjectInfo, quiet: boolean = false): Promise<boolean> {
   const suspendedMigration = await validateSuspendedState(project);
   if (!suspendedMigration) return false;
 

--- a/common/tools/dev-tool/src/config/rollup.base.config.ts
+++ b/common/tools/dev-tool/src/config/rollup.base.config.ts
@@ -168,7 +168,6 @@ export function sourcemaps() {
         debug("no map for file ", id);
         return { code, map: null };
       } catch (e) {
-        // eslint-disable-next-line no-inner-declarations
         function toString(error: unknown): string {
           return error instanceof Error ? (error.stack ?? error.toString()) : JSON.stringify(error);
         }

--- a/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.6.2",
     "rimraf": "latest"
   }
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.6.2",
     "rimraf": "latest"
   }
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.6.2",
     "rimraf": "latest"
   }
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.6.2",
     "rimraf": "latest"
   }
 }

--- a/common/tools/dev-tool/test/samples/files/expectations/special-characters/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/special-characters/typescript/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.6.2",
     "rimraf": "latest"
   }
 }


### PR DESCRIPTION
- some eslint-disable directives no long apply
- dev-tool stays at typescript@~5.6.2 but its unit-test baseline got upgraded incorrectly in the last NO_CI commit