### PR TITLE
[Core] stop packing d.ts.map files

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -39,6 +39,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -38,6 +38,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -31,6 +31,7 @@
   "react-native": "./dist/react-native/index.js",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -28,6 +28,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "LICENSE",
     "README.md"
   ],

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -42,6 +42,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "LICENSE",
     "README.md"
   ],

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "LICENSE",
     "README.md"
   ],

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
These declaration source map files are useful for code navigation (go-to-implementation) in local
development. However, since we don't pack source code, they are not usable in published packages.

This PR excludes them from packing.