### PR TITLE
[core-amqp] set `port` when it is not undefined in connection config

### DIFF
--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -154,10 +154,10 @@ export const ConnectionConfig = {
       connectionString: connectionString,
       endpoint: parsedCS.Endpoint,
       host: getHost(parsedCS.Endpoint),
-      port,
       sharedAccessKeyName: parsedCS.SharedAccessKeyName,
       sharedAccessKey: parsedCS.SharedAccessKey,
       useDevelopmentEmulator: parsedCS.UseDevelopmentEmulator === "true",
+      ... port !== undefined ? { port } : undefined,
     };
 
     if (path || parsedCS.EntityPath) {

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -157,7 +157,7 @@ export const ConnectionConfig = {
       sharedAccessKeyName: parsedCS.SharedAccessKeyName,
       sharedAccessKey: parsedCS.SharedAccessKey,
       useDevelopmentEmulator: parsedCS.UseDevelopmentEmulator === "true",
-      ... port !== undefined ? { port } : undefined,
+      ...(port !== undefined ? { port } : undefined),
     };
 
     if (path || parsedCS.EntityPath) {


### PR DESCRIPTION
PR #32406 adds the `port` property to parsed connection configuration even it is
`undefined`. While the effect is similar, it broke an Event Hub unit test that
expects the `port` property to not exist when a connection string does not
specify a port.

This PR changes to only add the `port` property when it is not `undefined`.

-------

### Packages impacted by this PR
`@azure/core-amqp`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could update broken test to check for `undefined` but it is slightly better to keep the existing behavior