### PR TITLE
[fabric] Migrate fabric projects to use snippet extraction

### DIFF
--- a/sdk/fabric/arm-fabric/README.md
+++ b/sdk/fabric/arm-fabric/README.md
@@ -44,20 +44,28 @@ Set the values of the client ID, tenant ID, and client secret of the AAD applica
 
 For more information about how to create an Azure AD Application check out [this guide](https://learn.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal).
 
-```javascript
-const { FabricClient } = require("@azure/arm-fabric");
-const { DefaultAzureCredential } = require("@azure/identity");
-// For client-side applications running in the browser, use InteractiveBrowserCredential instead of DefaultAzureCredential. See https://aka.ms/azsdk/js/identity/examples for more details.
+Using Node.js and Node-like environments, you can use the `DefaultAzureCredential` class to authenticate the client.
+
+```ts snippet:ReadmeSampleCreateClient_Node
+import { FabricClient } from "@azure/arm-fabric";
+import { DefaultAzureCredential } from "@azure/identity";
 
 const subscriptionId = "00000000-0000-0000-0000-000000000000";
 const client = new FabricClient(new DefaultAzureCredential(), subscriptionId);
+```
 
-// For client-side applications running in the browser, use this code instead:
-// const credential = new InteractiveBrowserCredential({
-//   tenantId: "<YOUR_TENANT_ID>",
-//   clientId: "<YOUR_CLIENT_ID>"
-// });
-// const client = new FabricClient(credential, subscriptionId);
+For browser environments, use the `InteractiveBrowserCredential` from the `@azure/identity` package to authenticate.
+
+```ts snippet:ReadmeSampleCreateClient_Browser
+import { InteractiveBrowserCredential } from "@azure/identity";
+import { FabricClient } from "@azure/arm-fabric";
+
+const subscriptionId = "00000000-0000-0000-0000-000000000000";
+const credential = new InteractiveBrowserCredential({
+  tenantId: "<YOUR_TENANT_ID>",
+  clientId: "<YOUR_CLIENT_ID>",
+});
+const client = new FabricClient(credential, subscriptionId);
 ```
 
 ### JavaScript Bundle
@@ -76,8 +84,9 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
-```javascript
-const { setLogLevel } = require("@azure/logger");
+```ts snippet:SetLogLevel
+import { setLogLevel } from "@azure/logger";
+
 setLogLevel("info");
 ```
 

--- a/sdk/fabric/arm-fabric/api-extractor.json
+++ b/sdk/fabric/arm-fabric/api-extractor.json
@@ -1,18 +1,31 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "./dist/esm/index.d.ts",
-  "docModel": { "enabled": true },
-  "apiReport": { "enabled": true, "reportFolder": "./review" },
+  "mainEntryPointFilePath": "dist/esm/index.d.ts",
+  "docModel": {
+    "enabled": true
+  },
+  "apiReport": {
+    "enabled": true,
+    "reportFolder": "./review"
+  },
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/arm-fabric.d.ts"
+    "publicTrimmedFilePath": "dist/arm-fabric.d.ts"
   },
   "messages": {
-    "tsdocMessageReporting": { "default": { "logLevel": "none" } },
+    "tsdocMessageReporting": {
+      "default": {
+        "logLevel": "none"
+      }
+    },
     "extractorMessageReporting": {
-      "ae-missing-release-tag": { "logLevel": "none" },
-      "ae-unresolved-link": { "logLevel": "none" }
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      },
+      "ae-unresolved-link": {
+        "logLevel": "none"
+      }
     }
   }
 }

--- a/sdk/fabric/arm-fabric/package.json
+++ b/sdk/fabric/arm-fabric/package.json
@@ -8,6 +8,7 @@
   "sideEffects": false,
   "autoPublish": false,
   "tshy": {
+    "project": "./tsconfig.src.json",
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts",
@@ -21,8 +22,7 @@
       "browser",
       "react-native"
     ],
