### PR TITLE
Made User Agent configurable post Cosmos client creation ; Added a new header x-ms-useragent

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -170,8 +170,6 @@ export type ClientConfigDiagnostic = {
 export class ClientContext {
     constructor(cosmosClientOptions: CosmosClientOptions, globalEndpointManager: GlobalEndpointManager, clientConfig: ClientConfigDiagnostic, diagnosticLevel: CosmosDbDiagnosticLevel);
     // (undocumented)
-    appendToUserAgent(userAgentSuffix: string): void;
-    // (undocumented)
     batch<T>({ body, path, partitionKey, resourceId, options, diagnosticNode, }: {
         body: T;
         path: string;
@@ -291,6 +289,8 @@ export class ClientContext {
         partitionKey?: PartitionKey;
         diagnosticNode: DiagnosticNodeInternal;
     }): Promise<Response_2<T & Resource>>;
+    // (undocumented)
+    updateHostFramework(hostFramework: string): void;
     // (undocumented)
     upsert<T, U = T>({ body, path, resourceType, resourceId, options, partitionKey, diagnosticNode, }: {
         body: T;
@@ -689,7 +689,6 @@ export class Containers {
 export class CosmosClient {
     constructor(connectionString: string);
     constructor(options: CosmosClientOptions);
-    appendToUserAgent(userAgentSuffix: string): Promise<void>;
     database(id: string): Database;
     readonly databases: Databases;
     dispose(): void;
@@ -702,6 +701,7 @@ export class CosmosClient {
     getWriteEndpoints(): Promise<readonly string[]>;
     offer(id: string): Offer;
     readonly offers: Offers;
+    updateHostFramework(hostFramework: string): Promise<void>;
 }
 
 // @public (undocumented)
@@ -718,6 +718,7 @@ export interface CosmosClientOptions {
     // (undocumented)
     diagnosticLevel?: CosmosDbDiagnosticLevel;
     endpoint?: string;
+    hostFramework?: string;
     httpClient?: HttpClient;
     key?: string;
     permissionFeed?: PermissionDefinition[];

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -290,6 +290,8 @@ export class ClientContext {
         diagnosticNode: DiagnosticNodeInternal;
     }): Promise<Response_2<T & Resource>>;
     // (undocumented)
+    updateUserAgent(userAgentSuffix: string): void;
+    // (undocumented)
     upsert<T, U = T>({ body, path, resourceType, resourceId, options, partitionKey, diagnosticNode, }: {
         body: T;
         path: string;
@@ -699,6 +701,7 @@ export class CosmosClient {
     getWriteEndpoints(): Promise<readonly string[]>;
     offer(id: string): Offer;
     readonly offers: Offers;
+    updateUserAgent(userAgentSuffix: string): Promise<void>;
 }
 
 // @public (undocumented)
@@ -706,6 +709,7 @@ export interface CosmosClientOptions {
     aadCredentials?: TokenCredential;
     agent?: Agent;
     connectionPolicy?: ConnectionPolicy;
+    connectionString?: string;
     consistencyLevel?: keyof typeof ConsistencyLevel;
     // Warning: (ae-forgotten-export) The symbol "CosmosHeaders_2" needs to be exported by the entry point index.d.ts
     //
@@ -713,7 +717,7 @@ export interface CosmosClientOptions {
     defaultHeaders?: CosmosHeaders_2;
     // (undocumented)
     diagnosticLevel?: CosmosDbDiagnosticLevel;
-    endpoint: string;
+    endpoint?: string;
     httpClient?: HttpClient;
     key?: string;
     permissionFeed?: PermissionDefinition[];

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -280,8 +280,6 @@ export class ClientContext {
     // (undocumented)
     recordDiagnostics(diagnostic: CosmosDiagnostics): void;
     // (undocumented)
-    refreshUserAgent(hostFramework: string): void;
-    // (undocumented)
     replace<T>({ body, path, resourceType, resourceId, options, partitionKey, diagnosticNode, }: {
         body: any;
         path: string;

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -280,6 +280,8 @@ export class ClientContext {
     // (undocumented)
     recordDiagnostics(diagnostic: CosmosDiagnostics): void;
     // (undocumented)
+    refreshUserAgent(hostFramework: string): void;
+    // (undocumented)
     replace<T>({ body, path, resourceType, resourceId, options, partitionKey, diagnosticNode, }: {
         body: any;
         path: string;
@@ -289,8 +291,6 @@ export class ClientContext {
         partitionKey?: PartitionKey;
         diagnosticNode: DiagnosticNodeInternal;
     }): Promise<Response_2<T & Resource>>;
-    // (undocumented)
-    updateHostFramework(hostFramework: string): void;
     // (undocumented)
     upsert<T, U = T>({ body, path, resourceType, resourceId, options, partitionKey, diagnosticNode, }: {
         body: T;
@@ -435,6 +435,7 @@ export const Constants: {
         ContentEncoding: string;
         CharacterSet: string;
         UserAgent: string;
+        CustomUserAgent: string;
         IfModifiedSince: string;
         IfMatch: string;
         IfNoneMatch: string;
@@ -701,7 +702,6 @@ export class CosmosClient {
     getWriteEndpoints(): Promise<readonly string[]>;
     offer(id: string): Offer;
     readonly offers: Offers;
-    updateHostFramework(hostFramework: string): Promise<void>;
 }
 
 // @public (undocumented)
@@ -718,7 +718,6 @@ export interface CosmosClientOptions {
     // (undocumented)
     diagnosticLevel?: CosmosDbDiagnosticLevel;
     endpoint?: string;
-    hostFramework?: string;
     httpClient?: HttpClient;
     key?: string;
     permissionFeed?: PermissionDefinition[];

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -170,6 +170,8 @@ export type ClientConfigDiagnostic = {
 export class ClientContext {
     constructor(cosmosClientOptions: CosmosClientOptions, globalEndpointManager: GlobalEndpointManager, clientConfig: ClientConfigDiagnostic, diagnosticLevel: CosmosDbDiagnosticLevel);
     // (undocumented)
+    appendToUserAgent(userAgentSuffix: string): void;
+    // (undocumented)
     batch<T>({ body, path, partitionKey, resourceId, options, diagnosticNode, }: {
         body: T;
         path: string;
@@ -289,8 +291,6 @@ export class ClientContext {
         partitionKey?: PartitionKey;
         diagnosticNode: DiagnosticNodeInternal;
     }): Promise<Response_2<T & Resource>>;
-    // (undocumented)
-    updateUserAgent(userAgentSuffix: string): void;
     // (undocumented)
     upsert<T, U = T>({ body, path, resourceType, resourceId, options, partitionKey, diagnosticNode, }: {
         body: T;
@@ -689,6 +689,7 @@ export class Containers {
 export class CosmosClient {
     constructor(connectionString: string);
     constructor(options: CosmosClientOptions);
+    appendToUserAgent(userAgentSuffix: string): Promise<void>;
     database(id: string): Database;
     readonly databases: Databases;
     dispose(): void;
@@ -701,7 +702,6 @@ export class CosmosClient {
     getWriteEndpoints(): Promise<readonly string[]>;
     offer(id: string): Offer;
     readonly offers: Offers;
-    updateUserAgent(userAgentSuffix: string): Promise<void>;
 }
 
 // @public (undocumented)

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -38,7 +38,6 @@ import type { DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { DefaultDiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { randomUUID } from "@azure/core-util";
-import { getUserAgent } from "./common/platform";
 
 const logger: AzureLogger = createClientLogger("ClientContext");
 
@@ -981,8 +980,11 @@ export class ClientContext {
   }
 
   public updateUserAgent(userAgentSuffix: string): void {
-    this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] =
-      getUserAgent(userAgentSuffix);
+    const updatedUserAgent =
+      this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] +
+      " " +
+      userAgentSuffix;
+    this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] = updatedUserAgent;
     this.clientConfig.userAgentSuffix = userAgentSuffix;
   }
 }

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -980,6 +980,9 @@ export class ClientContext {
     return this.clientConfig;
   }
 
+  /**
+   * @internal
+   */
   public refreshUserAgent(hostFramework: string): void {
     const updatedUserAgent = getUserAgent(this.cosmosClientOptions.userAgentSuffix, hostFramework);
     this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] = updatedUserAgent;

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -979,7 +979,7 @@ export class ClientContext {
     return this.clientConfig;
   }
 
-  public updateUserAgent(userAgentSuffix: string): void {
+  public appendToUserAgent(userAgentSuffix: string): void {
     const updatedUserAgent =
       this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] +
       " " +

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -38,6 +38,7 @@ import type { DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { DefaultDiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { randomUUID } from "@azure/core-util";
+import { getUserAgent } from "./common/platform";
 
 const logger: AzureLogger = createClientLogger("ClientContext");
 
@@ -977,5 +978,11 @@ export class ClientContext {
 
   public getClientConfig(): ClientConfigDiagnostic {
     return this.clientConfig;
+  }
+
+  public updateUserAgent(userAgentSuffix: string): void {
+    this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] =
+      getUserAgent(userAgentSuffix);
+    this.clientConfig.userAgentSuffix = userAgentSuffix;
   }
 }

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -980,16 +980,10 @@ export class ClientContext {
     return this.clientConfig;
   }
 
-  private refreshUserAgent(): void {
-    const updatedUserAgent = getUserAgent(
-      this.cosmosClientOptions.userAgentSuffix,
-      this.cosmosClientOptions.hostFramework,
-    );
+  public refreshUserAgent(hostFramework: string): void {
+    const updatedUserAgent = getUserAgent(this.cosmosClientOptions.userAgentSuffix, hostFramework);
     this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] = updatedUserAgent;
-  }
-
-  public updateHostFramework(hostFramework: string): void {
-    this.cosmosClientOptions.hostFramework = hostFramework;
-    this.refreshUserAgent();
+    this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.CustomUserAgent] =
+      updatedUserAgent;
   }
 }

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -38,6 +38,7 @@ import type { DiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { DefaultDiagnosticFormatter } from "./diagnostics/DiagnosticFormatter";
 import { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel";
 import { randomUUID } from "@azure/core-util";
+import { getUserAgent } from "./common/platform";
 
 const logger: AzureLogger = createClientLogger("ClientContext");
 
@@ -979,12 +980,16 @@ export class ClientContext {
     return this.clientConfig;
   }
 
-  public appendToUserAgent(userAgentSuffix: string): void {
-    const updatedUserAgent =
-      this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] +
-      " " +
-      userAgentSuffix;
+  private refreshUserAgent(): void {
+    const updatedUserAgent = getUserAgent(
+      this.cosmosClientOptions.userAgentSuffix,
+      this.cosmosClientOptions.hostFramework,
+    );
     this.cosmosClientOptions.defaultHeaders[Constants.HttpHeaders.UserAgent] = updatedUserAgent;
-    this.clientConfig.userAgentSuffix = userAgentSuffix;
+  }
+
+  public updateHostFramework(hostFramework: string): void {
+    this.cosmosClientOptions.hostFramework = hostFramework;
+    this.refreshUserAgent();
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -103,6 +103,7 @@ export class CosmosClient {
 
     optionsOrConnectionString.defaultHeaders[Constants.HttpHeaders.UserAgent] = getUserAgent(
       optionsOrConnectionString.userAgentSuffix,
+      optionsOrConnectionString.hostFramework,
     );
 
     const globalEndpointManager = new GlobalEndpointManager(
@@ -280,10 +281,11 @@ export class CosmosClient {
   }
 
   /**
-   * Append a custom string to the existing SDK user agent.
-   * @param userAgentSuffix - A custom string to append.
+   * Update the host framework. If provided host framework will be used to generate the defualt SDK user agent.
+   * @param hostFramework - A custom string.
+   * @hidden
    */
-  public async appendToUserAgent(userAgentSuffix: string): Promise<void> {
-    this.clientContext.appendToUserAgent(userAgentSuffix);
+  public async updateHostFramework(hostFramework: string): Promise<void> {
+    this.clientContext.updateHostFramework(hostFramework);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -101,10 +101,9 @@ export class CosmosClient {
         optionsOrConnectionString.consistencyLevel;
     }
 
-    optionsOrConnectionString.defaultHeaders[Constants.HttpHeaders.UserAgent] = getUserAgent(
-      optionsOrConnectionString.userAgentSuffix,
-      optionsOrConnectionString.hostFramework,
-    );
+    const userAgent = getUserAgent(optionsOrConnectionString.userAgentSuffix);
+    optionsOrConnectionString.defaultHeaders[Constants.HttpHeaders.UserAgent] = userAgent;
+    optionsOrConnectionString.defaultHeaders[Constants.HttpHeaders.CustomUserAgent] = userAgent;
 
     const globalEndpointManager = new GlobalEndpointManager(
       optionsOrConnectionString,
@@ -283,9 +282,9 @@ export class CosmosClient {
   /**
    * Update the host framework. If provided host framework will be used to generate the defualt SDK user agent.
    * @param hostFramework - A custom string.
-   * @hidden
+   * @internal
    */
   public async updateHostFramework(hostFramework: string): Promise<void> {
-    this.clientContext.updateHostFramework(hostFramework);
+    this.clientContext.refreshUserAgent(hostFramework);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -283,7 +283,7 @@ export class CosmosClient {
    * Update the SDK user agent.
    * @param userAgentSuffix - A custom string to append to the default SDK user agent.
    */
-  public async updateUserAgent(userAgentSuffix: string) {
+  public async updateUserAgent(userAgentSuffix: string): Promise<void> {
     this.clientContext.updateUserAgent(userAgentSuffix);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -280,10 +280,10 @@ export class CosmosClient {
   }
 
   /**
-   * Update the SDK user agent.
-   * @param userAgentSuffix - A custom string to append to the default SDK user agent.
+   * Append a custom string to the existing SDK user agent.
+   * @param userAgentSuffix - A custom string to append.
    */
-  public async updateUserAgent(userAgentSuffix: string): Promise<void> {
-    this.clientContext.updateUserAgent(userAgentSuffix);
+  public async appendToUserAgent(userAgentSuffix: string): Promise<void> {
+    this.clientContext.appendToUserAgent(userAgentSuffix);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -70,8 +70,14 @@ export class CosmosClient {
   constructor(optionsOrConnectionString: string | CosmosClientOptions) {
     if (typeof optionsOrConnectionString === "string") {
       optionsOrConnectionString = parseConnectionString(optionsOrConnectionString);
+    } else if (optionsOrConnectionString.connectionString) {
+      const { endpoint, key } = parseConnectionString(optionsOrConnectionString.connectionString);
+      optionsOrConnectionString.endpoint = endpoint;
+      optionsOrConnectionString.key = key;
     }
-
+    if (!optionsOrConnectionString.endpoint) {
+      throw new Error("Invalid endpoint specified");
+    }
     const endpoint = checkURL(optionsOrConnectionString.endpoint);
     if (!endpoint) {
       throw new Error("Invalid endpoint specified");
@@ -271,5 +277,13 @@ export class CosmosClient {
     if (this.endpointRefresher.unref && typeof this.endpointRefresher.unref === "function") {
       this.endpointRefresher.unref();
     }
+  }
+
+  /**
+   * Update the SDK user agent.
+   * @param userAgentSuffix - A custom string to append to the default SDK user agent.
+   */
+  public async updateUserAgent(userAgentSuffix: string) {
+    this.clientContext.updateUserAgent(userAgentSuffix);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -75,9 +75,7 @@ export class CosmosClient {
       optionsOrConnectionString.endpoint = endpoint;
       optionsOrConnectionString.key = key;
     }
-    if (!optionsOrConnectionString.endpoint) {
-      throw new Error("Invalid endpoint specified");
-    }
+
     const endpoint = checkURL(optionsOrConnectionString.endpoint);
     if (!endpoint) {
       throw new Error("Invalid endpoint specified");

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -20,7 +20,7 @@ export interface Agent {
 
 export interface CosmosClientOptions {
   /** The service endpoint to use to create the client. */
-  endpoint: string;
+  endpoint?: string;
   /** The account master or readonly key */
   key?: string;
   /** An object that contains resources tokens.
@@ -60,4 +60,6 @@ export interface CosmosClientOptions {
   diagnosticLevel?: CosmosDbDiagnosticLevel;
   /** @internal */
   plugins?: PluginConfig[];
+  /** An optional parameter that represents the connection string. Your database connection string can be found in the Azure Portal. */
+  connectionString?: string;
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -62,4 +62,6 @@ export interface CosmosClientOptions {
   plugins?: PluginConfig[];
   /** An optional parameter that represents the connection string. Your database connection string can be found in the Azure Portal. */
   connectionString?: string;
+  /** A custom string used to generate the default SDK user agent. */
+  hostFramework?: string;
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -62,6 +62,4 @@ export interface CosmosClientOptions {
   plugins?: PluginConfig[];
   /** An optional parameter that represents the connection string. Your database connection string can be found in the Azure Portal. */
   connectionString?: string;
-  /** A custom string used to generate the default SDK user agent. */
-  hostFramework?: string;
 }

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -22,6 +22,7 @@ export const Constants = {
     ContentEncoding: "Content-Encoding",
     CharacterSet: "CharacterSet",
     UserAgent: "User-Agent",
+    CustomUserAgent: "x-ms-useragent",
     IfModifiedSince: "If-Modified-Since",
     IfMatch: "If-Match",
     IfNoneMatch: "If-None-Match",

--- a/sdk/cosmosdb/cosmos/src/common/platform.ts
+++ b/sdk/cosmosdb/cosmos/src/common/platform.ts
@@ -6,11 +6,15 @@ import { Constants } from "./constants";
 /**
  * @hidden
  */
-export function getUserAgent(suffix?: string): string {
-  const ua = `${userAgentDetails()} ${Constants.SDKName}/${Constants.SDKVersion}`;
-  if (suffix) {
-    return ua + " " + suffix;
+export function getUserAgent(suffix?: string, hostFramework?: string): string {
+  let ua = `${userAgentDetails()} ${Constants.SDKName}/${Constants.SDKVersion}`;
+  if (hostFramework) {
+    ua = ua + " " + hostFramework;
   }
+  if (suffix) {
+    ua = ua + " " + suffix;
+  }
+
   return ua;
 }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos 

### Issues associated with this PR
#32191 
#20289 

### Describe the problem that is addressed by this PR

Currently there is no way to change user agent once CosmosClient has been created.But with addition of CosmosDB Integrations with AI libraries like Langchain and LlamaIndex, we want to track the adoption. Users can pass the CosmosClient instance itself during initialization of different stores (eg. vectorStore) which leads to default value of user-agent getting used and does not help in tracking adoption of these AI libraries. Also, if connectionString is passed, there is no way to set other CosmosClientOptions.

After merging this PR we will be able to :
1. Update the User Agent string after creating the client.
2. We can pass Connection string in the CosmosClientOptions itself, along with the other configurations during client creation.  
