### PR TITLE
Fix invalid date in template changelog

### DIFF
--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-## 1.0.13-beta.1 (2023-11/22)
+## 1.0.13-beta.1 (2023-11-22)
 
 ### Features Added
 - Test Release Pipeline


### PR DESCRIPTION
I think https://github.com/Azure/azure-sdk-for-js/pull/31849 introduced this invalid date which has thrown off the changelog parser. 