### PR TITLE
Revert "[EngSys] add `files: []` to tsconfig.json that uses "references""

### DIFF
--- a/sdk/advisor/arm-advisor/tsconfig.json
+++ b/sdk/advisor/arm-advisor/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/agrifood/agrifood-farming-rest/tsconfig.json
+++ b/sdk/agrifood/agrifood-farming-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/agrifood/arm-agrifood/tsconfig.json
+++ b/sdk/agrifood/arm-agrifood/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/ai/ai-inference-rest/tsconfig.json
+++ b/sdk/ai/ai-inference-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/analysisservices/arm-analysisservices/tsconfig.json
+++ b/sdk/analysisservices/arm-analysisservices/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/tsconfig.json
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/apicenter/arm-apicenter/tsconfig.json
+++ b/sdk/apicenter/arm-apicenter/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/apimanagement/api-management-custom-widgets-tools/tsconfig.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/apimanagement/arm-apimanagement/tsconfig.json
+++ b/sdk/apimanagement/arm-apimanagement/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/tsconfig.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appconfiguration/app-configuration/tsconfig.json
+++ b/sdk/appconfiguration/app-configuration/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/appconfiguration/arm-appconfiguration/tsconfig.json
+++ b/sdk/appconfiguration/arm-appconfiguration/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appcontainers/arm-appcontainers/tsconfig.json
+++ b/sdk/appcontainers/arm-appcontainers/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/applicationinsights/arm-appinsights/tsconfig.json
+++ b/sdk/applicationinsights/arm-appinsights/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appplatform/arm-appplatform/tsconfig.json
+++ b/sdk/appplatform/arm-appplatform/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appservice/arm-appservice-rest/tsconfig.json
+++ b/sdk/appservice/arm-appservice-rest/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/appservice/arm-appservice/tsconfig.json
+++ b/sdk/appservice/arm-appservice/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/astro/arm-astro/tsconfig.json
+++ b/sdk/astro/arm-astro/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/attestation/arm-attestation/tsconfig.json
+++ b/sdk/attestation/arm-attestation/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/attestation/attestation/tsconfig.json
+++ b/sdk/attestation/attestation/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/authorization/arm-authorization/tsconfig.json
+++ b/sdk/authorization/arm-authorization/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/automanage/arm-automanage/tsconfig.json
+++ b/sdk/automanage/arm-automanage/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/automation/arm-automation/tsconfig.json
+++ b/sdk/automation/arm-automation/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/avs/arm-avs/tsconfig.json
+++ b/sdk/avs/arm-avs/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/tsconfig.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/azurestack/arm-azurestack/tsconfig.json
+++ b/sdk/azurestack/arm-azurestack/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/azurestackhci/arm-azurestackhci/tsconfig.json
+++ b/sdk/azurestackhci/arm-azurestackhci/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/tsconfig.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/batch/arm-batch/tsconfig.json
+++ b/sdk/batch/arm-batch/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/batch/batch-rest/tsconfig.json
+++ b/sdk/batch/batch-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/billing/arm-billing/tsconfig.json
+++ b/sdk/billing/arm-billing/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/billingbenefits/arm-billingbenefits/tsconfig.json
+++ b/sdk/billingbenefits/arm-billingbenefits/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/botservice/arm-botservice/tsconfig.json
+++ b/sdk/botservice/arm-botservice/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/cdn/arm-cdn/tsconfig.json
+++ b/sdk/cdn/arm-cdn/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/changeanalysis/arm-changeanalysis/tsconfig.json
+++ b/sdk/changeanalysis/arm-changeanalysis/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/changes/arm-changes/tsconfig.json
+++ b/sdk/changes/arm-changes/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/chaos/arm-chaos/tsconfig.json
+++ b/sdk/chaos/arm-chaos/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/cognitivelanguage/ai-language-conversations/tsconfig.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/cognitivelanguage/ai-language-text/tsconfig.json
+++ b/sdk/cognitivelanguage/ai-language-text/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/cognitivelanguage/ai-language-textauthoring/tsconfig.json
+++ b/sdk/cognitivelanguage/ai-language-textauthoring/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/cognitiveservices/arm-cognitiveservices/tsconfig.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/commerce/arm-commerce/tsconfig.json
+++ b/sdk/commerce/arm-commerce/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/communication/arm-communication/tsconfig.json
+++ b/sdk/communication/arm-communication/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/communication/communication-alpha-ids/tsconfig.json
+++ b/sdk/communication/communication-alpha-ids/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-call-automation/tsconfig.json
+++ b/sdk/communication/communication-call-automation/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-chat/tsconfig.json
+++ b/sdk/communication/communication-chat/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-common/tsconfig.json
+++ b/sdk/communication/communication-common/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-email/tsconfig.json
+++ b/sdk/communication/communication-email/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-identity/tsconfig.json
+++ b/sdk/communication/communication-identity/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-job-router-rest/tsconfig.json
+++ b/sdk/communication/communication-job-router-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-job-router/tsconfig.json
+++ b/sdk/communication/communication-job-router/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-messages-rest/tsconfig.json
+++ b/sdk/communication/communication-messages-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-phone-numbers/tsconfig.json
+++ b/sdk/communication/communication-phone-numbers/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-recipient-verification/tsconfig.json
+++ b/sdk/communication/communication-recipient-verification/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-rooms/tsconfig.json
+++ b/sdk/communication/communication-rooms/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-short-codes/tsconfig.json
+++ b/sdk/communication/communication-short-codes/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-sms/tsconfig.json
+++ b/sdk/communication/communication-sms/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-tiering/tsconfig.json
+++ b/sdk/communication/communication-tiering/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/communication/communication-toll-free-verification/tsconfig.json
+++ b/sdk/communication/communication-toll-free-verification/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/compute/arm-compute-rest/tsconfig.json
+++ b/sdk/compute/arm-compute-rest/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/confidentialledger/arm-confidentialledger/tsconfig.json
+++ b/sdk/confidentialledger/arm-confidentialledger/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/confluent/arm-confluent/tsconfig.json
+++ b/sdk/confluent/arm-confluent/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/connectedvmware/arm-connectedvmware/tsconfig.json
+++ b/sdk/connectedvmware/arm-connectedvmware/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/consumption/arm-consumption/tsconfig.json
+++ b/sdk/consumption/arm-consumption/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/containerinstance/arm-containerinstance/tsconfig.json
+++ b/sdk/containerinstance/arm-containerinstance/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/containerregistry/arm-containerregistry/tsconfig.json
+++ b/sdk/containerregistry/arm-containerregistry/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/containerregistry/container-registry/tsconfig.json
+++ b/sdk/containerregistry/container-registry/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/containerservice/arm-containerservice-rest/tsconfig.json
+++ b/sdk/containerservice/arm-containerservice-rest/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/containerservice/arm-containerservice/tsconfig.json
+++ b/sdk/containerservice/arm-containerservice/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/containerservice/arm-containerservicefleet/tsconfig.json
+++ b/sdk/containerservice/arm-containerservicefleet/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/contentsafety/ai-content-safety-rest/tsconfig.json
+++ b/sdk/contentsafety/ai-content-safety-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/abort-controller/tsconfig.json
+++ b/sdk/core/abort-controller/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-amqp/tsconfig.json
+++ b/sdk/core/core-amqp/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-auth/tsconfig.json
+++ b/sdk/core/core-auth/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-client-rest/tsconfig.json
+++ b/sdk/core/core-client-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-client/tsconfig.json
+++ b/sdk/core/core-client/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-http-compat/tsconfig.json
+++ b/sdk/core/core-http-compat/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-lro/tsconfig.json
+++ b/sdk/core/core-lro/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-paging/tsconfig.json
+++ b/sdk/core/core-paging/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-rest-pipeline/tsconfig.json
+++ b/sdk/core/core-rest-pipeline/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-sse/tsconfig.json
+++ b/sdk/core/core-sse/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-tracing/tsconfig.json
+++ b/sdk/core/core-tracing/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-util/tsconfig.json
+++ b/sdk/core/core-util/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/core-xml/tsconfig.json
+++ b/sdk/core/core-xml/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/logger/tsconfig.json
+++ b/sdk/core/logger/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/core/ts-http-runtime/tsconfig.json
+++ b/sdk/core/ts-http-runtime/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/cosmosdb/arm-cosmosdb/tsconfig.json
+++ b/sdk/cosmosdb/arm-cosmosdb/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/tsconfig.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/cost-management/arm-costmanagement/tsconfig.json
+++ b/sdk/cost-management/arm-costmanagement/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/customer-insights/arm-customerinsights/tsconfig.json
+++ b/sdk/customer-insights/arm-customerinsights/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/dashboard/arm-dashboard/tsconfig.json
+++ b/sdk/dashboard/arm-dashboard/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/databoundaries/arm-databoundaries/tsconfig.json
+++ b/sdk/databoundaries/arm-databoundaries/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/databox/arm-databox/tsconfig.json
+++ b/sdk/databox/arm-databox/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/databoxedge/arm-databoxedge/tsconfig.json
+++ b/sdk/databoxedge/arm-databoxedge/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/databricks/arm-databricks/tsconfig.json
+++ b/sdk/databricks/arm-databricks/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/datacatalog/arm-datacatalog/tsconfig.json
+++ b/sdk/datacatalog/arm-datacatalog/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/devcenter/developer-devcenter-rest/tsconfig.json
+++ b/sdk/devcenter/developer-devcenter-rest/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/deviceregistry/arm-deviceregistry/tsconfig.json
+++ b/sdk/deviceregistry/arm-deviceregistry/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/deviceupdate/iot-device-update-rest/tsconfig.json
+++ b/sdk/deviceupdate/iot-device-update-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/tsconfig.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/digitaltwins/digital-twins-core/tsconfig.json
+++ b/sdk/digitaltwins/digital-twins-core/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/documentintelligence/ai-document-intelligence-rest/tsconfig.json
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/documenttranslator/ai-document-translator-rest/tsconfig.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/easm/defender-easm-rest/tsconfig.json
+++ b/sdk/easm/defender-easm-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/edgezones/arm-edgezones/tsconfig.json
+++ b/sdk/edgezones/arm-edgezones/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/entra/functions-authentication-events/tsconfig.json
+++ b/sdk/entra/functions-authentication-events/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventgrid/eventgrid-namespaces/tsconfig.json
+++ b/sdk/eventgrid/eventgrid-namespaces/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventgrid/eventgrid-system-events/tsconfig.json
+++ b/sdk/eventgrid/eventgrid-system-events/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventgrid/eventgrid/tsconfig.json
+++ b/sdk/eventgrid/eventgrid/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventhub/event-hubs/tsconfig.json
+++ b/sdk/eventhub/event-hubs/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/eventhub/mock-hub/tsconfig.json
+++ b/sdk/eventhub/mock-hub/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/fabric/arm-fabric/tsconfig.json
+++ b/sdk/fabric/arm-fabric/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/face/ai-vision-face-rest/tsconfig.json
+++ b/sdk/face/ai-vision-face-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/formrecognizer/ai-form-recognizer/tsconfig.json
+++ b/sdk/formrecognizer/ai-form-recognizer/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/tsconfig.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/healthdataaiservices/azure-health-deidentification/tsconfig.json
+++ b/sdk/healthdataaiservices/azure-health-deidentification/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/healthinsights/health-insights-cancerprofiling-rest/tsconfig.json
+++ b/sdk/healthinsights/health-insights-cancerprofiling-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/healthinsights/health-insights-clinicalmatching-rest/tsconfig.json
+++ b/sdk/healthinsights/health-insights-clinicalmatching-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/healthinsights/health-insights-radiologyinsights-rest/tsconfig.json
+++ b/sdk/healthinsights/health-insights-radiologyinsights-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/identity/identity-broker/tsconfig.json
+++ b/sdk/identity/identity-broker/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/identity/identity-cache-persistence/tsconfig.json
+++ b/sdk/identity/identity-cache-persistence/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/identity/identity-vscode/tsconfig.json
+++ b/sdk/identity/identity-vscode/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/tsconfig.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/iot/iot-modelsrepository/tsconfig.json
+++ b/sdk/iot/iot-modelsrepository/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/iotoperations/arm-iotoperations/tsconfig.json
+++ b/sdk/iotoperations/arm-iotoperations/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/keyvault/keyvault-admin/tsconfig.json
+++ b/sdk/keyvault/keyvault-admin/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/keyvault/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/keyvault/keyvault-common/tsconfig.json
+++ b/sdk/keyvault/keyvault-common/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/keyvault/keyvault-keys/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/tsconfig.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/loadtesting/load-testing-rest/tsconfig.json
+++ b/sdk/loadtesting/load-testing-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/maps/maps-geolocation-rest/tsconfig.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/maps/maps-render-rest/tsconfig.json
+++ b/sdk/maps/maps-render-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/maps/maps-route-rest/tsconfig.json
+++ b/sdk/maps/maps-route-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/maps/maps-search-rest/tsconfig.json
+++ b/sdk/maps/maps-search-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/maps/maps-timezone-rest/tsconfig.json
+++ b/sdk/maps/maps-timezone-rest/tsconfig.json
@@ -4,6 +4,5 @@
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.samples.json" },
     { "path": "./tsconfig.test.json" }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/tsconfig.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/mixedreality/mixed-reality-authentication/tsconfig.json
