### PR TITLE
[dev-tool] Revert restoring assets

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -6,8 +6,6 @@ import { leafCommand, makeCommandInfo } from "../../framework/command";
 import { runTestsWithProxyTool } from "../../util/testUtils";
 import { createPrinter } from "../../util/printer";
 import { shouldStartRelay, startRelayServer } from "../../util/browserRelayServer";
-import { runTestProxyCommandWithRetry } from "../../util/testProxyUtils";
-import fs from "fs";
 
 const log = createPrinter("test:vitest");
 
@@ -92,16 +90,6 @@ export default leafCommand(commandInfo, async (options) => {
   try {
     if (options["test-proxy"]) {
       if (options["test-proxy-debug"]) process.env["Logging__LogLevel__Default"] = "Debug";
-
-      // restore recordings first in CI to avoid impacting the first playback test
-      if (process.env["BUILD_BUILDNUMBER"] && fs.existsSync("assets.json")) {
-        log.info(`restoring recordings before testing`);
-        // This line runs the 'restore' command with retries.
-        // Introduced retries for the 'restore' command to mitigate EBUSY errors, which occur due to resource locking by simultaneous pipeline processes.
-        // The CI pipeline fails flakily for any of the packages in the run without the retries.
-        // Best solution would probably be to get rid of this code in favour of downloading the assets as part of a dedicated pipeline step that would be common for all languages.
-        await runTestProxyCommandWithRetry(["restore", "-a", "assets.json"], 1000, 10000);
-      }
 
       return await runTestsWithProxyTool(command);
     }

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -12,7 +12,7 @@ import envPaths from "env-paths";
 import { promisify } from "node:util";
 import { PassThrough } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { checkWithTimeout, delay } from "./checkWithTimeout";
+import { delay } from "./checkWithTimeout";
 
 const log = createPrinter("test-proxy");
 const downloadLocation = path.join(envPaths("azsdk-dev-tool").cache, "test-proxy");
@@ -195,30 +195,6 @@ export async function runTestProxyCommand(argv: string[]): Promise<void> {
   }
 }
 
-export async function runTestProxyCommandWithRetry(
-  argv: string[],
-  delayBetweenRetriesInMilliseconds = 1000,
-  maxWaitTimeInMilliseconds = 10000,
-) {
-  const success = await checkWithTimeout(
-    async () => {
-      try {
-        await runTestProxyCommand(argv);
-        return true;
-      } catch (error) {
-        console.error("runTestProxyCommand failed, retrying...", error);
-        return false;
-      }
-    },
-    delayBetweenRetriesInMilliseconds,
-    maxWaitTimeInMilliseconds,
-  );
-
-  if (!success) {
-    console.error("runTestProxyCommand failed after multiple retries");
-  }
-}
-
 export function createAssetsJson(project: ProjectInfo): Promise<void> {
   return runMigrationScript(project, false);
 }
@@ -328,8 +304,7 @@ export async function isProxyToolActive(): Promise<boolean> {
     }
 
     log.info(
-      `Proxy tool seems to be active at http://localhost:${
-        process.env.TEST_PROXY_HTTP_PORT ?? 5000
+      `Proxy tool seems to be active at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000
       }\n`,
     );
     return true;

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -304,7 +304,8 @@ export async function isProxyToolActive(): Promise<boolean> {
     }
 
     log.info(
-      `Proxy tool seems to be active at http://localhost:${process.env.TEST_PROXY_HTTP_PORT ?? 5000
+      `Proxy tool seems to be active at http://localhost:${
+        process.env.TEST_PROXY_HTTP_PORT ?? 5000
       }\n`,
     );
     return true;


### PR DESCRIPTION
### Description

This PR reverts the recent changes from [PR 32668](https://github.com/Azure/azure-sdk-for-js/pull/32668) and [PR 32752](https://github.com/Azure/azure-sdk-for-js/pull/32752). 

These changes did not fully resolve the race condition issues, as we observed continued failures, albeit with lesser frequency, even after increasing the timeouts. 

Increasing the timeouts further does not seem like a clean solution. Therefore, reverting these changes in this PR.

### Changes

- Revert the changes introduced in PR 32668 and PR 32752.
- [TO DO] A new approach to restore assets sequentially in a separate job will be implemented in a follow-up PR.

### Related Issue

Issues observed at the current state of restoring assets: [Issue 32805](https://github.com/Azure/azure-sdk-for-js/issues/32805)