### PR TITLE
[app-configuration] remove core-http-compat dependency

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Release History
 
-## 1.8.1 (Unreleased)
+## 1.9.0 (Unreleased)
 
 ### Features Added
 
@@ -11,6 +11,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Remove diagnostic `_response` properties from responses.
 
 ## 1.8.0 (2024-11-05)
 

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "sdk-type": "client",
   "keywords": [
     "node",
@@ -74,7 +74,6 @@
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-auth": "^1.3.0",
     "@azure/core-client": "^1.5.0",
-    "@azure/core-http-compat": "^2.0.0",
     "@azure/core-lro": "^2.5.1",
     "@azure/core-paging": "^1.4.0",
     "@azure/core-rest-pipeline": "^1.6.0",

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import type { CommonClientOptions } from '@azure/core-client';
-import type { CompatResponse } from '@azure/core-http-compat';
 import type { OperationOptions } from '@azure/core-client';
 import type { OperationState } from '@azure/core-lro';
 import type { PagedAsyncIterableIterator } from '@azure/core-paging';
@@ -20,7 +19,7 @@ export interface AddConfigurationSettingOptions extends OperationOptions {
 export type AddConfigurationSettingParam<T extends string | FeatureFlagValue | SecretReferenceValue = string> = ConfigurationSettingParam<T>;
 
 // @public
-export interface AddConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
+export interface AddConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField {
 }
 
 // @public
@@ -76,7 +75,7 @@ export type ConfigurationSettingParam<T extends string | FeatureFlagValue | Secr
 });
 
 // @public
-export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting & HttpResponseField<HeadersT> & Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
+export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting & Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
 
 // @public
 export interface ConfigurationSettingsFilter {
@@ -119,7 +118,7 @@ export interface DeleteConfigurationSettingOptions extends HttpOnlyIfUnchangedFi
 }
 
 // @public
-export interface DeleteConfigurationSettingResponse extends SyncTokenHeaderField, HttpResponseFields, HttpResponseField<SyncTokenHeaderField> {
+export interface DeleteConfigurationSettingResponse extends SyncTokenHeaderField, HttpResponseFields {
 }
 
 // @public
@@ -157,7 +156,7 @@ export interface GetConfigurationSettingOptions extends OperationOptions, HttpOn
 }
 
 // @public
