### PR TITLE
[@azure/cosmos] Move consistencyLevel and disableRUPerMinuteUsage to SharedOptions

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1930,9 +1930,7 @@ export interface RequestOptions extends SharedOptions {
         type: string;
         condition: string;
     };
-    consistencyLevel?: string;
     disableAutomaticIdGeneration?: boolean;
-    disableRUPerMinuteUsage?: boolean;
     enableScriptLogging?: boolean;
     indexingDirective?: string;
     offerThroughput?: number;
@@ -2194,6 +2192,8 @@ export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, reso
 export interface SharedOptions {
     abortSignal?: AbortSignal;
     bypassIntegratedCache?: boolean;
+    consistencyLevel?: string;
+    disableRUPerMinuteUsage?: boolean;
     initialHeaders?: CosmosHeaders;
     maxIntegratedCacheStalenessInMs?: number;
     priorityLevel?: PriorityLevel;

--- a/sdk/cosmosdb/cosmos/src/request/RequestOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestOptions.ts
@@ -13,13 +13,6 @@ export interface RequestOptions extends SharedOptions {
     /** Conditional HTTP method header value (the _etag field from the last version you read). */
     condition: string;
   };
-  /** Consistency level required by the client. */
-  consistencyLevel?: string;
-  /**
-   * DisableRUPerMinuteUsage is used to enable/disable Request Units(RUs)/minute capacity
-   * to serve the request if regular provisioned RUs/second is exhausted.
-   */
-  disableRUPerMinuteUsage?: boolean;
   /** Enables or disables logging in JavaScript stored procedures. */
   enableScriptLogging?: boolean;
   /** Specifies indexing directives (index, do not index .. etc). */

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -48,4 +48,13 @@ export interface SharedOptions {
    * <p>Default value is null. By default all requests are of High priority</p>
    */
   priorityLevel?: PriorityLevel;
+
+  /** Consistency level required by the client. */
+  consistencyLevel?: string;
+
+  /**
+   * DisableRUPerMinuteUsage is used to enable/disable Request Units(RUs)/minute capacity
+   * to serve the request if regular provisioned RUs/second is exhausted.
+   */
+  disableRUPerMinuteUsage?: boolean;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#27336

### Describe the problem that is addressed by this PR
This PR moves `consistencyLevel` and `disableRUPerMinuteUsage` from `RequestOptions` to `SharedOptions`. 
These options are used in both `RequestOptions` and `FeedOptions` and gets extended by `SharedOptions`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
