### PR TITLE
[service-bus] Remove uuid package and types

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -117,7 +117,6 @@
     "@types/debug": "^4.1.4",
     "@types/is-buffer": "^2.0.0",
     "@types/node": "^18.0.0",
-    "@types/uuid": "^8.0.0",
     "@types/ws": "^7.2.4",
     "@vitest/browser": "^3.0.3",
     "@vitest/coverage-istanbul": "^3.0.3",
@@ -131,7 +130,6 @@
     "https-proxy-agent": "^7.0.0",
     "playwright": "^1.46.1",
     "typescript": "~5.7.2",
-    "uuid": "^8.3.0",
     "vitest": "^3.0.3",
     "ws": "^8.0.0"
   },

--- a/sdk/servicebus/service-bus/test/public/amqpAnnotatedMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/public/amqpAnnotatedMessage.spec.ts
@@ -5,7 +5,7 @@ import {
   addServiceBusClientForLiveTesting,
 } from "../public/utils/testutils2.js";
 import type { AmqpAnnotatedMessage } from "@azure/core-amqp";
-import { v4 as generateUuid } from "uuid";
+import { randomUUID } from "@azure/core-util";
 import { TestClientType } from "./utils/testUtils.js";
 import { describe, it } from "vitest";
 import { assert, should } from "./utils/chai.js";
@@ -61,7 +61,7 @@ import { assert, should } from "./utils/chai.js";
           properties: {
             contentEncoding: "application/json; charset=utf-8",
             correlationId: randomTag,
-            messageId: generateUuid(),
+            messageId: randomUUID(),
           },
         };
       }

--- a/sdk/servicebus/service-bus/test/stress/app/package.json
+++ b/sdk/servicebus/service-bus/test/stress/app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "applicationinsights": "^1.8.8",
     "@azure/service-bus": "latest",
+    "@azure/core-util": "latest",
     "dotenv": "^16.0.0",
     "minimist": "^1.2.8",
     "uuid": "^8.3.0"

--- a/sdk/servicebus/service-bus/test/stress/app/src/scenarioLongRunning.ts
+++ b/sdk/servicebus/service-bus/test/stress/app/src/scenarioLongRunning.ts
@@ -9,7 +9,7 @@ import {
 } from "./serviceBusStressTester";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { ServiceBusClient, ServiceBusSender } from "@azure/service-bus";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "@azure/core-util";
 
 captureConsoleOutputToAppInsights();
 
@@ -36,7 +36,7 @@ async function sendMessagesForever(
 
         const messagesToSend = [
           {
-            messageId: uuidv4(),
+            messageId: randomUUID(),
             body: `Message: ${Date.now()}`,
           },
         ];

--- a/sdk/servicebus/service-bus/test/stress/app/src/scenarioShortLivedReceivers.ts
+++ b/sdk/servicebus/service-bus/test/stress/app/src/scenarioShortLivedReceivers.ts
@@ -17,7 +17,7 @@ import {
 import { EventEmitter } from "stream";
 import { EventContext, ReceiverEvents } from "rhea-promise";
 import parsedArgs from "minimist";
-import { v4 as generateUuid } from "uuid";
+import { randomUUID } from "@azure/core-util";
 
 const messageNumberPropertyName = "messageNumber";
 
@@ -32,7 +32,7 @@ async function main() {
   appInsightsClient.commonProperties = {
     // these will be reported with each event
     testName: "scenarioShortLivedReceiver",
-    testRunId: generateUuid(),
+    testRunId: randomUUID(),
   };
 
   const { receiveMode, maxWaitTimeInMs, numMessagesToSend, messagesPerReceive } = {

--- a/sdk/servicebus/service-bus/test/stress/app/src/utils.ts
+++ b/sdk/servicebus/service-bus/test/stress/app/src/utils.ts
@@ -1,4 +1,7 @@
-import { v4 as uuidv4 } from "uuid";
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { randomUUID } from "@azure/core-util";
 
 export interface OperationInfo {
   numberOfSuccesses: number;
@@ -61,7 +64,7 @@ export function generateMessage(useSessions: boolean, numberOfSessions: number) 
   return {
     body: `message ${Math.random()}`,
     sessionId: useSessions ? `session-${Math.ceil(Math.random() * numberOfSessions)}` : undefined,
-    messageId: uuidv4(),
+    messageId: randomUUID(),
   };
 }
 


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/service-bus

### Issues associated with this PR

- #32739

### Describe the problem that is addressed by this PR

Removes the `uuid` package and associated `@types/uuid` as they are not needed since we have `randomUUID` from `@azure/core-util`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
