### PR TITLE
[engSys] use module-kind: esm for migrated packages ***NO_CI***

### DIFF
--- a/sdk/agrifood/agrifood-farming-rest/swagger/README.md
+++ b/sdk/agrifood/agrifood-farming-rest/swagger/README.md
@@ -21,8 +21,8 @@ rest-level-client: true
 security: AADToken
 security-scopes: https://farmbeats.azure.net/.default
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 modelerfour:
   treat-type-object-as-anything: true
+module-kind: esm
 ```

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/swagger/README.md
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/swagger/README.md
@@ -22,6 +22,9 @@ generate-test: true
 #   "@autorest/typescript": "6.0.0-rc.1.20220928.1"
 use-extension:
   "@autorest/modelerfour": "https://tinyurl.com/2dx6b9fg"
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ```yaml

--- a/sdk/appconfiguration/app-configuration/swagger/swagger.md
+++ b/sdk/appconfiguration/app-configuration/swagger/swagger.md
@@ -22,6 +22,9 @@ disable-async-iterators: true
 api-version-parameter: choice
 v3: true
 hide-clients: true
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ### Patch endpoints for exception handling

--- a/sdk/appservice/arm-appservice-rest/swagger/README.md
+++ b/sdk/appservice/arm-appservice-rest/swagger/README.md
@@ -22,5 +22,6 @@ rest-level-client: true
 add-credentials: true
 credential-scopes: "https://management.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/attestation/attestation/swagger/README.md
+++ b/sdk/attestation/attestation/swagger/README.md
@@ -31,15 +31,14 @@ title: AzureAttestationRestClient
 v3: true
 no-namespace-folders: true
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Azure.Security.Attestation"
   packagePrefix: "Azure.Security.Attestation"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/cognitivelanguage/ai-language-conversations/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-conversations/swagger/README.md
@@ -32,6 +32,9 @@ tag: release_2022_05_15_preview
 package-version: 1.0.0-beta.1
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ## Batch Execution

--- a/sdk/cognitivelanguage/ai-language-text/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-text/swagger/README.md
@@ -18,6 +18,9 @@ package-version: 1.1.0
 v3: true
 hide-clients: true
 typescript: true
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/cognitivelanguage/ai-language-textauthoring/package.json
+++ b/sdk/cognitivelanguage/ai-language-textauthoring/package.json
@@ -40,7 +40,7 @@
     "execute:samples": "echo skipped",
     "extract-api": "dev-tool run vendored rimraf review && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript swagger/README.md && dev-tool admin migrate-source && npm run format",
+    "generate:client": "autorest --typescript swagger/README.md",
     "integration-test": "echo skipped",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",

--- a/sdk/cognitivelanguage/ai-language-textauthoring/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-textauthoring/swagger/README.md
@@ -21,6 +21,9 @@ hide-clients: false
 rest-level-client: true
 generate-sample: true
 typescript: true
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/communication/communication-alpha-ids/package.json
+++ b/sdk/communication/communication-alpha-ids/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "build:autorest": "autorest --typescript --v3 ./swagger/README.md",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-alpha-ids/swagger/README.md
+++ b/sdk/communication/communication-alpha-ids/swagger/README.md
@@ -18,14 +18,14 @@ add-credentials: false
 skip-enum-validation: true
 title: Alpha IDs Client
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -9,7 +9,7 @@
   "browser": "./dist/browser/index.js",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "build:autorest": "autorest ./swagger/README.md",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:node": "dev-tool run build-package && dev-tool run bundle",
     "build:samples": "dev-tool samples publish --force",
@@ -19,7 +19,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -21,7 +21,7 @@ typescript: true
 azure-arm: false
 add-credentials: false
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 directive:
   - rename-model:
       from: CallParticipant
@@ -200,6 +200,7 @@ directive:
   - rename-model:
       from: HoldAudioCompleted
       to: RestHoldAudioCompleted
