### PR TITLE
Save package version in package info file before updating version to daily alpha

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -17,6 +17,11 @@ steps:
       echo "##vso[task.setvariable variable=folder]$folder"
     displayName: "Set folder variable for readme links"
 
+  # Create package info file with package version before it's updated to daily dev version
+  - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+    parameters:
+      ServiceDirectory: ${{parameters.ServiceDirectory}}
+
   # we are not passing service directory, so we only ever set dev build to true
   - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
 
@@ -27,6 +32,7 @@ steps:
     condition: and(succeeded(),eq(variables['SetDevVersion'],'true'))
     displayName: "Update package versions for dev build"
 
+  # Update the package info file to include dev version
   - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}


### PR DESCRIPTION
Information in package info file is used by CI to create/update package work item. Package info file is created after version is updated to daily dev version by CI so package work item adds daily alpha version as next version to be released. Package work item should show the version before converting to alpha version and solution is to generate the package properties file before version is updated to alpha version.