-    "selfLink": false,
-    "project": "./tsconfig.src.json"
+    "selfLink": false
   },
   "type": "module",
   "keywords": [
@@ -36,10 +36,10 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "files": [
-    "dist",
+    "dist/",
     "README.md",
     "LICENSE",
-    "review/*",
+    "review/",
     "CHANGELOG.md"
   ],
   "sdk-type": "mgmt",
@@ -57,54 +57,55 @@
     ]
   },
   "dependencies": {
-    "@azure/core-util": "^1.9.2",
     "@azure-rest/core-client": "^2.1.0",
-    "@azure/core-auth": "^1.6.0",
-    "@azure/core-rest-pipeline": "^1.5.0",
-    "@azure/logger": "^1.0.0",
-    "tslib": "^2.6.2",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-auth": "^1.9.0",
     "@azure/core-lro": "^3.0.0",
-    "@azure/abort-controller": "^2.1.2"
+    "@azure/core-rest-pipeline": "^1.18.2",
+    "@azure/core-util": "^1.11.0",
+    "@azure/logger": "^1.1.4",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "dotenv": "^16.0.0",
+    "@azure-tools/test-credential": "^2.0.0",
+    "@azure-tools/test-recorder": "^4.1.0",
+    "@azure-tools/test-utils-vitest": "^1.0.0",
+    "@azure/dev-tool": "^1.0.0",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
+    "@azure/identity": "^4.6.0",
     "@types/node": "^18.0.0",
-    "eslint": "^9.9.0",
-    "prettier": "^3.2.5",
-    "typescript": "~5.7.2",
-    "@azure/identity": "^4.2.1",
     "@vitest/browser": "^3.0.3",
     "@vitest/coverage-istanbul": "^3.0.3",
-    "playwright": "^1.41.2",
-    "vitest": "^3.0.3",
-    "@azure-tools/test-credential": "^2.0.0",
-    "@azure-tools/test-recorder": "^4.0.0",
-    "@azure/dev-tool": "^1.0.0",
-    "@azure/eslint-plugin-azure-sdk": "^3.0.0"
+    "dotenv": "^16.0.0",
+    "eslint": "^9.9.0",
+    "playwright": "^1.50.1",
+    "prettier": "^3.2.5",
+    "typescript": "~5.7.2",
+    "vitest": "^3.0.3"
   },
   "scripts": {
-    "clean": "dev-tool run vendored rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "extract-api": "dev-tool run vendored rimraf review && dev-tool run extract-api",
-    "pack": "npm pack 2>&1",
-    "lint": "echo skipped",
-    "lint:fix": "echo skipped",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "unit-test:browser": "npm run build:test && dev-tool run test:vitest --browser",
-    "unit-test:node": "dev-tool run test:vitest",
-    "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "integration-test:browser": "echo skipped",
-    "integration-test:node": "echo skipped",
+    "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
     "build:samples": "tsc -p tsconfig.samples.json && dev-tool samples publish -f",
+    "build:test": "npm run clean && dev-tool run build-package && dev-tool run build-test",
     "check-format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\" \"samples-dev/*.ts\"",
+    "clean": "dev-tool run vendored rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "execute:samples": "dev-tool samples run samples-dev",
+    "extract-api": "dev-tool run vendored rimraf review && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.{ts,cts,mts}\" \"test/**/*.{ts,cts,mts}\" \"*.{js,cjs,mjs,json}\"",
     "generate:client": "echo skipped",
-    "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
+    "integration-test": "npm run integration-test:node && npm run integration-test:browser",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "dev-tool run test:vitest --esm",
+    "lint": "echo skipped",
+    "lint:fix": "echo skipped",
     "minify": "dev-tool run vendored uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
-    "build:test": "npm run clean && dev-tool run build-package && dev-tool run build-test",
-    "build": "npm run clean && dev-tool run build-package && dev-tool run extract-api",
+    "pack": "npm pack 2>&1",
+    "test": "npm run clean && dev-tool run build-package && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
+    "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
-    "test": "npm run clean && dev-tool run build-package && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "unit-test:browser": "echo skipped",
+    "unit-test:node": "dev-tool run test:vitest"
   },
   "//sampleConfiguration": {
     "productName": "@azure/arm-fabric",
@@ -155,5 +156,7 @@
   },
   "main": "./dist/commonjs/index.js",
   "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/browser/index.js",
+  "react-native": "./dist/react-native/index.js"
 }

--- a/sdk/fabric/arm-fabric/package.json
+++ b/sdk/fabric/arm-fabric/package.json
@@ -105,7 +105,8 @@
     "test:node": "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "dev-tool run test:vitest"
