### PR TITLE
modified readme of [DocumentIntelligence] wrong import of AnalyzeOper…

### DIFF
--- a/sdk/documentintelligence/ai-document-intelligence-rest/README.md
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/README.md
@@ -128,7 +128,7 @@ Continue creating the poller from initial response
 ```ts
 import {
   getLongRunningPoller,
-  AnalyzeResultOperationOutput,
+  AnalyzeOperationOutput,
   isUnexpected,
 } from "@azure-rest/ai-document-intelligence";
 
@@ -136,7 +136,7 @@ if (isUnexpected(initialResponse)) {
   throw initialResponse.body.error;
 }
 const poller = getLongRunningPoller(client, initialResponse);
-const result = (await poller.pollUntilDone()).body as AnalyzeResultOperationOutput;
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
 console.log(result);
 // {
 //   status: 'succeeded',
@@ -365,7 +365,7 @@ if (isUnexpected(initialResponse)) {
 
 const poller = getLongRunningPoller(client, initialResponse, { ...testPollingOptions });
 
-const result = (await poller.pollUntilDone()).body as AnalyzeResultOperationOutput;
+const result = (await poller.pollUntilDone()).body as AnalyzeOperationOutput;
 const figures = result.analyzeResult?.figures;
 assert.isArray(figures);
 assert.isNotEmpty(figures?.[0]);


### PR DESCRIPTION
…ationOutput.  changes in changelog, samples and release note for GA 1.0.0 #32326


### Packages impacted by this PR
Azure Documentintelligence

### Issues associated with this PR
Fixed wrong import of AnalyzeOperationOutput 

### Describe the problem that is addressed by this PR
Previously in the readme of Azure DocumentIntelligence (formerly FormRecognizer) REST client library for JavaScript in Continue creating the poller from initial response section the import of AnalyzeOperationOutput was wrongly added as AnalyzeResultOperationOutput in 3 counts that has been modified.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
It was the only simple solution

### Are there test cases added in this PR? _(If not, why?)_
No just modified readme to update documentation of wrong import

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
