### PR TITLE
Update template version before dumping package props

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -4,6 +4,12 @@ parameters:
   TestPipeline: false
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+    parameters:
+      PackageName: "@azure/template"
+      ServiceDirectory: "template"
+      TestPipeline: ${{ parameters.TestPipeline }}
+
   - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}
@@ -22,12 +28,6 @@ steps:
       arguments: -ChangedServices "$(ChangedServices)"
       pwsh: true
     displayName: Spell check public API
-
-  - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
-    parameters:
-      PackageName: "@azure/template"
-      ServiceDirectory: "template"
-      TestPipeline: ${{ parameters.TestPipeline }}
 
   - template: /eng/common/pipelines/templates/steps/verify-readmes.yml
     parameters:

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -3,12 +3,7 @@
 ## 1.0.13-beta.2 (Unreleased)
 
 ### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Test Release Pipeline
 
 ## 1.0.13-beta.1 (2023-11-22)
 


### PR DESCRIPTION
@jeremymeng I guess my last change didn't fix the template pipeline. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4392967&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=d34cfe88-f3e1-5ca1-ec50-18a5cea1099a

It looks like after @scbedd refactoring we aren't setting the template package version early enough. We need to set that version before the save package properties otherwise things like verify change log will fail as what is on disk doesn't match the package properties. 