-export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseFields, HttpResponseField<GetConfigurationHeaders> {
+export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseFields {
 }
 
 // @public
@@ -176,14 +175,6 @@ export interface HttpOnlyIfChangedField {
 // @public
 export interface HttpOnlyIfUnchangedField {
     onlyIfUnchanged?: boolean;
-}
-
-// @public
-export interface HttpResponseField<HeadersT> {
-    _response: CompatResponse & {
-        parsedHeaders: HeadersT;
-        bodyAsText: string;
-    };
 }
 
 // @public
@@ -212,7 +203,7 @@ export enum KnownSnapshotComposition {
 }
 
 // @public
-export interface ListConfigurationSettingPage extends HttpResponseField<SyncTokenHeaderField>, PageSettings, EtagEntity {
+export interface ListConfigurationSettingPage extends PageSettings, EtagEntity {
     items: ConfigurationSetting[];
 }
 
@@ -232,7 +223,7 @@ export interface ListLabelsOptions extends OperationOptions, OptionalLabelsField
 }
 
 // @public
-export interface ListLabelsPage extends HttpResponseField<SyncTokenHeaderField>, PageSettings, EtagEntity {
+export interface ListLabelsPage extends PageSettings, EtagEntity {
     items: SettingLabel[];
 }
 
@@ -241,7 +232,7 @@ export interface ListRevisionsOptions extends OperationOptions, ListSettingsOpti
 }
 
 // @public
-export interface ListRevisionsPage extends HttpResponseField<SyncTokenHeaderField>, PageSettings {
+export interface ListRevisionsPage extends PageSettings {
     items: ConfigurationSetting[];
 }
 
@@ -316,7 +307,7 @@ export interface SetConfigurationSettingOptions extends HttpOnlyIfUnchangedField
 export type SetConfigurationSettingParam<T extends string | FeatureFlagValue | SecretReferenceValue = string> = ConfigurationSettingParam<T>;
 
 // @public
-export interface SetConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
+export interface SetConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField {
 }
 
 // @public
@@ -324,7 +315,7 @@ export interface SetReadOnlyOptions extends HttpOnlyIfUnchangedField, OperationO
 }
 
 // @public
-export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
+export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField {
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -19,7 +19,6 @@ import type {
   GetConfigurationSettingResponse,
   GetSnapshotOptions,
   GetSnapshotResponse,
-  HttpResponseField,
   ListConfigurationSettingPage,
   ListConfigurationSettingsForSnapshotOptions,
   ListConfigurationSettingsOptions,
@@ -41,15 +40,11 @@ import type {
   UpdateSnapshotResponse,
 } from "./models.js";
 import type {
-  AppConfigurationGetKeyValuesHeaders,
-  AppConfigurationGetRevisionsHeaders,
-  AppConfigurationGetSnapshotsHeaders,
   GetKeyValuesResponse,
   GetRevisionsResponse,
   GetSnapshotsResponse,
   ConfigurationSnapshot,
   GetLabelsResponse,
-  AppConfigurationGetLabelsHeaders,
 } from "./generated/src/models/index.js";
 import type { InternalClientPipelineOptions } from "@azure/core-client";
 import type { PagedAsyncIterableIterator, PagedResult } from "@azure/core-paging";
@@ -64,7 +59,6 @@ import type {
   SendLabelsRequestOptions,
 } from "./internal/helpers.js";
 import {
-  assertResponse,
   checkAndFormatIfAndIfNoneMatch,
   extractAfterTokenFromLinkHeader,
   extractAfterTokenFromNextLink,
@@ -240,7 +234,6 @@ export class AppConfigurationClient {
             ...updatedOptions,
           });
           const response = transformKeyValueResponse(originalResponse);
-          assertResponse(response);
           return response;
         } catch (error) {
           const err = error as RestError;
@@ -296,7 +289,6 @@ export class AppConfigurationClient {
         });
 
         const response = transformKeyValueResponseWithStatusCode(originalResponse, status);
-        assertResponse(response);
         return response;
       },
     );
@@ -353,7 +345,6 @@ export class AppConfigurationClient {
           // and now we'll undefine all the other properties that are not HTTP related
           makeConfigurationSettingEmpty(response);
         }
-        assertResponse(response);
         return response;
       },
     );
@@ -398,7 +389,6 @@ export class AppConfigurationClient {
               continuationToken: response.nextLink
                 ? extractAfterTokenFromNextLink(response.nextLink)
                 : undefined,
-              _response: response._response,
             };
             return {
               page: currentResponse,
@@ -512,7 +502,6 @@ export class AppConfigurationClient {
           continuationToken: response.nextLink
             ? extractAfterTokenFromNextLink(response.nextLink)
             : undefined,
-          _response: response._response,
         };
         return {
           page: currentResponse,
@@ -527,7 +516,7 @@ export class AppConfigurationClient {
   private async sendLabelsRequest(
     options: SendLabelsRequestOptions & PageSettings = {},
     pageLink: string | undefined,
-  ): Promise<GetLabelsResponse & HttpResponseField<AppConfigurationGetLabelsHeaders>> {
+  ): Promise<GetLabelsResponse> {
     return tracingClient.withSpan(
       "AppConfigurationClient.listConfigurationSettings",
       options,
@@ -539,7 +528,7 @@ export class AppConfigurationClient {
           after: pageLink,
         });
 
-        return response as GetLabelsResponse & HttpResponseField<AppConfigurationGetLabelsHeaders>;
+        return response as GetLabelsResponse;
       },
     );
   }
@@ -547,7 +536,7 @@ export class AppConfigurationClient {
   private async sendConfigurationSettingsRequest(
     options: SendConfigurationSettingsOptions & PageSettings = {},
     pageLink: string | undefined,
-  ): Promise<GetKeyValuesResponse & HttpResponseField<AppConfigurationGetKeyValuesHeaders>> {
+  ): Promise<GetKeyValuesResponse> {
     return tracingClient.withSpan(
       "AppConfigurationClient.listConfigurationSettings",
       options,
@@ -560,8 +549,7 @@ export class AppConfigurationClient {
           after: pageLink,
         });
 
-        return response as GetKeyValuesResponse &
-          HttpResponseField<AppConfigurationGetKeyValuesHeaders>;
+        return response as GetKeyValuesResponse;
       },
     );
   }
