### PR TITLE
[ServiceBus] remove port in namespace extracted from connection string

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Other Changes
 
-- upgrade dependency `@azure/abort-controller` version to `^2.1.2`.
+- Upgrade dependency `@azure/abort-controller` version to `^2.1.2`.
+- Remove port number from fully qualified namespace.
 
 ## 7.9.5 (2024-06-11)
 

--- a/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
+++ b/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
@@ -78,8 +78,11 @@ export function parseServiceBusConnectionString(
     );
   }
 
-  const fullyQualifiedNamespace = parsedResult.Endpoint.includes("0:0:0:0:0:0:0:1") ? "0:0:0:0:0:0:0:1" :
-    parsedResult.Endpoint.includes("::1") ? "::1" : (parsedResult.Endpoint.match(".*://([^/:]*)") || [])[1]
+  const fullyQualifiedNamespace = parsedResult.Endpoint.includes("0:0:0:0:0:0:0:1")
+    ? "0:0:0:0:0:0:0:1"
+    : parsedResult.Endpoint.includes("::1")
+      ? "::1"
+      : (parsedResult.Endpoint.match(".*://([^/:]*)") || [])[1];
 
   const output: ServiceBusConnectionStringProperties = {
     fullyQualifiedNamespace,

--- a/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
+++ b/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
@@ -78,8 +78,11 @@ export function parseServiceBusConnectionString(
     );
   }
 
+  const fullyQualifiedNamespace = parsedResult.Endpoint.includes("0:0:0:0:0:0:0:1") ? "0:0:0:0:0:0:0:1" :
+    parsedResult.Endpoint.includes("::1") ? "::1" : (parsedResult.Endpoint.match(".*://([^/:]*)") || [])[1]
+
   const output: ServiceBusConnectionStringProperties = {
-    fullyQualifiedNamespace: (parsedResult.Endpoint.match(".*://([^/]*)") || [])[1],
+    fullyQualifiedNamespace,
     endpoint: parsedResult.Endpoint,
   };
   if (parsedResult.EntityPath) {

--- a/sdk/servicebus/service-bus/test/internal/unit/connectionString.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/connectionString.spec.ts
@@ -63,6 +63,34 @@ describe("Connection String", () => {
     assert.equal(connectionStringProperties.sharedAccessKeyName, expectedSharedKeyName);
   });
 
+  it("Extracts Service Bus properties for 0:0:0:0:0:0:0:1 with port", () => {
+    const connectionString = `Endpoint=sb://0:0:0:0:0:0:0:1:6765`;
+    const connectionStringProperties = parseServiceBusConnectionString(connectionString);
+    assert.equal(connectionStringProperties.endpoint, "sb://0:0:0:0:0:0:0:1:6765");
+    assert.equal(connectionStringProperties.fullyQualifiedNamespace, "0:0:0:0:0:0:0:1");
+  });
+
+  it("Extracts Service Bus properties for 127.0.0.1 with port", () => {
+    const connectionString = `Endpoint=sb://127.0.0.1:6765`;
+    const connectionStringProperties = parseServiceBusConnectionString(connectionString);
+    assert.equal(connectionStringProperties.endpoint, "sb://127.0.0.1:6765");
+    assert.equal(connectionStringProperties.fullyQualifiedNamespace, "127.0.0.1");
+  });
+
+  it("Extracts Service Bus properties for ::1 with port", () => {
+    const connectionString = `Endpoint=sb://::1:6765`;
+    const connectionStringProperties = parseServiceBusConnectionString(connectionString);
+    assert.equal(connectionStringProperties.endpoint, "sb://::1:6765");
+    assert.equal(connectionStringProperties.fullyQualifiedNamespace, "::1");
+  });
+
+  it("Extracts Service Bus properties for localhost with port", () => {
+    const connectionString = `Endpoint=sb://localhost:6765`;
+    const connectionStringProperties = parseServiceBusConnectionString(connectionString);
+    assert.equal(connectionStringProperties.endpoint, "sb://localhost:6765");
+    assert.equal(connectionStringProperties.fullyQualifiedNamespace, "localhost");
+  });
+
   it("Throws when no Endpoint", () => {
     const connectionString = `EntityPath=${expectedEntityPath};SharedAccessSignature=${expectedSharedAccessSignature}`;
     assert.throws(() => {


### PR DESCRIPTION
In local emulator scenario, a custom port may be specified in the endpoint of a
connection string. This PR ensures the extracted namespace doesn't contain the
port.

-------

### Packages impacted by this PR
`@azure/service-bus`