+module-kind: esm
 ```
 
 ```yaml

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-chat/swagger/README.md
+++ b/sdk/communication/communication-chat/swagger/README.md
@@ -18,14 +18,14 @@ add-credentials: false
 disable-async-iterators: true
 package-version: 1.5.5
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Azure.Communication"
   packagePrefix: "Microsoft.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ### Rename CommunicationError to ChatError

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-email/swagger/README.md
+++ b/sdk/communication/communication-email/swagger/README.md
@@ -21,7 +21,8 @@ azure-arm: false
 add-credentials: false
 v3: true
 use-extension:
-  "@autorest/typescript": "6.0.0-rc.1"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customizations for Email Client Generator

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -19,7 +19,7 @@
     "execute:ts-samples": "dev-tool samples run dist-samples/typescript/dist/dist-samples/typescript/src/",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-identity/swagger/README.md
+++ b/sdk/communication/communication-identity/swagger/README.md
@@ -18,14 +18,13 @@ optional-response-headers: true
 payload-flattening-threshold: 10
 add-credentials: false
 v3: true
-
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -17,7 +17,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-phone-numbers/swagger/README-SipRouting.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README-SipRouting.md
@@ -18,11 +18,12 @@ require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/speci
 optional-response-headers: true
 payload-flattening-threshold: 10
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
 add-credentials: false
 azure-arm: false
 title: Sip Routing Client
 v3: true
+module-kind: esm
 ```
 
 ### Directive renaming "Trunk" model to "SipTrunk"

--- a/sdk/communication/communication-phone-numbers/swagger/README.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README.md
@@ -20,15 +20,15 @@ skip-enum-validation: true
 title: Phone Numbers Client
 v3: true
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 use-legacy-lro: true
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/communication/communication-recipient-verification/package.json
+++ b/sdk/communication/communication-recipient-verification/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-recipient-verification/swagger/README.md
+++ b/sdk/communication/communication-recipient-verification/swagger/README.md
@@ -19,14 +19,14 @@ skip-enum-validation: true
 v3: true
 title: Recipient Verification Client
 use-extension:
-  "@autorest/typescript": "6.0.0-rc.1"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/communication/communication-rooms/package.json
+++ b/sdk/communication/communication-rooms/package.json
@@ -71,7 +71,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript --disable-async-iterators ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript --disable-async-iterators ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-rooms/swagger/README.md
+++ b/sdk/communication/communication-rooms/swagger/README.md
@@ -18,16 +18,15 @@ optional-response-headers: true
 payload-flattening-threshold: 10
 add-credentials: false
 v3: true
-
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ### Set Role Model as string false

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-short-codes/swagger/README.md
+++ b/sdk/communication/communication-short-codes/swagger/README.md
@@ -19,14 +19,14 @@ skip-enum-validation: true
 v3: true
 title: Short Codes Client
 use-extension:
-  "@autorest/typescript": "6.0.0-rc.1"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -18,7 +18,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "dev-tool run test:browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/communication/communication-sms/swagger/README.md
+++ b/sdk/communication/communication-sms/swagger/README.md
@@ -16,17 +16,16 @@ require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/refs/heads
 model-date-time-as-string: false
 optional-response-headers: true
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 azure-arm: false
 add-credentials: false
 package-version: 1.2.0-beta.4
 v3: true
-
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```

--- a/sdk/communication/communication-tiering/package.json
+++ b/sdk/communication/communication-tiering/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "build:autorest": "autorest --typescript ./swagger/README.md",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-tiering/swagger/README.md
+++ b/sdk/communication/communication-tiering/swagger/README.md
@@ -19,14 +19,14 @@ skip-enum-validation: true
 v3: true
 title: Tiering Client
 use-extension:
