### PR TITLE
[engsys] Fix rush-runner

### DIFF
--- a/eng/tools/rush-runner/index.js
+++ b/eng/tools/rush-runner/index.js
@@ -154,50 +154,43 @@ const rushx_runner_path = path.join(baseDir, "common/scripts/install-run-rushx.j
 let exitCode = 0;
 if (serviceDirs.length === 0) {
   exitCode = spawnNode(baseDir, "common/scripts/install-run-rush.js", action, ...rushParams);
-  if (exitCode) {
-    process.exit(exitCode);
-  }
 } else {
   switch (actionComponents[0]) {
     case "build":
-      rushRunAllWithDirection(packagesWithDirection);
+      exitCode = rushRunAllWithDirection(packagesWithDirection);
       break;
 
     case "test":
     case "unit-test":
     case "integration-test":
-      var rushCommandFlag = "--impacted-by";
+      let rushCommandFlag = "--impacted-by";
 
       if (isReducedTestScopeEnabled || serviceDirs.length > 1) {
         // If a service is configured to have reduced test matrix then run rush test only for those projects
         rushCommandFlag = "--only";
       }
 
-      rushRunAll(rushCommandFlag, packageNames);
+      exitCode = rushRunAll(rushCommandFlag, packageNames);
       break;
 
     case "lint":
       for (const packageDir of packageDirs) {
-        const code = spawnNode(packageDir, rushx_runner_path, action);
-        if (code) {
-          exitCode = code;
-        }
+        exitCode = spawnNode(packageDir, rushx_runner_path, action);
       }
       break;
     case "check-format":
       for (const packageDir of packageDirs) {
-        const code = spawnNode(packageDir, rushx_runner_path, action);
-        if (code !== 0) {
+        exitCode = spawnNode(packageDir, rushx_runner_path, action);
+        if (exitCode !== 0) {
           console.log(
             `\nInvoke "rushx format" inside ${tryGetPkgRelativePath(packageDir)} to fix formatting\n`,
           );
-          exitCode = code;
         }
       }
       break;
 
     default:
-      rushRunAll("--to", packageNames);
+      exitCode = rushRunAll("--to", packageNames);
       break;
   }
 }

--- a/eng/tools/rush-runner/test/helpers.spec.js
+++ b/eng/tools/rush-runner/test/helpers.spec.js
@@ -2,7 +2,7 @@ import { assert, describe, it } from "vitest";
 import { getDirectionMappedPackages, reducedDependencyTestMatrix } from "../helpers.js";
 
 describe("getDirectionMappedPackages", () => {
-  it("should use --to reduced core scope for changed core package", () => {
+  it.only("should use --to reduced core scope for changed core package", () => {
     const changed = ["@azure/core-client"];
     const mapped = getDirectionMappedPackages(changed, ["unit-test"]);
 

--- a/eng/tools/rush-runner/test/helpers.spec.js
+++ b/eng/tools/rush-runner/test/helpers.spec.js
@@ -2,7 +2,7 @@ import { assert, describe, it } from "vitest";
 import { getDirectionMappedPackages, reducedDependencyTestMatrix } from "../helpers.js";
 
 describe("getDirectionMappedPackages", () => {
-  it.only("should use --to reduced core scope for changed core package", () => {
+  it("should use --to reduced core scope for changed core package", () => {
     const changed = ["@azure/core-client"];
     const mapped = getDirectionMappedPackages(changed, ["unit-test"]);
 

--- a/sdk/eventgrid/eventgrid-namespaces/samples/v1/javascript/namespaceActivities.js
+++ b/sdk/eventgrid/eventgrid-namespaces/samples/v1/javascript/namespaceActivities.js
@@ -1,17 +1,6 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-/**
- * @summary Publish and Receive events to Event Grid.
- */
-
 const { EventGridSenderClient, EventGridReceiverClient } = require("@azure/eventgrid-namespaces");
 const { AzureKeyCredential } = require("@azure/core-auth");
-
-const dotenv = require("dotenv");
-
-// Load the .env file if it exists
-dotenv.config();
+require("dotenv/config");
 
 const endpoint = process.env["EVENT_GRID_NAMESPACES_ENDPOINT"] ?? "https://endpoint";
 const key = process.env["EVENT_GRID_NAMESPACES_KEY"] ?? "api_key";

--- a/sdk/eventgrid/eventgrid-namespaces/samples/v1/javascript/package.json
+++ b/sdk/eventgrid/eventgrid-namespaces/samples/v1/javascript/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@azure/eventgrid-namespaces": "latest",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.7.0"
+    "@azure/core-auth": "^1.9.0"
   }
 }

--- a/sdk/eventgrid/eventgrid-namespaces/samples/v1/typescript/package.json
+++ b/sdk/eventgrid/eventgrid-namespaces/samples/v1/typescript/package.json
@@ -32,11 +32,11 @@
   "dependencies": {
     "@azure/eventgrid-namespaces": "latest",
     "dotenv": "latest",
-    "@azure/core-auth": "^1.7.0"
+    "@azure/core-auth": "^1.9.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.6.2",
     "rimraf": "latest"
   }
 }

--- a/sdk/eventgrid/eventgrid-namespaces/samples/v1/typescript/src/namespaceActivities.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/samples/v1/typescript/src/namespaceActivities.ts
@@ -5,18 +5,10 @@
  * @summary Publish and Receive events to Event Grid.
  */
 
-import {
-  EventGridSenderClient,
-  EventGridReceiverClient,
-  CloudEvent,
-  ReceiveResult,
-} from "@azure/eventgrid-namespaces";
+import type { CloudEvent, ReceiveResult } from "@azure/eventgrid-namespaces";
+import { EventGridSenderClient, EventGridReceiverClient } from "@azure/eventgrid-namespaces";
 import { AzureKeyCredential } from "@azure/core-auth";
-
-import * as dotenv from "dotenv";
-
-// Load the .env file if it exists
-dotenv.config();
+import "dotenv/config";
 
 const endpoint = process.env["EVENT_GRID_NAMESPACES_ENDPOINT"] ?? "https://endpoint";
 const key = process.env["EVENT_GRID_NAMESPACES_KEY"] ?? "api_key";


### PR DESCRIPTION
### Packages impacted by this PR

All packages using CI

### Describe the problem that is addressed by this PR

@qiaozha noticed that tests were no longer failing the build. After some investigation, I realized that PR #32148 introduced a regression with how the process exitCode was being propagated. Previously, we were setting it globally via `process.exitCode` where we spawn the node process, but this was refactored to use return codes.

However, the return code was never used when the task was anything except `lint` and `check-format` meaning that build and test operations did not report failure correctly.

In the future, we should figure out a better way to abstract and test this script's return codes, but I'd like to get a fix in to prevent bad PRs from being merged in the meantime.