### PR TITLE
[ai-inference] Fix browser tests

### DIFF
--- a/sdk/ai/ai-inference-rest/assets.json
+++ b/sdk/ai/ai-inference-rest/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/ai/ai-inference-rest",
-  "Tag": "js/ai/ai-inference-rest_adc3d6a0ba"
+  "Tag": "js/ai/ai-inference-rest_edf67ede5e"
 }


### PR DESCRIPTION
Fix browser tests by removing the `Origin` header from the recordings as it is no longer part of the request.