-  "@autorest/typescript": "6.0.0"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/communication/communication-toll-free-verification/package.json
+++ b/sdk/communication/communication-toll-free-verification/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "scripts": {
     "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
-    "build:autorest": "autorest --typescript --version=3.0.6267 --v3 ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "build:autorest": "autorest --typescript --v3 ./swagger/README.md",
     "build:browser": "dev-tool run build-package && dev-tool run bundle",
     "build:clean": "rush update --recheck && rush rebuild && npm run build",
     "build:node": "dev-tool run build-package && dev-tool run bundle",

--- a/sdk/communication/communication-toll-free-verification/swagger/README.md
+++ b/sdk/communication/communication-toll-free-verification/swagger/README.md
@@ -18,14 +18,14 @@ add-credentials: false
 skip-enum-validation: true
 title: Toll Free Verification Client
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Communication"
   packagePrefix: "Azure.Communication"
-
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/compute/arm-compute-rest/swagger/README.md
+++ b/sdk/compute/arm-compute-rest/swagger/README.md
@@ -23,8 +23,9 @@ add-credentials: true
 security: AADToken
 security-scopes: "https://management.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 modelerfour:
   lenient-model-deduplication: true
   treat-type-object-as-anything: true
+module-kind: esm
 ```

--- a/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
@@ -21,7 +21,8 @@ rest-level-client: true
 security: "AADToken"
 security-scopes: "https://confidential-ledger.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ```yaml

--- a/sdk/containerregistry/container-registry/swagger/README.md
+++ b/sdk/containerregistry/container-registry/swagger/README.md
@@ -21,6 +21,9 @@ disable-async-iterators: true
 hide-clients: true
 api-version-parameter: choice
 package-version: 1.1.1
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/containerservice/arm-containerservice-rest/swagger/README.md
+++ b/sdk/containerservice/arm-containerservice-rest/swagger/README.md
@@ -22,5 +22,6 @@ rest-level-client: true
 security: AADToken
 security-scopes: "https://management.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/deviceupdate/iot-device-update-rest/swagger/README.md
+++ b/sdk/deviceupdate/iot-device-update-rest/swagger/README.md
@@ -21,7 +21,8 @@ rest-level-client: true
 add-credentials: true
 credential-scopes: https://api.adu.microsoft.com/.default
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ### Fix 304s

--- a/sdk/digitaltwins/digital-twins-core/swagger/README.md
+++ b/sdk/digitaltwins/digital-twins-core/swagger/README.md
@@ -8,7 +8,7 @@ typescript:
   title: GeneratedClient
   description: Digitaltwins Client
 use-extension:
-  "@autorest/typescript": "6.0.0-rc.6.20221226.1"
+  "@autorest/typescript": "6.0.34"
 generate-metadata: false
 add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
@@ -16,6 +16,7 @@ input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specificatio
 output-folder: ../
 source-code-folder-path: ./src/generated
 package-version: 2.0.0
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/documenttranslator/ai-document-translator-rest/swagger/README.md
+++ b/sdk/documenttranslator/ai-document-translator-rest/swagger/README.md
@@ -23,5 +23,6 @@ add-credentials: true
 credential-scopes: "https://cognitiveservices.azure.com/.default"
 credential-key-header-name: "Ocp-Apim-Subscription-Key"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/eventgrid/eventgrid/swagger/README.md
+++ b/sdk/eventgrid/eventgrid/swagger/README.md
@@ -19,8 +19,9 @@ source-code-folder-path: ./src/generated
 typescript: true
 hide-clients: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.4"
+  "@autorest/typescript": "6.0.34"
 v3: true
+module-kind: esm
 ```
 
 ## Customizations

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -18,7 +18,8 @@ add-credentials: false
 typescript: true
 package-version: "5.0.0"
 use-extension:
-  "@autorest/typescript": "6.0.0-alpha.20.20220622.1"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/keyvault/keyvault-admin/swagger/README.md
+++ b/sdk/keyvault/keyvault-admin/swagger/README.md
@@ -18,7 +18,8 @@ output-folder: ../
 source-code-folder-path: ./src/generated
 package-version: 4.6.1
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ### Hide LROs

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -10,7 +10,7 @@ api-version-parameter: choice
 use-core-v2: true
 v3: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.19"
+  "@autorest/typescript": "6.0.34"
 azure-arm: false
 generate-metadata: false
 add-credentials: false
@@ -22,6 +22,7 @@ source-code-folder-path: ./src/generated
 hide-clients: true
 package-version: 4.9.1
 openapi-type: data-plane
+module-kind: esm
 ```
 
 ## Rename certain models back to what they were before 7.4

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -17,7 +17,8 @@ disable-async-iterators: true
 api-version-parameter: choice
 package-version: 4.9.1
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.19"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -10,7 +10,7 @@ disable-async-iterators: true
 v3: true
 use-core-v2: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.19"
+  "@autorest/typescript": "6.0.34"
 azure-arm: false
 generate-metadata: false
 add-credentials: false
@@ -21,4 +21,5 @@ output-folder: ../
 source-code-folder-path: ./src/generated
 hide-clients: true
 package-version: 4.9.1
+module-kind: esm
 ```

--- a/sdk/loadtesting/load-testing-rest/swagger/README.md
+++ b/sdk/loadtesting/load-testing-rest/swagger/README.md
@@ -19,7 +19,8 @@ rest-level-client: true
 security: AADToken
 security-scopes: "https://cnt-prod.loadtesting.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "6.0.0-rc.3"
+  "@autorest/typescript": "6.0.34"
 service-versions:
 - '2022-11-01'
+module-kind: esm
 ```

--- a/sdk/maps/maps-geolocation-rest/swagger/README.md
+++ b/sdk/maps/maps-geolocation-rest/swagger/README.md
@@ -34,7 +34,8 @@ rest-level-client: true
 security: AzureKey
 security-header-name: subscription-key
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customization for Track 2 Generator

--- a/sdk/maps/maps-render-rest/swagger/README.md
+++ b/sdk/maps/maps-render-rest/swagger/README.md
@@ -31,7 +31,8 @@ rest-level-client: true
 security: AzureKey
 security-header-name: subscription-key
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customization for Track 2 Generator

--- a/sdk/maps/maps-route-rest/swagger/README.md
+++ b/sdk/maps/maps-route-rest/swagger/README.md
@@ -31,7 +31,8 @@ rest-level-client: true
 security: AzureKey
 security-header-name: subscription-key
 use-extension:
-  "@autorest/typescript": "6.0.28"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customization for Track 2 Generator

--- a/sdk/maps/maps-search-rest/swagger/README.md
+++ b/sdk/maps/maps-search-rest/swagger/README.md
@@ -34,7 +34,8 @@ rest-level-client: true
 security: AzureKey
 security-header-name: subscription-key
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customization for Track 2 Generator

--- a/sdk/maps/maps-timezone-rest/swagger/README.md
+++ b/sdk/maps/maps-timezone-rest/swagger/README.md
@@ -31,7 +31,8 @@ rest-level-client: true
 security: AzureKey
 security-header-name: subscription-key
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customization for Track 2 Generator

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -57,7 +57,7 @@
     "execute:samples": "dev-tool samples run samples-dev",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript ./swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
+++ b/sdk/metricsadvisor/ai-metrics-advisor/swagger/README.md
@@ -18,12 +18,13 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/08f5e39
 add-credentials: false
 override-client-name: GeneratedClient
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.16"
+  "@autorest/typescript": "6.0.34"
 disable-async-iterators: true
 hide-clients: true
 package-version: 1.0.1
 typescript: true
 core-http-compat-mode: true
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/mixedreality/mixed-reality-authentication/swagger/README.md
+++ b/sdk/mixedreality/mixed-reality-authentication/swagger/README.md
@@ -17,14 +17,14 @@ source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/aa19725fe79aea2a9dc580f3c66f77f89cc34563/specification/mixedreality/data-plane/Microsoft.MixedReality/preview/2019-02-28-preview/mr-sts.json
 add-credentials: false
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 hide-clients: true
 package-version: 1.0.0-beta.2
 v3: true
-
 tracing-info:
   namespace: "Microsoft.MixedReality"
   packagePrefix: "Azure.MixedReality"
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/monitor/monitor-ingestion/swagger/README.md
+++ b/sdk/monitor/monitor-ingestion/swagger/README.md
@@ -18,5 +18,6 @@ add-credentials: true
 package-version: 1.1.1
 hide-clients: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/monitor/monitor-opentelemetry-exporter/swagger/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/swagger/README.md
@@ -24,8 +24,9 @@ source-code-folder-path: ./src/generated
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/applicationinsights/data-plane/Monitor.Exporters/preview/v2.1/swagger.json
 add-credentials: false
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 package-version: 1.0.0-beta.25
 typescript: true
 v3: true
+module-kind: esm
 ```

--- a/sdk/monitor/monitor-query/swagger/logquery.md
+++ b/sdk/monitor/monitor-query/swagger/logquery.md
@@ -22,7 +22,8 @@ hide-clients: true
 v3: true
 typescript: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/monitor/monitor-query/swagger/metric-Batch.md
+++ b/sdk/monitor/monitor-query/swagger/metric-Batch.md
@@ -22,5 +22,6 @@ hide-clients: true
 v3: true
 typescript: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/monitor/monitor-query/swagger/metric-definitions.md
+++ b/sdk/monitor/monitor-query/swagger/metric-definitions.md
@@ -23,7 +23,8 @@ hide-clients: true
 v3: true
 typescript: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ### Add missing x-ms-parameter-location for SubscriptionIdParameter

--- a/sdk/monitor/monitor-query/swagger/metric-namespaces.md
+++ b/sdk/monitor/monitor-query/swagger/metric-namespaces.md
@@ -22,5 +22,6 @@ hide-clients: true
 v3: true
 typescript: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/monitor/monitor-query/swagger/metrics.md
+++ b/sdk/monitor/monitor-query/swagger/metrics.md
@@ -23,7 +23,8 @@ v3: true
 typescript: true
 title: MonitorManagementClient
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ### Add missing x-ms-parameter-location for SubscriptionIdParameter

--- a/sdk/network/arm-network-rest/swagger/README.md
+++ b/sdk/network/arm-network-rest/swagger/README.md
@@ -23,5 +23,6 @@ add-credentials: true
 security: AADToken
 security-scopes: "https://management.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/purview/purview-administration-rest/swagger/README.md
+++ b/sdk/purview/purview-administration-rest/swagger/README.md
@@ -33,8 +33,9 @@ rest-level-client: true
 add-credentials: true
 credential-scopes: "https://purview.azure.net/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 batch:
   - purview-metadata: true
   - purview-account: true
+module-kind: esm
 ```

--- a/sdk/purview/purview-catalog-rest/swagger/README.md
+++ b/sdk/purview/purview-catalog-rest/swagger/README.md
@@ -18,7 +18,8 @@ rest-level-client: true
 add-credentials: true
 credential-scopes: "https://purview.azure.net/.default"
 use-extension:
-  "@autorest/typescript": "6.0.0-alpha.17.20220328.1"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ```yaml

--- a/sdk/purview/purview-scanning-rest/swagger/README.md
+++ b/sdk/purview/purview-scanning-rest/swagger/README.md
@@ -21,7 +21,8 @@ rest-level-client: true
 add-credentials: true
 credential-scopes: "https://purview.azure.net/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```

--- a/sdk/purview/purview-sharing-rest/swagger/README.md
+++ b/sdk/purview/purview-sharing-rest/swagger/README.md
@@ -22,7 +22,7 @@ generate-metadata: false
 generate-test: false
 generate-sample: false
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 modelerfour:
   lenient-model-deduplication: true
 directive:
@@ -59,4 +59,5 @@ directive:
       from: "ShareResources_List",
       to: "ShareResources_GetAllShareResources"
     ]