+++ b/sdk/mixedreality/mixed-reality-authentication/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/mongocluster/arm-mongocluster/tsconfig.json
+++ b/sdk/mongocluster/arm-mongocluster/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/monitor/monitor-ingestion/tsconfig.json
+++ b/sdk/monitor/monitor-ingestion/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/tsconfig.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/monitor/monitor-query/tsconfig.json
+++ b/sdk/monitor/monitor-query/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/neonpostgres/arm-neonpostgres/tsconfig.json
+++ b/sdk/neonpostgres/arm-neonpostgres/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/network/arm-network-rest/tsconfig.json
+++ b/sdk/network/arm-network-rest/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/notificationhubs/arm-notificationhubs/tsconfig.json
+++ b/sdk/notificationhubs/arm-notificationhubs/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/notificationhubs/notification-hubs/tsconfig.json
+++ b/sdk/notificationhubs/notification-hubs/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/openai/openai/tsconfig.json
+++ b/sdk/openai/openai/tsconfig.json
@@ -1,18 +1,11 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "target": "ES2017",
     "moduleResolution": "nodenext"
-  },
-  "files": []
+  }
 }

--- a/sdk/playwrighttesting/arm-playwrighttesting/tsconfig.json
+++ b/sdk/playwrighttesting/arm-playwrighttesting/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/playwrighttesting/create-microsoft-playwright-testing/tsconfig.json
+++ b/sdk/playwrighttesting/create-microsoft-playwright-testing/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/policy/arm-policy/tsconfig.json
+++ b/sdk/policy/arm-policy/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/postgresql/arm-postgresql-flexible/tsconfig.json
+++ b/sdk/postgresql/arm-postgresql-flexible/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/purview/purview-administration-rest/tsconfig.json
+++ b/sdk/purview/purview-administration-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/purview/purview-catalog-rest/tsconfig.json
+++ b/sdk/purview/purview-catalog-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/purview/purview-datamap-rest/tsconfig.json
+++ b/sdk/purview/purview-datamap-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/purview/purview-scanning-rest/tsconfig.json
+++ b/sdk/purview/purview-scanning-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/purview/purview-sharing-rest/tsconfig.json
+++ b/sdk/purview/purview-sharing-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/purview/purview-workflow-rest/tsconfig.json
+++ b/sdk/purview/purview-workflow-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/quantum/quantum-jobs/tsconfig.json
+++ b/sdk/quantum/quantum-jobs/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/remoterendering/mixed-reality-remote-rendering/tsconfig.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/schemaregistry/schema-registry-avro/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry-avro/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/schemaregistry/schema-registry-json/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry-json/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/schemaregistry/schema-registry/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/search/search-documents/tsconfig.json
+++ b/sdk/search/search-documents/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/servicebus/service-bus/tsconfig.json
+++ b/sdk/servicebus/service-bus/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "files": [],
   "references": [
     { "path": "./tsconfig.src.json" },
     { "path": "./tsconfig.samples.json" },

--- a/sdk/servicefabric/arm-servicefabric-rest/tsconfig.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/standbypool/arm-standbypool/tsconfig.json
+++ b/sdk/standbypool/arm-standbypool/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/synapse/synapse-access-control-rest/tsconfig.json
+++ b/sdk/synapse/synapse-access-control-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/synapse/synapse-access-control/tsconfig.json
+++ b/sdk/synapse/synapse-access-control/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/synapse/synapse-artifacts/tsconfig.json
+++ b/sdk/synapse/synapse-artifacts/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/synapse/synapse-managed-private-endpoints/tsconfig.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/synapse/synapse-monitoring/tsconfig.json
+++ b/sdk/synapse/synapse-monitoring/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/synapse/synapse-spark/tsconfig.json
+++ b/sdk/synapse/synapse-spark/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/tables/data-tables/tsconfig.json
+++ b/sdk/tables/data-tables/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/template/template-dpg/tsconfig.json
+++ b/sdk/template/template-dpg/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/template/template/tsconfig.json
+++ b/sdk/template/template/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/templatespecs/arm-templatespecs/tsconfig.json
+++ b/sdk/templatespecs/arm-templatespecs/tsconfig.json
@@ -9,14 +9,25 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6", "dom"],
+    "lib": [
+      "es6",
+      "dom"
+    ],
     "declaration": true,
     "outDir": "./dist-esm",
     "importHelpers": true,
     "paths": {
-      "@azure/arm-templatespecs": ["./src/index"]
+      "@azure/arm-templatespecs": [
+        "./src/index"
+      ]
     }
   },
