### PR TITLE
[samples][ai-document-translator] fix broken links

### DIFF
--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/README.md
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/README.md
@@ -51,7 +51,7 @@ node listFormats.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env ENDPOINT="<endpoint>" DOCUMENT_TRANSLATOR_API_KEY="<document translator api key>" node listFormats.js
+npx dev-tool run vendored cross-env ENDPOINT="<endpoint>" DOCUMENT_TRANSLATOR_API_KEY="<document translator api key>" node listFormats.js
 ```
 
 ## Next Steps
@@ -60,7 +60,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 
 [listformats]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/listFormats.js
 [translatefromblob]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/translateFromBlob.js
-[apiref]: https://learn.microsoft.com/javascript/api/@azure/ai-document-translator
+[apiref]: https://learn.microsoft.com/javascript/api/@azure-rest/ai-document-translator?view=azure-node-preview
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azurecognitiveservicesinstance]: https://learn.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/documenttranslator/ai-document-translator-rest/README.md

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/listFormats.js
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/listFormats.js
@@ -9,8 +9,7 @@
  */
 
 const DocumentTranslator = require("@azure-rest/ai-document-translator").default;
-
-require("dotenv").config();
+require("dotenv/config");
 
 const endpoint = process.env["ENDPOINT"] || "document-translator endpoint";
 const apiKey = process.env["DOCUMENT_TRANSLATOR_API_KEY"] || "<api key>";

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/translateFromBlob.js
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/javascript/translateFromBlob.js
@@ -14,8 +14,7 @@
  */
 
 const DocumentTranslator = require("@azure-rest/ai-document-translator").default;
-
-require("dotenv").config();
+require("dotenv/config");
 
 /**
  * These are states of the Long Running Operation considered as terminal

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/README.md
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/README.md
@@ -63,7 +63,7 @@ node dist/listFormats.js
 Alternatively, run a single sample with the correct environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
 
 ```bash
-npx cross-env ENDPOINT="<endpoint>" DOCUMENT_TRANSLATOR_API_KEY="<document translator api key>" node dist/listFormats.js
+npx dev-tool run vendored cross-env ENDPOINT="<endpoint>" DOCUMENT_TRANSLATOR_API_KEY="<document translator api key>" node dist/listFormats.js
 ```
 
 ## Next Steps
@@ -72,7 +72,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 
 [listformats]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/src/listFormats.ts
 [translatefromblob]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/src/translateFromBlob.ts
-[apiref]: https://learn.microsoft.com/javascript/api/@azure/ai-document-translator
+[apiref]: https://learn.microsoft.com/javascript/api/@azure-rest/ai-document-translator?view=azure-node-preview
 [freesub]: https://azure.microsoft.com/free/
 [createinstance_azurecognitiveservicesinstance]: https://learn.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/documenttranslator/ai-document-translator-rest/README.md

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "~5.5.3",
+    "typescript": "~5.7.2",
     "rimraf": "latest"
   }
 }

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/src/listFormats.ts
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/src/listFormats.ts
@@ -9,14 +9,12 @@
  */
 
 import DocumentTranslator from "@azure-rest/ai-document-translator";
-
-import * as dotenv from "dotenv";
-dotenv.config();
+import "dotenv/config";
 
 const endpoint = process.env["ENDPOINT"] || "document-translator endpoint";
 const apiKey = process.env["DOCUMENT_TRANSLATOR_API_KEY"] || "<api key>";
 
-export async function main() {
+export async function main(): Promise<void> {
   console.log("== List supported document formats sample ==");
 
   const client = DocumentTranslator(endpoint, { key: apiKey });

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/src/translateFromBlob.ts
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/src/translateFromBlob.ts
@@ -13,10 +13,9 @@
  * @summary translates a collection of documents
  */
 
-import DocumentTranslator, { StartTranslationDetails } from "@azure-rest/ai-document-translator";
-
-import * as dotenv from "dotenv";
-dotenv.config();
+import type { StartTranslationDetails } from "@azure-rest/ai-document-translator";
+import DocumentTranslator from "@azure-rest/ai-document-translator";
+import "dotenv/config";
 
 /**
  * These are states of the Long Running Operation considered as terminal
@@ -48,7 +47,7 @@ const batchSubmissionRequest: StartTranslationDetails = {
   ],
 };
 
-export async function main() {
+export async function main(): Promise<void> {
   console.log("== Translate documents in a container sample ==");
 
   // Create a new client
@@ -112,7 +111,7 @@ function wait(seconds: number): Promise<void> {
 }
 
 // Helper function that extracts the batch id from operation-location header
-function extractBatchId(batchUrl: string = "") {
+function extractBatchId(batchUrl: string = ""): string {
   const parts = batchUrl.split("/");
 
   return parts[parts.length - 1];

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/tsconfig.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1-beta/typescript/tsconfig.json
@@ -1,17 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "module": "commonjs",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
+    "lib": [],
+    "importHelpers": true,
     "strict": true,
-    "alwaysStrict": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node10",
+    "esModuleInterop": true,
+    "outDir": "./dist",
+    "resolveJsonModule": true
   },
   "include": [
-    "src/**/*.ts"
+    "./src"
   ]
 }


### PR DESCRIPTION
The apiref links don't have correct scope `@azure-rest`. This fixes them
by re-publishing samples. No changes around features used in samples.