+    "unit-test:node": "dev-tool run test:vitest",
+    "update-snippets": "dev-tool run update-snippets"
   },
   "//sampleConfiguration": {
     "productName": "@azure/arm-fabric",

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesCheckNameAvailabilitySample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesCheckNameAvailabilitySample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary implements local CheckNameAvailability operations
  * x-ms-original-file: 2023-11-01/FabricCapacities_CheckNameAvailability.json
  */
-async function checkNameAvailabilityOfACapacity() {
+async function checkNameAvailabilityOfACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -21,7 +21,7 @@ async function checkNameAvailabilityOfACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await checkNameAvailabilityOfACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesCreateOrUpdateSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesCreateOrUpdateSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary create a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_CreateOrUpdate.json
  */
-async function createOrUpdateACapacity() {
+async function createOrUpdateACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -26,7 +26,7 @@ async function createOrUpdateACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await createOrUpdateACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesDeleteSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesDeleteSample.ts
@@ -10,14 +10,14 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary delete a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Delete.json
  */
-async function deleteACapacity() {
+async function deleteACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
   await client.fabricCapacities.delete("TestRG", "azsdktest");
 }
 
-async function main() {
+async function main(): Promise<void> {
   await deleteACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesGetSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesGetSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary get a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Get.json
  */
-async function getACapacity() {
+async function getACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -18,7 +18,7 @@ async function getACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await getACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListByResourceGroupSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListByResourceGroupSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list FabricCapacity resources by resource group
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListByResourceGroup.json
  */
-async function listCapacitiesByResourceGroup() {
+async function listCapacitiesByResourceGroup(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listCapacitiesByResourceGroup() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await listCapacitiesByResourceGroup();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListBySubscriptionSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListBySubscriptionSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list FabricCapacity resources by subscription ID
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListBySubscription.json
  */
-async function listCapacitiesBySubscription() {
+async function listCapacitiesBySubscription(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listCapacitiesBySubscription() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await listCapacitiesBySubscription();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListSkusForCapacitySample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListSkusForCapacitySample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list eligible SKUs for a Microsoft Fabric resource
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListSkusForCapacity.json
  */
-async function listEligibleSKUsForAnExistingCapacity() {
+async function listEligibleSKUsForAnExistingCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listEligibleSKUsForAnExistingCapacity() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await listEligibleSKUsForAnExistingCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListSkusSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesListSkusSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list eligible SKUs for Microsoft Fabric resource provider
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListSkus.json
  */
-async function listEligibleSKUsForANewCapacity() {
+async function listEligibleSKUsForANewCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listEligibleSKUsForANewCapacity() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await listEligibleSKUsForANewCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesResumeSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesResumeSample.ts
@@ -10,14 +10,14 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary resume operation of the specified Fabric capacity instance.
  * x-ms-original-file: 2023-11-01/FabricCapacities_Resume.json
  */
-async function resumeCapacity() {
+async function resumeCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
   await client.fabricCapacities.resume("TestRG", "azsdktest");
 }
 
-async function main() {
+async function main(): Promise<void> {
   await resumeCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesSuspendSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesSuspendSample.ts
@@ -10,14 +10,14 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary suspend operation of the specified Fabric capacity instance.
  * x-ms-original-file: 2023-11-01/FabricCapacities_Suspend.json
  */
-async function suspendCapacity() {
+async function suspendCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
   await client.fabricCapacities.suspend("TestRG", "azsdktest");
 }
 
-async function main() {
+async function main(): Promise<void> {
   await suspendCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesUpdateSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/fabricCapacitiesUpdateSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary update a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Update.json
  */
-async function updateCapacityProperties() {
+async function updateCapacityProperties(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function updateCapacityProperties() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await updateCapacityProperties();
 }
 

--- a/sdk/fabric/arm-fabric/samples-dev/operationsListSample.ts
+++ b/sdk/fabric/arm-fabric/samples-dev/operationsListSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list the operations for the provider
  * x-ms-original-file: 2023-11-01/Operations_List.json
  */
-async function listOperations() {
+async function listOperations(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "00000000-0000-0000-0000-00000000000";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listOperations() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   await listOperations();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesCheckNameAvailabilitySample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesCheckNameAvailabilitySample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary implements local CheckNameAvailability operations
  * x-ms-original-file: 2023-11-01/FabricCapacities_CheckNameAvailability.json
  */
-async function checkNameAvailabilityOfACapacity() {
+async function checkNameAvailabilityOfACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -21,7 +21,7 @@ async function checkNameAvailabilityOfACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   checkNameAvailabilityOfACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesCreateOrUpdateSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesCreateOrUpdateSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary create a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_CreateOrUpdate.json
  */
-async function createOrUpdateACapacity() {
+async function createOrUpdateACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -30,7 +30,7 @@ async function createOrUpdateACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   createOrUpdateACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesDeleteSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesDeleteSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary delete a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Delete.json
  */
-async function deleteACapacity() {
+async function deleteACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -18,7 +18,7 @@ async function deleteACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   deleteACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesGetSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesGetSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary get a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Get.json
  */
-async function getACapacity() {
+async function getACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -18,7 +18,7 @@ async function getACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   getACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListByResourceGroupSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListByResourceGroupSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list FabricCapacity resources by resource group
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListByResourceGroup.json
  */
-async function listCapacitiesByResourceGroup() {
+async function listCapacitiesByResourceGroup(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -24,7 +24,7 @@ async function listCapacitiesByResourceGroup() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listCapacitiesByResourceGroup();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListBySubscriptionSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListBySubscriptionSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list FabricCapacity resources by subscription ID
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListBySubscription.json
  */
-async function listCapacitiesBySubscription() {
+async function listCapacitiesBySubscription(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listCapacitiesBySubscription() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listCapacitiesBySubscription();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListSkusForCapacitySample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListSkusForCapacitySample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list eligible SKUs for a Microsoft Fabric resource
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListSkusForCapacity.json
  */
-async function listEligibleSKUsForAnExistingCapacity() {
+async function listEligibleSKUsForAnExistingCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -25,7 +25,7 @@ async function listEligibleSKUsForAnExistingCapacity() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listEligibleSKUsForAnExistingCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListSkusSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesListSkusSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list eligible SKUs for Microsoft Fabric resource provider
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListSkus.json
  */
-async function listEligibleSKUsForANewCapacity() {
+async function listEligibleSKUsForANewCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listEligibleSKUsForANewCapacity() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listEligibleSKUsForANewCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesResumeSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesResumeSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary resume operation of the specified Fabric capacity instance.
  * x-ms-original-file: 2023-11-01/FabricCapacities_Resume.json
  */
-async function resumeCapacity() {
+async function resumeCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -18,7 +18,7 @@ async function resumeCapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   resumeCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesSuspendSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesSuspendSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary suspend operation of the specified Fabric capacity instance.
  * x-ms-original-file: 2023-11-01/FabricCapacities_Suspend.json
  */
-async function suspendCapacity() {
+async function suspendCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -18,7 +18,7 @@ async function suspendCapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   suspendCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesUpdateSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/fabricCapacitiesUpdateSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary update a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Update.json
  */
-async function updateCapacityProperties() {
+async function updateCapacityProperties(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function updateCapacityProperties() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   updateCapacityProperties();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/operationsListSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1-beta/typescript/src/operationsListSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list the operations for the provider
  * x-ms-original-file: 2023-11-01/Operations_List.json
  */
-async function listOperations() {
+async function listOperations(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "00000000-0000-0000-0000-00000000000";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listOperations() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listOperations();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesCheckNameAvailabilitySample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesCheckNameAvailabilitySample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary implements local CheckNameAvailability operations
  * x-ms-original-file: 2023-11-01/FabricCapacities_CheckNameAvailability.json
  */
-async function checkNameAvailabilityOfACapacity() {
+async function checkNameAvailabilityOfACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -21,7 +21,7 @@ async function checkNameAvailabilityOfACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   checkNameAvailabilityOfACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesCreateOrUpdateSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesCreateOrUpdateSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary create a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_CreateOrUpdate.json
  */
-async function createOrUpdateACapacity() {
+async function createOrUpdateACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -30,7 +30,7 @@ async function createOrUpdateACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   createOrUpdateACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesDeleteSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesDeleteSample.ts
@@ -10,14 +10,14 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary delete a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Delete.json
  */
-async function deleteACapacity() {
+async function deleteACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
   await client.fabricCapacities.delete("TestRG", "azsdktest");
 }
 
-async function main() {
+async function main(): Promise<void> {
   deleteACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesGetSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesGetSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary get a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Get.json
  */
-async function getACapacity() {
+async function getACapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -18,7 +18,7 @@ async function getACapacity() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   getACapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListByResourceGroupSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListByResourceGroupSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list FabricCapacity resources by resource group
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListByResourceGroup.json
  */
-async function listCapacitiesByResourceGroup() {
+async function listCapacitiesByResourceGroup(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -24,7 +24,7 @@ async function listCapacitiesByResourceGroup() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listCapacitiesByResourceGroup();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListBySubscriptionSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListBySubscriptionSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list FabricCapacity resources by subscription ID
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListBySubscription.json
  */
-async function listCapacitiesBySubscription() {
+async function listCapacitiesBySubscription(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listCapacitiesBySubscription() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listCapacitiesBySubscription();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListSkusForCapacitySample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListSkusForCapacitySample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list eligible SKUs for a Microsoft Fabric resource
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListSkusForCapacity.json
  */
-async function listEligibleSKUsForAnExistingCapacity() {
+async function listEligibleSKUsForAnExistingCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -25,7 +25,7 @@ async function listEligibleSKUsForAnExistingCapacity() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listEligibleSKUsForAnExistingCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListSkusSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesListSkusSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list eligible SKUs for Microsoft Fabric resource provider
  * x-ms-original-file: 2023-11-01/FabricCapacities_ListSkus.json
  */
-async function listEligibleSKUsForANewCapacity() {
+async function listEligibleSKUsForANewCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listEligibleSKUsForANewCapacity() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listEligibleSKUsForANewCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesResumeSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesResumeSample.ts
@@ -10,14 +10,14 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary resume operation of the specified Fabric capacity instance.
  * x-ms-original-file: 2023-11-01/FabricCapacities_Resume.json
  */
-async function resumeCapacity() {
+async function resumeCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
   await client.fabricCapacities.resume("TestRG", "azsdktest");
 }
 
-async function main() {
+async function main(): Promise<void> {
   resumeCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesSuspendSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesSuspendSample.ts
@@ -10,14 +10,14 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary suspend operation of the specified Fabric capacity instance.
  * x-ms-original-file: 2023-11-01/FabricCapacities_Suspend.json
  */
-async function suspendCapacity() {
+async function suspendCapacity(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
   await client.fabricCapacities.suspend("TestRG", "azsdktest");
 }
 
-async function main() {
+async function main(): Promise<void> {
   suspendCapacity();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesUpdateSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/fabricCapacitiesUpdateSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary update a FabricCapacity
  * x-ms-original-file: 2023-11-01/FabricCapacities_Update.json
  */
-async function updateCapacityProperties() {
+async function updateCapacityProperties(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "548B7FB7-3B2A-4F46-BB02-66473F1FC22C";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function updateCapacityProperties() {
   console.log(result);
 }
 
-async function main() {
+async function main(): Promise<void> {
   updateCapacityProperties();
 }
 

--- a/sdk/fabric/arm-fabric/samples/v1/typescript/src/operationsListSample.ts
+++ b/sdk/fabric/arm-fabric/samples/v1/typescript/src/operationsListSample.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  * @summary list the operations for the provider
  * x-ms-original-file: 2023-11-01/Operations_List.json
  */
-async function listOperations() {
+async function listOperations(): Promise<void> {
   const credential = new DefaultAzureCredential();
   const subscriptionId = "00000000-0000-0000-0000-00000000000";
   const client = new FabricClient(credential, subscriptionId);
@@ -22,7 +22,7 @@ async function listOperations() {
   console.log(resArray);
 }
 
-async function main() {
+async function main(): Promise<void> {
   listOperations();
 }
 

--- a/sdk/fabric/arm-fabric/test/public/fabric_operations_test.spec.ts
+++ b/sdk/fabric/arm-fabric/test/public/fabric_operations_test.spec.ts
@@ -6,7 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { env, Recorder, isPlaybackMode } from "@azure-tools/test-recorder";
+import type { Recorder } from "@azure-tools/test-recorder";
+import { env, isPlaybackMode } from "@azure-tools/test-recorder";
 import { createTestCredential } from "@azure-tools/test-credential";
 import { assert, beforeEach, afterEach, it, describe } from "vitest";
 import { createRecorder } from "./utils/recordedClient.js";
@@ -34,9 +35,9 @@ describe("Fabric test", () => {
     await recorder.stop();
   });
 
-  it("operations list test", async function () {
+  it("operations list test", async () => {
     const resArray = new Array();
-    for await (let item of client.operations.list()) {
+    for await (const item of client.operations.list()) {
       resArray.push(item);
     }
     assert.notEqual(resArray.length, 0);

--- a/sdk/fabric/arm-fabric/test/public/fabric_operations_test.spec.ts
+++ b/sdk/fabric/arm-fabric/test/public/fabric_operations_test.spec.ts
@@ -30,9 +30,9 @@ describe("Fabric test", () => {
     client = new FabricClient(credential, subscriptionId, recorder.configureClientOptions({}));
   });
 
-  afterEach(async function () {
-    await recorder.stop();
-  });
+  afterEach(async () => {
+      await recorder.stop();
+    });
 
   it("operations list test", async function () {
     const resArray = new Array();

--- a/sdk/fabric/arm-fabric/test/public/fabric_operations_test.spec.ts
+++ b/sdk/fabric/arm-fabric/test/public/fabric_operations_test.spec.ts
@@ -31,8 +31,8 @@ describe("Fabric test", () => {
   });
 
   afterEach(async () => {
-      await recorder.stop();
-    });
+    await recorder.stop();
+  });
 
   it("operations list test", async function () {
     const resArray = new Array();

--- a/sdk/fabric/arm-fabric/test/public/utils/recordedClient.ts
+++ b/sdk/fabric/arm-fabric/test/public/utils/recordedClient.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Recorder, RecorderStartOptions, VitestTestContext } from "@azure-tools/test-recorder";
+import type { RecorderStartOptions, VitestTestContext } from "@azure-tools/test-recorder";
+import { Recorder } from "@azure-tools/test-recorder";
 
 const replaceableVariables: Record<string, string> = {
   SUBSCRIPTION_ID: "azure_subscription_id",

--- a/sdk/fabric/arm-fabric/test/snippets.spec.ts
+++ b/sdk/fabric/arm-fabric/test/snippets.spec.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { FabricClient } from "../src/index.js";
+import { DefaultAzureCredential, InteractiveBrowserCredential } from "@azure/identity";
+import { setLogLevel } from "@azure/logger";
+import { describe, it } from "vitest";
+
+describe("snippets", () => {
+  it("ReadmeSampleCreateClient_Node", async () => {
+    const subscriptionId = "00000000-0000-0000-0000-000000000000";
+    const client = new FabricClient(new DefaultAzureCredential(), subscriptionId);
+  });
+
+  it("ReadmeSampleCreateClient_Browser", async () => {
+    const subscriptionId = "00000000-0000-0000-0000-000000000000";
+    const credential = new InteractiveBrowserCredential({
+      tenantId: "<YOUR_TENANT_ID>",
+      clientId: "<YOUR_CLIENT_ID>",
+    });
+    const client = new FabricClient(credential, subscriptionId);
+  });
+
+  it("SetLogLevel", async () => {
+    setLogLevel("info");
+  });
+});

--- a/sdk/fabric/arm-fabric/tsconfig.browser.config.json
+++ b/sdk/fabric/arm-fabric/tsconfig.browser.config.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "./tsconfig.test.json",
-    "../../../tsconfig.browser.base.json"
-  ]
+  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
 }

--- a/sdk/fabric/arm-fabric/tsconfig.browser.config.json
+++ b/sdk/fabric/arm-fabric/tsconfig.browser.config.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["./tsconfig.test.json", "../../../tsconfig.browser.base.json"]
+  "extends": [
+    "./tsconfig.test.json",
+    "../../../tsconfig.browser.base.json"
+  ]
 }

--- a/sdk/fabric/arm-fabric/tsconfig.json
+++ b/sdk/fabric/arm-fabric/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    }
   ]
 }

--- a/sdk/fabric/arm-fabric/tsconfig.samples.json
+++ b/sdk/fabric/arm-fabric/tsconfig.samples.json
@@ -2,9 +2,7 @@
   "extends": "../../../tsconfig.samples.base.json",
   "compilerOptions": {
     "paths": {
-      "@azure/arm-fabric": [
-        "./dist/esm"
-      ]
+      "@azure/arm-fabric": ["./dist/esm"]
     }
   }
 }

--- a/sdk/fabric/arm-fabric/tsconfig.samples.json
+++ b/sdk/fabric/arm-fabric/tsconfig.samples.json
@@ -2,7 +2,9 @@
   "extends": "../../../tsconfig.samples.base.json",
   "compilerOptions": {
     "paths": {
-      "@azure/arm-fabric": ["./dist/esm"]
+      "@azure/arm-fabric": [
+        "./dist/esm"
+      ]
     }
   }
 }

--- a/sdk/fabric/arm-fabric/tsconfig.test.json
+++ b/sdk/fabric/arm-fabric/tsconfig.test.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "./tsconfig.src.json",
-    "../../../tsconfig.test.base.json"
-  ]
+  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
 }

--- a/sdk/fabric/arm-fabric/tsconfig.test.json
+++ b/sdk/fabric/arm-fabric/tsconfig.test.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["./tsconfig.src.json", "../../../tsconfig.test.base.json"]
+  "extends": [
+    "./tsconfig.src.json",
+    "../../../tsconfig.test.base.json"
+  ]
 }

--- a/sdk/fabric/arm-fabric/vitest.browser.config.ts
+++ b/sdk/fabric/arm-fabric/vitest.browser.config.ts
@@ -1,42 +1,17 @@
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { defineConfig } from "vitest/config";
-import { relativeRecordingsPath } from "@azure-tools/test-recorder";
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "../../../vitest.browser.shared.config.ts";
 
-process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
-
-export default defineConfig({
-  define: {
-    "process.env": process.env,
-  },
-  test: {
-    reporters: ["verbose", "junit"],
-    outputFile: {
-      junit: "test-results.browser.xml",
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      include: ["dist-test/browser/test/**/*.spec.js",],
+      testTimeout: 1200000,
+      hookTimeout: 1200000,
     },
-    browser: {
-      instances: [
-        {
-          browser: "chromium",
-        },
-      ],
-      enabled: true,
-      headless: true,
-      provider: "playwright",
-    },
-    fakeTimers: {
-      toFake: ["setTimeout", "Date"],
-    },
-    watch: false,
-    include: ["dist-test/browser/**/*.spec.js"],
-    coverage: {
-      include: ["dist-test/browser/**/*.spec.js"],
-      provider: "istanbul",
-      reporter: ["text", "json", "html"],
-      reportsDirectory: "coverage-browser",
-    },
-    testTimeout: 1200000,
-    hookTimeout: 1200000
-  },
-});
+  }),
+);

--- a/sdk/fabric/arm-fabric/vitest.browser.config.ts
+++ b/sdk/fabric/arm-fabric/vitest.browser.config.ts
@@ -1,4 +1,3 @@
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -9,7 +8,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      include: ["dist-test/browser/test/**/*.spec.js",],
+      include: ["dist-test/browser/test/**/*.spec.js"],
       testTimeout: 1200000,
       hookTimeout: 1200000,
     },

--- a/sdk/fabric/arm-fabric/vitest.config.ts
+++ b/sdk/fabric/arm-fabric/vitest.config.ts
@@ -1,3 +1,4 @@
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/sdk/fabric/arm-fabric/vitest.config.ts
+++ b/sdk/fabric/arm-fabric/vitest.config.ts
@@ -1,4 +1,3 @@
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/sdk/fabric/arm-fabric/vitest.esm.config.ts
+++ b/sdk/fabric/arm-fabric/vitest.esm.config.ts
@@ -1,0 +1,12 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { mergeConfig } from "vitest/config";
+import vitestConfig from "./vitest.config.ts";
+import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
+
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig
+);

--- a/sdk/fabric/arm-fabric/vitest.esm.config.ts
+++ b/sdk/fabric/arm-fabric/vitest.esm.config.ts
@@ -1,4 +1,3 @@
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -6,7 +5,4 @@ import { mergeConfig } from "vitest/config";
 import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
-export default mergeConfig(
-  vitestConfig,
-  vitestEsmConfig
-);
+export default mergeConfig(vitestConfig, vitestEsmConfig);


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/arm-fabric

### Issues associated with this PR

- https://github.com/Azure/azure-sdk-for-js/issues/32416

### Describe the problem that is addressed by this PR

Updates all projects under `fabric` to use snippets extraction.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
