### PR TITLE
[@azure/cosmos] fix changefeed iterator TimeOutError bug

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -72,7 +72,7 @@
     "test:signoff": "npm run integration-test:node -- --fgrep \"nosignoff\" --invert",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 100000 './test/internal/unit/*.spec.ts'",
+    "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 100000 './test/internal/unit/**/*.spec.ts'",
     "update-snippets": "echo skipped"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/cosmosdb/cosmos/src/client/ChangeFeed/ChangeFeedForPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/client/ChangeFeed/ChangeFeedForPartitionKey.ts
@@ -4,7 +4,7 @@ import type { InternalChangeFeedIteratorOptions } from "./InternalChangeFeedOpti
 import { ChangeFeedIteratorResponse } from "./ChangeFeedIteratorResponse";
 import type { Container, Resource } from "../../client";
 import type { ClientContext } from "../../ClientContext";
-import { Constants, ResourceType, StatusCodes } from "../../common";
+import { Constants, ResourceType } from "../../common";
 import type { FeedOptions, Response } from "../../request";
 import { ErrorResponse } from "../../request";
 import { ContinuationTokenForPartitionKey } from "./ContinuationTokenForPartitionKey";
@@ -177,17 +177,7 @@ export class ChangeFeedForPartitionKey<T> implements ChangeFeedPullModelIterator
         getEmptyCosmosDiagnostics(),
       );
     } catch (err) {
-      // If partition split/merge is encountered, handle it gracefully and continue fetching results.
-      if (err.code === StatusCodes.Gone) {
-        return new ChangeFeedIteratorResponse(
-          [],
-          0,
-          err.code,
-          err.headers,
-          getEmptyCosmosDiagnostics(),
-        );
-      }
-      // If any other errors are encountered, throw the error.
+      // If any errors are encountered, throw the error.
       const errorResponse = new ErrorResponse(err.message);
       errorResponse.code = err.code;
       errorResponse.headers = err.headers;

--- a/sdk/cosmosdb/cosmos/test/internal/unit/changeFeed/ChangeFeedForEpkRange.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/changeFeed/ChangeFeedForEpkRange.spec.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import assert from "assert";
+import sinon from "sinon";
+import { ChangeFeedForEpkRange, ChangeFeedMode } from "../../../../src/client/ChangeFeed";
+import { ClientContext, Container, ErrorResponse, TimeoutError } from "../../../../src";
+import { PartitionKeyRangeCache, QueryRange } from "../../../../src/routing";
+import { ChangeFeedRange } from "../../../../src/client/ChangeFeed/ChangeFeedRange";
+import { MockedQueryIterator } from "../../../public/common/MockQueryIterator";
+
+interface Resource {
+  id: string;
+  [key: string]: any;
+}
+
+class MockClientContext {
+  constructor(private partitionKeyRanges: unknown) {}
+  public queryPartitionKeyRanges(): MockedQueryIterator {
+    return new MockedQueryIterator(this.partitionKeyRanges);
+  }
+  public queryFeed() {
+    throw new TimeoutError();
+  }
+  public getClientConfig() {
+    return {};
+  }
+  public recordDiagnostics() {
+    return;
+  }
+}
+
+describe("ChangeFeedForEpkRange Unit Tests", () => {
+  const partitionKeyRanges = [{ id: "0", minInclusive: "", maxExclusive: "FF" }];
+
+  const clientContext: ClientContext = new MockClientContext(partitionKeyRanges) as any;
+  const partitionKeyRangeCache = new PartitionKeyRangeCache(clientContext);
+  let container: sinon.SinonStubbedInstance<Container>;
+  let changeFeedForEpkRange: ChangeFeedForEpkRange<Resource>;
+
+  beforeEach(() => {
+    container = sinon.createStubInstance(Container);
+
+    // Initialize ChangeFeedForEpkRange instance with mocked dependencies
+    changeFeedForEpkRange = new ChangeFeedForEpkRange<Resource>(
+      clientContext,
+      container as unknown as Container,
+      partitionKeyRangeCache as PartitionKeyRangeCache,
+      "resource-id",
+      "/dbs/db/colls/coll",
+      "https://localhost:8081/dbs/db/colls/coll",
+      {
+        continuationToken: undefined,
+        startFromNow: false,
+        startTime: undefined,
+        changeFeedMode: ChangeFeedMode.LatestVersion,
+        maxItemCount: 10,
+        sessionToken: "session-token",
+      },
+      new QueryRange("", "FF", true, false),
+    );
+
+    sinon.stub(changeFeedForEpkRange as any, "setIteratorRid").resolves();
+    sinon.stub(changeFeedForEpkRange as any, "fillChangeFeedQueue").resolves();
+    (changeFeedForEpkRange as any).isInstantiated = true;
+
+    const mockFeedRange = new ChangeFeedRange("", "FF", "abc");
+    (changeFeedForEpkRange as any).queue.enqueue(mockFeedRange);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should throw TimeOutError instead of handling it internally", async () => {
+    const timeOutError = new TimeoutError();
+
+    try {
+      await changeFeedForEpkRange.readNext();
+      assert.fail("should throw exception");
+    } catch (err) {
+      assert(err instanceof ErrorResponse);
+      assert.strictEqual(err.message, "Timeout Error");
+      assert.strictEqual(err.code, timeOutError.code);
+    }
+  });
+});

--- a/sdk/cosmosdb/cosmos/test/internal/unit/changeFeed/ChangeFeedForEpkRange.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/changeFeed/ChangeFeedForEpkRange.spec.ts
@@ -3,20 +3,21 @@
 import assert from "assert";
 import sinon from "sinon";
 import { ChangeFeedForEpkRange, ChangeFeedMode } from "../../../../src/client/ChangeFeed";
-import { ClientContext, Container, ErrorResponse, TimeoutError } from "../../../../src";
+import type { ClientContext } from "../../../../src";
+import { Container, ErrorResponse, TimeoutError } from "../../../../src";
 import { PartitionKeyRangeCache, QueryRange } from "../../../../src/routing";
 import { ChangeFeedRange } from "../../../../src/client/ChangeFeed/ChangeFeedRange";
-import { MockedQueryIterator } from "../../../public/common/MockQueryIterator";
+import { MockedClientContext } from "../../../public/common/MockClientContext";
 
 interface Resource {
   id: string;
   [key: string]: any;
 }
 
-class MockClientContext {
-  constructor(private partitionKeyRanges: unknown) {}
-  public queryPartitionKeyRanges(): MockedQueryIterator {
-    return new MockedQueryIterator(this.partitionKeyRanges);
+class MockClientContext extends MockedClientContext {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(partitionKeyRanges: unknown) {
+    super(partitionKeyRanges);
   }
   public queryFeed() {
     throw new TimeoutError();


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
#32652

### Describe the problem that is addressed by this PR
- SDK is currently incorrectly handling TimeoutError in items.getChangeFeedIterator(). Empty response gets generated internally instead of throwing the error.
- Fix unit test command 


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
