### PR TITLE
[identity] Fix case-sensitivity for Windows environment variables

### DIFF
--- a/sdk/identity/identity/src/credentials/azureCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.ts
@@ -26,10 +26,10 @@ export const cliCredentialInternals = {
    */
   getSafeWorkingDir(): string {
     if (process.platform === "win32") {
-      if (!process.env.SystemRoot) {
-        throw new Error("Azure CLI credential expects a 'SystemRoot' environment variable");
+      if (!process.env["SYSTEMROOT"]) {
+        throw new Error("Azure CLI credential expects a 'SYSTEMROOT' environment variable");
       }
-      return process.env.SystemRoot;
+      return process.env["SYSTEMROOT"];
     } else {
       return "/bin";
     }

--- a/sdk/identity/identity/src/credentials/azureDeveloperCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureDeveloperCliCredential.ts
@@ -24,12 +24,12 @@ export const developerCliCredentialInternals = {
    */
   getSafeWorkingDir(): string {
     if (process.platform === "win32") {
-      if (!process.env.SystemRoot) {
+      if (!process.env["SYSTEMROOT"]) {
         throw new Error(
-          "Azure Developer CLI credential expects a 'SystemRoot' environment variable",
+          "Azure Developer CLI credential expects a 'SYSTEMROOT' environment variable",
         );
       }
-      return process.env.SystemRoot;
+      return process.env["SYSTEMROOT"];
     } else {
       return "/bin";
     }


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/identity

### Issues associated with this PR

- #32374

### Describe the problem that is addressed by this PR

Fixes the case-sensitivity issue with getting environment variables such as enforcing `SYSTEMROOT` instead of a cased `SystemRoot`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
