### PR TITLE
[EngSys] bump dev dependency `mocha` to v11

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3088,7 +3088,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-extendedlocation@file:projects/arm-extendedlocation.tgz':
-    resolution: {integrity: sha512-j2XY+SuSD2mFdpJeHSDpX3rP39/uansqBWn4zeYllMO+BtzMeAczXukLb3tuSfhpYKa50osJGDIm8DhoEfclWA==, tarball: file:projects/arm-extendedlocation.tgz}
+    resolution: {integrity: sha512-mhaJ6Omd/viOSXvzaWdju3lxQJzXJ8DDQ4sdWdkcoNu5fyv24s7VEvHN3QrVP6Nxjv9dE6d9EAQYfBRI8pX0Aw==, tarball: file:projects/arm-extendedlocation.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-fabric@file:projects/arm-fabric.tgz':
@@ -3332,7 +3332,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-network-1@file:projects/arm-network-1.tgz':
-    resolution: {integrity: sha512-ar1Oosj8hqVBwgZ+v5w/QDMGslyj2F/aUQXQLULArSUjENHzoEGSrrfFXCHbi+iE8AE+wShw2afER5oqqHfrrQ==, tarball: file:projects/arm-network-1.tgz}
+    resolution: {integrity: sha512-sRgBROMhwIVOKRFrGmn+1pQ6e+PxSKuQW12V55011ya2cGIinS1F8XIwgsQFQSqVH+ETWHizhHKXqtn58hsBBA==, tarball: file:projects/arm-network-1.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-network-profile-2020-09-01-hybrid@file:projects/arm-network-profile-2020-09-01-hybrid.tgz':
@@ -3560,7 +3560,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-servicefabricmanagedclusters@file:projects/arm-servicefabricmanagedclusters.tgz':
-    resolution: {integrity: sha512-xCkGElJtVReO5TDCkZ309jB7+ZGD0zkVnvEGKd+lFb7jR7y1oFVSk9hWDQ1AX615A1L4YGJrgemVpFymZhsr+g==, tarball: file:projects/arm-servicefabricmanagedclusters.tgz}
+    resolution: {integrity: sha512-XJORCYQaxGTI4A/xLddK8PR4axcz55i7KHb9iXpwJCTbEt7VGQKD6HoRGSYrHVK1/zZjH91U2uTtIVZTCfB6nw==, tarball: file:projects/arm-servicefabricmanagedclusters.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-servicefabricmesh@file:projects/arm-servicefabricmesh.tgz':
@@ -4024,7 +4024,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/openai@file:projects/openai.tgz':
-    resolution: {integrity: sha512-jayeVd5uwRMKpPlpcpfe18IH7vq9LLcRBIcumGtKOe9IoCu4/WHkFslqF7QIr7II0wFC3fqLzhDMp9CV5eGcLA==, tarball: file:projects/openai.tgz}
+    resolution: {integrity: sha512-mPX1Aau04IC1JPC68Y9/c4IlQfRSDotxS4i5iHYeKYyG/iBQWiBP4rHNJAFJA/ubzp4fLxXLG3YTzpK/t+7sAA==, tarball: file:projects/openai.tgz}
     version: 0.0.0
 
   '@rush-temp/opentelemetry-instrumentation-azure-sdk@file:projects/opentelemetry-instrumentation-azure-sdk.tgz':
@@ -6817,11 +6817,6 @@ packages:
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
-    hasBin: true
-
-  mocha@10.8.2:
-    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
-    engines: {node: '>= 14.0.0'}
     hasBin: true
 
   mocha@11.1.0:
@@ -15400,7 +15395,7 @@ snapshots:
       '@types/node': 18.19.74
       chai: 4.5.0
       dotenv: 16.4.7
-      mocha: 10.8.2
+      mocha: 11.1.0
       ts-node: 10.9.2(@types/node@18.19.74)(typescript@5.7.3)
       tslib: 2.8.1
       tsx: 4.19.2
@@ -16655,7 +16650,7 @@ snapshots:
       '@types/node': 18.19.74
       chai: 4.5.0
       dotenv: 16.4.7
-      mocha: 10.8.2
+      mocha: 11.1.0
       ts-node: 10.9.2(@types/node@18.19.74)(typescript@5.7.3)
       tslib: 2.8.1
       tsx: 4.19.2
@@ -25048,29 +25043,6 @@ snapshots:
   mkdirp@1.0.4: {}
 
   mkdirp@3.0.1: {}
-
-  mocha@10.8.2:
-    dependencies:
-      ansi-colors: 4.1.3
-      browser-stdout: 1.3.1
-      chokidar: 3.6.0
-      debug: 4.4.0(supports-color@8.1.1)
-      diff: 5.2.0
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 8.1.0
-      he: 1.2.0
-      js-yaml: 4.1.0
-      log-symbols: 4.1.0
-      minimatch: 5.1.6
-      ms: 2.1.3
-      serialize-javascript: 6.0.2
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      workerpool: 6.5.1
-      yargs: 16.2.0
-      yargs-parser: 20.2.9
-      yargs-unparser: 2.0.0
 
   mocha@11.1.0:
     dependencies:

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -34,7 +34,7 @@
     "@azure/identity": "^4.2.1",
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure-tools/test-credential": "^1.1.0",
-    "mocha": "^10.0.0",
+    "mocha": "^11.0.2",
     "@types/mocha": "^10.0.0",
     "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
@@ -34,7 +34,7 @@
     "@azure/identity": "^4.2.1",
     "@azure-tools/test-recorder": "^3.0.0",
     "@azure-tools/test-credential": "^1.1.0",
-    "mocha": "^10.0.0",
+    "mocha": "^11.0.2",
     "@types/mocha": "^10.0.0",
     "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",


### PR DESCRIPTION
for leftover packages to make them consistent with rest of this repository.