### PR TITLE
[eslint] restore custom rules for bin scripts

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/eslint.config.mjs
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/eslint.config.mjs
@@ -2,11 +2,11 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 
 export default azsdkEslint.config([
   {
-    // shebang needs to come first
-    files: ["src/index.ts"],
+    files: ["src/bin/execute.ts"],
     rules: {
       "n/no-process-exit": "off",
       "n/hashbang": "off",
+      // shebang needs to come first
       "@azure/azure-sdk/github-source-headers": "off",
     },
   },

--- a/sdk/formrecognizer/ai-form-recognizer/eslint.config.mjs
+++ b/sdk/formrecognizer/ai-form-recognizer/eslint.config.mjs
@@ -2,11 +2,11 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 
 export default azsdkEslint.config([
   {
-    // shebang needs to come first
-    files: ["src/index.ts"],
+    files: ["src/bin/gen-model.ts"],
     rules: {
       "n/no-process-exit": "off",
       "n/hashbang": "off",
+      // shebang needs to come first
       "@azure/azure-sdk/github-source-headers": "off",
     },
   },


### PR DESCRIPTION
The custom rules to suppress errors/warnings for bin scripts were removed in
previous commits. This PR restores them.