### PR TITLE
[test][communication] fix mock tests after vitest v3 upgrade

### DIFF
--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
@@ -7,11 +7,15 @@ import { getTokenForTeamsUserHttpClient, getTokenHttpClient } from "./utils/mock
 import { CommunicationIdentityClient } from "../../src/index.js";
 import { TestCommunicationIdentityClient } from "./utils/testCommunicationIdentityClient.js";
 import { isNodeLike } from "@azure/core-util";
-import { describe, it, assert, expect, vi } from "vitest";
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
 
 describe("CommunicationIdentityClient [Mocked]", () => {
   const dateHeader = "x-ms-date";
   const user: CommunicationUserIdentifier = { communicationUserId: "ACS_ID" };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
 
   it("creates instance of CommunicationIdentityClient", () => {
     const client = new CommunicationIdentityClient(

--- a/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
@@ -9,7 +9,7 @@ import { getPhoneNumberHttpClient } from "../public/utils/mockHttpClients.js";
 import { SDK_VERSION } from "../../src/utils/constants.js";
 import { createMockToken } from "../public/utils/recordedClient.js";
 import type { PipelineRequest } from "@azure/core-rest-pipeline";
-import { describe, it, assert, expect, vi } from "vitest";
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
 
 describe("PhoneNumbersClient - headers", () => {
   const endpoint = "https://contoso.spool.azure.local";
@@ -18,6 +18,10 @@ describe("PhoneNumbersClient - headers", () => {
     httpClient: getPhoneNumberHttpClient,
   });
   let request: PipelineRequest;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
 
   it("calls the spy", async () => {
     const spy = vi.spyOn(getPhoneNumberHttpClient, "sendRequest");

--- a/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
@@ -9,7 +9,7 @@ import { getTrunksHttpClient } from "../../public/siprouting/utils/mockHttpClien
 import { SDK_VERSION } from "../../../src/utils/constants.js";
 import { createMockToken } from "../../public/utils/recordedClient.js";
 import type { PipelineRequest } from "@azure/core-rest-pipeline";
-import { describe, it, assert, expect, vi } from "vitest";
+import { describe, it, assert, expect, vi, beforeEach } from "vitest";
 
 describe("SipRoutingClient - headers", () => {
   const endpoint = "https://contoso.spool.azure.local";
@@ -18,6 +18,10 @@ describe("SipRoutingClient - headers", () => {
     httpClient: getTrunksHttpClient,
   });
   let request: PipelineRequest;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
 
   it("calls the spy", async () => {
     const spy = vi.spyOn(getTrunksHttpClient, "sendRequest");


### PR DESCRIPTION
In v3 vitest changes `vi.spyOn` to reuses mock. Previously it always assigned a new spy.

https://vitest.dev/guide/migration.html#vi-spyon-reuses-mock-if-method-is-already-mocked

This PR resets mocks before running tests to avoid mock from previous tests from being used.