+module-kind: esm
 ```

--- a/sdk/purview/purview-workflow-rest/swagger/README.md
+++ b/sdk/purview/purview-workflow-rest/swagger/README.md
@@ -22,5 +22,6 @@ rest-level-client: true
 add-credentials: true
 credential-scopes: "https://purview.azure.net/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -21,7 +21,7 @@
     "execute:samples": "npm run build:samples && dev-tool samples run dist-samples/javascript dist-samples/typescript/dist/dist-samples/typescript/src/",
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
-    "generate:client": "autorest --typescript --use=@autorest/modelerfour@4.15.452 swagger/README.md && dev-tool admin migrate-source && rushx format",
+    "generate:client": "autorest --typescript --use=@autorest/modelerfour@4.15.452 swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "dev-tool run test:vitest --esm",

--- a/sdk/quantum/quantum-jobs/swagger/readme.md
+++ b/sdk/quantum/quantum-jobs/swagger/readme.md
@@ -18,9 +18,10 @@ security: AADToken
 title: QuantumJobClient
 v3: true
 use-extension:
-  "@autorest/typescript": "6.0.0-rc.1"
+  "@autorest/typescript": "6.0.34"
 tracing-info:
   namespace: "Microsoft.Quantum"
   packagePrefix: "Azure.Quantum.QuantumJobs"
 use-core-v2: true
+module-kind: esm
 ```

