### PR TITLE
[engSys] use module-kind esm for migrated arm packages ***NO_CI***

### DIFF
--- a/sdk/advisor/arm-advisor/_meta.json
+++ b/sdk/advisor/arm-advisor/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "54ee1a9eb50c13e0790627749f986c886ad4f4db",
   "readme": "specification\\advisor\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\advisor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\advisor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.5"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/agrifood/arm-agrifood/_meta.json
+++ b/sdk/agrifood/arm-agrifood/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "3eb2a407e29fa9c79cf537722384b12b9753d59e",
   "readme": "specification/agrifood/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\agrifood\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\agrifood\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/analysisservices/arm-analysisservices/_meta.json
+++ b/sdk/analysisservices/arm-analysisservices/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "b5112cf604d9c89f250fb0810731a9a86e9d2230",
   "readme": "specification\\analysisservices\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\analysisservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\analysisservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/apicenter/arm-apicenter/_meta.json
+++ b/sdk/apicenter/arm-apicenter/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d4205894880b989ede35d62d97c8e901ed14fb5a",
   "readme": "specification/apicenter/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\apicenter\\resource-manager\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\apicenter\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.15"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/apimanagement/arm-apimanagement/_meta.json
+++ b/sdk/apimanagement/arm-apimanagement/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "c2e836ccebb6a08245631ca1d68927abf8a79ba1",
   "readme": "specification/apimanagement/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\apimanagement\\resource-manager\\readme.md --use=@autorest/typescript@6.0.8 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\apimanagement\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
-  "use": "@autorest/typescript@6.0.8"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/_meta.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "cfe9fa198c87ac665d79458810b9f8179912a6d2",
   "readme": "specification/appcomplianceautomation/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\appcomplianceautomation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\appcomplianceautomation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.10",
-  "use": "@autorest/typescript@6.0.23"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/appconfiguration/arm-appconfiguration/_meta.json
+++ b/sdk/appconfiguration/arm-appconfiguration/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "2d4992bd73955a93f972ba6c476e980e7e16a992",
   "readme": "specification/appconfiguration/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\appconfiguration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\appconfiguration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/appcontainers/arm-appcontainers/_meta.json
+++ b/sdk/appcontainers/arm-appcontainers/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "abe3209e7c6924a58ab560ebab2349bc8fde6aa7",
   "readme": "specification/app/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\app\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\app\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/applicationinsights/arm-appinsights/_meta.json
+++ b/sdk/applicationinsights/arm-appinsights/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "261f2cd5b009f319d44149da020c42e3d0832a7a",
   "readme": "specification/applicationinsights/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\applicationinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\applicationinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/appplatform/arm-appplatform/_meta.json
+++ b/sdk/appplatform/arm-appplatform/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "2f74f79b243484837a6d7b6dfa78b3e16274d006",
   "readme": "specification/appplatform/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\appplatform\\resource-manager\\readme.md --use=@autorest/typescript@6.0.13 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\appplatform\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.13"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/web/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\web\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\web\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/appservice/arm-appservice/_meta.json
+++ b/sdk/appservice/arm-appservice/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "e9f47ec88eb06646c53f2a561f3b27434ac5ac57",
   "readme": "specification/web/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\web\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\web\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.9",
-  "use": "@autorest/typescript@6.0.23"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/astro/arm-astro/_meta.json
+++ b/sdk/astro/arm-astro/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "5e060c76edd4fab38e9202055062154006463018",
   "readme": "specification/liftrastronomer/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\liftrastronomer\\resource-manager\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\liftrastronomer\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.15"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/attestation/arm-attestation/_meta.json
+++ b/sdk/attestation/arm-attestation/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "54ee1a9eb50c13e0790627749f986c886ad4f4db",
   "readme": "specification\\attestation\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\attestation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\attestation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/authorization/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\authorization\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\authorization\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/authorization/arm-authorization/_meta.json
+++ b/sdk/authorization/arm-authorization/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "a8fb6bcb9872431012ed1c7edbb7f369295422a5",
   "readme": "specification/authorization/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\authorization\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\authorization\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.5"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/automanage/arm-automanage/_meta.json
+++ b/sdk/automanage/arm-automanage/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1dd79c416cdccde274113ec03b92b75069fad464",
   "readme": "specification\\automanage\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\automanage\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.6.20221226.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\automanage\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.6.20221226.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/automation/arm-automation/_meta.json
+++ b/sdk/automation/arm-automation/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "405811c51aa09803caedfe17fd305e110db1ca5e",
   "readme": "specification\\automation\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\automation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.6.20221226.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\automation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.6.20221226.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/avs/arm-avs/_meta.json
+++ b/sdk/avs/arm-avs/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "386aaedd2edd916b8cef6aa0fffd7b72688787fc",
   "readme": "specification/vmware/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\vmware\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\vmware\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/_meta.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "20df2424a278ca19437e437a7dbf3a7857a0dd9d",
   "readme": "specification/cpim/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cpim\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cpim\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/azurestack/arm-azurestack/_meta.json
+++ b/sdk/azurestack/arm-azurestack/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "4042a47cff72c950d35dd72149895b044ed79713",
   "readme": "specification\\azurestack\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azurestack\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azurestack\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/azurestackhci/arm-azurestackhci/_meta.json
+++ b/sdk/azurestackhci/arm-azurestackhci/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "9c83b59d4ce4920d87488c46cc20511b5bf474a3",
   "readme": "specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azurestackhci\\resource-manager\\Microsoft.AzureStackHCI\\StackHCI\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azurestackhci\\resource-manager\\Microsoft.AzureStackHCI\\StackHCI\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
-  "use": "@autorest/typescript@6.0.23"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/_meta.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "4a361fccb94e82da94a239d3563f1e3e3b9d007d",
   "readme": "specification/baremetalinfrastructure/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\baremetalinfrastructure\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\baremetalinfrastructure\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
-  "use": "@autorest/typescript@6.0.12"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/batch/arm-batch/_meta.json
+++ b/sdk/batch/arm-batch/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "3519c80fe510a268f6e59a29ccac8a53fdec15b6",
   "readme": "specification/batch/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\batch\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\batch\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.12",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/billing/arm-billing/_meta.json
+++ b/sdk/billing/arm-billing/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "f958cceb74699d24953a6ea04536ed65767fbeb6",
   "readme": "specification/billing/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\billing\\resource-manager\\readme.md --use=@autorest/typescript@6.0.26 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\billing\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "js-sdk-release-tools@2.7.21-beta",
-  "use": "@autorest/typescript@6.0.26"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/billingbenefits/arm-billingbenefits/_meta.json
+++ b/sdk/billingbenefits/arm-billingbenefits/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "9b3aa35e75751e751070a7af1f96518cb8820e44",
   "readme": "specification/billingbenefits/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\billingbenefits\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\billingbenefits\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.2",
-  "use": "@autorest/typescript@6.0.0-rc.4"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/botservice/arm-botservice/_meta.json
+++ b/sdk/botservice/arm-botservice/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "4359ee079cc0f0d7c596cafeb8b363466d2d95f6",
   "readme": "specification/botservice/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\botservice\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\botservice\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.7"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/cdn/arm-cdn/_meta.json
+++ b/sdk/cdn/arm-cdn/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "835b124ff8160d23823c0e770b4989ca79e7418c",
   "readme": "specification/cdn/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cdn\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cdn\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.20"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/changeanalysis/arm-changeanalysis/_meta.json
+++ b/sdk/changeanalysis/arm-changeanalysis/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d29e6eb4894005c52e67cb4b5ac3faf031113e7d",
   "readme": "specification\\changeanalysis\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\changeanalysis\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\changeanalysis\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/changes/arm-changes/_meta.json
+++ b/sdk/changes/arm-changes/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "20df2424a278ca19437e437a7dbf3a7857a0dd9d",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/chaos/arm-chaos/_meta.json
+++ b/sdk/chaos/arm-chaos/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "0bfc45106eea53d49f1b554c25c509a9fd69b9fa",
   "readme": "specification/chaos/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\chaos\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\chaos\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.17"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/cognitiveservices/arm-cognitiveservices/_meta.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "bf420af156ea90b4226e96582bdb4c9647491ae6",
   "readme": "specification/cognitiveservices/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cognitiveservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cognitiveservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
