### PR TITLE
[ServiceBus] update atom admin client to use HTTP for emulator

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -364,6 +364,7 @@ export interface ServiceBusConnectionStringProperties {
     sharedAccessKey?: string;
     sharedAccessKeyName?: string;
     sharedAccessSignature?: string;
+    useDevelopmentEmulator?: boolean;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
+++ b/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
@@ -42,6 +42,11 @@ export interface ServiceBusConnectionStringProperties {
    * user and appended to the connection string for ease of use.
    */
   sharedAccessSignature?: string;
+  /**
+   * The value for "UseDevelopmentEmulator" in the connection string. This is typically only present in
+   * the connection string for emulator running locally.
+   */
+  useDevelopmentEmulator?: boolean;
 }
 
 /**
@@ -59,6 +64,7 @@ export function parseServiceBusConnectionString(
     SharedAccessSignature?: string;
     SharedAccessKey?: string;
     SharedAccessKeyName?: string;
+    UseDevelopmentEmulator?: string;
   }>(connectionString);
   if (!parsedResult.Endpoint) {
     throw new Error("Connection string should have an Endpoint key.");
@@ -98,5 +104,11 @@ export function parseServiceBusConnectionString(
     output.sharedAccessKey = parsedResult.SharedAccessKey;
     output.sharedAccessKeyName = parsedResult.SharedAccessKeyName;
   }
+  if (parsedResult.UseDevelopmentEmulator) {
+    output.useDevelopmentEmulator = Boolean(parsedResult.UseDevelopmentEmulator);
+  } else {
+    output.useDevelopmentEmulator = false;
+  }
+
   return output;
 }

--- a/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
+++ b/sdk/servicebus/service-bus/src/util/connectionStringUtils.ts
@@ -104,11 +104,7 @@ export function parseServiceBusConnectionString(
     output.sharedAccessKey = parsedResult.SharedAccessKey;
     output.sharedAccessKeyName = parsedResult.SharedAccessKeyName;
   }
-  if (parsedResult.UseDevelopmentEmulator) {
-    output.useDevelopmentEmulator = Boolean(parsedResult.UseDevelopmentEmulator);
-  } else {
-    output.useDevelopmentEmulator = false;
-  }
+  output.useDevelopmentEmulator = Boolean(parsedResult.UseDevelopmentEmulator);
 
   return output;
 }

--- a/sdk/servicebus/service-bus/test/internal/unit/atomAdminClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/atomAdminClient.spec.ts
@@ -8,12 +8,12 @@ describe("ServiceBusAtomAdminClient", () => {
   it("use HTTPS by default", () => {
     const connectionString = "Endpoint=sb://mynamespace.servicebus.windows.net;";
     const adminClient = new ServiceBusAdministrationClient(connectionString);
-    assert.equal((adminClient)["useTls"], true);
+    assert.equal(adminClient["useTls"], true);
   });
 
   it("use HTTP when connect to emulator", () => {
     const connectionString = "Endpoint=sb://192.168.y.z;UseDevelopmentEmulator=true;";
     const adminClient = new ServiceBusAdministrationClient(connectionString);
-    assert.equal((adminClient)["useTls"], false);
+    assert.equal(adminClient["useTls"], false);
   });
 });

--- a/sdk/servicebus/service-bus/test/internal/unit/atomAdminClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/atomAdminClient.spec.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert, describe, it } from "vitest";
+import { ServiceBusAdministrationClient } from "../../../src/serviceBusAtomManagementClient.js";
+
+describe("ServiceBusAtomAdminClient", () => {
+  it("use HTTPS by default", () => {
+    const connectionString = "Endpoint=sb://mynamespace.servicebus.windows.net;";
+    const adminClient = new ServiceBusAdministrationClient(connectionString);
+    assert.equal((adminClient)["useTls"], true);
+  });
+
+  it("use HTTP when connect to emulator", () => {
+    const connectionString = "Endpoint=sb://192.168.y.z;UseDevelopmentEmulator=true;";
+    const adminClient = new ServiceBusAdministrationClient(connectionString);
+    assert.equal((adminClient)["useTls"], false);
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/unit/connectionString.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/connectionString.spec.ts
@@ -132,4 +132,16 @@ describe("Connection String", () => {
       parseServiceBusConnectionString(connectionString);
     }, /Connection string/);
   });
+
+  it("Extracts UseDevelopmentEmulator property", () => {
+    const connectionString = "Endpoint=sb://192.168.y.z;UseDevelopmentEmulator=true;";
+    const parsed = parseServiceBusConnectionString(connectionString);
+    assert.equal(parsed.useDevelopmentEmulator, true);
+  });
+
+  it("sets UseDevelopmentEmulator default value", () => {
+    const connectionString = `Endpoint=${expectedEndpoint};`;
+    const parsed = parseServiceBusConnectionString(connectionString);
+    assert.equal(parsed.useDevelopmentEmulator, false);
+  });
 });


### PR DESCRIPTION
even though today service bus emulator doesn't support on the fly management
API, the support may be added in the future.  This PR updates the atom admin
client to use HTTP when emulator is targeted.