### PR TITLE
[core-amqp] parse port number from endpoint

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix parsing of connetion string to account to extract port number properly.
+
 ### Other Changes
 
 ## 4.3.3 (2024-11-07)
@@ -36,6 +38,7 @@
 ## 4.3.0 (2024-05-20)
 
 ### Breaking Changes
+
 - Moved to ESM core with builds for ESM, CommonJS, React-Native and Browser.
 - Moved unit tests from mocha to vitest.
 
@@ -79,7 +82,7 @@
 
 ### Features Added
 
-- Changed `TokenProvider` to use native crypto libraries.  This changes the signature from `getToken` from being sync to async.
+- Changed `TokenProvider` to use native crypto libraries. This changes the signature from `getToken` from being sync to async.
 
 ### Breaking Changes
 

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix parsing of connetion string to account to extract port number properly.
+- Fix parsing of connection string to extract port number properly.
 
 ### Other Changes
 

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -85,10 +85,32 @@ export interface ConnectionConfig {
   useDevelopmentEmulator?: boolean;
 }
 
+const specialLocalIPs = ["::1", "0:0:0:0:0:0:0:1"];
+
 function getHost(endpoint: string): string {
-  const matches = /.*:\/\/([^/]*)/.exec(endpoint);
+  for (const ip of specialLocalIPs) {
+    if (endpoint.includes(ip)) {
+      return ip;
+    }
+  }
+
+  const matches = /.*:\/\/([^/:]*)/.exec(endpoint);
   const match = matches?.[1];
   return !match ? endpoint : match;
+}
+
+function getPort(endpoint: string): number | undefined {
+  for (const ip of specialLocalIPs) {
+    if (endpoint.includes(ip)) {
+      const matches = /.*:(\d*)/.exec(endpoint.replace(ip, ""));
+      const match = matches?.[1];
+      return match ? parseInt(match, 10) : undefined;
+    }
+  }
+
+  const matches = /.*:(\d*)/.exec(endpoint);
+  const match = matches?.[1];
+  return match ? parseInt(match, 10) : undefined;
 }
 
 /**
@@ -121,10 +143,16 @@ export const ConnectionConfig = {
 
     if (!parsedCS.Endpoint.endsWith("/")) parsedCS.Endpoint += "/";
 
+    let port: number | undefined;
+    if (parsedCS.Endpoint.includes(":")) {
+      port = getPort(parsedCS.Endpoint);
+    }
+
     const result: ConnectionConfig = {
       connectionString: connectionString,
       endpoint: parsedCS.Endpoint,
       host: getHost(parsedCS.Endpoint),
+      port,
       sharedAccessKeyName: parsedCS.SharedAccessKeyName,
       sharedAccessKey: parsedCS.SharedAccessKey,
       useDevelopmentEmulator: parsedCS.UseDevelopmentEmulator === "true",
@@ -157,6 +185,10 @@ export const ConnectionConfig = {
       throw new TypeError("Missing 'host' in configuration");
     }
     config.host = String(config.host);
+
+    if (config.port !== undefined && !(config.port >= 0 && config.port <= 65535)) {
+      throw new TypeError(`Invalid 'port' of ${config.port} in configuration`);
+    }
 
     if (options.isEntityPathRequired && !config.entityPath) {
       throw new TypeError("Missing 'entityPath' in configuration");

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -99,18 +99,20 @@ function getHost(endpoint: string): string {
   return !match ? endpoint : match;
 }
 
+function extractPort(ep: string): number | undefined {
+  const matches = /.*:(\d*)/.exec(ep);
+  const match = matches?.[1];
+  return match ? parseInt(match, 10) : undefined;
+}
+
 function getPort(endpoint: string): number | undefined {
   for (const ip of specialLocalIPs) {
     if (endpoint.includes(ip)) {
-      const matches = /.*:(\d*)/.exec(endpoint.replace(ip, ""));
-      const match = matches?.[1];
-      return match ? parseInt(match, 10) : undefined;
+      return extractPort(endpoint.replace(ip, ""));
     }
   }
 
-  const matches = /.*:(\d*)/.exec(endpoint);
-  const match = matches?.[1];
-  return match ? parseInt(match, 10) : undefined;
+  return extractPort(endpoint);
 }
 
 /**

--- a/sdk/core/core-amqp/test/config.spec.ts
+++ b/sdk/core/core-amqp/test/config.spec.ts
@@ -91,7 +91,68 @@ describe("ConnectionConfig", function () {
         "Endpoint=sb://localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
       );
       assert.equal(config.endpoint, "sb://localhost:6765/");
-      assert.equal(config.host, "localhost:6765");
+      assert.equal(config.host, "localhost");
+      assert.equal(config.port, 6765);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for 127.0.0.1", async function () {
+      const config = ConnectionConfig.create(
+        "Endpoint=sb://127.0.0.1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://127.0.0.1:6765/");
+      assert.equal(config.host, "127.0.0.1");
+      assert.equal(config.port, 6765);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for 127.0.0.1", async function () {
+      const config = ConnectionConfig.create(
+        "Endpoint=sb://127.0.0.1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://127.0.0.1:6765/");
+      assert.equal(config.host, "127.0.0.1");
+      assert.equal(config.port, 6765);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for ::1", async function () {
+      const config = ConnectionConfig.create(
+        "Endpoint=sb://::1;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://::1/");
+      assert.equal(config.host, "::1");
+      assert.isUndefined(config.port);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for ::1 with port", async function () {
+      const config = ConnectionConfig.create(
+        "Endpoint=sb://::1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://::1:6765/");
+      assert.equal(config.host, "::1");
+      assert.equal(config.port, 6765);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for 0:0:0:0:0:0:0:1", async function () {
+      const config = ConnectionConfig.create(
+        "Endpoint=sb://0:0:0:0:0:0:0:1;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://0:0:0:0:0:0:0:1/");
+      assert.equal(config.host, "0:0:0:0:0:0:0:1");
+      assert.isUndefined(config.port);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for 0:0:0:0:0:0:0:1 with port", async function () {
+      const config = ConnectionConfig.create(
+        "Endpoint=sb://0:0:0:0:0:0:0:1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://0:0:0:0:0:0:0:1:6765/");
+      assert.equal(config.host, "0:0:0:0:0:0:0:1");
+      assert.equal(config.port, 6765);
       assert.isTrue(config.useDevelopmentEmulator);
     });
 
@@ -227,8 +288,9 @@ describe("ConnectionConfig", function () {
           "Endpoint=sb://localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "localhost:6765/",
-          host: "sb://localhost:6765/",
+          endpoint: "sb://localhost:6765/",
+          host: "localhost",
+          port: 6765,
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -241,8 +303,9 @@ describe("ConnectionConfig", function () {
           "Endpoint=sb://127.0.0.1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "127.0.0.1:6765/",
-          host: "sb://127.0.0.1:6765",
+          endpoint: "sb://127.0.0.1:6765/",
+          host: "127.0.0.1",
+          port: 6765,
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -255,8 +318,23 @@ describe("ConnectionConfig", function () {
           "Endpoint=sb://0:0:0:0:0:0:0:1;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "0:0:0:0:0:0:0:1/",
-          host: "sb://0:0:0:0:0:0:0:1",
+          endpoint: "sb://0:0:0:0:0:0:0:1/",
+          host: "0:0:0:0:0:0:0:1",
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+          useDevelopmentEmulator: true,
+        };
+        ConnectionConfig.validate(config);
+      });
+
+      it("Accepts 0:0:0:0:0:0:0:1 with port", async function () {
+        const connectionString =
+          "Endpoint=sb://0:0:0:0:0:0:0:1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "sb://0:0:0:0:0:0:0:1/",
+          host: "0:0:0:0:0:0:0:1",
+          port: 6765,
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -269,8 +347,23 @@ describe("ConnectionConfig", function () {
           "Endpoint=sb://::1;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
         const config: ConnectionConfig = {
           connectionString,
-          endpoint: "::1/",
-          host: "sb://::1",
+          endpoint: "sb://::1/",
+          host: "::1",
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+          useDevelopmentEmulator: true,
+        };
+        ConnectionConfig.validate(config);
+      });
+
+      it("Accepts ::1 with port", async function () {
+        const connectionString =
+          "Endpoint=sb://::1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "sb://::1/",
+          host: "::1",
+          port: 6765,
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -284,7 +377,8 @@ describe("ConnectionConfig", function () {
         const config: ConnectionConfig = {
           connectionString,
           endpoint: "localhost:6765/",
-          host: "localhost:6765/",
+          host: "localhost",
+          port: 6765,
           sharedAccessKeyName: "sakName",
           sharedAccessKey: "abcd",
           useDevelopmentEmulator: true,
@@ -304,6 +398,103 @@ describe("ConnectionConfig", function () {
           useDevelopmentEmulator: true,
         };
         ConnectionConfig.validate(config);
+      });
+
+      it("Accepts non-local host with a port", async function () {
+        const connectionString =
+          "Endpoint=sb://hostname.servicebus.windows.net:6575/;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "sb://hostname.servicebus.windows.net/",
+          host: "hostname.servicebus.windows.net",
+          port: 6575,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+          useDevelopmentEmulator: true,
+        };
+        ConnectionConfig.validate(config);
+      });
+    });
+
+    describe("Port Validation", function () {
+      it("accepts port 0", async function () {
+        // Min valid port number.
+        const connectionString = "Endpoint=sb://localhost:0";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "localhost/",
+          host: "sb://localhost/",
+          port: 0,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+        };
+        ConnectionConfig.validate(config);
+      });
+
+      it("accepts port 65535", async function () {
+        // Max valid port number.
+        const connectionString = "Endpoint=sb://localhost;Port=0";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "localhost/",
+          host: "sb://localhost/",
+          port: 65535,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+        };
+        ConnectionConfig.validate(config);
+      });
+
+      it("rejects port -1", async function () {
+        const connectionString = "Endpoint=sb://localhost;Port=0";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "localhost/",
+          host: "sb://localhost/",
+          port: -1,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+        };
+        assert.throw(() => ConnectionConfig.validate(config), /Invalid 'port'/);
+      });
+
+      it("rejects port 65536", async function () {
+        const connectionString = "Endpoint=sb://localhost;Port=0";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "localhost/",
+          host: "sb://localhost/",
+          port: 65536,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+        };
+        assert.throw(() => ConnectionConfig.validate(config), /Invalid 'port'/);
+      });
+
+      it("rejects port NaN", async function () {
+        const connectionString = "Endpoint=sb://localhost;Port=0";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "localhost/",
+          host: "sb://localhost/",
+          port: Number.NaN,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+        };
+        assert.throw(() => ConnectionConfig.validate(config), /Invalid 'port'/);
+      });
+
+      it("rejects port Infinity", async function () {
+        const connectionString = "Endpoint=sb://localhost;Port=0";
+        const config: ConnectionConfig = {
+          connectionString,
+          endpoint: "localhost/",
+          host: "sb://localhost/",
+          port: Number.POSITIVE_INFINITY,
+          sharedAccessKeyName: "sakName",
+          sharedAccessKey: "abcd",
+        };
+        assert.throw(() => ConnectionConfig.validate(config), /Invalid 'port'/);
       });
     });
   });

--- a/sdk/core/core-amqp/test/config.spec.ts
+++ b/sdk/core/core-amqp/test/config.spec.ts
@@ -88,6 +88,16 @@ describe("ConnectionConfig", function () {
 
     it("Parses the connection string for the development emulator", async function () {
       const config = ConnectionConfig.create(
+        "Endpoint=sb://localhost;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+      );
+      assert.equal(config.endpoint, "sb://localhost/");
+      assert.equal(config.host, "localhost");
+      assert.isUndefined(config.port);
+      assert.isTrue(config.useDevelopmentEmulator);
+    });
+
+    it("Parses the connection string for the development emulator with port", async function () {
+      const config = ConnectionConfig.create(
         "Endpoint=sb://localhost:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
       );
       assert.equal(config.endpoint, "sb://localhost:6765/");
@@ -98,15 +108,15 @@ describe("ConnectionConfig", function () {
 
     it("Parses the connection string for 127.0.0.1", async function () {
       const config = ConnectionConfig.create(
-        "Endpoint=sb://127.0.0.1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
+        "Endpoint=sb://127.0.0.1;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
       );
-      assert.equal(config.endpoint, "sb://127.0.0.1:6765/");
+      assert.equal(config.endpoint, "sb://127.0.0.1/");
       assert.equal(config.host, "127.0.0.1");
-      assert.equal(config.port, 6765);
+      assert.isUndefined(config.port);
       assert.isTrue(config.useDevelopmentEmulator);
     });
 
-    it("Parses the connection string for 127.0.0.1", async function () {
+    it("Parses the connection string for 127.0.0.1 with port", async function () {
       const config = ConnectionConfig.create(
         "Endpoint=sb://127.0.0.1:6765;SharedAccessKeyName=<< REDACTED >>;SharedAccessKey=<< REDACTED >>;UseDevelopmentEmulator=true",
       );


### PR DESCRIPTION
We should but currently don't extract point number from the endpoint into connection configuration. This PR fixes that.

### Packages impacted by this PR
`@azure/core-amqp`
