### PR TITLE
[core-client-rest] correctly throw RestError when response has no body

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Handle error responses with no body without causing a `TypeError`.
+- Handle error responses with no body without causing a `TypeError`. PR [#32566](https://github.com/Azure/azure-sdk-for-js/pull/32566)
 
 ### Other Changes
 

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Handle error responses with no body without causing a `TypeError`.
+
 ### Other Changes
 
 ## 2.3.2 (2025-01-10)

--- a/sdk/core/core-client-rest/src/restError.ts
+++ b/sdk/core/core-client-rest/src/restError.ts
@@ -18,7 +18,7 @@ export function createRestError(
   response?: PathUncheckedResponse,
 ): RestError {
   const resp = typeof messageOrResponse === "string" ? response! : messageOrResponse;
-  const internalError = resp.body?.error || resp.body;
+  const internalError = resp.body?.error ?? resp.body;
   const message =
     typeof messageOrResponse === "string"
       ? messageOrResponse

--- a/sdk/core/core-client-rest/src/restError.ts
+++ b/sdk/core/core-client-rest/src/restError.ts
@@ -18,14 +18,14 @@ export function createRestError(
   response?: PathUncheckedResponse,
 ): RestError {
   const resp = typeof messageOrResponse === "string" ? response! : messageOrResponse;
-  const internalError = resp.body.error || resp.body;
+  const internalError = resp.body?.error || resp.body;
   const message =
     typeof messageOrResponse === "string"
       ? messageOrResponse
       : (internalError.message ?? `Unexpected status code: ${resp.status}`);
   return new RestError(message, {
     statusCode: statusCodeToNumber(resp.status),
-    code: internalError.code,
+    code: internalError?.code,
     request: resp.request,
     response: toPipelineResponse(resp),
   });

--- a/sdk/core/core-client-rest/test/createRestError.spec.ts
+++ b/sdk/core/core-client-rest/test/createRestError.spec.ts
@@ -73,4 +73,17 @@ describe("createRestError", () => {
     assert.equal(error.code, "code");
     assert.equal(error.message, "error message");
   });
+
+  it("should create a rest error from an error response with an undefined body", () => {
+    const response = {
+      status: "400",
+      headers: {},
+      request: {} as PipelineRequest,
+      body: undefined,
+    };
+    const error = createRestError("error message", response);
+    assert.equal(error.statusCode, 400);
+    assert.equal(error.code, undefined);
+    assert.equal(error.message, "error message");
+  });
 });

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -773,7 +773,7 @@ index c7c1eb6..15bdc45 100644
      onResponse: options.onResponse,
    };
 diff --git a/src/client/restError.ts b/src/client/restError.ts
-index 1ecc969..9b98b21 100644
+index 3df6036..d653f06 100644
 --- a/src/client/restError.ts
 +++ b/src/client/restError.ts
 @@ -1,8 +1,9 @@

--- a/sdk/core/ts-http-runtime/src/client/restError.ts
+++ b/sdk/core/ts-http-runtime/src/client/restError.ts
@@ -19,7 +19,7 @@ export function createRestError(
   response?: PathUncheckedResponse,
 ): RestError {
   const resp = typeof messageOrResponse === "string" ? response! : messageOrResponse;
-  const internalError = resp.body?.error || resp.body;
+  const internalError = resp.body?.error ?? resp.body;
   const message =
     typeof messageOrResponse === "string"
       ? messageOrResponse

--- a/sdk/core/ts-http-runtime/src/client/restError.ts
+++ b/sdk/core/ts-http-runtime/src/client/restError.ts
@@ -19,14 +19,14 @@ export function createRestError(
   response?: PathUncheckedResponse,
 ): RestError {
   const resp = typeof messageOrResponse === "string" ? response! : messageOrResponse;
-  const internalError = resp.body.error || resp.body;
+  const internalError = resp.body?.error || resp.body;
   const message =
     typeof messageOrResponse === "string"
       ? messageOrResponse
       : (internalError.message ?? `Unexpected status code: ${resp.status}`);
   return new RestError(message, {
     statusCode: statusCodeToNumber(resp.status),
-    code: internalError.code,
+    code: internalError?.code,
     request: resp.request,
     response: toPipelineResponse(resp),
   });

--- a/sdk/core/ts-http-runtime/test/client/createRestError.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/createRestError.spec.ts
@@ -73,7 +73,7 @@ describe("createRestError", () => {
     assert.equal(error.code, "code");
     assert.equal(error.message, "error message");
   });
-  
+
   it("should create a rest error from an error response with an undefined body", () => {
     const response = {
       status: "400",

--- a/sdk/core/ts-http-runtime/test/client/createRestError.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/createRestError.spec.ts
@@ -73,4 +73,17 @@ describe("createRestError", () => {
     assert.equal(error.code, "code");
     assert.equal(error.message, "error message");
   });
+  
+  it("should create a rest error from an error response with an undefined body", () => {
+    const response = {
+      status: "400",
+      headers: {},
+      request: {} as PipelineRequest,
+      body: undefined,
+    };
+    const error = createRestError("error message", response);
+    assert.equal(error.statusCode, 400);
+    assert.equal(error.code, undefined);
+    assert.equal(error.message, "error message");
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-rest/core-client`
- `@typespec/ts-http-runtime`

### Describe the problem that is addressed by this PR

Noticed with Jose when testing the todo end-to-end demo TypeSpec.

If we receive an unexpected status from the service (an error or otherwise), we try to create an error with `createRestError`. It is possible that a service might for some reason return an error response with no body, intentionally or otherwise. Currently this causes a TypeError when createRestError tries to read properties off of the body. This PR guards against the body being undefined so that the expected `RestError` is thrown instead.