### PR TITLE
[dev-tool] don't add `files: []` in migration-package

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -253,7 +253,6 @@ async function upgradeTypeScriptConfig(tsconfigPath: string): Promise<void> {
         path: "./tsconfig.test.json",
       },
     ],
-    files: [],
   };
 
   await saveJson(tsconfigPath, tsConfig);


### PR DESCRIPTION
as it prevents `ts-morph` from finding any files in the project thus no further
source transformations can be done.  This PR reverts the previous change.