### PR TITLE
[Event Hubs] Bump major version

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 5.13.0 (Unreleased)
+## 6.0.0-beta.1 (Unreleased)
 
 ### Features Added
 
+- Support Geographic replication to enable recovery in case of geographic disasters.
+
 ### Breaking Changes
+
+- `offset` type is updated from `number` to `string`.
 
 ### Bugs Fixed
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.13.0",
+  "version": "6.0.0-beta.1",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -93,7 +93,7 @@ export function isLatestPosition(eventPosition: EventPosition): boolean {
  * first event in the partition which has not expired due to the retention policy.
  */
 export const earliestEventPosition: EventPosition = {
-  offset: "-1",
+  offset: "-1:-1",
 };
 
 /**

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.13.0",
+  version: "6.0.0-beta.1",
 };
 
 /**

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/CHANGELOG.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
+## 2.0.0-beta.1 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- The `offset` property of a checkpoint is no longer re-interpreted as a number.
 
 ## 1.1.0-beta.1 (2024-06-06)
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/eventhubs-checkpointstore-blob",
   "sdk-type": "client",
-  "version": "1.1.0-beta.2",
+  "version": "2.0.0-beta.1",
   "description": "An Azure Storage Blob solution to store checkpoints when using Event Hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -72,7 +72,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-paging": "^1.6.2",
-    "@azure/event-hubs": "^5.13.0",
+    "@azure/event-hubs": "6.0.0-beta.1",
     "@azure/logger": "^1.1.3",
     "@azure/storage-blob": "^12.24.0",
     "tslib": "^2.6.3"

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.1.2",
     "@azure/data-tables": "^13.2.2",
-    "@azure/event-hubs": "^5.13.0",
+    "@azure/event-hubs": "6.0.0-beta.1",
     "@azure/logger": "^1.1.4",
     "tslib": "^2.6.3"
   },

--- a/sdk/eventhub/perf-tests/event-hubs/package.json
+++ b/sdk/eventhub/perf-tests/event-hubs/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/core-amqp": "^4.3.3",
-    "@azure/event-hubs": "^5.12.2",
+    "@azure/event-hubs": "^6.0.0-beta.1",
     "dotenv": "^16.0.0",
     "moment": "^2.30.1",
     "tslib": "^2.8.1"

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -80,7 +80,7 @@
     "@azure/core-rest-pipeline": "^1.12.1",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/event-hubs": "^5.8.0",
+    "@azure/event-hubs": "^6.0.0-beta.1",
     "@azure/identity": "^4.4.1",
     "@rollup/plugin-inject": "^5.0.5",
     "@types/node": "^18.0.0",

--- a/sdk/schemaregistry/schema-registry-json/package.json
+++ b/sdk/schemaregistry/schema-registry-json/package.json
@@ -79,7 +79,7 @@
     "@azure/core-util": "^1.3.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
-    "@azure/event-hubs": "^5.12.2",
+    "@azure/event-hubs": "^6.0.0-beta.1",
     "@azure/identity": "^4.5.0",
     "@rollup/plugin-inject": "^5.0.5",
     "@types/node": "^18.0.0",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/event-hubs, @azure/eventhubs-checkpointstore-blob

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
GeoDR support requires the type of the `offset` property to be string instead of a number. This PR bumps the major version to guard against breaking user code.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
N/A

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-js/pull/29932

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
