### PR TITLE
Remove @azure/identity-cache-persistence@1.0.0 from regression testing. 

### DIFF
--- a/eng/scripts/docs/tests/rex-tool-tests.json
+++ b/eng/scripts/docs/tests/rex-tool-tests.json
@@ -15,11 +15,6 @@
     "Comment": "Valid package, passes build"
   },
   {
-    "Package": "@azure/identity-cache-persistence@1.0.0",
-    "ExpectedResult": true,
-    "Comment": "Valid as of 2.x, passes build"
-  },
-  {
     "Package": "@azure/identity-vscode@1.0.0",
     "ExpectedResult": true,
     "Comment": "Valid as of 2.x, passes build"


### PR DESCRIPTION
This is an old package, tooling and dependencies have moved on, and it's not a valuable exercise of type2docfx.