### PR TITLE
[@azure/cosmos] Make retryOptions as Optional

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -544,6 +544,9 @@ export const Constants: {
         ForceRefresh: string;
         PriorityLevel: string;
     };
+    ThrottledRequestMaxRetryAttemptCount: number;
+    ThrottledRequestMaxWaitTimeInSeconds: number;
+    ThrottledRequestFixedRetryIntervalInMs: number;
     WritableLocations: string;
     ReadableLocations: string;
     LocationUnavailableExpirationTimeInMs: number;
@@ -2028,9 +2031,9 @@ export type RetryDiagnostics = {
 
 // @public
 export interface RetryOptions {
-    fixedRetryIntervalInMilliseconds: number;
-    maxRetryAttemptCount: number;
-    maxWaitTimeInSeconds: number;
+    fixedRetryIntervalInMilliseconds?: number;
+    maxRetryAttemptCount?: number;
+    maxWaitTimeInSeconds?: number;
 }
 
 // @public (undocumented)

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -183,6 +183,10 @@ export const Constants = {
     // Priority Based throttling header
     PriorityLevel: "x-ms-cosmos-priority-level",
   },
+  // ThrottledRequests Retry policy default values
+  ThrottledRequestMaxRetryAttemptCount: 9,
+  ThrottledRequestMaxWaitTimeInSeconds: 30,
+  ThrottledRequestFixedRetryIntervalInMs: 0,
 
   // GlobalDB related constants
   WritableLocations: "writableLocations",

--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+import { Constants } from "../common/constants";
 import type { RetryOptions } from "../retry/retryOptions";
 import { ConnectionMode } from "./ConnectionMode";
 /**
@@ -40,9 +41,9 @@ export const defaultConnectionPolicy: ConnectionPolicy = Object.freeze({
   enableEndpointDiscovery: true,
   preferredLocations: [],
   retryOptions: {
-    maxRetryAttemptCount: 9,
-    fixedRetryIntervalInMilliseconds: 0,
-    maxWaitTimeInSeconds: 30,
+    maxRetryAttemptCount: Constants.ThrottledRequestMaxRetryAttemptCount,
+    fixedRetryIntervalInMilliseconds: Constants.ThrottledRequestFixedRetryIntervalInMs,
+    maxWaitTimeInSeconds: Constants.ThrottledRequestMaxWaitTimeInSeconds,
   },
   useMultipleWriteLocations: true,
   endpointRefreshRateInMs: 300000,

--- a/sdk/cosmosdb/cosmos/src/retry/resourceThrottleRetryPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/resourceThrottleRetryPolicy.ts
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+import { Constants } from "../common/constants";
 import type { DiagnosticNodeInternal } from "../diagnostics/DiagnosticNodeInternal";
 import type { ErrorResponse } from "../request";
+import type { RetryOptions } from "./retryOptions";
 
 /**
  * This class implements the resource throttle retry policy for requests.
@@ -24,11 +26,15 @@ export class ResourceThrottleRetryPolicy {
    * @param timeoutInSeconds - Max wait time in seconds to wait for a request while the
    * retries are happening.
    */
-  constructor(
-    private maxTries: number = 9,
-    private fixedRetryIntervalInMs: number = 0,
-    timeoutInSeconds: number = 30,
-  ) {
+
+  private maxTries: number;
+  private fixedRetryIntervalInMs: number;
+  constructor(options: RetryOptions) {
+    this.maxTries = options.maxRetryAttemptCount ?? Constants.ThrottledRequestMaxRetryAttemptCount;
+    this.fixedRetryIntervalInMs =
+      options.fixedRetryIntervalInMilliseconds ?? Constants.ThrottledRequestFixedRetryIntervalInMs;
+    const timeoutInSeconds =
+      options.maxWaitTimeInSeconds ?? Constants.ThrottledRequestMaxWaitTimeInSeconds;
     this.timeoutInMs = timeoutInSeconds * 1000;
     this.currentRetryAttemptCount = 0;
     this.cummulativeWaitTimeinMs = 0;

--- a/sdk/cosmosdb/cosmos/src/retry/retryOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryOptions.ts
@@ -5,9 +5,9 @@
  */
 export interface RetryOptions {
   /** Max number of retries to be performed for a request. Default value 9. */
-  maxRetryAttemptCount: number;
+  maxRetryAttemptCount?: number;
   /** Fixed retry interval in milliseconds to wait between each retry ignoring the retryAfter returned as part of the response. */
-  fixedRetryIntervalInMilliseconds: number;
+  fixedRetryIntervalInMilliseconds?: number;
   /** Max wait time in seconds to wait for a request while the retries are happening. Default value 30 seconds. */
-  maxWaitTimeInSeconds: number;
+  maxWaitTimeInSeconds?: number;
 }

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -64,9 +64,7 @@ export async function execute({
             requestContext.operationType,
           ),
           resourceThrottleRetryPolicy: new ResourceThrottleRetryPolicy(
-            requestContext.connectionPolicy.retryOptions.maxRetryAttemptCount,
-            requestContext.connectionPolicy.retryOptions.fixedRetryIntervalInMilliseconds,
-            requestContext.connectionPolicy.retryOptions.maxWaitTimeInSeconds,
+            requestContext.connectionPolicy.retryOptions ?? {},
           ),
           sessionReadRetryPolicy: new SessionRetryPolicy(
             requestContext.globalEndpointManager,


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#27312

### Describe the problem that is addressed by this PR
This PR makes `RetryOptions` for throttled requests in `ConnectionPolicy` optional. User can now pass some of the retry options, default value is picked for rest of the options.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
