### PR TITLE
[EngSys] fix typo in pullrequest pipeline exclusion

### DIFF
--- a/sdk/pullrequest.yml
+++ b/sdk/pullrequest.yml
@@ -11,7 +11,7 @@ pr:
     - "*"
 
     exclude:
-    - sdk/cosmos
+    - sdk/cosmosdb/cosmos
 
 parameters:
   - name: Service


### PR DESCRIPTION
We want to exclude cosmos data plane as it has a special CI pipeline.