-  "use": "@autorest/typescript@6.0.29"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/commerce/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\commerce\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\commerce\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/commerce/arm-commerce/_meta.json
+++ b/sdk/commerce/arm-commerce/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d29e6eb4894005c52e67cb4b5ac3faf031113e7d",
   "readme": "specification\\commerce\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\commerce\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\commerce\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/communication/arm-communication/_meta.json
+++ b/sdk/communication/arm-communication/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1a011ff0d72315ef3c530fe545c4fe82d0450201",
   "readme": "specification/communication/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\communication\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\communication\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.17"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/compute/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\compute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\compute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/compute/arm-compute/_meta.json
+++ b/sdk/compute/arm-compute/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "10925e3dec73699b950f256576cd6983947faaa3",
   "readme": "specification/compute/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\compute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.31 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\compute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.18",
-  "use": "@autorest/typescript@6.0.31"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/confidentialledger/arm-confidentialledger/_meta.json
+++ b/sdk/confidentialledger/arm-confidentialledger/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "15c4ed25135164c257da37731b3fa926a4f44d4a",
   "readme": "specification/confidentialledger/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\confidentialledger\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\confidentialledger\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
-  "use": "@autorest/typescript@6.0.20"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/confluent/arm-confluent/_meta.json
+++ b/sdk/confluent/arm-confluent/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "3004d02873a4b583ba6a3966a370f1ba19b5da1d",
   "readme": "specification/confluent/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\confluent\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\confluent\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.17"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/connectedvmware/arm-connectedvmware/_meta.json
+++ b/sdk/connectedvmware/arm-connectedvmware/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "6a2e3c7617314fe4ea7e5706da5437214e8a602b",
   "readme": "specification/connectedvmware/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\connectedvmware\\resource-manager\\readme.md --use=@autorest/typescript@6.0.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\connectedvmware\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
-  "use": "@autorest/typescript@6.0.9"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/consumption/arm-consumption/_meta.json
+++ b/sdk/consumption/arm-consumption/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d600759c3516b61a7c353bc8682bccbab85a6f65",
   "readme": "specification\\consumption\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\consumption\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\consumption\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/containerinstance/arm-containerinstance/_meta.json
+++ b/sdk/containerinstance/arm-containerinstance/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "abe3209e7c6924a58ab560ebab2349bc8fde6aa7",
   "readme": "specification/containerinstance/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerinstance\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerinstance\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/containerregistry/arm-containerregistry/_meta.json
+++ b/sdk/containerregistry/arm-containerregistry/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "6301be1289cf6b8cf44074f0e4229c2adf822991",
   "readme": "specification/containerregistry/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerregistry\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerregistry\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
-  "use": "@autorest/typescript@6.0.12"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/containerservice/arm-containerservice/_meta.json
+++ b/sdk/containerservice/arm-containerservice/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "2bde125befabb21807a2021765901f20e3e74ec8",
   "readme": "specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerservice\\resource-manager\\Microsoft.ContainerService\\aks\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerservice\\resource-manager\\Microsoft.ContainerService\\aks\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
-  "use": "@autorest/typescript@6.0.29"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/containerservice/arm-containerservicefleet/_meta.json
+++ b/sdk/containerservice/arm-containerservicefleet/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "f0573da04ed934620c566b96e04ddd80d46d2742",
   "readme": "specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerservice\\resource-manager\\Microsoft.ContainerService\\fleet\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\containerservice\\resource-manager\\Microsoft.ContainerService\\fleet\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/cosmosdb/arm-cosmosdb/_meta.json
+++ b/sdk/cosmosdb/arm-cosmosdb/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d811ed172ae395f3849439a305cf25d0eb6a426c",
   "readme": "specification/cosmos-db/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cosmos-db\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cosmos-db\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
-  "use": "@autorest/typescript@6.0.29"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/_meta.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "41d1c179dc166b7f16b7e40ef4f2a1d9c85b10cc",
   "readme": "specification/postgresqlhsc/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\postgresqlhsc\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\postgresqlhsc\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.17"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/cost-management/arm-costmanagement/_meta.json
+++ b/sdk/cost-management/arm-costmanagement/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d5c8648e01a2a2a743c2649c9522d21f5db952ce",
   "readme": "specification/cost-management/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cost-management\\resource-manager\\readme.md --use=@autorest/typescript@6.0.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\cost-management\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
-  "use": "@autorest/typescript@6.0.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/customer-insights/arm-customerinsights/_meta.json
+++ b/sdk/customer-insights/arm-customerinsights/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "e6a2296d02ec6c4b2c32479198bfbcb9b16ea247",
   "readme": "specification/customer-insights/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\customer-insights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\customer-insights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/dashboard/arm-dashboard/_meta.json
+++ b/sdk/dashboard/arm-dashboard/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "db9788dde7a0c2c0d82e4fdf5f7b4de3843937e3",
   "readme": "specification/dashboard/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dashboard\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dashboard\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
-  "use": "@autorest/typescript@6.0.12"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/databoundaries/arm-databoundaries/_meta.json
+++ b/sdk/databoundaries/arm-databoundaries/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "bc3aa2bbc4494553649019585c3bc8a4229a25d0",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/databox/arm-databox/_meta.json
+++ b/sdk/databox/arm-databox/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "756495dd7e0e2f5181039def47a8c85ff0787b66",
   "readme": "specification/databox/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databox\\resource-manager\\readme.md --use=@autorest/typescript@6.0.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databox\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
-  "use": "@autorest/typescript@6.0.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/databoxedge/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databoxedge\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databoxedge\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/databoxedge/arm-databoxedge/_meta.json
+++ b/sdk/databoxedge/arm-databoxedge/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "e6a2296d02ec6c4b2c32479198bfbcb9b16ea247",
   "readme": "specification\\databoxedge\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databoxedge\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databoxedge\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/databricks/arm-databricks/_meta.json
+++ b/sdk/databricks/arm-databricks/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "4af52aaac2c3b4af4a0e61378d33c5bc050e65e2",
   "readme": "specification/databricks/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databricks\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\databricks\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
-  "use": "@autorest/typescript@6.0.12"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/datacatalog/arm-datacatalog/_meta.json
+++ b/sdk/datacatalog/arm-datacatalog/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "20df2424a278ca19437e437a7dbf3a7857a0dd9d",
   "readme": "specification/datacatalog/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datacatalog\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datacatalog\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/datadog/arm-datadog/_meta.json
+++ b/sdk/datadog/arm-datadog/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "583e15ceb4cf23dc23b2300bd352f16d781e69ac",
   "readme": "specification/datadog/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datadog\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datadog\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.12"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/datafactory/arm-datafactory/_meta.json
+++ b/sdk/datafactory/arm-datafactory/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "552b4dd311f90f4a7b2f7adf45461d7a8774a1cc",
   "readme": "specification/datafactory/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datafactory\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datafactory\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
-  "use": "@autorest/typescript@6.0.29"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/datalake-analytics/arm-datalake-analytics/_meta.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "270ba8923ce458af2b59cd66b008355676bccd49",
   "readme": "specification\\datalake-analytics\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datalake-analytics\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datalake-analytics\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/datamigration/arm-datamigration/_meta.json
+++ b/sdk/datamigration/arm-datamigration/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d29e6eb4894005c52e67cb4b5ac3faf031113e7d",
   "readme": "specification\\datamigration\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datamigration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\datamigration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/dataprotection/arm-dataprotection/_meta.json
+++ b/sdk/dataprotection/arm-dataprotection/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "6d47e106e5dbe91ee5d124785fe1779fc170cac9",
   "readme": "specification/dataprotection/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dataprotection\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dataprotection\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
