### PR TITLE
[core-amqp] Use AggregateError

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Throws `AggregateError` when collecting multiple errors across retries.
+
 ### Other Changes
 
 ## 4.3.4 (2025-01-10)

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -278,17 +278,9 @@ export async function retry<T>(config: RetryConfig<T>): Promise<T> {
   if (success) {
     return result;
   } else {
-    throw compileErrors(errors);
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    throw new AggregateError(errors);
   }
-}
-
-function compileErrors(errors: (MessagingError | Error)[]): MessagingError | Error {
-  if (!errors.length) {
-    throw new RangeError("Error array is empty");
-  }
-  let i = 0;
-  const str = errors.map((error) => `Error ${i++}: ${error}`).join("\n\n");
-  const lastError = errors[errors.length - 1];
-  lastError.message = str;
-  return lastError;
 }

--- a/sdk/core/core-amqp/test/retry.spec.ts
+++ b/sdk/core/core-amqp/test/retry.spec.ts
@@ -16,6 +16,12 @@ import debugModule from "debug";
 
 const debug = debugModule("azure:core-amqp:retry-spec");
 
+function assertError(err: unknown, check: RegExp): asserts err is AggregateError {
+  assert.instanceOf(err, AggregateError);
+  const errors = (err as AggregateError).errors;
+  assert.match(errors[errors.length - 1].message, check);
+}
+
 [RetryMode.Exponential, RetryMode.Fixed].forEach((mode) => {
   describe(`retry function for "${
     mode === RetryMode.Exponential ? "Exponential" : "Fixed"
@@ -169,9 +175,7 @@ const debug = debugModule("azure:core-amqp:retry-spec");
         };
         await retry(config);
       } catch (err) {
-        assert.isDefined(err);
-        assert.instanceOf(err, MessagingError);
-        assert.match((err as MessagingError).message, /I would like to fail./);
+        assertError(err, /I would like to fail./);
         assert.equal(counter, 3);
       }
     });
@@ -193,12 +197,7 @@ const debug = debugModule("azure:core-amqp:retry-spec");
         };
         await retry(config);
       } catch (err) {
-        assert.isDefined(err);
-        assert.instanceOf(err, MessagingError);
-        assert.match(
-          (err as MessagingError).message,
-          /I would always like to fail, keep retrying./,
-        );
+        assertError(err, /I would always like to fail, keep retrying./);
         assert.equal(counter, 5);
       }
     });
@@ -266,12 +265,7 @@ const debug = debugModule("azure:core-amqp:retry-spec");
         // If we get here, `delay` won :-(
         throw new Error("TestFailure: 'retry' took longer than expected to return.");
       } catch (err) {
-        assert.isDefined(err);
-        assert.instanceOf(err, MessagingError);
-        assert.match(
-          (err as MessagingError).message,
-          /I would always like to fail, keep retrying./,
-        );
+        assertError(err, /I would always like to fail, keep retrying./);
         assert.equal(counter, 2);
         // Clear delay's setTimeout...we don't need it anymore.
         delayAbortController.abort();
@@ -460,9 +454,7 @@ const debug = debugModule("azure:core-amqp:retry-spec");
           };
           await retry(config);
         } catch (err) {
-          assert.isDefined(err);
-          assert.instanceOf(err, MessagingError);
-          assert.match((err as MessagingError).message, /I would like to fail./);
+          assertError(err, /I would like to fail./);
           assert.equal(counter, 3);
         }
       });

--- a/sdk/core/core-amqp/test/retry.spec.ts
+++ b/sdk/core/core-amqp/test/retry.spec.ts
@@ -16,7 +16,7 @@ import debugModule from "debug";
 
 const debug = debugModule("azure:core-amqp:retry-spec");
 
-function assertError(err: unknown, check: RegExp): asserts err is AggregateError {
+function assertAggregateError(err: unknown, check: RegExp): asserts err is AggregateError {
   assert.instanceOf(err, AggregateError);
   const errors = (err as AggregateError).errors;
   assert.match(errors[errors.length - 1].message, check);
@@ -175,7 +175,7 @@ function assertError(err: unknown, check: RegExp): asserts err is AggregateError
         };
         await retry(config);
       } catch (err) {
-        assertError(err, /I would like to fail./);
+        assertAggregateError(err, /I would like to fail./);
         assert.equal(counter, 3);
       }
     });
@@ -197,7 +197,7 @@ function assertError(err: unknown, check: RegExp): asserts err is AggregateError
         };
         await retry(config);
       } catch (err) {
-        assertError(err, /I would always like to fail, keep retrying./);
+        assertAggregateError(err, /I would always like to fail, keep retrying./);
         assert.equal(counter, 5);
       }
     });
@@ -265,7 +265,7 @@ function assertError(err: unknown, check: RegExp): asserts err is AggregateError
         // If we get here, `delay` won :-(
         throw new Error("TestFailure: 'retry' took longer than expected to return.");
       } catch (err) {
-        assertError(err, /I would always like to fail, keep retrying./);
+        assertAggregateError(err, /I would always like to fail, keep retrying./);
         assert.equal(counter, 2);
         // Clear delay's setTimeout...we don't need it anymore.
         delayAbortController.abort();
@@ -454,7 +454,7 @@ function assertError(err: unknown, check: RegExp): asserts err is AggregateError
           };
           await retry(config);
         } catch (err) {
-          assertError(err, /I would like to fail./);
+          assertAggregateError(err, /I would like to fail./);
           assert.equal(counter, 3);
         }
       });

--- a/sdk/core/core-amqp/tsconfig.src.json
+++ b/sdk/core/core-amqp/tsconfig.src.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.lib.json",
   "compilerOptions": {
-    "lib": ["DOM"]
+    "lib": ["DOM", "ES2021.Promise"]
   }
 }

--- a/sdk/eventhub/event-hubs/tsconfig.test.json
+++ b/sdk/eventhub/event-hubs/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"],
   "compilerOptions": {
-    "lib": ["DOM"],
+    "lib": ["DOM", "ES2021.Promise"],
     "resolveJsonModule": true
   },
   "exclude": ["./test/stress"]

--- a/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/abortSignal.spec.ts
@@ -22,7 +22,7 @@ import { MessageSession } from "../../../src/session/messageSession.js";
 import type { ProcessErrorArgs } from "../../../src/index.js";
 import type { ReceiveMode } from "../../../src/models.js";
 import { afterEach, beforeEach, describe, it } from "vitest";
-import { assert } from "../../public/utils/chai.js";
+import { assert, assertAggregateError } from "../../public/utils/chai.js";
 
 const abortMsgRegex = new RegExp(StandardAbortMessage);
 
@@ -156,12 +156,15 @@ describe("AbortSignal", () => {
         // in this case init() does get called - we abort through a timer.
         assert.isTrue(initWasCalled);
 
+        assertAggregateError(err);
+        const lastError = err.errors[err.errors.length - 1];
+
         assert.match(
-          err.message,
+          lastError.message,
           /.*was not able to send the message right now, due to operation timeout.*/,
         );
 
-        assert.isTrue((err as any).retryable);
+        assert.isTrue(lastError.retryable);
       }
     });
 

--- a/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/messageSender.spec.ts
@@ -47,17 +47,32 @@ describe("MessageSender unit tests", () => {
           abortSignal: undefined,
           retryOptions,
         }),
-      {
-        name: "ServiceBusError",
-        code: "GeneralError",
-        message: `Error 0: ServiceBusError: Link failed to initialize, cannot get max message size.
-
-Error 1: ServiceBusError: Link failed to initialize, cannot get max message size.
-
-Error 2: ServiceBusError: Link failed to initialize, cannot get max message size.
-
-Error 3: ServiceBusError: Link failed to initialize, cannot get max message size.`,
-      },
+      [
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message: "Link failed to initialize, cannot get max message size.",
+          retryable: true,
+        },
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message: "Link failed to initialize, cannot get max message size.",
+          retryable: true,
+        },
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message: "Link failed to initialize, cannot get max message size.",
+          retryable: true,
+        },
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message: "Link failed to initialize, cannot get max message size.",
+          retryable: true,
+        },
+      ],
     );
 
     assert.equal(openCalled, retryOptions.maxRetries + 1);
@@ -136,17 +151,35 @@ Error 3: ServiceBusError: Link failed to initialize, cannot get max message size
       } as any;
     };
 
-    await assertThrows(() => messageSender.send({ body: "message" }), {
-      name: "ServiceBusError",
-      code: "GeneralError",
-      message: `Error 0: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.
-
-Error 1: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.
-
-Error 2: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.
-
-Error 3: ServiceBusError: SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.`,
-    });
+    await assertThrows(
+      () => messageSender.send({ body: "message" }),
+      [
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message:
+            "SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
+        },
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message:
+            "SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
+        },
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message:
+            "SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
+        },
+        {
+          name: "ServiceBusError",
+          code: "GeneralError",
+          message:
+            "SenderNotReadyError: [fakeSenderForSendRetry] Cannot send the message. Link is not ready.",
+        },
+      ],
+    );
 
     assert.equal(openCalled, retryOptions.maxRetries + 1);
   });

--- a/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
@@ -165,6 +165,7 @@ describe("shared receiver code", () => {
           ),
         {
           message: MessageAlreadySettled,
+          name: "Error",
         },
       );
     });
@@ -190,6 +191,7 @@ describe("shared receiver code", () => {
           ),
         {
           message: MessageAlreadySettled,
+          name: "Error",
         },
       );
     });
@@ -219,7 +221,7 @@ describe("shared receiver code", () => {
 
       await assertThrows(() => retryForeverPromise, {
         name: "AbortError",
-        message: "Error 0: AbortError: Purposefully abort",
+        message: "Purposefully abort",
       });
 
       assert.notOk(onErrorError?.message);

--- a/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/streamingReceiver.spec.ts
@@ -170,8 +170,7 @@ describe("StreamingReceiver unit tests", () => {
 
       await assertThrows(() => subscribePromise, {
         name: "AbortError",
-        message:
-          "Error 0: AbortError: Cannot request messages on the receiver since it is suspended.",
+        message: "Cannot request messages on the receiver since it is suspended.",
       });
 
       // closeLink is called on cleanup when we fail to add credits (which we would because our receiver
@@ -210,7 +209,7 @@ describe("StreamingReceiver unit tests", () => {
 
       await assertThrows(() => subscribePromise, {
         name: "AbortError",
-        message: "Error 0: AbortError: Receiver was suspended during initialization.",
+        message: "Receiver was suspended during initialization.",
       });
 
       // closeLink should not be called if no link was created
@@ -218,7 +217,7 @@ describe("StreamingReceiver unit tests", () => {
 
       assert.deepEqual(errors, [
         {
-          message: "Error 0: AbortError: Receiver was suspended during initialization.",
+          message: "Receiver was suspended during initialization.",
           errorSource: "receive",
         },
       ]);

--- a/sdk/servicebus/service-bus/test/public/utils/chai.ts
+++ b/sdk/servicebus/service-bus/test/public/utils/chai.ts
@@ -11,3 +11,7 @@ chai.use(chaiExclude);
 chai.use(chaiAzure);
 const should = shouldFn();
 export { assert, expect, should };
+
+export function assertAggregateError(err: unknown): asserts err is AggregateError {
+  assert.instanceOf(err, AggregateError);
+}

--- a/sdk/servicebus/service-bus/tsconfig.test.json
+++ b/sdk/servicebus/service-bus/tsconfig.test.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"],
+  "compilerOptions": {
+    "lib": ["DOM", "ES2021.Promise"]
+  }
 }


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-amqp

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/32767

### Describe the problem that is addressed by this PR
See linked issue.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
We shouldn't set the message property on the error object, hence using `AggregateError`.

### Are there test cases added in this PR? _(If not, why?)_
N/A

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
