### PR TITLE
[eslint-plugin] switch to `parserOptions.projectService`

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/eslint.perftests.config.mjs
+++ b/common/tools/eslint-plugin-azure-sdk/eslint.perftests.config.mjs
@@ -5,7 +5,7 @@ export default tsEsLint.config(
   {
     languageOptions: {
       parserOptions: {
-        project: "./tsconfig.json",
+        projectService: true,
       },
       parser: tsEsLint.parser,
     },

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
@@ -170,7 +170,7 @@ export default (parser: FlatConfig.Parser): FlatConfig.ConfigArray => [
     languageOptions: {
       parser,
       parserOptions: {
-        project: ["./tsconfig.json"],
+        projectService: true,
       },
     },
     rules,

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
@@ -17,14 +17,6 @@ function recommended(plugin: FlatConfig.Plugin, options: { typeChecked: boolean 
     {
       ignores: ["**/generated/**", "**/*.config.{js,cjs,mjs,ts,cts,mts}"],
     },
-    {
-      languageOptions: {
-        parser: typescriptEslint.parser,
-        parserOptions: {
-          project: ["./tsconfig.json"],
-        },
-      },
-    },
     eslint.configs.recommended,
     ...(options.typeChecked
       ? typescriptEslint.configs.recommendedTypeChecked
@@ -59,7 +51,7 @@ export default (plugin: FlatConfig.Plugin) => ({
       languageOptions: {
         parser: typescriptEslint.parser,
         parserOptions: {
-          project: ["./tsconfig.json"],
+          projectService: true,
         },
       },
     },


### PR DESCRIPTION
This address the issue when running `lint:fix` using the first suggestion provided by typescript-eslint

>  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/test/public/utils/recordedClient.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
That TSConfig uses project "references" and doesn't include `<tsconfigRootDir>/test/public/utils/recordedClient.ts` directly, which is not supported by `parserOptions.project`.
Either:
>- Switch to `parserOptions.projectService`
>- Use an ESLint-specific TSConfig
See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#are-typescript-project-references-supported

-------

### Packages impacted by this PR
eslint-plugin

### Issues associated with this PR
#32350