-  "use": "@autorest/typescript@6.0.23"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/defendereasm/arm-defendereasm/_meta.json
+++ b/sdk/defendereasm/arm-defendereasm/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "87dfda760beb01669cd5e5d36b48b14bf215b13b",
   "readme": "specification/riskiq/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\riskiq\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\riskiq\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.5"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/deploymentmanager/arm-deploymentmanager/_meta.json
+++ b/sdk/deploymentmanager/arm-deploymentmanager/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "dc439efcfc15448824877603f66fc1578d1c71c5",
   "readme": "specification\\deploymentmanager\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\deploymentmanager\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\deploymentmanager\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/_meta.json
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "3519c80fe510a268f6e59a29ccac8a53fdec15b6",
   "readme": "specification/desktopvirtualization/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\desktopvirtualization\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\desktopvirtualization\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/devcenter/arm-devcenter/_meta.json
+++ b/sdk/devcenter/arm-devcenter/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "106483d9f698ac3b6c0d481ab0c5fab14152e21f",
   "readme": "specification/devcenter/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\devcenter\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\devcenter\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
-  "use": "@autorest/typescript@6.0.20"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/devhub/arm-devhub/_meta.json
+++ b/sdk/devhub/arm-devhub/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "5595c3c7082fe447f32e637f06191f67fa8cfab2",
   "readme": "specification/developerhub/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\developerhub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\developerhub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.2"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/_meta.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "922e13fc8912d11a1cd1f08cedecedf1aa18120a",
   "readme": "specification/deviceprovisioningservices/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\deviceprovisioningservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\deviceprovisioningservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.2"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/deviceupdate/arm-deviceupdate/_meta.json
+++ b/sdk/deviceupdate/arm-deviceupdate/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d0c0ce3db26b90fefe5a4be126fdf913e3efa7af",
   "readme": "specification/deviceupdate/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\deviceupdate\\resource-manager\\readme.md --use=@autorest/typescript@6.0.13 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\deviceupdate\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.13"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/devspaces/arm-devspaces/_meta.json
+++ b/sdk/devspaces/arm-devspaces/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "20df2424a278ca19437e437a7dbf3a7857a0dd9d",
   "readme": "specification/devspaces/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\devspaces\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\devspaces\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/devtestlabs/arm-devtestlabs/_meta.json
+++ b/sdk/devtestlabs/arm-devtestlabs/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\devtestlabs\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\devtestlabs\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\devtestlabs\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/digitaltwins/arm-digitaltwins/_meta.json
+++ b/sdk/digitaltwins/arm-digitaltwins/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "b187f8bbf2171697f327ad16577c1b9cba2ef18e",
   "readme": "specification/digitaltwins/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\digitaltwins\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\digitaltwins\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
-  "use": "@autorest/typescript@6.0.0-rc.9"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/dns/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dns\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dns\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/dns/arm-dns/_meta.json
+++ b/sdk/dns/arm-dns/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "f0573da04ed934620c566b96e04ddd80d46d2742",
   "readme": "specification/dns/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dns\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dns\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/dnsresolver/arm-dnsresolver/_meta.json
+++ b/sdk/dnsresolver/arm-dnsresolver/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "abe3209e7c6924a58ab560ebab2349bc8fde6aa7",
   "readme": "specification/dnsresolver/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dnsresolver\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dnsresolver\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/domainservices/arm-domainservices/_meta.json
+++ b/sdk/domainservices/arm-domainservices/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1f1d5b0b9ce6cc94605b2fd619dce374fb6e033a",
   "readme": "specification\\domainservices\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\domainservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\domainservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/dynatrace/arm-dynatrace/_meta.json
+++ b/sdk/dynatrace/arm-dynatrace/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "2d2d12d271c13bd1b56c1ed5e41c5f418ae46067",
   "readme": "specification/dynatrace/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dynatrace\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\dynatrace\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.5"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/education/arm-education/_meta.json
+++ b/sdk/education/arm-education/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "ac155b972d0619a6e5bf665a863fb05ee7eeb30f",
   "readme": "specification\\education\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\education\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.6.20221226.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\education\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.6.20221226.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/elastic/arm-elastic/_meta.json
+++ b/sdk/elastic/arm-elastic/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "7d0134ad6d42786b1ff2d49a3cfb331b336c3099",
   "readme": "specification/elastic/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\elastic\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\elastic\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/elasticsans/arm-elasticsan/_meta.json
+++ b/sdk/elasticsans/arm-elasticsan/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "abe3209e7c6924a58ab560ebab2349bc8fde6aa7",
   "readme": "specification/elasticsan/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\elasticsan\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\elasticsan\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/eventgrid/arm-eventgrid/_meta.json
+++ b/sdk/eventgrid/arm-eventgrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "b8691fbfca8fcdc5a241a0b501c32fd4a76bb0cd",
   "readme": "specification/eventgrid/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\eventgrid\\resource-manager\\readme.md --use=@autorest/typescript@6.0.21 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\eventgrid\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.7",
-  "use": "@autorest/typescript@6.0.21"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/eventhub/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\eventhub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\eventhub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/eventhub/arm-eventhub/_meta.json
+++ b/sdk/eventhub/arm-eventhub/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "b574e2a41acda14a90ef237006e8bbdda2b63c63",
   "readme": "specification/eventhub/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\eventhub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\eventhub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
-  "use": "@autorest/typescript@6.0.23"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/extendedlocation/arm-extendedlocation/_meta.json
+++ b/sdk/extendedlocation/arm-extendedlocation/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "ca5d9600e4950afdae3c23c71d9407b6aa3fce63",
   "readme": "specification\\extendedlocation\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\extendedlocation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.6.20221226.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\extendedlocation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.6.20221226.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/features/arm-features/_meta.json
+++ b/sdk/features/arm-features/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "a42f1b58607091c4f255ead152a8ef323fa0b280",
   "readme": "specification\\resources\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
-  "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/fluidrelay/arm-fluidrelay/_meta.json
+++ b/sdk/fluidrelay/arm-fluidrelay/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "c03c258c7a01a7d57b3110cc20e2e76752b6f2d6",
   "readme": "specification\\fluidrelay\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\fluidrelay\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.6.20221226.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\fluidrelay\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
-  "use": "@autorest/typescript@6.0.0-rc.6.20221226.1"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/frontdoor/arm-frontdoor/_meta.json
+++ b/sdk/frontdoor/arm-frontdoor/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "b54ffc9278eff071455b1dbb4ad2e772afce885d",
   "readme": "specification/frontdoor/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\frontdoor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\frontdoor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
-  "use": "@autorest/typescript@6.0.20"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/graphservices/arm-graphservices/_meta.json
+++ b/sdk/graphservices/arm-graphservices/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "aea36c92c00247b195efb08a0161ab74859e606e",
   "readme": "specification/graphservicesprod/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\graphservicesprod\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\graphservicesprod\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
   "use": "@autorest/typescript@6.0.2"

--- a/sdk/guestconfiguration/arm-guestconfiguration/_meta.json
+++ b/sdk/guestconfiguration/arm-guestconfiguration/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "e6a20fec72ed3bcb4b43c559ee20b56ca2786ec0",
   "readme": "specification/guestconfiguration/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\guestconfiguration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\guestconfiguration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
   "use": "@autorest/typescript@6.0.20"

--- a/sdk/hanaonazure/arm-hanaonazure/_meta.json
+++ b/sdk/hanaonazure/arm-hanaonazure/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1f1d5b0b9ce6cc94605b2fd619dce374fb6e033a",
   "readme": "specification\\hanaonazure\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hanaonazure\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hanaonazure\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/_meta.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "766fbdcae199a5b2a3b7d2910f32b37cac7947de",
   "readme": "specification/hardwaresecuritymodules/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hardwaresecuritymodules\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hardwaresecuritymodules\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
   "use": "@autorest/typescript@6.0.27"

--- a/sdk/hdinsight/arm-hdinsight/_meta.json
+++ b/sdk/hdinsight/arm-hdinsight/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "7a62a78daa08ba4f65166c00efaa4d43018d8378",
   "readme": "specification/hdinsight/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hdinsight\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hdinsight\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/hdinsight/arm-hdinsightcontainers/_meta.json