@@ -612,7 +600,7 @@ export class AppConfigurationClient {
   private async sendRevisionsRequest(
     options: ListConfigurationSettingsOptions & PageSettings = {},
     pageLink: string | undefined,
-  ): Promise<GetKeyValuesResponse & HttpResponseField<AppConfigurationGetKeyValuesHeaders>> {
+  ): Promise<GetKeyValuesResponse> {
     return tracingClient.withSpan(
       "AppConfigurationClient.listRevisions",
       options,
@@ -624,8 +612,7 @@ export class AppConfigurationClient {
           after: pageLink,
         });
 
-        return response as GetRevisionsResponse &
-          HttpResponseField<AppConfigurationGetRevisionsHeaders>;
+        return response as GetRevisionsResponse;
       },
     );
   }
@@ -670,7 +657,6 @@ export class AppConfigurationClient {
             ...checkAndFormatIfAndIfNoneMatch(configurationSetting, options),
           }),
         );
-        assertResponse(response);
         return response;
       },
     );
@@ -706,7 +692,6 @@ export class AppConfigurationClient {
           });
         }
         response = transformKeyValueResponse(response);
-        assertResponse(response);
         return response;
       },
     );
@@ -784,7 +769,6 @@ export class AppConfigurationClient {
           ...updatedOptions,
         });
         const response = transformSnapshotResponse(originalResponse);
-        assertResponse(response);
         return response;
       },
     );
@@ -830,7 +814,6 @@ export class AppConfigurationClient {
           },
         );
         const response = transformSnapshotResponse(originalResponse);
-        assertResponse(response);
         return response;
       },
     );
@@ -875,7 +858,6 @@ export class AppConfigurationClient {
           },
         );
         const response = transformSnapshotResponse(originalResponse);
-        assertResponse(response);
         return response;
       },
     );
@@ -929,7 +911,7 @@ export class AppConfigurationClient {
   private async sendSnapShotsRequest(
     options: ListSnapshotsOptions & PageSettings = {},
     pageLink: string | undefined,
-  ): Promise<GetSnapshotsResponse & HttpResponseField<AppConfigurationGetSnapshotsHeaders>> {
+  ): Promise<GetSnapshotsResponse> {
     return tracingClient.withSpan(
       "AppConfigurationClient.listSnapshots",
       options,
@@ -940,8 +922,7 @@ export class AppConfigurationClient {
           after: pageLink,
         });
 
-        return response as GetSnapshotsResponse &
-          HttpResponseField<AppConfigurationGetSnapshotsHeaders>;
+        return response as GetSnapshotsResponse;
       },
     );
   }

--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfiguration.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfiguration.ts
@@ -1,4 +1,4 @@
-  /*
+/*
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  *
@@ -7,7 +7,6 @@
  */
 
 import * as coreClient from "@azure/core-client";
