### PR TITLE
[data-tables] Add options to submitTransaction

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fix issue [#28624](https://github.com/Azure/azure-sdk-for-js/issues/28624) where request options were not available when submitting a transaction operation.
 
 ### Other Changes
 

--- a/sdk/tables/data-tables/review/data-tables.api.md
+++ b/sdk/tables/data-tables/review/data-tables.api.md
@@ -246,7 +246,7 @@ export class TableClient {
     listEntities<T extends object = Record<string, unknown>>(options?: ListTableEntitiesOptions): PagedAsyncIterableIterator<TableEntityResult<T>, TableEntityResultPage<T>>;
     pipeline: Pipeline;
     setAccessPolicy(tableAcl: SignedIdentifier[], options?: OperationOptions): Promise<SetAccessPolicyResponse>;
-    submitTransaction(actions: TransactionAction[]): Promise<TableTransactionResponse>;
+    submitTransaction(actions: TransactionAction[], options?: OperationOptions): Promise<TableTransactionResponse>;
     readonly tableName: string;
     updateEntity<T extends object>(entity: TableEntity<T>, mode?: UpdateMode, options?: UpdateTableEntityOptions): Promise<UpdateEntityResponse>;
     upsertEntity<T extends object>(entity: TableEntity<T>, mode?: UpdateMode, options?: OperationOptions): Promise<UpsertEntityResponse>;

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -855,8 +855,11 @@ export class TableClient {
    * @param actions - tuple that contains the action to perform, and the entity to perform the action with
    * @param options - Options for the request.
    */
-  // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
-  public async submitTransaction(actions: TransactionAction[], options: OperationOptions = {}): Promise<TableTransactionResponse> {
+  public async submitTransaction(
+    actions: TransactionAction[],
+    // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
+    options: OperationOptions = {},
+  ): Promise<TableTransactionResponse> {
     const partitionKey = actions[0][1].partitionKey;
     const transactionId = Uuid.generateUuid();
     const changesetId = Uuid.generateUuid();

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -853,8 +853,9 @@ export class TableClient {
    * ```
    *
    * @param actions - tuple that contains the action to perform, and the entity to perform the action with
+   * @param options - Options for the request.
    */
-  public async submitTransaction(actions: TransactionAction[]): Promise<TableTransactionResponse> {
+  public async submitTransaction(actions: TransactionAction[], options: OperationOptions = {}): Promise<TableTransactionResponse> {
     const partitionKey = actions[0][1].partitionKey;
     const transactionId = Uuid.generateUuid();
     const changesetId = Uuid.generateUuid();
@@ -888,7 +889,7 @@ export class TableClient {
       }
     }
 
-    return transactionClient.submitTransaction();
+    return transactionClient.submitTransaction(options);
   }
 
   /**

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -855,6 +855,7 @@ export class TableClient {
    * @param actions - tuple that contains the action to perform, and the entity to perform the action with
    * @param options - Options for the request.
    */
+  // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
   public async submitTransaction(actions: TransactionAction[], options: OperationOptions = {}): Promise<TableTransactionResponse> {
     const partitionKey = actions[0][1].partitionKey;
     const transactionId = Uuid.generateUuid();

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -274,7 +274,9 @@ export class InternalTableTransaction {
    * Submits the operations in the transaction
    * @param options - Options for the request.
    */
-  public async submitTransaction(options: OperationOptions = {}): Promise<TableTransactionResponse> {
+  public async submitTransaction(
+    options: OperationOptions = {},
+  ): Promise<TableTransactionResponse> {
     await Promise.all(this.state.pendingOperations);
     const body = getTransactionHttpRequestBody(
       this.state.bodyParts,

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -289,11 +289,11 @@ export class InternalTableTransaction {
       options,
       async (updatedOptions) => {
         const request = createPipelineRequest({
+          ...updatedOptions,
           url: this.url,
           method: "POST",
           body,
           headers: createHttpHeaders(headers),
-          tracingOptions: updatedOptions.tracingOptions,
           allowInsecureConnection: this.allowInsecureConnection,
         });
 

--- a/sdk/tables/data-tables/src/TableTransaction.ts
+++ b/sdk/tables/data-tables/src/TableTransaction.ts
@@ -272,8 +272,9 @@ export class InternalTableTransaction {
 
   /**
    * Submits the operations in the transaction
+   * @param options - Options for the request.
    */
-  public async submitTransaction(): Promise<TableTransactionResponse> {
+  public async submitTransaction(options: OperationOptions = {}): Promise<TableTransactionResponse> {
     await Promise.all(this.state.pendingOperations);
     const body = getTransactionHttpRequestBody(
       this.state.bodyParts,
@@ -285,7 +286,7 @@ export class InternalTableTransaction {
 
     return tracingClient.withSpan(
       "TableTransaction.submitTransaction",
-      {} as OperationOptions,
+      options,
       async (updatedOptions) => {
         const request = createPipelineRequest({
           url: this.url,


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/data-tables`

### Issues associated with this PR

Fixes #28624

### Describe the problem that is addressed by this PR

`submitTransaction` on `TableClient` didn't allow for passing request-level options, such as an `AbortSignal` to cancel the request.

