### PR TITLE
[dev-tool] Restore the assets only when they are present

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -6,7 +6,7 @@ import { leafCommand, makeCommandInfo } from "../../framework/command";
 import { runTestsWithProxyTool } from "../../util/testUtils";
 import { createPrinter } from "../../util/printer";
 import { shouldStartRelay, startRelayServer } from "../../util/browserRelayServer";
-import { runTestProxyCommand } from "../../util/testProxyUtils";
+import { runTestProxyCommandWithRetry } from "../../util/testProxyUtils";
 import fs from "fs";
 
 const log = createPrinter("test:vitest");
@@ -96,7 +96,7 @@ export default leafCommand(commandInfo, async (options) => {
       // restore recordings first in CI to avoid impacting the first playback test
       if (process.env["BUILD_BUILDNUMBER"] && fs.existsSync("assets.json")) {
         log.info(`restoring recordings before testing`);
-        await runTestProxyCommand(["restore", "-a", "assets.json"]);
+        await runTestProxyCommandWithRetry(["restore", "-a", "assets.json"], 1000, 10000);
       }
 
       return await runTestsWithProxyTool(command);

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -7,6 +7,7 @@ import { runTestsWithProxyTool } from "../../util/testUtils";
 import { createPrinter } from "../../util/printer";
 import { shouldStartRelay, startRelayServer } from "../../util/browserRelayServer";
 import { runTestProxyCommand } from "../../util/testProxyUtils";
+import fs from "fs-extra";
 
 const log = createPrinter("test:vitest");
 
@@ -93,7 +94,7 @@ export default leafCommand(commandInfo, async (options) => {
       if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
 
       // restore recordings first in CI to avoid impacting the first playback test
-      if (process.env["BUILD_BUILDNUMBER"]) {
+      if (process.env["BUILD_BUILDNUMBER"] && await fs.pathExists("assets.json")) {
         log.info(`restoring recordings before testing`);
         await runTestProxyCommand(["restore", "-a", "assets.json"]);
       }

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -7,7 +7,7 @@ import { runTestsWithProxyTool } from "../../util/testUtils";
 import { createPrinter } from "../../util/printer";
 import { shouldStartRelay, startRelayServer } from "../../util/browserRelayServer";
 import { runTestProxyCommand } from "../../util/testProxyUtils";
-import fs from "fs-extra";
+import fs from "fs";
 
 const log = createPrinter("test:vitest");
 
@@ -94,7 +94,7 @@ export default leafCommand(commandInfo, async (options) => {
       if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
 
       // restore recordings first in CI to avoid impacting the first playback test
-      if (process.env["BUILD_BUILDNUMBER"] && (await fs.pathExists("assets.json"))) {
+      if (process.env["BUILD_BUILDNUMBER"] && fs.existsSync("assets.json")) {
         log.info(`restoring recordings before testing`);
         await runTestProxyCommand(["restore", "-a", "assets.json"]);
       }

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -96,10 +96,10 @@ export default leafCommand(commandInfo, async (options) => {
       // restore recordings first in CI to avoid impacting the first playback test
       if (process.env["BUILD_BUILDNUMBER"] && fs.existsSync("assets.json")) {
         log.info(`restoring recordings before testing`);
-        // This line runs the 'restore' command with retries. 
-        // Without retries, `Error: spawn EBUSY` is observed since the common resource being locked by another process since the pipeline often runs multiple simultaneous processes.
-        // The pipeline fails flakily for any of the packages in the run.
-        // Best solution would be to getting rid of this code in favour of downloading the assets as part of a dedicated pipeline step that would be common for all languages.
+        // This line runs the 'restore' command with retries.
+        // Introduced retries for the 'restore' command to mitigate EBUSY errors, which occur due to resource locking by simultaneous pipeline processes.
+        // The CI pipeline fails flakily for any of the packages in the run without the retries.
+        // Best solution would probably be to get rid of this code in favour of downloading the assets as part of a dedicated pipeline step that would be common for all languages.
         await runTestProxyCommandWithRetry(["restore", "-a", "assets.json"], 1000, 10000);
       }
 

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -96,6 +96,10 @@ export default leafCommand(commandInfo, async (options) => {
       // restore recordings first in CI to avoid impacting the first playback test
       if (process.env["BUILD_BUILDNUMBER"] && fs.existsSync("assets.json")) {
         log.info(`restoring recordings before testing`);
+        // This line runs the 'restore' command with retries. 
+        // Without retries, `Error: spawn EBUSY` is observed since the common resource being locked by another process since the pipeline often runs multiple simultaneous processes.
+        // The pipeline fails flakily for any of the packages in the run.
+        // Best solution would be to getting rid of this code in favour of downloading the assets as part of a dedicated pipeline step that would be common for all languages.
         await runTestProxyCommandWithRetry(["restore", "-a", "assets.json"], 1000, 10000);
       }
 

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -94,7 +94,7 @@ export default leafCommand(commandInfo, async (options) => {
       if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
 
       // restore recordings first in CI to avoid impacting the first playback test
-      if (process.env["BUILD_BUILDNUMBER"] && await fs.pathExists("assets.json")) {
+      if (process.env["BUILD_BUILDNUMBER"] && (await fs.pathExists("assets.json"))) {
         log.info(`restoring recordings before testing`);
         await runTestProxyCommand(["restore", "-a", "assets.json"]);
       }

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -12,7 +12,7 @@ import envPaths from "env-paths";
 import { promisify } from "node:util";
 import { PassThrough } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { delay } from "./checkWithTimeout";
+import { checkWithTimeout, delay } from "./checkWithTimeout";
 
 const log = createPrinter("test-proxy");
 const downloadLocation = path.join(envPaths("azsdk-dev-tool").cache, "test-proxy");
@@ -192,6 +192,30 @@ export async function runTestProxyCommand(argv: string[]): Promise<void> {
   }).result;
   if (await fs.pathExists("assets.json")) {
     await linkRecordingsDirectory();
+  }
+}
+
+export async function runTestProxyCommandWithRetry(
+  argv: string[],
+  delayBetweenRetriesInMilliseconds = 1000,
+  maxWaitTimeInMilliseconds = 10000,
+) {
+  const success = await checkWithTimeout(
+    async () => {
+      try {
+        await runTestProxyCommand(argv);
+        return true;
+      } catch (error) {
+        console.error("runTestProxyCommand failed, retrying...", error);
+        return false;
+      }
+    },
+    delayBetweenRetriesInMilliseconds,
+    maxWaitTimeInMilliseconds,
+  );
+
+  if (!success) {
+    console.error("runTestProxyCommand failed after multiple retries");
   }
 }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/eventhub.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/eventhub.spec.ts
@@ -48,6 +48,7 @@ describe("#parseEventHubSpan(...)", () => {
 
     assert.strictEqual((baseData as any).source, undefined);
     assert.strictEqual(baseData.measurements, undefined);
+    assert.strictEqual("abc", "abc") // added to test https://github.com/Azure/azure-sdk-for-js/pull/32752, revert this after testing
   });
 
   it("should correctly parse SpanKind.PRODUCER", () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/eventhub.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/eventhub.spec.ts
@@ -48,7 +48,6 @@ describe("#parseEventHubSpan(...)", () => {
 
     assert.strictEqual((baseData as any).source, undefined);
     assert.strictEqual(baseData.measurements, undefined);
-    assert.strictEqual("abc", "abc") // added to test https://github.com/Azure/azure-sdk-for-js/pull/32752, revert this after testing
   });
 
   it("should correctly parse SpanKind.PRODUCER", () => {


### PR DESCRIPTION
## Description

This pull request addresses an issue in [PR #32668](https://github.com/Azure/azure-sdk-for-js/pull/32668) where the existence of the `assets.json` file was not checked before pulling the recordings. This PR adds a check for the file's existence.

### Problem 2
Introduced retries for the 'restore' command to mitigate EBUSY errors, which occur due to resource locking by simultaneous pipeline processes.

## Fixes

This change fixes the failing pipelines, such as the `monitor-opentelemetry-exporter` package.

## Pipeline Results

- **Before**: [Pipeline Results](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4512250&view=logs&j=2993fb17-9fe5-5b0b-e997-efa0cab8f900&t=dd1086b5-315c-5d00-e372-83915904aafa) ❌
- **After**: [Pipeline Results](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4512907&view=logs&j=2a01393f-ea32-556d-315a-d0f84478d58d&t=8b58e9a6-2d08-532e-b9e8-0f3231e5553f) ✅