### PR TITLE
[eslint-plugin] fix prettier.json export

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -53,24 +53,7 @@
         "default": "./dist/commonjs/index.js"
       }
     },
-    "./prettier.json": {
-      "browser": {
-        "types": "./dist/browser/prettier.json/index.d.ts",
-        "default": "./dist/browser/prettier.json/index.js"
-      },
-      "react-native": {
-        "types": "./dist/react-native/prettier.json/index.d.ts",
-        "default": "./dist/react-native/prettier.json/index.js"
-      },
-      "import": {
-        "types": "./dist/esm/prettier.json/index.d.ts",
-        "default": "./dist/esm/prettier.json/index.js"
-      },
-      "require": {
-        "types": "./dist/commonjs/prettier.json/index.d.ts",
-        "default": "./dist/commonjs/prettier.json/index.js"
-      }
-    }
+    "./prettier.json": "./prettier.json"
   },
   "files": [
     "dist/",
@@ -147,7 +130,7 @@
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
-      "./prettier.json": "./src/prettier.json/index.ts"
+      "./prettier.json": "./prettier.json"
     },
     "dialects": [
       "esm",

--- a/sdk/communication/communication-sms/README.md
+++ b/sdk/communication/communication-sms/README.md
@@ -112,13 +112,13 @@ for (const sendResult of sendResults) {
 To check if the recipients are in the Opt Out list, call the `check` function from the `SmsClient.optOuts` with a list of recipient phone numbers.
 
 ```typescript
- const optOutCheckResults = await client.optOuts.check(
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
-    to: ["<to-phone-number-1>", "<to-phone-number-2>"], E.164 formatted recipient phone numbers
-    );
+  const optOutCheckResults = await client.optOuts.check(
+    "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    ["<to-phone-number-1>", "<to-phone-number-2>"], // E.164 formatted recipient phone numbers
+  );
 
   for (const optOutCheckResult of optOutCheckResults) {
-    if (optOutCheckResult.httpStatusCode == 200) {
+    if (optOutCheckResult.httpStatusCode === 200) {
       console.log("Success: ", optOutCheckResult);
     } else {
       console.error("Something went wrong when trying to send opt out check request: ", optOutCheckResult);
@@ -130,13 +130,13 @@ To check if the recipients are in the Opt Out list, call the `check` function fr
 To add the list of recipients to Opt Out list, call the `add` function from the `SmsClient.pptOuts` with a list of recipient phone numbers.
 
 ```typescript
-const optOutAddResults = await client.optOuts.add(
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
-    to: ["<to-phone-number-1>", "<to-phone-number-2>"], // E.164 formatted recipient phone numbers
-    );
+  const optOutAddResults = await client.optOuts.add(
+    "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    ["<to-phone-number-1>", "<to-phone-number-2>"], // E.164 formatted recipient phone numbers
+  );
 
   for (const optOutAddResult of optOutAddResults) {
-    if (optOutAddResult.httpStatusCode == 200) {
+    if (optOutAddResult.httpStatusCode === 200) {
       console.log("Success: ", optOutAddResult);
     } else {
       console.error("Something went wrong when trying to send opt out add request: ", optOutAddResult);
@@ -148,13 +148,13 @@ const optOutAddResults = await client.optOuts.add(
 To remove the list of recipients to Opt Out list, call the `remove` function from the `SmsClient.optOuts.` with a list of recipient phone numbers.
 
 ```typescript
-const optOutRemoveResults = await client.optOuts.remove(
-    from: "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
-    to: ["<to-phone-number-1>", "<to-phone-number-2>"], // E.164 formatted recipient phone numbers
-    );
+  const optOutRemoveResults = await client.optOuts.remove(
+    "<from-phone-number>", // Your E.164 formatted phone number used to send SMS
+    ["<to-phone-number-1>", "<to-phone-number-2>"], // E.164 formatted recipient phone numbers
+  );
 
   for (const optOutRemoveResult of optOutRemoveResults) {
-    if (optOutRemoveResult.httpStatusCode == 200) {
+    if (optOutRemoveResult.httpStatusCode === 200) {
       console.log("Success: ", optOutRemoveResult);
     } else {
       console.error("Something went wrong when trying to send opt out remove request: ", optOutRemoveResult);


### PR DESCRIPTION
There's a regression from eslint-plugin's ESM migration.  `./prettier.json` should be exported
as-is to be used by other packages as their formatting configs in VS Code.