### PR TITLE
[core-xml] keep leading and trailing spaces when parsing

### DIFF
--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue where leading and trailing spaces are not preserved in parsed result [PR #33020](https://github.com/Azure/azure-sdk-for-js/pull/33020)
+
 ### Other Changes
 
 ## 1.4.4 (2024-10-03)

--- a/sdk/core/core-xml/src/xml.ts
+++ b/sdk/core/core-xml/src/xml.ts
@@ -51,6 +51,7 @@ function getParserOptions(options: XmlOptions = {}): {
   attributeNamePrefix: string;
   stopNodes?: string[];
   processEntities: boolean;
+  trimValues: boolean;
 } {
   return {
     ...getCommonOptions(options),
@@ -59,6 +60,7 @@ function getParserOptions(options: XmlOptions = {}): {
     attributeNamePrefix: "",
     stopNodes: options.stopNodes,
     processEntities: true,
+    trimValues: false,
   };
 }
 /**

--- a/sdk/core/core-xml/test/xml.spec.ts
+++ b/sdk/core/core-xml/test/xml.spec.ts
@@ -525,6 +525,12 @@ describe("XML serializer", function () {
       );
     });
 
+    it("should handling leading and trailing spaces", function () {
+      const xml = stringifyXML({ name: "   leadingspace"});
+      assert.equal(xml,
+                   `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root><name>   leadingspace</name></root>`);
+    });
+
     it("should handle CDATA sections with default value", function () {
       const xml = stringifyXML(
         {
@@ -603,4 +609,18 @@ describe("XML serializer", function () {
     const parsed = await parseXML(input);
     assert.isDefined(parsed.Blobs);
   });
+
+  it("should keep leading spaces", async function () {
+    const input = `<Blob><Name>  leadingspace.txt</Name></Blob>`;
+    const parsed = await parseXML(input);
+    assert.isDefined(parsed.Name);
+    assert.deepEqual(parsed.Name, "  leadingspace.txt");
+  })
+
+  it.only("should keep trailing spaces", async function () {
+    const input = `<Blob><Name>trailingspace   </Name></Blob>`;
+    const parsed = await parseXML(input);
+    assert.isDefined(parsed.Name);
+    assert.deepEqual(parsed.Name, "trailingspace   ");
+  })
 });

--- a/sdk/core/core-xml/test/xml.spec.ts
+++ b/sdk/core/core-xml/test/xml.spec.ts
@@ -231,14 +231,9 @@ describe("XML serializer", function () {
       assert.deepStrictEqual(json, { fruit: `` });
     });
 
-    it("with atribute namespace", async () => {
+    it("with attribute namespace", async () => {
       const json = await parseXML(
-        `<h:table xmlns:h="http://www.w3.org/TR/html4/">
-          <h:tr>
-            <h:td>Apples</h:td>
-            <h:td>Bananas</h:td>
-          </h:tr>
-        </h:table>`,
+        `<h:table xmlns:h="http://www.w3.org/TR/html4/"><h:tr><h:td>Apples</h:td><h:td>Bananas</h:td></h:tr></h:table>`,
         { includeRoot: true },
       );
 
@@ -617,7 +612,7 @@ describe("XML serializer", function () {
     assert.deepEqual(parsed.Name, "  leadingspace.txt");
   })
 
-  it.only("should keep trailing spaces", async function () {
+  it("should keep trailing spaces", async function () {
     const input = `<Blob><Name>trailingspace   </Name></Blob>`;
     const parsed = await parseXML(input);
     assert.isDefined(parsed.Name);

--- a/sdk/core/core-xml/test/xml.spec.ts
+++ b/sdk/core/core-xml/test/xml.spec.ts
@@ -521,9 +521,11 @@ describe("XML serializer", function () {
     });
 
     it("should handling leading and trailing spaces", function () {
-      const xml = stringifyXML({ name: "   leadingspace"});
-      assert.equal(xml,
-                   `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root><name>   leadingspace</name></root>`);
+      const xml = stringifyXML({ name: "   leadingspace" });
+      assert.equal(
+        xml,
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root><name>   leadingspace</name></root>`,
+      );
     });
 
     it("should handle CDATA sections with default value", function () {
@@ -610,12 +612,12 @@ describe("XML serializer", function () {
     const parsed = await parseXML(input);
     assert.isDefined(parsed.Name);
     assert.deepEqual(parsed.Name, "  leadingspace.txt");
-  })
+  });
 
   it("should keep trailing spaces", async function () {
     const input = `<Blob><Name>trailingspace   </Name></Blob>`;
     const parsed = await parseXML(input);
     assert.isDefined(parsed.Name);
     assert.deepEqual(parsed.Name, "trailingspace   ");
-  })
+  });
 });


### PR DESCRIPTION
- add a unit-test
- pass `trimValues: false` to fast-xml-parser XMLParser.parse()
- stringifyXML() does not have any issue. Adding a unit test to cover the scenario anyway

Browser version works correctly.

-------

### Packages impacted by this PR
`@azure/core-xml`

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/32486