### PR TITLE
[opentelemetry] skip marking 304 RestError as an error on spans

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/internal/node/instrumentation.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/internal/node/instrumentation.spec.ts
@@ -33,10 +33,14 @@ describe("instrumentation end-to-end tests", () => {
       assert.equal(inner.kind, SpanKind.CLIENT);
 
       // Check status
-      // https://github.com/Azure/azure-sdk-for-js/pull/32018 changed from OK to UNSET as per spec https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+      // Status MUST be kept UNSET for http spans https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
       assert.deepEqual(coreRestPipeline.status, { code: SpanStatusCode.UNSET });
-      assert.deepEqual(inner.status, { code: SpanStatusCode.OK });
-      assert.deepEqual(outer.status, { code: SpanStatusCode.OK });
+      // For general spans:
+      // > Generally, Instrumentation Libraries SHOULD NOT set the status code to Ok, unless explicitly configured to do so.
+      // > Instrumentation Libraries SHOULD leave the status code as Unset unless there is an error, as described above.
+      // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/trace/api.md#set-status
+      assert.deepEqual(inner.status, { code: SpanStatusCode.UNSET });
+      assert.deepEqual(outer.status, { code: SpanStatusCode.UNSET });
 
       // Check instrumentationLibrary
       assert.equal(outer.instrumentationLibrary.name, tracingClientAttributes.packageName);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/opentelemetry-instrumentation-azure-sdk

### Issues associated with this PR

Fixes #32454

### Describe the problem that is addressed by this PR

When a conditional request comes back from the server with a status of 304, that
signals that the cached resource is still valid. While some libraries handle
that gracefully, others may throw an error due to backwards compatibility.

Regardless of whether an error is thrown to the user or not, a 304 is generally
not an error from a tracing perspective and can be suppressed.

In passing, I am also updating the implementation to skip setting span status to
OK in general scenarios as per the OTel spec.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

https://github.com/Azure/azure-sdk-for-js/pull/32663 explores doing this at the
core-tracing level; however, I think these semantics are specific to OTel and
this approach allows core-tracing to remain simple.

