### PR TITLE
Update CODEOWNERS Health Deidentification to use team alias

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -151,7 +151,7 @@
 
 # ServiceLabel: %Health Deidentification
 # PRLabel: %Health Deidentification
-/sdk/healthdataaiservices/azure-health-deidentification/ @GrahamMThomas @alexathomases
+/sdk/healthdataaiservices/azure-health-deidentification/ @GrahamMThomas @alexathomases @Azure/healthdatadeidentification
 
 # PRLabel: %Azure.Identity
 /sdk/identity/ @KarishmaGhiya @minhanh-phan @maorleger @schaabs @Azure/azure-sdk-write-identity


### PR DESCRIPTION
Updated "Health Deidentification" so it uses a team alias instead of user aliases. Left the original user aliases for now. 
New team alias reference: https://github.com/orgs/Azure/teams/healthdatadeidentification/members

### Packages impacted by this PR
/sdk/healthdataaiservices/azure-health-deidentification

### Issues associated with this PR

### Describe the problem that is addressed by this PR

Allows easier management of team codeowners, and avoids a new PR on every member change

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_

### Provide a list of related PRs _(if any)_

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
