### PR TITLE
[dev-tool] consume response body of fetch() result

### DIFF
--- a/common/tools/dev-tool/src/util/browserRelayServer.ts
+++ b/common/tools/dev-tool/src/util/browserRelayServer.ts
@@ -124,8 +124,8 @@ async function isRelayAlive(options: TestCredentialServerOptions = {}): Promise<
     const res = await fetch(
       `http://${options.listenHost ?? "localhost"}:${options.port ?? 4895}/health`,
     );
-
     if (res.ok) {
+      await res.text();
       printer("Browser relay is already alive");
       return true;
     } else {

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -296,6 +296,8 @@ export async function isProxyToolActive(): Promise<boolean> {
       `http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000}/info/available`,
     );
 
+    await response.text();
+
     if (!response.ok) {
       return false;
     }


### PR DESCRIPTION
Due to https://github.com/nodejs/node/issues/52909, fetch() may be stuck
indefinitely in NodeJS v20 or lower if body is not read. This PR consumes the
response body to avoid that from happening.