### PR TITLE
[test-credential] Export createLiveCredential

### DIFF
--- a/sdk/openai/openai/test/utils/createClients.ts
+++ b/sdk/openai/openai/test/utils/createClients.ts
@@ -4,7 +4,7 @@
 import OpenAI, { AzureOpenAI } from "openai";
 import { getBearerTokenProvider } from "@azure/identity";
 import { APIVersion, filterDeployments } from "./utils.js";
-import { createTestCredential } from "@azure-tools/test-credential";
+import { createLiveCredential } from "@azure-tools/test-credential";
 import { getResourcesInfo } from "./injectables.js";
 import type { ClientsAndDeploymentsInfo, CreateClientOptions, ModelCapabilities } from "./types.js";
 
@@ -20,7 +20,7 @@ export function createClientsAndDeployments(
   switch (apiVersion) {
     case APIVersion.Preview:
     case APIVersion.Stable: {
-      const credential = createTestCredential();
+      const credential = createLiveCredential();
       const azureADTokenProvider = getBearerTokenProvider(credential, scope);
       let count = 0;
       const clientsAndDeployments = filterDeployments(resourcesInfo, {

--- a/sdk/openai/openai/test/utils/setup.ts
+++ b/sdk/openai/openai/test/utils/setup.ts
@@ -5,7 +5,7 @@ import type { TestProject } from "vitest/node";
 import { EnvironmentVariableNames } from "./envVars.js";
 import type { DeploymentInfo, ResourceInfo, ResourcesInfo } from "./types.js";
 import { CognitiveServicesManagementClient } from "@azure/arm-cognitiveservices";
-import { createTestCredential } from "@azure-tools/test-credential";
+import { createLiveCredential } from "@azure-tools/test-credential";
 import { logger } from "./logger.js";
 import "dotenv/config";
 import { readFile, writeFile } from "node:fs/promises";
@@ -49,7 +49,7 @@ async function listDeployments(
   accountName: string,
 ): Promise<DeploymentInfo[]> {
   const deployments: DeploymentInfo[] = [];
-  const mgmtClient = new CognitiveServicesManagementClient(createTestCredential(), subId);
+  const mgmtClient = new CognitiveServicesManagementClient(createLiveCredential(), subId);
   for await (const deployment of mgmtClient.deployments.list(rgName, accountName)) {
     const deploymentName = deployment.name;
     const modelName = deployment.properties?.model?.name;

--- a/sdk/test-utils/test-credential/review/test-credential.api.md
+++ b/sdk/test-utils/test-credential/review/test-credential.api.md
@@ -11,6 +11,9 @@ import { DefaultAzureCredentialResourceIdOptions } from '@azure/identity';
 import { TokenCredential } from '@azure/core-auth';
 
 // @public
+export function createLiveCredential(tokenCredentialOptions?: CreateTestCredentialOptions): TokenCredential;
+
+// @public
 export function createTestCredential(tokenCredentialOptions?: CreateTestCredentialOptions): TokenCredential;
 
 // @public

--- a/sdk/test-utils/test-credential/src/index.ts
+++ b/sdk/test-utils/test-credential/src/index.ts
@@ -54,7 +54,21 @@ export function createTestCredential(
 ): TokenCredential {
   if (isPlaybackMode()) {
     return new NoOpCredential();
-  } else if (isBrowser) {
+  } else {
+    return createLiveCredential(tokenCredentialOptions);
+  }
+}
+
+/**
+ * ## Credential to be used in live tests.
+ *  - returns the ChainedTokenCredential in Node (expects that you used [`User Auth` or `Auth via development tools`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#authenticate-users) credentials)
+ *  - Returns browser relay credential in browser. Requires the dev-tool browser relay server to be running (dev-tool run start-browser-relay, or is automatically started when using the dev-tool browser test command)
+ *  - AAD traffic won't be recorded if this credential is used.
+ */
+export function createLiveCredential(
+  tokenCredentialOptions: CreateTestCredentialOptions = {},
+): TokenCredential {
+  if (isBrowser) {
     return createBrowserRelayCredential(tokenCredentialOptions);
   } else {
     const { browserRelayServerUrl: _, ...dacOptions } = tokenCredentialOptions;


### PR DESCRIPTION
 Introduces the `createLiveCredential` function for tests that run exclusively in live mode. Unlike `createTestCredential`, which defaults to playback mode and returns a non-functional token unless the `TEST_MODE` environment variable is set to "live" or "record," `createLiveCredential` always provides a functional token without requiring any additional configuration.