+++ b/sdk/hdinsight/arm-hdinsightcontainers/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1040c6b9bd69bf414c895f7bef87bfd470e90127",
   "readme": "specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsightOnAks/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hdinsight\\resource-manager\\Microsoft.HDInsight\\HDInsightOnAks\\readme.md --use=@autorest/typescript@6.0.24 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hdinsight\\resource-manager\\Microsoft.HDInsight\\HDInsightOnAks\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.24"

--- a/sdk/healthbot/arm-healthbot/_meta.json
+++ b/sdk/healthbot/arm-healthbot/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1f1d5b0b9ce6cc94605b2fd619dce374fb6e033a",
   "readme": "specification\\healthbot\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\healthbot\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\healthbot\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/healthcareapis/arm-healthcareapis/_meta.json
+++ b/sdk/healthcareapis/arm-healthcareapis/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "791ef5476e10bb15ab9ad46e2c2d8835ac24ac24",
   "readme": "specification/healthcareapis/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\healthcareapis\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\healthcareapis\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
   "use": "@autorest/typescript@6.0.20"

--- a/sdk/hybridcompute/arm-hybridcompute/_meta.json
+++ b/sdk/hybridcompute/arm-hybridcompute/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "2d4992bd73955a93f972ba6c476e980e7e16a992",
   "readme": "specification/hybridcompute/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridcompute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.28 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridcompute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
   "use": "@autorest/typescript@6.0.28"

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/_meta.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "6ef4a4ab04df6cea16702dd935ac036509e6bd12",
   "readme": "specification/hybridconnectivity/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridconnectivity\\resource-manager\\readme.md --use=@autorest/typescript@6.0.8 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridconnectivity\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.8"

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/_meta.json
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "e79c2debdebd659662c78885c117603d991d3b06",
   "readme": "specification/hybridaks/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridaks\\resource-manager\\readme.md --use=@autorest/typescript@6.0.13 --generate-sample=true --modelerfour.flatten-models=false",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridaks\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --modelerfour.flatten-models=false",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.13"

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/_meta.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1f1d5b0b9ce6cc94605b2fd619dce374fb6e033a",
   "readme": "specification\\hybridkubernetes\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridkubernetes\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridkubernetes\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/hybridnetwork/arm-hybridnetwork/_meta.json
+++ b/sdk/hybridnetwork/arm-hybridnetwork/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d0c0ce3db26b90fefe5a4be126fdf913e3efa7af",
   "readme": "specification/hybridnetwork/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridnetwork\\resource-manager\\readme.md --use=@autorest/typescript@6.0.13 --generate-sample=true --modelerfour.flatten-models=false",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\hybridnetwork\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --modelerfour.flatten-models=false",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.13"

--- a/sdk/imagebuilder/arm-imagebuilder/_meta.json
+++ b/sdk/imagebuilder/arm-imagebuilder/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "ab55ecf92ab915af9d788238969b9d9a996e137d",
   "readme": "specification/imagebuilder/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\imagebuilder\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\imagebuilder\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.10",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/informatica/arm-informaticadatamanagement/_meta.json
+++ b/sdk/informatica/arm-informaticadatamanagement/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1aa912658531534e4e57ea613591075f7b97897c",
   "readme": "specification/informatica/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\informatica\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\informatica\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/iotcentral/arm-iotcentral/_meta.json
+++ b/sdk/iotcentral/arm-iotcentral/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1fefe3f5cee88319b17c08a2dbf95e1e983a9f8c",
   "readme": "specification/iotcentral/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\iotcentral\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\iotcentral\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/_meta.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1a011ff0d72315ef3c530fe545c4fe82d0450201",
   "readme": "specification/fist/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\fist\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\fist\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.17"

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/iothub/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\iothub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\iothub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/iothub/arm-iothub/_meta.json
+++ b/sdk/iothub/arm-iothub/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "5c5709864014f50b93bbb00e68c997bec46c550b",
   "readme": "specification/iothub/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\iothub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.8 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\iothub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.8"

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/keyvault/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\keyvault\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\keyvault\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/keyvault/arm-keyvault/_meta.json
+++ b/sdk/keyvault/arm-keyvault/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0a25ea9680cf080b7d34e8c5f35f564425c6b1f7",
   "readme": "specification/keyvault/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\keyvault\\resource-manager\\readme.md --use=@autorest/typescript@6.0.11 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\keyvault\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.11"

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/_meta.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "baa82396a21dcc1c79a6aeea185589749515012d",
   "readme": "specification/kubernetesconfiguration/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\kubernetesconfiguration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.8 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\kubernetesconfiguration\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.8"

--- a/sdk/kusto/arm-kusto/_meta.json
+++ b/sdk/kusto/arm-kusto/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "62e3312e67873d702fb2c6e5c7717d99cf4d369b",
   "readme": "specification/azure-kusto/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azure-kusto\\resource-manager\\readme.md --use=@autorest/typescript@6.0.33 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azure-kusto\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.18",
-  "use": "@autorest/typescript@6.0.33"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/labservices/arm-labservices/_meta.json
+++ b/sdk/labservices/arm-labservices/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "4c2cdccf6ca3281dd50ed8788ce1de2e0d480973",
   "readme": "specification\\labservices\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\labservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\labservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/largeinstance/arm-largeinstance/_meta.json
+++ b/sdk/largeinstance/arm-largeinstance/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "3c53209fed2c7d50efb6ba8c0f0a1ee882b82d44",
   "readme": "specification/azurelargeinstance/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azurelargeinstance\\resource-manager\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\azurelargeinstance\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.15"

--- a/sdk/liftrqumulo/arm-qumulo/_meta.json
+++ b/sdk/liftrqumulo/arm-qumulo/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "928047803788f7377fa003a26ba2bdc2e0fcccc0",
   "readme": "specification/liftrqumulo/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\liftrqumulo\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\liftrqumulo\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/links/arm-links/_meta.json
+++ b/sdk/links/arm-links/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "a42f1b58607091c4f255ead152a8ef323fa0b280",
   "readme": "specification\\resources\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/loadtesting/arm-loadtesting/_meta.json
+++ b/sdk/loadtesting/arm-loadtesting/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "91af1c93c771c12d8b147f122c3519eae087d0ff",
   "readme": "specification/loadtestservice/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\loadtestservice\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\loadtestservice\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "989a7d0e47a71a77d9a8e56f2a3eee0d366b6909",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-locks-2016-09",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-locks-2016-09",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/locks/arm-locks/_meta.json
+++ b/sdk/locks/arm-locks/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "a42f1b58607091c4f255ead152a8ef323fa0b280",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/logic/arm-logic/_meta.json
+++ b/sdk/logic/arm-logic/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "2d9846d81852452cf10270b18329ac382a881bf7",
   "readme": "specification/logic/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\logic\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\logic\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/machinelearning/arm-commitmentplans/_meta.json
+++ b/sdk/machinelearning/arm-commitmentplans/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1b0a465061c68175898f8f5d27f0301f42ce994c",
   "readme": "specification\\machinelearning\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearning\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearning\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/machinelearning/arm-machinelearning/_meta.json
+++ b/sdk/machinelearning/arm-machinelearning/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "41c3d8cd458627f85820d6028b37e31f8f3b2906",
   "readme": "specification/machinelearningservices/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearningservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearningservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/machinelearning/arm-webservices/_meta.json
+++ b/sdk/machinelearning/arm-webservices/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1b0a465061c68175898f8f5d27f0301f42ce994c",
   "readme": "specification\\machinelearning\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearning\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearning\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/machinelearning/arm-workspaces/_meta.json
+++ b/sdk/machinelearning/arm-workspaces/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1b0a465061c68175898f8f5d27f0301f42ce994c",
   "readme": "specification\\machinelearning\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearning\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearning\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/_meta.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "184b23b63ee3a79fb41ca3aa55a31a8d9e636772",
   "readme": "specification\\machinelearningcompute\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearningcompute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearningcompute\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/_meta.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "96e52e2b911d533f95a0ad8e324c828d556c5f2b",
   "readme": "specification\\machinelearningexperimentation\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearningexperimentation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\machinelearningexperimentation\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/maintenance/arm-maintenance/_meta.json
