### PR TITLE
[web-pubsub] disable type check test

### DIFF
--- a/sdk/web-pubsub/web-pubsub/vitest.config.ts
+++ b/sdk/web-pubsub/web-pubsub/vitest.config.ts
@@ -10,6 +10,9 @@ export default mergeConfig(
     test: {
       hookTimeout: 500000,
       testTimeout: 500000,
+      typecheck: {
+        enabled: false,
+      },
     },
   }),
 );


### PR DESCRIPTION
Due to some vitest bug, type check testing is failing for web-pubsub after PR #32712.

This PR disables type checking test for web-pubsub.