-import * as coreHttpCompat from "@azure/core-http-compat";
 import {
   PipelineRequest,
   PipelineResponse,
@@ -81,7 +80,7 @@ import {
 } from "./models/index.js";
 
 /** @internal */
-export class AppConfiguration extends coreHttpCompat.ExtendedServiceClient {
+export class AppConfiguration extends coreClient.ServiceClient {
   endpoint: string;
   syncToken?: string;
   apiVersion: ApiVersion20231101;
@@ -112,7 +111,7 @@ export class AppConfiguration extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-app-configuration/1.8.1`;
+    const packageDetails = `azsdk-js-app-configuration/1.9.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/appconfiguration/app-configuration/src/generated/src/models/index.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/models/index.ts
@@ -7,7 +7,6 @@
  */
 
 import * as coreClient from "@azure/core-client";
-import * as coreHttpCompat from "@azure/core-http-compat";
 
 /** The result of a list request. */
 export interface KeyListResult {
@@ -945,7 +944,7 @@ export type GetRevisionsNextResponse = AppConfigurationGetRevisionsNextHeaders &
 
 /** Optional parameters. */
 export interface AppConfigurationOptionalParams
-  extends coreHttpCompat.ExtendedServiceClientOptions {
+  extends coreClient.ServiceClientOptions {
   /** Used to guarantee real-time consistency between requests. */
   syncToken?: string;
   /** Overrides client endpoint. */

--- a/sdk/appconfiguration/app-configuration/src/internal/constants.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/constants.ts
@@ -4,7 +4,7 @@
 /**
  * @internal
  */
-export const packageVersion = "1.8.1";
+export const packageVersion = "1.9.0";
 
 /**
  * @internal

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -6,7 +6,6 @@ import type {
   ConfigurationSettingParam,
   HttpOnlyIfChangedField,
   HttpOnlyIfUnchangedField,
-  HttpResponseField,
   HttpResponseFields,
   ListRevisionsOptions,
   ListSettingsOptions,
@@ -357,13 +356,6 @@ export function transformKeyValueResponseWithStatusCode<T extends KeyValue>(
     ...transformKeyValue(kvp),
     statusCode: status ?? -1,
   };
-
-  if (hasUnderscoreResponse(kvp)) {
-    Object.defineProperty(response, "_response", {
-      enumerable: false,
-      value: kvp._response,
-    });
-  }
   return response;
 }
 
@@ -374,12 +366,6 @@ export function transformKeyValueResponse<T extends KeyValue & { eTag?: string }
   kvp: T,
 ): ConfigurationSetting {
   const setting = transformKeyValue(kvp);
-  if (hasUnderscoreResponse(kvp)) {
-    Object.defineProperty(setting, "_response", {
-      enumerable: false,
-      value: kvp._response,
-    });
-  }
 
   delete setting.eTag;
   return setting;
@@ -391,12 +377,6 @@ export function transformKeyValueResponse<T extends KeyValue & { eTag?: string }
 export function transformSnapshotResponse<T extends ConfigurationSnapshot>(
   snapshot: T,
 ): SnapshotResponse {
-  if (hasUnderscoreResponse(snapshot)) {
-    Object.defineProperty(snapshot, "_response", {
-      enumerable: false,
-      value: snapshot._response,
-    });
-  }
   return snapshot as any;
 }
 
@@ -440,22 +420,4 @@ export function errorMessageForUnexpectedSetting(
   expectedType: "FeatureFlag" | "SecretReference",
 ): string {
   return `Setting with key ${key} is not a valid ${expectedType}, make sure to have the correct content-type and a valid non-null value.`;
-}
-
-export function assertResponse<T extends object>(
-  result: T,
-): asserts result is T & HttpResponseField<any> {
-  if (!hasUnderscoreResponse(result)) {
-    Object.defineProperty(result, "_response", {
-      enumerable: false,
-      value:
-        "Something went wrong, _response(raw response) is supposed to be part of the response. Please file a bug at https://github.com/Azure/azure-sdk-for-js",
-    });
-  }
-}
-
-export function hasUnderscoreResponse<T extends object>(
-  result: T,
-): result is T & HttpResponseField<any> {
-  return Object.prototype.hasOwnProperty.call(result, "_response");
 }

--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -21,6 +21,7 @@ export const SyncTokenHeaderName = "sync-token";
  * @param syncTokens - the sync tokens store to be used across requests.
  * @internal
  */
+// eslint-disable-next-line @azure/azure-sdk/ts-use-interface-parameters
 export function syncTokenPolicy(syncTokens: SyncTokens): PipelinePolicy {
   return {
     name: "Sync Token Policy",

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { CompatResponse } from "@azure/core-http-compat";
 import type { FeatureFlagValue } from "./featureFlag.js";
 import type { CommonClientOptions, OperationOptions } from "@azure/core-client";
 import type { SecretReferenceValue } from "./secretReference.js";
@@ -103,25 +102,6 @@ export interface HttpResponseFields {
   statusCode: number;
 }
 /**
- * HTTP response related information - headers and raw body.
- */
-export interface HttpResponseField<HeadersT> {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: CompatResponse & {
-    /**
-     * The parsed HTTP response headers.
-     */
-    parsedHeaders: HeadersT;
-
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-  };
-}
-/**
  * Parameters for adding a new configuration setting
  */
 export type AddConfigurationSettingParam<
@@ -139,7 +119,6 @@ export type SetConfigurationSettingParam<
  * Standard base response for getting, deleting or updating a configuration setting
  */
 export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting &
-  HttpResponseField<HeadersT> &
   Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
 
 /**
@@ -213,16 +192,14 @@ export interface AddConfigurationSettingOptions extends OperationOptions {}
  */
 export interface AddConfigurationSettingResponse
   extends ConfigurationSetting,
-    SyncTokenHeaderField,
-    HttpResponseField<SyncTokenHeaderField> {}
+    SyncTokenHeaderField {}
 
 /**
  * Response from deleting a ConfigurationSetting.
  */
 export interface DeleteConfigurationSettingResponse
   extends SyncTokenHeaderField,
-    HttpResponseFields,
-    HttpResponseField<SyncTokenHeaderField> {}
+    HttpResponseFields {}
 
 /**
  * Options for deleting a ConfigurationSetting.
@@ -243,8 +220,7 @@ export interface SetConfigurationSettingOptions
  */
 export interface SetConfigurationSettingResponse
   extends ConfigurationSetting,
-    SyncTokenHeaderField,
-    HttpResponseField<SyncTokenHeaderField> {}
+    SyncTokenHeaderField {}
 
 /**
  * Headers from getting a ConfigurationSetting.
@@ -257,8 +233,7 @@ export interface GetConfigurationHeaders extends SyncTokenHeaderField {}
 export interface GetConfigurationSettingResponse
   extends ConfigurationSetting,
     GetConfigurationHeaders,
-    HttpResponseFields,
-    HttpResponseField<GetConfigurationHeaders> {}
+    HttpResponseFields {}
 
 /**
  * Options for getting a ConfigurationSetting.
@@ -404,10 +379,7 @@ export interface EtagEntity {
 /**
  * A page of configuration settings and the corresponding HTTP response
  */
-export interface ListConfigurationSettingPage
-  extends HttpResponseField<SyncTokenHeaderField>,
-    PageSettings,
-    EtagEntity {
+export interface ListConfigurationSettingPage extends PageSettings, EtagEntity {
   /**
    * The configuration settings for this page of results.
    */
@@ -417,10 +389,7 @@ export interface ListConfigurationSettingPage
 /**
  * A page of configuration settings and the corresponding HTTP response
  */
-export interface ListLabelsPage
-  extends HttpResponseField<SyncTokenHeaderField>,
-    PageSettings,
-    EtagEntity {
+export interface ListLabelsPage extends PageSettings, EtagEntity {
   /**
    * The collection of labels
    */
@@ -447,7 +416,7 @@ export interface ListRevisionsOptions extends OperationOptions, ListSettingsOpti
 /**
  * A page of configuration settings and the corresponding HTTP response
  */
-export interface ListRevisionsPage extends HttpResponseField<SyncTokenHeaderField>, PageSettings {
+export interface ListRevisionsPage extends PageSettings {
   /**
    * The configuration settings for this page of results.
    */
@@ -462,10 +431,7 @@ export interface SetReadOnlyOptions extends HttpOnlyIfUnchangedField, OperationO
 /**
  * Response when setting a value to read-only.
  */
-export interface SetReadOnlyResponse
-  extends ConfigurationSetting,
-    SyncTokenHeaderField,
-    HttpResponseField<SyncTokenHeaderField> {}
+export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField {}
 
 /**
  * Options that control how to retry failed requests.

--- a/sdk/appconfiguration/app-configuration/swagger/swagger.md
+++ b/sdk/appconfiguration/app-configuration/swagger/swagger.md
@@ -4,7 +4,7 @@
 
 ```yaml
 package-name: app-configuration
-package-version: "1.8.1"
+package-version: "1.9.0"
 title: AppConfiguration
 description: App Configuration client
 enable-xml: true
@@ -16,7 +16,6 @@ input-file: https://github.com/Azure/azure-rest-api-specs/blob/c1af3ab8e803da2f4
 model-date-time-as-string: false
 optional-response-headers: true
 sample-generation: false
-core-http-compat-mode: true
 typescript: true
 disable-async-iterators: true
 api-version-parameter: choice

--- a/sdk/appconfiguration/app-configuration/test/public/featureFlag.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/featureFlag.spec.ts
@@ -75,7 +75,7 @@ describe("AppConfigurationClient - FeatureFlag", () => {
     });
 
     function assertFeatureFlagProps(
-      actual: Omit<AddConfigurationSettingResponse, "_response">,
+      actual: AddConfigurationSettingResponse,
       expected: ConfigurationSetting<FeatureFlagValue>,
     ): void {
       assert.equal(isFeatureFlag(actual), true, "Expected to get the feature flag");

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -1091,13 +1091,13 @@ describe("AppConfigurationClient", () => {
       iterator = client.listConfigurationSettings({ keyFilter: key, pageEtags: etags }).byPage();
 
       let response = await iterator.next();
-      assertPage(response.value, 0, 304);
+      assertPage(response.value, 0);
 
       response = await iterator.next();
-      assertPage(response.value, 0, 304);
+      assertPage(response.value, 0);
 
       response = await iterator.next();
-      assertPage(response.value, 0, 304);
+      assertPage(response.value, 0);
 
       // This number is arbitrarily chosen to add new setting to the 3rd page
       const additionalNumberOfLabels = 50;
@@ -1108,22 +1108,17 @@ describe("AppConfigurationClient", () => {
 
       // First page no change
       response = await iterator.next();
-      assertPage(response.value, 0, 304);
+      assertPage(response.value, 0);
 
       // Second page: full settings with change
       response = await iterator.next();
-      assertPage(response.value, pageSize, 200);
+      assertPage(response.value, pageSize);
 
       // Third page: new settings with changes
       response = await iterator.next();
-      assertPage(response.value, additionalNumberOfLabels, 200);
+      assertPage(response.value, additionalNumberOfLabels);
 
-      function assertPage(
-        page: ListConfigurationSettingPage,
-        expectedLength: number,
-        status: number,
-      ): void {
-        assert.equal(page._response.status, status);
+      function assertPage(page: ListConfigurationSettingPage, expectedLength: number): void {
         assert.equal(page.items.length, expectedLength);
         assert.isDefined(page.etag);
       }

--- a/sdk/appconfiguration/app-configuration/test/public/secretReference.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/secretReference.spec.ts
@@ -46,7 +46,7 @@ describe("AppConfigurationClient - SecretReference", () => {
     };
 
     function assertSecretReferenceProps(
-      actual: Omit<AddConfigurationSettingResponse, "_response">,
+      actual: AddConfigurationSettingResponse,
       expected: ConfigurationSetting<SecretReferenceValue>,
     ): void {
       assert.equal(isSecretReference(actual), true, "Expected to get the SecretReference");


### PR DESCRIPTION
and the diagnostic `_response` properties from response types.

This is technically breaking...