+++ b/sdk/maintenance/arm-maintenance/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "728bf18574fb1edb6294873387f01aac8357108c",
   "readme": "specification/maintenance/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\maintenance\\resource-manager\\readme.md --use=@autorest/typescript@6.0.21 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\maintenance\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.7",
   "use": "@autorest/typescript@6.0.21"

--- a/sdk/managedapplications/arm-managedapplications/_meta.json
+++ b/sdk/managedapplications/arm-managedapplications/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "baa82396a21dcc1c79a6aeea185589749515012d",
   "readme": "specification/solutions/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\solutions\\resource-manager\\readme.md --use=@autorest/typescript@6.0.8 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\solutions\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.8"

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/_meta.json
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "3731ac6150dcb22856183e9f1ca49eb912459f83",
   "readme": "specification/managednetworkfabric/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\managednetworkfabric\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\managednetworkfabric\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
   "use": "@autorest/typescript@6.0.5"

--- a/sdk/managementgroups/arm-managementgroups/_meta.json
+++ b/sdk/managementgroups/arm-managementgroups/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "184b23b63ee3a79fb41ca3aa55a31a8d9e636772",
   "readme": "specification\\managementgroups\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\managementgroups\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\managementgroups\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/managementpartner/arm-managementpartner/_meta.json
+++ b/sdk/managementpartner/arm-managementpartner/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d967edeee8fd6af6d40bffe53cceed1bd053d7ad",
   "readme": "specification\\managementpartner\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\managementpartner\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\managementpartner\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/maps/arm-maps/_meta.json
+++ b/sdk/maps/arm-maps/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "2888f49ff0b4ce0587780b83530a7974dae71015",
   "readme": "specification/maps/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\maps\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\maps\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
   "use": "@autorest/typescript@6.0.5"

--- a/sdk/mariadb/arm-mariadb/_meta.json
+++ b/sdk/mariadb/arm-mariadb/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d967edeee8fd6af6d40bffe53cceed1bd053d7ad",
   "readme": "specification\\mariadb\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mariadb\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mariadb\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/marketplaceordering/arm-marketplaceordering/_meta.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d967edeee8fd6af6d40bffe53cceed1bd053d7ad",
   "readme": "specification\\marketplaceordering\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\marketplaceordering\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\marketplaceordering\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/mediaservices/arm-mediaservices/_meta.json
+++ b/sdk/mediaservices/arm-mediaservices/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "4359ee079cc0f0d7c596cafeb8b363466d2d95f6",
   "readme": "specification/mediaservices/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mediaservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mediaservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/migrate/arm-migrate/_meta.json
+++ b/sdk/migrate/arm-migrate/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d967edeee8fd6af6d40bffe53cceed1bd053d7ad",
   "readme": "specification\\migrate\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\migrate\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\migrate\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/_meta.json
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "3004d02873a4b583ba6a3966a370f1ba19b5da1d",
   "readme": "specification/workloads/resource-manager/Microsoft.Workloads/SAPDiscoverySites/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\workloads\\resource-manager\\Microsoft.Workloads\\SAPDiscoverySites\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\workloads\\resource-manager\\Microsoft.Workloads\\SAPDiscoverySites\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.17"

--- a/sdk/mixedreality/arm-mixedreality/_meta.json
+++ b/sdk/mixedreality/arm-mixedreality/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d967edeee8fd6af6d40bffe53cceed1bd053d7ad",
   "readme": "specification\\mixedreality\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mixedreality\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mixedreality\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/mobilenetwork/arm-mobilenetwork/_meta.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "368680db8f33d586c230f619f603f8cc1a5a118f",
   "readme": "specification/mobilenetwork/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mobilenetwork\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mobilenetwork\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.9",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/monitor/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\monitor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\monitor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/monitor/arm-monitor/_meta.json
+++ b/sdk/monitor/arm-monitor/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "6fc313ed7a6e926d4409d4ddb435f6532922652f",
   "readme": "specification/monitor/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\monitor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.18 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\monitor\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.18"

--- a/sdk/msi/arm-msi/_meta.json
+++ b/sdk/msi/arm-msi/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "9f33c53e4b6d09e22329df29ac2ef404fe2149de",
   "readme": "specification/msi/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\msi\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\msi\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/mysql/arm-mysql-flexible/_meta.json
+++ b/sdk/mysql/arm-mysql-flexible/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "3b4d92c1a4a57aeec9c13f32d5211bff484302b6",
   "readme": "specification/mysql/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mysql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true --tag=package-flexibleserver-2023-12-30",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mysql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --tag=package-flexibleserver-2023-12-30",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.9",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/mysql/arm-mysql/_meta.json
+++ b/sdk/mysql/arm-mysql/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d967edeee8fd6af6d40bffe53cceed1bd053d7ad",
   "readme": "specification/mysql/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mysql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true --tag=package-2020-01-01 --typescript",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\mysql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --tag=package-2020-01-01 --typescript",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/netapp/arm-netapp/_meta.json
+++ b/sdk/netapp/arm-netapp/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "86d9b39c82444344723eb239f2f16aa47280dad7",
   "readme": "specification/netapp/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\netapp\\resource-manager\\readme.md --use=@autorest/typescript@6.0.28 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\netapp\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
   "use": "@autorest/typescript@6.0.28"

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1067b78669466324a1a2666adf053433c61e7f77",
   "readme": "specification/network/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\network\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\network\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/network/arm-network/_meta.json
+++ b/sdk/network/arm-network/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "552b4dd311f90f4a7b2f7adf45461d7a8774a1cc",
   "readme": "specification/network/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\network\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\network\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
   "use": "@autorest/typescript@6.0.29"

--- a/sdk/networkanalytics/arm-networkanalytics/_meta.json
+++ b/sdk/networkanalytics/arm-networkanalytics/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "21a8d55d74e4425e96d76e5835f52cfc9eb95a22",
   "readme": "specification/networkanalytics/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\networkanalytics\\resource-manager\\readme.md --use=@autorest/typescript@6.0.13 --generate-sample=true --modelerfour.flatten-models=false",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\networkanalytics\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --modelerfour.flatten-models=false",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.13"

--- a/sdk/networkcloud/arm-networkcloud/_meta.json
+++ b/sdk/networkcloud/arm-networkcloud/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "297c3a012316e290e6a6ab737ec8944611554542",
   "readme": "specification/networkcloud/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\networkcloud\\resource-manager\\readme.md --use=@autorest/typescript@6.0.28 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\networkcloud\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.15",
   "use": "@autorest/typescript@6.0.28"

--- a/sdk/networkfunction/arm-networkfunction/_meta.json
+++ b/sdk/networkfunction/arm-networkfunction/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "c583b05741fadfdca116be3b9ccb1c4be8a73258",
   "readme": "specification/networkfunction/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\networkfunction\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\networkfunction\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/newrelicobservability/arm-newrelicobservability/_meta.json
+++ b/sdk/newrelicobservability/arm-newrelicobservability/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1a011ff0d72315ef3c530fe545c4fe82d0450201",
   "readme": "specification/newrelic/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\newrelic\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\newrelic\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.17"

--- a/sdk/nginx/arm-nginx/_meta.json
+++ b/sdk/nginx/arm-nginx/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "9fb75a3c4ca9b753271bd6db2e42e5f98366cbae",
   "readme": "specification/nginx/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\nginx\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\nginx\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.17"

--- a/sdk/notificationhubs/arm-notificationhubs/_meta.json
+++ b/sdk/notificationhubs/arm-notificationhubs/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "0cca8953ec713d8cc0e940c37e865d36b43d18f8",
   "readme": "specification/notificationhubs/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\notificationhubs\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\notificationhubs\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.17"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/oep/arm-oep/_meta.json
+++ b/sdk/oep/arm-oep/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "f9a6cb686bcc0f1b23761db19f2491c5c4df95cb",
   "readme": "specification\\oep\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\oep\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\oep\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/operationalinsights/arm-operationalinsights/_meta.json
