### PR TITLE
[communication] Fix vitest mock teardown calls

### DIFF
--- a/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
+++ b/sdk/communication/communication-identity/test/public/communicationIdentityClient.mocked.spec.ts
@@ -7,11 +7,15 @@ import { getTokenForTeamsUserHttpClient, getTokenHttpClient } from "./utils/mock
 import { CommunicationIdentityClient } from "../../src/index.js";
 import { TestCommunicationIdentityClient } from "./utils/testCommunicationIdentityClient.js";
 import { isNodeLike } from "@azure/core-util";
-import { describe, it, assert, expect, vi } from "vitest";
+import { describe, it, assert, expect, vi, afterEach } from "vitest";
 
 describe("CommunicationIdentityClient [Mocked]", () => {
   const dateHeader = "x-ms-date";
   const user: CommunicationUserIdentifier = { communicationUserId: "ACS_ID" };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("creates instance of CommunicationIdentityClient", () => {
     const client = new CommunicationIdentityClient(

--- a/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/headers.spec.ts
@@ -9,7 +9,7 @@ import { getPhoneNumberHttpClient } from "../public/utils/mockHttpClients.js";
 import { SDK_VERSION } from "../../src/utils/constants.js";
 import { createMockToken } from "../public/utils/recordedClient.js";
 import type { PipelineRequest } from "@azure/core-rest-pipeline";
-import { describe, it, assert, expect, vi } from "vitest";
+import { describe, it, assert, expect, vi, afterEach } from "vitest";
 
 describe("PhoneNumbersClient - headers", () => {
   const endpoint = "https://contoso.spool.azure.local";
@@ -18,6 +18,10 @@ describe("PhoneNumbersClient - headers", () => {
     httpClient: getPhoneNumberHttpClient,
   });
   let request: PipelineRequest;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("calls the spy", async () => {
     const spy = vi.spyOn(getPhoneNumberHttpClient, "sendRequest");

--- a/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
+++ b/sdk/communication/communication-phone-numbers/test/internal/siprouting/headers.spec.ts
@@ -9,7 +9,7 @@ import { getTrunksHttpClient } from "../../public/siprouting/utils/mockHttpClien
 import { SDK_VERSION } from "../../../src/utils/constants.js";
 import { createMockToken } from "../../public/utils/recordedClient.js";
 import type { PipelineRequest } from "@azure/core-rest-pipeline";
-import { describe, it, assert, expect, vi } from "vitest";
+import { describe, it, assert, expect, vi, afterEach } from "vitest";
 
 describe("SipRoutingClient - headers", () => {
   const endpoint = "https://contoso.spool.azure.local";
@@ -18,6 +18,10 @@ describe("SipRoutingClient - headers", () => {
     httpClient: getTrunksHttpClient,
   });
   let request: PipelineRequest;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("calls the spy", async () => {
     const spy = vi.spyOn(getTrunksHttpClient, "sendRequest");


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/communication-phone-numbers
- @azure/communication-identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Fixes vitest methods to ensure after each a `vi.restoreAllMocks` is called to ensure the mock is reset.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- #32680

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
