### PR TITLE
[dev-tool] use "/" in relative paths in published sample README

### DIFF
--- a/common/tools/dev-tool/src/templates/sampleReadme.md.ts
+++ b/common/tools/dev-tool/src/templates/sampleReadme.md.ts
@@ -52,9 +52,9 @@ function fileLinks(info: SampleReadmeConfiguration) {
 
   return filterModules(info)
     .map(({ relativeSourcePath }) => {
-      const sourcePath = info.useTypeScript
-        ? relativeSourcePath
-        : relativeSourcePath.replace(/\.ts$/, ".js");
+      const sourcePath = (
+        info.useTypeScript ? relativeSourcePath : relativeSourcePath.replace(/\.ts$/, ".js")
+      ).replace(path.sep, "/");
       return `[${sampleLinkTag(
         relativeSourcePath,
       )}]: https://github.com/Azure/azure-sdk-for-js/blob/main/${packageSamplesPathFragment}/${sourcePath}`;
@@ -112,9 +112,9 @@ function filterModules(info: SampleReadmeConfiguration): SampleReadmeConfigurati
  */
 function table(info: SampleReadmeConfiguration) {
   const contents = filterModules(info).map(({ summary, relativeSourcePath }) => {
-    const fileName = info.useTypeScript
-      ? relativeSourcePath
-      : relativeSourcePath.replace(/\.ts$/, ".js");
+    const fileName = (
+      info.useTypeScript ? relativeSourcePath : relativeSourcePath.replace(/\.ts$/, ".js")
+    ).replace(path.sep, "/");
     if (summary && summary.includes("|")) {
       summary = summary.replace(/\|/g, "\\|");
     }


### PR DESCRIPTION
On Windows, relative path string has "\" as path separator, which leads to broken GitHub links to the sample code files. This PR normalizes path separator in relative paths to "/" when generate file names and links in sample README.
