### PR TITLE
[dev-tool] fix unit tests

### DIFF
--- a/common/tools/dev-tool/src/templates/sampleReadme.md.ts
+++ b/common/tools/dev-tool/src/templates/sampleReadme.md.ts
@@ -179,7 +179,7 @@ async function urlExists(url: string): Promise<boolean> {
 async function createApiRef(info: SampleReadmeConfiguration): Promise<string> {
   if (info.apiRefLink) {
     return `[apiref]: ${info.apiRefLink}`;
-  } else if (info.scope.startsWith("@azure")) {
+  } else if (info.scope?.startsWith("@azure")) {
     const link = `https://learn.microsoft.com/javascript/api/${info.scope}/${info.baseName}${info.isBeta ? "?view=azure-node-preview" : ""}`;
     if (await urlExists(link)) {
       return `[apiref]: ${link}`;

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -97,8 +97,14 @@ export async function makeSampleGenerationInfo(
 
   const sampleConfiguration = getSampleConfiguration(projectInfo.packageJson);
 
-  const [scope, baseName] = projectInfo.name.split("/");
-  log.debug("Determined project baseName:", baseName);
+  let scope, baseName: string | undefined;
+  [scope, baseName] = projectInfo.name.split("/");
+  if (baseName === undefined) {
+    log.debug(`unscoped package name: ${projectInfo.name}`);
+    baseName = scope;
+    scope = undefined;
+  }
+  log.debug(`Determined project scope: ${scope}, baseName: ${baseName}`);
 
   // A helper to handle configuration errors.
   function fail(...values: unknown[]): never {

--- a/common/tools/dev-tool/src/util/samples/info.ts
+++ b/common/tools/dev-tool/src/util/samples/info.ts
@@ -54,7 +54,7 @@ export interface SampleGenerationInfo extends SampleConfiguration {
   /**
    * The scope part of the package name. For example, the base part of "@azure/template" is "@azure".
    */
-  scope: string;
+  scope?: string;
   /**
    * The base part of the package name. For example, the base part of "@azure/template" is "template".
    */


### PR DESCRIPTION
Sample generation tests use package names that doesn't have scope so they are broken by e8acf696589 which
assumes package names are always in the form of "@scope/packageName". This PR handles the non-scope case.