-  "include": ["./src/**/*.ts", "./test/**/*.ts", "samples-dev/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "./src/**/*.ts",
+    "./test/**/*.ts",
+    "samples-dev/**/*.ts",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/sdk/terraform/arm-terraform/tsconfig.json
+++ b/sdk/terraform/arm-terraform/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/test-utils/recorder/tsconfig.json
+++ b/sdk/test-utils/recorder/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/test-utils/test-credential/tsconfig.json
+++ b/sdk/test-utils/test-credential/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/test-utils/test-utils-vitest/tsconfig.json
+++ b/sdk/test-utils/test-utils-vitest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/textanalytics/ai-text-analytics/tsconfig.json
+++ b/sdk/textanalytics/ai-text-analytics/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/translation/ai-translation-text-rest/tsconfig.json
+++ b/sdk/translation/ai-translation-text-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/trustedsigning/arm-trustedsigning/tsconfig.json
+++ b/sdk/trustedsigning/arm-trustedsigning/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/vision/ai-vision-image-analysis-rest/tsconfig.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/voiceservices/arm-voiceservices/tsconfig.json
+++ b/sdk/voiceservices/arm-voiceservices/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/web-pubsub/arm-webpubsub/tsconfig.json
+++ b/sdk/web-pubsub/arm-webpubsub/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/web-pubsub/web-pubsub-client/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-client/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/web-pubsub/web-pubsub-express/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-express/tsconfig.json
@@ -1,17 +1,10 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
   ],
   "compilerOptions": {
     "esModuleInterop": true
-  },
-  "files": []
+  }
 }

--- a/sdk/web-pubsub/web-pubsub/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub/tsconfig.json
@@ -1,14 +1,7 @@
 {
   "references": [
-    {
-      "path": "./tsconfig.src.json"
-    },
-    {
-      "path": "./tsconfig.samples.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
-    }
-  ],
-  "files": []
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.samples.json" },
+    { "path": "./tsconfig.test.json" }
+  ]
 }

--- a/sdk/workloads/arm-workloads/tsconfig.json
+++ b/sdk/workloads/arm-workloads/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }

--- a/sdk/workloads/arm-workloadssapvirtualinstance/tsconfig.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/tsconfig.json
@@ -9,6 +9,5 @@
     {
       "path": "./tsconfig.test.json"
     }
-  ],
-  "files": []
+  ]
 }


### PR DESCRIPTION
This reverts commit 910dbeefb7a1e5bb206c905df65765886a4c85b0 because it prevents `ts-morph` from finding any source files. We should investigate whether there's a better fix to the VS Code errors for tsconfig files.

***NO_CI***