+++ b/sdk/operationalinsights/arm-operationalinsights/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "c94b5583e56b7ffcfeaee8dbb9e09516c43fc324",
   "readme": "specification/operationalinsights/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\operationalinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\operationalinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.1",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/operationsmanagement/arm-operations/_meta.json
+++ b/sdk/operationsmanagement/arm-operations/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "4915d469327059ad5b2c6aa628066c107f265ab5",
   "readme": "specification/operationsmanagement/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\operationsmanagement\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\operationsmanagement\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/oracledatabase/arm-oracledatabase/_meta.json
+++ b/sdk/oracledatabase/arm-oracledatabase/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "3aef2f96202eec656fca4abc4df0fbfe10b89ac0",
   "readme": "specification/oracle/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\oracle\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\oracle\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/orbital/arm-orbital/_meta.json
+++ b/sdk/orbital/arm-orbital/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "4f4044394791773e6e7e82a9bd90d3935caaca1b",
   "readme": "specification/orbital/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\orbital\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\orbital\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
   "use": "@autorest/typescript@6.0.0-rc.9"

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/_meta.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "8cd51b5240f4773621ec74346b6f5fb13f2c0e83",
   "readme": "specification/paloaltonetworks/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\paloaltonetworks\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\paloaltonetworks\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.12"

--- a/sdk/peering/arm-peering/_meta.json
+++ b/sdk/peering/arm-peering/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "f9a6cb686bcc0f1b23761db19f2491c5c4df95cb",
   "readme": "specification\\peering\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\peering\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\peering\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "989a7d0e47a71a77d9a8e56f2a3eee0d366b6909",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-policy-2016-12",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-policy-2016-12",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/policy/arm-policy/_meta.json
+++ b/sdk/policy/arm-policy/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "a42f1b58607091c4f255ead152a8ef323fa0b280",
   "readme": "specification\\resources\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
-  "use": "@autorest/typescript@6.0.2"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/policyinsights/arm-policyinsights/_meta.json
+++ b/sdk/policyinsights/arm-policyinsights/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "10925e3dec73699b950f256576cd6983947faaa3",
   "readme": "specification/policyinsights/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\policyinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.31 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\policyinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.18",
-  "use": "@autorest/typescript@6.0.31"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/portal/arm-portal/_meta.json
+++ b/sdk/portal/arm-portal/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\portal\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\portal\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\portal\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/postgresql/arm-postgresql-flexible/_meta.json
+++ b/sdk/postgresql/arm-postgresql-flexible/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "10925e3dec73699b950f256576cd6983947faaa3",
   "readme": "specification/postgresql/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\postgresql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true --tag=package-flexibleserver-2024-08-01 --typescript",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\postgresql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --tag=package-flexibleserver-2024-08-01 --typescript --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
-  "use": "@autorest/typescript@6.0.29"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/postgresql/arm-postgresql/_meta.json
+++ b/sdk/postgresql/arm-postgresql/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification/postgresql/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\postgresql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true --tag=package-2020-01-01",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\postgresql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --tag=package-2020-01-01",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/powerbidedicated/arm-powerbidedicated/_meta.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\powerbidedicated\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\powerbidedicated\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\powerbidedicated\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/powerbiembedded/arm-powerbiembedded/_meta.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\powerbiembedded\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\powerbiembedded\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\powerbiembedded\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/privatedns/arm-privatedns/_meta.json
+++ b/sdk/privatedns/arm-privatedns/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "4e5b64a647cccbddbfac5c4a9635f751def8feb0",
   "readme": "specification/privatedns/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\privatedns\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\privatedns\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
   "use": "@autorest/typescript@6.0.27"

--- a/sdk/purview/arm-purview/_meta.json
+++ b/sdk/purview/arm-purview/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\purview\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\purview\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\purview\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/quantum/arm-quantum/_meta.json
+++ b/sdk/quantum/arm-quantum/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "c45a7f47c1901149828eb8a33c74898c554659c0",
   "readme": "specification/quantum/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\quantum\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\quantum\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.17"

--- a/sdk/quota/arm-quota/_meta.json
+++ b/sdk/quota/arm-quota/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "acd0437204d5fcd0ccfcbe09257caec0edfc198e",
   "readme": "specification/quota/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\quota\\resource-manager\\readme.md --use=@autorest/typescript@6.0.33 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\quota\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.18",
-  "use": "@autorest/typescript@6.0.33"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/recoveryservices/arm-recoveryservices/_meta.json
+++ b/sdk/recoveryservices/arm-recoveryservices/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "c4e661cdf92c8f579574008d0cd11874cc303da0",
   "readme": "specification/recoveryservices/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
   "use": "@autorest/typescript@6.0.20"

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/_meta.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "dd1b1d0a58a10c4a34f55231c7035c80dd09b746",
   "readme": "specification/recoveryservicesbackup/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservicesbackup\\resource-manager\\readme.md --use=@autorest/typescript@6.0.21 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservicesbackup\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.7",
   "use": "@autorest/typescript@6.0.21"

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/_meta.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "85d0d6c98a47a6b6c2c1684cf94cc8e089c3c4ab",
   "readme": "specification/recoveryservicesdatareplication/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservicesdatareplication\\resource-manager\\readme.md --use=@autorest/typescript@6.0.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservicesdatareplication\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.9"

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/_meta.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "a342331c3ce13271517cf24978534f1ad2f88665",
   "readme": "specification/recoveryservicessiterecovery/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservicessiterecovery\\resource-manager\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\recoveryservicessiterecovery\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.15"

--- a/sdk/redhatopenshift/arm-redhatopenshift/_meta.json
+++ b/sdk/redhatopenshift/arm-redhatopenshift/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "72244b5c2da668820a5b9d56d44bd6a2a63189c5",
   "readme": "specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/openshiftclusters/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\redhatopenshift\\resource-manager\\Microsoft.RedHatOpenShift\\openshiftclusters\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\redhatopenshift\\resource-manager\\Microsoft.RedHatOpenShift\\openshiftclusters\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/redis/arm-rediscache/_meta.json
+++ b/sdk/redis/arm-rediscache/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "10925e3dec73699b950f256576cd6983947faaa3",
   "readme": "specification/redis/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\redis\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\redis\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
-  "use": "@autorest/typescript@6.0.29"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/redisenterprise/arm-redisenterprisecache/_meta.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "04c0350ee69b9d7a788af5774c5418afab64a7b1",
   "readme": "specification/redisenterprise/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\redisenterprise\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\redisenterprise\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
   "use": "@autorest/typescript@6.0.27"

--- a/sdk/relay/arm-relay/_meta.json
+++ b/sdk/relay/arm-relay/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\relay\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\relay\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\relay\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/reservations/arm-reservations/_meta.json
+++ b/sdk/reservations/arm-reservations/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "7c51d749a0d737fe69852f97862ab6389cf60bad",
   "readme": "specification/reservations/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\reservations\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\reservations\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
   "use": "@autorest/typescript@6.0.0-rc.9"

--- a/sdk/resourceconnector/arm-resourceconnector/_meta.json
+++ b/sdk/resourceconnector/arm-resourceconnector/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "6c6b16dc98d720304633b76c8e82c282ffa9cc08",
   "readme": "specification/resourceconnector/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourceconnector\\resource-manager\\readme.md --use=@autorest/typescript@6.0.5 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourceconnector\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
   "use": "@autorest/typescript@6.0.5"

--- a/sdk/resourcegraph/arm-resourcegraph/_meta.json
+++ b/sdk/resourcegraph/arm-resourcegraph/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0cd7b3e83d5e7e21222dcc4bdde4565562da0cdf",
   "readme": "specification\\resourcegraph\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourcegraph\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourcegraph\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.2",
   "use": "@autorest/typescript@6.0.0-rc.4"