--- a/sdk/remoterendering/mixed-reality-remote-rendering/swagger/README.md
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/swagger/README.md
@@ -17,17 +17,15 @@ add-credentials: false
 package-version: 1.0.0-beta.2
 disable-async-iterators: true
 hide-clients: true
-
 tracing-info:
   namespace: "Microsoft.MixedReality"
   packagePrefix: "Azure.mixed-reality-remote-rendering"
-
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 typescript:
   generate-metadata: false
   azure-arm: false
+module-kind: esm
 ```
 
 ```yaml

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -14,7 +14,7 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/14531a7
 add-credentials: false
 title: SearchClient
 use-extension:
-  "@autorest/typescript": "6.0.27"
+  "@autorest/typescript": "6.0.34"
 core-http-compat-mode: true
 package-version: 12.2.0-beta.2
 disable-async-iterators: true
@@ -22,6 +22,7 @@ api-version-parameter: choice
 v3: true
 hide-clients: true
 use-core-v2: true
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -13,7 +13,7 @@ source-code-folder-path: ./src/generated/service
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/14531a7cf6101c1dd57e7c1c83103a047bb8f5bb/specification/search/data-plane/Azure.Search/preview/2024-11-01-preview/searchservice.json
 add-credentials: false
 use-extension:
-  "@autorest/typescript": "6.0.27"
+  "@autorest/typescript": "6.0.34"
 core-http-compat-mode: true
 package-version: 12.2.0-beta.2
 disable-async-iterators: true
