### PR TITLE
[EngSys] add VS Code launch.json configurations for current file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,58 @@
       "console": "integratedTerminal",
       "attachSimplePort": 9229,
       "cwd": "${workspaceFolder}/sdk/${input:package-directory}"
+    },
+    {
+      "name": "unit:current-file",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "rushx",
+      "runtimeArgs": ["unit-test:node"],
+      "args": ["--", "--inspect-brk", "--no-file-parallelism", "${fileBasename}"],
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "attachSimplePort": 9229,
+      "cwd": "${fileDirname}"
+    },
+    {
+      "name": "unit-customized:current-file",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "rushx",
+      "runtimeArgs": ["unit-test:node"],
+      "args": ["--inspect-brk", "--no-file-parallelism", "${fileBasename}"],
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "attachSimplePort": 9229,
+      "cwd": "${fileDirname}"
+    },
+    {
+      "name": "integration:current-file",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "rushx",
+      "runtimeArgs": ["integration-test:node"],
+      "args": ["--", "--inspect-brk", "--no-file-parallelism", "${fileBasename}"],
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "attachSimplePort": 9229,
+      "cwd": "${fileDirname}"
+    },
+    {
+      "name": "integration-customized:current-file",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "rushx",
+      "runtimeArgs": ["integration-test:node"],
+      "args": ["--inspect-brk", "--no-file-parallelism", "${fileBasename}"],
+      "autoAttachChildProcesses": false,
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "attachSimplePort": 9229,
+      "cwd": "${fileDirname}"
     }
   ],
   "inputs": [


### PR DESCRIPTION
It appears that with `rushx` we can run NPM scripts under sub directories. This PR adds debug launch
configurations that start debugging current active test file in the editor.

I had to add `*-customized:current-file` configurations because some packages pass additional arguments with
`--` already so it would be wrong to include `"--"` in the `"args"` again. Developers need to pick one
configuration to use based on their test scripts.