### PR TITLE
[OpenTelemetry Exporter] Remove Faulty Span Exception Emitting Logic

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.29 ()
+
+### Other Changes
+
+- Removed faulty span exception exporting logic.
+
 ## 1.0.0-beta.28 (2025-01-28)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.spec.ts
@@ -1264,25 +1264,6 @@ describe("spanUtils.ts", () => {
         expectedBaseData,
       );
     });
-    it("should not create an envelope for client exception span events", () => {
-      const testError = new Error("test error");
-      const span = new Span(
-        tracer,
-        ROOT_CONTEXT,
-        "parent span",
-        { traceId: "4bf92f3577b34da6a3ce929d0e0e4736", spanId: "00f067aa0ba902b7", traceFlags: 0 },
-        SpanKind.CLIENT,
-        "parentSpanId",
-      );
-      span.recordException(testError);
-      span.end();
-      const envelopes = spanEventsToEnvelopes(span, "ikey");
-
-      const expectedTags: Tags = {};
-      expectedTags[KnownContextTagKeys.AiOperationId] = span.spanContext().traceId;
-      expectedTags[KnownContextTagKeys.AiOperationParentId] = "spanId";
-      assert.ok(envelopes.length === 0);
-    });
   });
   it("should create an envelope for internal exception span events", () => {
     const testError = new Error("test error");


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR
#32387 

### Describe the problem that is addressed by this PR
We should remove the faulty logic that filters span exception events until the changes can be made upstream in OpenTelemetry JS to support proper filtering logic.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
