### PR TITLE
[quantum-jobs][test] reduce size of recorded data

### DIFF
--- a/sdk/quantum/quantum-jobs/assets.json
+++ b/sdk/quantum/quantum-jobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/quantum/quantum-jobs",
-  "Tag": "js/quantum/quantum-jobs_9e3613da21"
+  "Tag": "js/quantum/quantum-jobs_f7105f0ae9"
 }

--- a/sdk/quantum/quantum-jobs/test/public/quantumJobClient.spec.ts
+++ b/sdk/quantum/quantum-jobs/test/public/quantumJobClient.spec.ts
@@ -136,11 +136,11 @@ describe("Quantum job lifecycle", () => {
     for await (const job of jobs) {
       if (job.id === jobDetails.id) {
         jobFound = true;
-        assert.equal(jobDetails.inputDataFormat, jobDetails.inputDataFormat);
-        assert.equal(jobDetails.outputDataFormat, jobDetails.outputDataFormat);
-        assert.equal(jobDetails.providerId, jobDetails.providerId);
-        assert.equal(jobDetails.target, jobDetails.target);
-        assert.equal(jobDetails.name, jobDetails.name);
+        assert.equal(job.inputDataFormat, jobDetails.inputDataFormat);
+        assert.equal(job.outputDataFormat, jobDetails.outputDataFormat);
+        assert.equal(job.providerId, jobDetails.providerId);
+        assert.equal(job.target, jobDetails.target);
+        assert.equal(job.name, jobDetails.name);
       }
     }
     assert.isTrue(jobFound);


### PR DESCRIPTION
Reduced number of entries in the result array of a recorded response from over 1300 to 35.

https://github.com/Azure/azure-sdk-assets/blob/f7105f0ae9cc5e7582368af3c4ade9abeae6d7c3/js/sdk/quantum/quantum-jobs/recordings/node/quantum_job_lifecycle/recording_test_quantum_job_lifecycle.json#L192
