### PR TITLE
[Monitor OpenTelemetry] Live Metrics Next.js > 12 Fix

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Should not use reserved 7th bit for statsbeat instrumentations.
 - Fix incorrectly setting the cloud role name and role instance to undefined on standard metrics in AKS environments.
+- Handle exceptions thrown when no http url is present on request telemetry quickpulse documents.
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/src/logs/logRecordProcessor.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/logRecordProcessor.ts
@@ -20,7 +20,7 @@ export class AzureLogRecordProcessor implements LogRecordProcessor {
     try {
       this._metricHandler.recordLog(logRecord);
     } catch (error) {
-      Logger.getInstance().error("Error while recording log", error);
+      Logger.getInstance().warn("Error while recording log", error);
     }
   }
 

--- a/sdk/monitor/monitor-opentelemetry/src/logs/logRecordProcessor.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/logRecordProcessor.ts
@@ -3,6 +3,7 @@
 
 import type { MetricHandler } from "../metrics/handler";
 import type { LogRecord, LogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { Logger } from "../shared/logging";
 
 /**
  * Azure Monitor LogRecord Processor.
@@ -16,7 +17,11 @@ export class AzureLogRecordProcessor implements LogRecordProcessor {
   }
 
   public onEmit(logRecord: LogRecord): void {
-    this._metricHandler.recordLog(logRecord);
+    try {
+      this._metricHandler.recordLog(logRecord);
+    } catch (error) {
+      Logger.getInstance().error("Error while recording log", error);
+    }
   }
 
   public forceFlush(): Promise<void> {

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -64,6 +64,7 @@ import { getOsPrefix } from "../../utils/common";
 import { getResourceProvider } from "../../utils/common";
 import type { LogAttributes } from "@opentelemetry/api-logs";
 import { getDependencyTarget, isSqlDB, isExceptionTelemetry } from "../utils";
+import { Logger } from "../../shared/logging";
 
 /** Get the internal SDK version */
 export function getSdkVersion(): string {
@@ -232,8 +233,8 @@ function getRequestData(span: ReadableSpan): RequestData {
       try {
         const urlObj = new URL(requestData.Url);
         requestData.Name = `${httpMethod} ${urlObj.pathname}`;
-      } catch (ex) {
-        /* no-op */
+      } catch (ex: any) {
+        Logger.getInstance().info("Request data sent to live metrics has no valid URL field.", ex);
       }
     }
     const httpStatusCode = span.attributes[SEMATTRS_HTTP_STATUS_CODE];
@@ -278,7 +279,10 @@ function getDependencyData(span: ReadableSpan): DependencyData {
         const dependencyUrl = new URL(String(httpUrl));
         dependencyData.Name = `${httpMethod} ${dependencyUrl.pathname}`;
       } catch (ex: any) {
-        /* no-op */
+        Logger.getInstance().info(
+          "Dependency data sent to live metrics has no valid URL field.",
+          ex,
+        );
       }
     }
     dependencyData.Type = DependencyTypes.Http;

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -227,6 +227,7 @@ function getRequestData(span: ReadableSpan): RequestData {
   const httpMethod = span.attributes[SEMATTRS_HTTP_METHOD];
   const grpcStatusCode = span.attributes[SEMATTRS_RPC_GRPC_STATUS_CODE];
   if (httpMethod) {
+    requestData.Url = getUrl(span.attributes);
     if (requestData.Url) {
       try {
         const urlObj = new URL(requestData.Url);

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -227,9 +227,14 @@ function getRequestData(span: ReadableSpan): RequestData {
   const httpMethod = span.attributes[SEMATTRS_HTTP_METHOD];
   const grpcStatusCode = span.attributes[SEMATTRS_RPC_GRPC_STATUS_CODE];
   if (httpMethod) {
-    requestData.Url = getUrl(span.attributes);
-    const urlObj = new URL(requestData.Url);
-    requestData.Name = `${httpMethod} ${urlObj.pathname}`;
+    if (requestData.Url) {
+      try {
+        const urlObj = new URL(requestData.Url);
+        requestData.Name = `${httpMethod} ${urlObj.pathname}`;
+      } catch (ex) {
+        /* no-op */
+      }
+    }
     const httpStatusCode = span.attributes[SEMATTRS_HTTP_STATUS_CODE];
     if (httpStatusCode) {
       requestData.ResponseCode = Number(httpStatusCode);

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -229,13 +229,11 @@ function getRequestData(span: ReadableSpan): RequestData {
   const grpcStatusCode = span.attributes[SEMATTRS_RPC_GRPC_STATUS_CODE];
   if (httpMethod) {
     requestData.Url = getUrl(span.attributes);
-    if (requestData.Url) {
-      try {
-        const urlObj = new URL(requestData.Url);
-        requestData.Name = `${httpMethod} ${urlObj.pathname}`;
-      } catch (ex: any) {
-        Logger.getInstance().info("Request data sent to live metrics has no valid URL field.", ex);
-      }
+    try {
+      const urlObj = new URL(requestData.Url);
+      requestData.Name = `${httpMethod} ${urlObj.pathname}`;
+    } catch (ex: any) {
+      Logger.getInstance().info("Request data sent to live metrics has no valid URL field.", ex);
     }
     const httpStatusCode = span.attributes[SEMATTRS_HTTP_STATUS_CODE];
     if (httpStatusCode) {

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/utils.ts
@@ -229,11 +229,11 @@ function getRequestData(span: ReadableSpan): RequestData {
   const grpcStatusCode = span.attributes[SEMATTRS_RPC_GRPC_STATUS_CODE];
   if (httpMethod) {
     requestData.Url = getUrl(span.attributes);
-    try {
+    if (URL.canParse(requestData.Url)) {
       const urlObj = new URL(requestData.Url);
       requestData.Name = `${httpMethod} ${urlObj.pathname}`;
-    } catch (ex: any) {
-      Logger.getInstance().info("Request data sent to live metrics has no valid URL field.", ex);
+    } else {
+      Logger.getInstance().info("Request data sent to live metrics has no valid URL field.");
     }
     const httpStatusCode = span.attributes[SEMATTRS_HTTP_STATUS_CODE];
     if (httpStatusCode) {
@@ -273,14 +273,11 @@ function getDependencyData(span: ReadableSpan): DependencyData {
   if (httpMethod) {
     const httpUrl = span.attributes[SEMATTRS_HTTP_URL];
     if (httpUrl) {
-      try {
+      if (URL.canParse(String(httpUrl))) {
         const dependencyUrl = new URL(String(httpUrl));
         dependencyData.Name = `${httpMethod} ${dependencyUrl.pathname}`;
-      } catch (ex: any) {
-        Logger.getInstance().info(
-          "Dependency data sent to live metrics has no valid URL field.",
-          ex,
-        );
+      } else {
+        Logger.getInstance().info("Dependency data sent to live metrics has no valid URL field.");
       }
     }
     dependencyData.Type = DependencyTypes.Http;

--- a/sdk/monitor/monitor-opentelemetry/src/traces/spanProcessor.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/spanProcessor.ts
@@ -29,7 +29,7 @@ export class AzureMonitorSpanProcessor implements SpanProcessor {
     try {
       this._metricHandler.recordSpan(span);
     } catch (error) {
-      Logger.getInstance().error("Error while recording span", error);
+      Logger.getInstance().warn("Error while recording span", error);
     }
   }
 

--- a/sdk/monitor/monitor-opentelemetry/src/traces/spanProcessor.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/traces/spanProcessor.ts
@@ -4,6 +4,7 @@
 import type { Context } from "@opentelemetry/api";
 import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import type { MetricHandler } from "../metrics";
+import { Logger } from "../shared/logging";
 
 /**
  * Azure Monitor Span Processor.
@@ -25,7 +26,11 @@ export class AzureMonitorSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    this._metricHandler.recordSpan(span);
+    try {
+      this._metricHandler.recordSpan(span);
+    } catch (error) {
+      Logger.getInstance().error("Error while recording span", error);
+    }
   }
 
   shutdown(): Promise<void> {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetrics.test.ts
@@ -217,10 +217,11 @@ describe("#LiveMetrics", () => {
       assert.strictEqual((documents[i] as Exception).exceptionMessage, "testExceptionMessage");
       assert.strictEqual(documents[i].properties?.length, 0);
     }
-    assert.strictEqual(documents[6].documentType, "RemoteDependency");
-    assert.strictEqual((documents[6] as RemoteDependency).commandName, "http://test.com");
-    assert.strictEqual((documents[6] as RemoteDependency).resultCode, "200");
-    assert.strictEqual((documents[6] as RemoteDependency).duration, "PT12345.678S");
+    const dependencyDoc6 = documents[6] as RemoteDependency;
+    assert.strictEqual(dependencyDoc6.documentType, "RemoteDependency");
+    assert.strictEqual(dependencyDoc6.commandName, "http://test.com");
+    assert.strictEqual(dependencyDoc6.resultCode, "200");
+    assert.strictEqual(dependencyDoc6.duration, "PT12345.678S");
     assert.equal((documents[6].properties as any)[0].key, "customAttribute");
     assert.equal((documents[6].properties as any)[0].value, "test");
     for (let i = 7; i < 9; i++) {
@@ -246,12 +247,13 @@ describe("#LiveMetrics", () => {
       assert.equal((documents[i].properties as any)[0].value, "test");
     }
     // Ensure that requests with no URL don't throw
-    assert.strictEqual((documents[16] as Request).url, "");
-    assert.strictEqual((documents[16] as Request).name, "test-name");
-    assert.strictEqual((documents[16] as Request).responseCode, "200");
-    assert.strictEqual((documents[16] as Request).duration, "PT12345.678S");
-    assert.equal((documents[16].properties as any)[0].key, "customAttribute");
-    assert.equal((documents[16].properties as any)[0].value, "test");
+    const requestDoc16 = documents[16] as Request;
+    assert.strictEqual(requestDoc16.url, "");
+    assert.strictEqual(requestDoc16.name, "test-name");
+    assert.strictEqual(requestDoc16.responseCode, "200");
+    assert.strictEqual(requestDoc16.duration, "PT12345.678S");
+    assert.equal((requestDoc16.properties as any)[0].key, "customAttribute");
+    assert.equal((requestDoc16.properties as any)[0].value, "test");
 
     // testing that the old/new names for the perf counters appear in the monitoring data point,
     // with the values of the process counters

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetrics.test.ts
@@ -113,6 +113,21 @@ describe("#LiveMetrics", () => {
       autoCollect.recordSpan(serverSpan);
     }
 
+    const noUrlClientSpan: any = {
+      name: "test-name",
+      kind: SpanKind.SERVER,
+      duration: millisToHrTime(12345678),
+      attributes: {
+        "http.status_code": 200,
+        "http.method": "GET",
+        customAttribute: "test",
+      },
+      status: {
+        code: SpanStatusCode.OK,
+      },
+    };
+    autoCollect.recordSpan(noUrlClientSpan);
+
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     assert.ok(exportStub.called);
@@ -133,10 +148,10 @@ describe("#LiveMetrics", () => {
       QuickPulseOpenTelemetryMetricNames.REQUEST_DURATION,
     );
     assert.strictEqual(metrics[0].dataPoints.length, 1, "dataPoints count");
-    // ( (98765432 * 2) + (100000 * 4)/6)
+    // ( (98765432 * 2) + (100000 * 4) + 12345678 /7)
     assert.strictEqual(
       metrics[0].dataPoints[0].value.toFixed(2),
-      "32988477.33",
+      "30039506.00",
       "REQUEST_DURATION value",
     );
     assert.strictEqual(metrics[1].descriptor.name, QuickPulseOpenTelemetryMetricNames.REQUEST_RATE);
@@ -192,7 +207,7 @@ describe("#LiveMetrics", () => {
 
     // Validate documents
     const documents = autoCollect.getDocuments();
-    assert.strictEqual(documents.length, 16, "documents count");
+    assert.strictEqual(documents.length, 17, "documents count");
     // assert.strictEqual(JSON.stringify(documents), "documents count");
     assert.strictEqual(documents[0].documentType, "Trace");
     assert.strictEqual(documents[0].properties?.length, 0);
@@ -230,6 +245,13 @@ describe("#LiveMetrics", () => {
       assert.equal((documents[i].properties as any)[0].key, "customAttribute");
       assert.equal((documents[i].properties as any)[0].value, "test");
     }
+    // Ensure that requests with no URL don't throw
+    assert.strictEqual((documents[16] as Request).url, "");
+    assert.strictEqual((documents[16] as Request).name, "test-name");
+    assert.strictEqual((documents[16] as Request).responseCode, "200");
+    assert.strictEqual((documents[16] as Request).duration, "PT12345.678S");
+    assert.equal((documents[16].properties as any)[0].key, "customAttribute");
+    assert.equal((documents[16].properties as any)[0].value, "test");
 
     // testing that the old/new names for the perf counters appear in the monitoring data point,
     // with the values of the process counters


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
Crashes experienced when opening live metrics when using Next.js versions > 12 as some of the requests sent do not contain a valid HTTP.url value which throws an exception when passed to `URL()`.

### Are there test cases added in this PR? _(If not, why?)_
Yes, test case added to ensure that requests without a populated HTTP field don't throw exceptions.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
