### PR TITLE
[dev-tool] replace "rushx" with "npm run" in migrate-package

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -88,8 +88,8 @@ export default leafCommand(commandInfo, async ({ "package-name": packageName, br
   await applyCodemods(projectFolder);
 
   log.info("Formatting files");
-  await run(["rushx", "format"], { cwd: projectFolder, shell: isWindows() });
-  await commitChanges(projectFolder, "rushx format");
+  await run(["npm", "run", "format"], { cwd: projectFolder, shell: isWindows() });
+  await commitChanges(projectFolder, "npm run format");
 
   log.info(
     "Done. Please run `rush update`, `rush build -t <project-name>`, and run tests to verify the changes.",


### PR DESCRIPTION
as @microsoft/rush might not be available in CI pipeline and the recommendation
for CI is to use `common/scripts/install-run-rushx.js`. For this scenario though
"npm run" is good enough.

-------

### Packages impacted by this PR
dev-tool