--- a/sdk/resourcehealth/arm-resourcehealth/_meta.json
+++ b/sdk/resourcehealth/arm-resourcehealth/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "0a25ea9680cf080b7d34e8c5f35f564425c6b1f7",
   "readme": "specification/resourcehealth/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourcehealth\\resource-manager\\readme.md --use=@autorest/typescript@6.0.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourcehealth\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.9"

--- a/sdk/resourcemover/arm-resourcemover/_meta.json
+++ b/sdk/resourcemover/arm-resourcemover/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "6a2e3c7617314fe4ea7e5706da5437214e8a602b",
   "readme": "specification/resourcemover/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourcemover\\resource-manager\\readme.md --use=@autorest/typescript@6.0.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resourcemover\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.9"

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/_meta.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "2b5927fd07bfb51809a06ca35b6142f63ba77bab",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
   "use": "@autorest/typescript@6.0.2"

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "989a7d0e47a71a77d9a8e56f2a3eee0d366b6909",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-resources-2019-10",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-resources-2019-10",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/resources/arm-resources/_meta.json
+++ b/sdk/resources/arm-resources/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "a42f1b58607091c4f255ead152a8ef323fa0b280",
   "readme": "specification\\resources\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.9.20230306.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
   "use": "@autorest/typescript@6.0.0-rc.9.20230306.1"

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/_meta.json
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "3a9110b06d1053fb4ef5f5c56002506dcc283c95",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.9",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/scvmm/arm-scvmm/_meta.json
+++ b/sdk/scvmm/arm-scvmm/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "768c1f32bbfdcea80bdadf92dc2fba2c114c2dda",
   "readme": "specification/scvmm/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\scvmm\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\scvmm\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/search/arm-search/_meta.json
+++ b/sdk/search/arm-search/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "e9f47ec88eb06646c53f2a561f3b27434ac5ac57",
   "readme": "specification/search/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\search\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\search\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.10",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/security/arm-security/_meta.json
+++ b/sdk/security/arm-security/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "c43d0d41a6edc75a2cf452e33ea9344863db3c9e",
   "readme": "specification/security/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\security\\resource-manager\\readme.md --use=@autorest/typescript@6.0.18 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\security\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.18"

--- a/sdk/securitydevops/arm-securitydevops/_meta.json
+++ b/sdk/securitydevops/arm-securitydevops/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "dad644cc6d0c88991f291eda37e18f27c16739b2",
   "readme": "specification\\securitydevops\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\securitydevops\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\securitydevops\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/securityinsight/arm-securityinsight/_meta.json
+++ b/sdk/securityinsight/arm-securityinsight/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "b41f929626289b59e31be8a1091c99994864b096",
   "readme": "specification\\securityinsights\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\securityinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\securityinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/selfhelp/arm-selfhelp/_meta.json
+++ b/sdk/selfhelp/arm-selfhelp/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1c63635d66ae38cff18045ab416a6572d3e15f6e",
   "readme": "specification/help/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\help\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\help\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.10",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/serialconsole/arm-serialconsole/_meta.json
+++ b/sdk/serialconsole/arm-serialconsole/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "f9a6cb686bcc0f1b23761db19f2491c5c4df95cb",
   "readme": "specification\\serialconsole\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\serialconsole\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\serialconsole\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.2",
   "use": "@autorest/typescript@6.0.0-rc.4"

--- a/sdk/service-map/arm-servicemap/_meta.json
+++ b/sdk/service-map/arm-servicemap/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d6b9d9d7ea3fa4e6c0c2122f7641b9b009ce482e",
   "readme": "specification/service-map/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\service-map\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\service-map\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/servicebus/arm-servicebus/_meta.json
+++ b/sdk/servicebus/arm-servicebus/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "48c0c2036efcf0ccae7c0592a597699aac75ec4d",
   "readme": "specification/servicebus/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicebus\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicebus\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.1",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/servicefabric/arm-servicefabric/_meta.json
+++ b/sdk/servicefabric/arm-servicefabric/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "cb798ffa99c193a88388f358965f377fde3699e8",
   "readme": "specification/servicefabric/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicefabric\\resource-manager\\readme.md --use=@autorest/typescript@6.0.12 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicefabric\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.12"

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/_meta.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "552b4dd311f90f4a7b2f7adf45461d7a8774a1cc",
   "readme": "specification/servicefabricmanagedclusters/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicefabricmanagedclusters\\resource-manager\\readme.md --use=@autorest/typescript@6.0.29 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicefabricmanagedclusters\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.16",
   "use": "@autorest/typescript@6.0.29"

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/_meta.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "aa42d66d5b919ea80c8dde04ae19d30a9c974d7d",
   "readme": "specification\\servicefabricmesh\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicefabricmesh\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicefabricmesh\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/servicelinker/arm-servicelinker/_meta.json
+++ b/sdk/servicelinker/arm-servicelinker/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "ae950a4d68bd5bae23f85a8d575a213e9b0442d3",
   "readme": "specification/servicelinker/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicelinker\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicelinker\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
   "use": "@autorest/typescript@6.0.27"

--- a/sdk/servicenetworking/arm-servicenetworking/_meta.json
+++ b/sdk/servicenetworking/arm-servicenetworking/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "ba268c5654f002bc17914e0bc157f19529f1fec1",
   "readme": "specification/servicenetworking/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicenetworking\\resource-manager\\readme.md --use=@autorest/typescript@6.0.24 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\servicenetworking\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.24"

--- a/sdk/signalr/arm-signalr/_meta.json
+++ b/sdk/signalr/arm-signalr/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "663ea6835c33bca216b63f777227db6a459a06b3",
   "readme": "specification/signalr/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\signalr\\resource-manager\\readme.md --use=@autorest/typescript@6.0.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\signalr\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.2",
   "use": "@autorest/typescript@6.0.9"

--- a/sdk/sphere/arm-sphere/_meta.json
+++ b/sdk/sphere/arm-sphere/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "589cb3afdc76fe9a989ef36952eec816906d481f",
   "readme": "specification/sphere/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\sphere\\resource-manager\\readme.md --use=@autorest/typescript@6.0.18 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\sphere\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.18"

--- a/sdk/springappdiscovery/arm-springappdiscovery/_meta.json
+++ b/sdk/springappdiscovery/arm-springappdiscovery/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "7b07cc90244d4a2e850cdf3d9c7e200242cc2677",
   "readme": "specification/offazurespringboot/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\offazurespringboot\\resource-manager\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\offazurespringboot\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.15"

--- a/sdk/sql/arm-sql/_meta.json
+++ b/sdk/sql/arm-sql/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "1db2fcc22dec6f21d359d3b56f822f61f5d6ee12",
   "readme": "specification/sql/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\sql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.24 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\sql\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.11",
   "use": "@autorest/typescript@6.0.24"

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/_meta.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "483cdd30332340a14e3d09eafdc1a18f3ba4324c",
   "readme": "specification/sqlvirtualmachine/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\sqlvirtualmachine\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\sqlvirtualmachine\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
   "use": "@autorest/typescript@6.0.2"

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "989a7d0e47a71a77d9a8e56f2a3eee0d366b6909",
   "readme": "specification/storage/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storage\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storage\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/storage/arm-storage/_meta.json
+++ b/sdk/storage/arm-storage/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "43f10d3b8bacd5fc6b01254b5050c613f26c3573",
   "readme": "specification/storage/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storage\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storage\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.10",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/storageactions/arm-storageactions/_meta.json
+++ b/sdk/storageactions/arm-storageactions/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "84849e5293de3a8e01cbdde13b2d7086d3fb34d6",
   "readme": "specification/storageactions/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storageactions\\resource-manager\\readme.md --use=@autorest/typescript@6.0.17 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storageactions\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.17"

--- a/sdk/storagecache/arm-storagecache/_meta.json
+++ b/sdk/storagecache/arm-storagecache/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "fdc2e7b8efa15b521c7af6b041f226d5a090d5e1",
   "readme": "specification/storagecache/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storagecache\\resource-manager\\readme.md --use=@autorest/typescript@6.0.21 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storagecache\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.7",
   "use": "@autorest/typescript@6.0.21"

