### PR TITLE
[dev-tool] create ./review directory if it doesn't exist

### DIFF
--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -15,7 +15,7 @@ import { leafCommand, makeCommandInfo } from "../../framework/command";
 
 import { createPrinter } from "../../util/printer";
 import path from "path";
-import { readFile, writeFile, unlink } from "node:fs/promises";
+import { readFile, writeFile, unlink, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolveProject } from "../../util/resolveProject";
 
@@ -120,6 +120,12 @@ export default leafCommand(commandInfo, async () => {
   const projectInfo = await resolveProject(process.cwd());
   const packageJsonPath = path.join(projectInfo.path, "package.json");
   const packageJson = JSON.parse(await readFile(packageJsonPath, { encoding: "utf-8" }));
+
+  const reviewDirPath = path.join(projectInfo.path, "review");
+  if (!existsSync(reviewDirPath)) {
+    log.info(`creating directory ${reviewDirPath}`);
+    await mkdir(reviewDirPath);
+  }
 
   const apiExtractorJsonPath: string = path.join(projectInfo.path, "api-extractor.json");
   const extractorConfigObject = ExtractorConfig.loadFile(apiExtractorJsonPath);

--- a/sdk/defendereasm/arm-defendereasm/package.json
+++ b/sdk/defendereasm/arm-defendereasm/package.json
@@ -56,7 +56,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "npm run clean && dev-tool run build-package && dev-tool run vendored mkdirp ./review && dev-tool run extract-api",
+    "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "build:browser": "echo skipped",
     "build:node": "echo skipped",
     "build:samples": "echo skipped.",


### PR DESCRIPTION
This allows us to remove the `dev-tool vendored mkdirp ./review` NPM script
befor extracting api report.