@@ -21,6 +21,7 @@ api-version-parameter: choice
 v3: true
 hide-clients: true
 use-core-v2: true
+module-kind: esm
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/servicefabric/arm-servicefabric-rest/swagger/README.md
+++ b/sdk/servicefabric/arm-servicefabric-rest/swagger/README.md
@@ -21,5 +21,6 @@ rest-level-client: true
 security: AADToken
 security-scopes: "https://management.azure.com/.default"
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```

--- a/sdk/synapse/synapse-access-control-rest/swagger/README.md
+++ b/sdk/synapse/synapse-access-control-rest/swagger/README.md
@@ -19,13 +19,12 @@ output-folder: ..
 clear-output-folder: false
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/synapse/data-plane/readme.md
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 typescript:
   generate-metadata: false
   azure-arm: true
   rest-level-client: true
-
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```

--- a/sdk/synapse/synapse-access-control/swagger/README.md
+++ b/sdk/synapse/synapse-access-control/swagger/README.md
@@ -19,12 +19,11 @@ tracing-info:
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1a0701d25874ac7a43620a2dad2f893562ac1340/specification/synapse/data-plane/readme.md
 tag: package-access-control-2020-12-01
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 typescript:
   generate-metadata: false
   azure-arm: true
-
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```

--- a/sdk/synapse/synapse-artifacts/swagger/README.md
+++ b/sdk/synapse/synapse-artifacts/swagger/README.md
@@ -20,15 +20,14 @@ tracing-info:
   packagePrefix: "Microsoft.Synapse"
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/02e1bd495ad6215aacec5d636a5ef7ad6f20281e/specification/synapse/data-plane/readme.md
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tag: package-artifacts-composite-v7
-
 typescript:
   generate-metadata: false
   azure-arm: true
-
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```
 
 ```yaml

--- a/sdk/synapse/synapse-managed-private-endpoints/swagger/README.md
+++ b/sdk/synapse/synapse-managed-private-endpoints/swagger/README.md
@@ -20,12 +20,11 @@ tracing-info:
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b9d36b704e582a2bd5677fedc813607e73963469/specification/synapse/data-plane/readme.md
 tag: package-vnet-2020-12-01
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 typescript:
   generate-metadata: false
   azure-arm: true
-
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```