--- a/sdk/storageimportexport/arm-storageimportexport/_meta.json
+++ b/sdk/storageimportexport/arm-storageimportexport/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "f9a6cb686bcc0f1b23761db19f2491c5c4df95cb",
   "readme": "specification\\storageimportexport\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storageimportexport\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storageimportexport\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/storagemover/arm-storagemover/_meta.json
+++ b/sdk/storagemover/arm-storagemover/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "412364b282e52b50eadc3cd88d56d283b6c8712a",
   "readme": "specification/storagemover/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storagemover\\resource-manager\\readme.md --use=@autorest/typescript@6.0.23 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storagemover\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.10",
   "use": "@autorest/typescript@6.0.23"

--- a/sdk/storagesync/arm-storagesync/_meta.json
+++ b/sdk/storagesync/arm-storagesync/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "f9a6cb686bcc0f1b23761db19f2491c5c4df95cb",
   "readme": "specification\\storagesync\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storagesync\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storagesync\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.2",
   "use": "@autorest/typescript@6.0.0-rc.4"

--- a/sdk/storsimple1200series/arm-storsimple1200series/_meta.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d600759c3516b61a7c353bc8682bccbab85a6f65",
   "readme": "specification\\storsimple1200series\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storsimple1200series\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storsimple1200series\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.2",
   "use": "@autorest/typescript@6.0.0-rc.4"

--- a/sdk/storsimple8000series/arm-storsimple8000series/_meta.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d600759c3516b61a7c353bc8682bccbab85a6f65",
   "readme": "specification\\storsimple8000series\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storsimple8000series\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\storsimple8000series\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.2",
   "use": "@autorest/typescript@6.0.0-rc.4"

--- a/sdk/streamanalytics/arm-streamanalytics/_meta.json
+++ b/sdk/streamanalytics/arm-streamanalytics/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "5e060c76edd4fab38e9202055062154006463018",
   "readme": "specification/streamanalytics/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\streamanalytics\\resource-manager\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\streamanalytics\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
   "use": "@autorest/typescript@6.0.15"

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/_meta.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "989a7d0e47a71a77d9a8e56f2a3eee0d366b6909",
   "readme": "specification/resources/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5.20221215.1 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-subscriptions-2016-06",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --profile-content=profile-hybrid-2020-09-01 --tag=package-subscriptions-2016-06",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5.20221215.1"

--- a/sdk/subscription/arm-subscriptions/_meta.json
+++ b/sdk/subscription/arm-subscriptions/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "52a770004c3019a067e9dcdbb2e95b4992d42728",
   "readme": "specification/subscription/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\subscription\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1 --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\subscription\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/support/arm-support/_meta.json
+++ b/sdk/support/arm-support/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "15c4ed25135164c257da37731b3fa926a4f44d4a",
   "readme": "specification/support/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\support\\resource-manager\\readme.md --use=@autorest/typescript@6.0.20 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\support\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.5",
   "use": "@autorest/typescript@6.0.20"

--- a/sdk/synapse/arm-synapse/_meta.json
+++ b/sdk/synapse/arm-synapse/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "340d577969b7bff5ad0488d79543314bc17daa50",
   "readme": "specification\\synapse\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\synapse\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\synapse\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.1",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/templatespecs/arm-templatespecs/_meta.json
+++ b/sdk/templatespecs/arm-templatespecs/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "a42f1b58607091c4f255ead152a8ef323fa0b280",
   "readme": "specification\\resources\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.3.20221108.1  --generate-sample=true",
+  "autorest_command": "autorest --version=3.8.4 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\resources\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.4.2",
   "use": "@autorest/typescript@6.0.0-rc.3.20221108.1"

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/_meta.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "d600759c3516b61a7c353bc8682bccbab85a6f65",
   "readme": "specification\\timeseriesinsights\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\timeseriesinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.5  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\timeseriesinsights\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.4",
   "use": "@autorest/typescript@6.0.0-rc.5"

--- a/sdk/trafficmanager/arm-trafficmanager/_meta.json
+++ b/sdk/trafficmanager/arm-trafficmanager/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "a7db288cbce8b520781be6b23444fc895c4d6c81",
   "readme": "specification/trafficmanager/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\trafficmanager\\resource-manager\\readme.md --use=@autorest/typescript@6.0.2 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\trafficmanager\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.0",
-  "use": "@autorest/typescript@6.0.2"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/visualstudio/arm-visualstudio/_meta.json
+++ b/sdk/visualstudio/arm-visualstudio/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "d600759c3516b61a7c353bc8682bccbab85a6f65",
   "readme": "specification\\visualstudio\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\visualstudio\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.4  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\visualstudio\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.5.3",
-  "use": "@autorest/typescript@6.0.0-rc.4"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/_meta.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/_meta.json
@@ -1,7 +1,7 @@
 {
   "commit": "58a1320584b1d26bf7dab969a2593cd22b39caec",
   "readme": "specification\\vmwarecloudsimple\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\vmwarecloudsimple\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.7  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=F:\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\vmwarecloudsimple\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.0",
   "use": "@autorest/typescript@6.0.0-rc.7"

--- a/sdk/voiceservices/arm-voiceservices/_meta.json
+++ b/sdk/voiceservices/arm-voiceservices/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "c417434958b676b441ce184474210a8210a074b6",
   "readme": "specification\\voiceservices\\resource-manager\\readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\voiceservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.10  --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\voiceservices\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34  --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
-  "use": "@autorest/typescript@6.0.0-rc.10"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/web-pubsub/arm-webpubsub/_meta.json
+++ b/sdk/web-pubsub/arm-webpubsub/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "3519c80fe510a268f6e59a29ccac8a53fdec15b6",
   "readme": "specification/webpubsub/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\webpubsub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.27 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\webpubsub\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.13",
-  "use": "@autorest/typescript@6.0.27"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/workloads/arm-workloads/_meta.json
+++ b/sdk/workloads/arm-workloads/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "241e964afe675a7be98aa6a2e171a3c5f830816c",
   "readme": "specification/workloads/resource-manager/readme.md",
-  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\workloads\\resource-manager\\readme.md --use=@autorest/typescript@6.0.0-rc.9 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.3 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\workloads\\resource-manager\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.6.2",
-  "use": "@autorest/typescript@6.0.0-rc.9"
+  "use": "@autorest/typescript@6.0.34"
 }

--- a/sdk/workloads/arm-workloadssapvirtualinstance/_meta.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/_meta.json
@@ -1,8 +1,8 @@
 {
   "commit": "ea95dc025eef49e82a7fa88f991fb9ce328a4c30",
   "readme": "specification/workloads/resource-manager/Microsoft.Workloads/SAPVirtualInstance/readme.md",
-  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\workloads\\resource-manager\\Microsoft.Workloads\\SAPVirtualInstance\\readme.md --use=@autorest/typescript@6.0.15 --generate-sample=true",
+  "autorest_command": "autorest --version=3.9.7 --typescript --modelerfour.lenient-model-deduplication --azure-arm --head-as-boolean=true --license-header=MICROSOFT_MIT_NO_VERSION --generate-test --typescript-sdks-folder=D:\\Git\\azure-sdk-for-js ..\\azure-rest-api-specs\\specification\\workloads\\resource-manager\\Microsoft.Workloads\\SAPVirtualInstance\\readme.md --use=@autorest/typescript@6.0.34 --generate-sample=true --module-kind=esm",
   "repository_url": "https://github.com/Azure/azure-rest-api-specs.git",
   "release_tool": "@azure-tools/js-sdk-release-tools@2.7.4",
-  "use": "@autorest/typescript@6.0.15"
+  "use": "@autorest/typescript@6.0.34"
 }


### PR DESCRIPTION
Updates the _meta.json file's autorest command with the newly available [module-kind](https://github.com/Azure/autorest.typescript/tree/main/packages/autorest.typescript#options) flag, generating esm-style imports/exports instead of CJS. 

This PR handles ARM packages that have migrated. A follow-up PR will update the migrate-package script to include this as part of the changes.

Note: I'm not sure how to properly test this and would appreciate some pointers / doc links to how to generate ARM packages 🙇 