--- a/sdk/synapse/synapse-monitoring/swagger/README.md
+++ b/sdk/synapse/synapse-monitoring/swagger/README.md
@@ -19,12 +19,11 @@ tracing-info:
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b9d36b704e582a2bd5677fedc813607e73963469/specification/synapse/data-plane/readme.md
 tag: package-monitoring-2020-12-01
 use-extension:
-  "@autorest/typescript": "latest"
-
+  "@autorest/typescript": "6.0.34"
 typescript:
   generate-metadata: false
   azure-arm: true
-
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```

--- a/sdk/synapse/synapse-spark/swagger/README.md
+++ b/sdk/synapse/synapse-spark/swagger/README.md
@@ -18,13 +18,12 @@ tracing-info:
   packagePrefix: "Microsoft.Synapse"
 require: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b9d36b704e582a2bd5677fedc813607e73963469/specification/synapse/data-plane/readme.md
 use-extension:
-  "@autorest/typescript": "latest"
+  "@autorest/typescript": "6.0.34"
 tag: package-spark-2020-12-01
-
 typescript:
   generate-metadata: false
   azure-arm: true
-
 modelerfour:
   lenient-model-deduplication: true
+module-kind: esm
 ```

--- a/sdk/tables/data-tables/swagger/README.md
+++ b/sdk/tables/data-tables/swagger/README.md
@@ -18,9 +18,10 @@ input-file: https://github.com/Azure/azure-rest-api-specs/blob/4ae412cf228fb0320
 add-credentials: false
 override-client-name: GeneratedClient
 use-extension:
-  "@autorest/typescript": "6.0.0-alpha.19.20220425.1"
+  "@autorest/typescript": "6.0.34"
 hide-clients: true
 openapi-type: data-plane
+module-kind: esm
 ```
 
 ```yaml

--- a/sdk/template/template/swagger/README.md
+++ b/sdk/template/template/swagger/README.md
@@ -19,7 +19,8 @@ package-version: 1.0.13-beta.2
 disable-async-iterators: true
 hide-clients: true
 use-extension:
-  "@autorest/typescript": "6.0.0-beta.15"
+  "@autorest/typescript": "6.0.34"
+module-kind: esm
 ```
 
 ### Rename KeyValue to ConfigurationSetting

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -18,6 +18,9 @@ package-version: 5.1.1
 v3: true
 hide-clients: true
 typescript: true
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/web-pubsub/web-pubsub/swagger/README.md
+++ b/sdk/web-pubsub/web-pubsub/swagger/README.md
@@ -18,6 +18,9 @@ package-version: 1.1.4
 v3: true
 hide-clients: true
 use-core-v2: true
+module-kind: esm
+use-extension:
+  "@autorest/typescript": "6.0.34"
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Packages that have migrated to tshy must use ESM style imports and exports. Now
that the @autorest/typescript extension is released we can start updating the
flags. This updates all data-plane packages. ARM packages will be done in a
separate PR.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR: _(Applicable only to SDK release request PRs)_


### Checklists
- [ ] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).
