### PR TITLE
[core-rest-pipeline] use different abort error messages

### DIFF
--- a/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/fetchHttpClient.ts
@@ -155,7 +155,7 @@ function setupAbortSignal(request: PipelineRequest): {
   let abortListener: ((event: any) => void) | undefined;
   if (request.abortSignal) {
     if (request.abortSignal.aborted) {
-      throw new AbortError("The operation was aborted.");
+      throw new AbortError("The operation was aborted. Request has already been canceled");
     }
 
     abortListener = (event: Event) => {

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -235,7 +235,9 @@ class NodeHttpClient implements HttpClient {
       });
 
       abortController.signal.addEventListener("abort", () => {
-        const abortError = new AbortError("The operation was aborted. Rejecting from abort signal callback while making request");
+        const abortError = new AbortError(
+          "The operation was aborted. Rejecting from abort signal callback while making request",
+        );
         req.destroy(abortError);
         reject(abortError);
       });

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -88,7 +88,7 @@ class NodeHttpClient implements HttpClient {
     let abortListener: ((event: any) => void) | undefined;
     if (request.abortSignal) {
       if (request.abortSignal.aborted) {
-        throw new AbortError("The operation was aborted.");
+        throw new AbortError("The operation was aborted. Request has already been canceled");
       }
 
       abortListener = (event: Event) => {
@@ -235,7 +235,7 @@ class NodeHttpClient implements HttpClient {
       });
 
       abortController.signal.addEventListener("abort", () => {
-        const abortError = new AbortError("The operation was aborted.");
+        const abortError = new AbortError("The operation was aborted. Rejecting from abort signal callback while making request");
         req.destroy(abortError);
         reject(abortError);
       });

--- a/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/xhrHttpClient.ts
@@ -39,7 +39,7 @@ class XhrHttpClient implements HttpClient {
     const abortSignal = request.abortSignal;
     if (abortSignal) {
       if (abortSignal.aborted) {
-        throw new AbortError("The operation was aborted.");
+        throw new AbortError("The operation was aborted. Request has already been canceled");
       }
 
       const listener = (): void => {

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -1335,7 +1335,7 @@ index 3e33a3b..3654566 100644
 +  return TYPESPEC_RUNTIME_LOG_LEVELS.includes(logLevel as any);
  }
 diff --git a/src/nodeHttpClient.ts b/src/nodeHttpClient.ts
-index 8667167..d83db74 100644
+index 6a8cea4..2aa0ea3 100644
 --- a/src/nodeHttpClient.ts
 +++ b/src/nodeHttpClient.ts
 @@ -5,7 +5,7 @@ import * as http from "node:http";

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -900,7 +900,7 @@ index fefe550..fb56a78 100644
      // Both XHR and Fetch expect to handle redirects automatically,
      // so only include this policy when we're in Node.
 diff --git a/src/fetchHttpClient.ts b/src/fetchHttpClient.ts
-index e9751e2..e4f8769 100644
+index 0c8c805..7086724 100644
 --- a/src/fetchHttpClient.ts
 +++ b/src/fetchHttpClient.ts
 @@ -1,7 +1,7 @@
@@ -1335,7 +1335,7 @@ index 3e33a3b..3654566 100644
 +  return TYPESPEC_RUNTIME_LOG_LEVELS.includes(logLevel as any);
  }
 diff --git a/src/nodeHttpClient.ts b/src/nodeHttpClient.ts
-index 1ac007a..66abe50 100644
+index 8667167..d83db74 100644
 --- a/src/nodeHttpClient.ts
 +++ b/src/nodeHttpClient.ts
 @@ -5,7 +5,7 @@ import * as http from "node:http";
@@ -3208,7 +3208,7 @@ index bd11d61..3f6a12b 100644
  interface Crypto {
    randomUUID(): string;
 diff --git a/src/xhrHttpClient.ts b/src/xhrHttpClient.ts
-index 71bc439..c82fcb7 100644
+index 7e4d563..223f257 100644
 --- a/src/xhrHttpClient.ts
 +++ b/src/xhrHttpClient.ts
 @@ -1,7 +1,7 @@

--- a/sdk/core/ts-http-runtime/src/fetchHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/fetchHttpClient.ts
@@ -155,7 +155,7 @@ function setupAbortSignal(request: PipelineRequest): {
   let abortListener: ((event: any) => void) | undefined;
   if (request.abortSignal) {
     if (request.abortSignal.aborted) {
-      throw new AbortError("The operation was aborted.");
+      throw new AbortError("The operation was aborted. Request has already been canceled");
     }
 
     abortListener = (event: Event) => {

--- a/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
@@ -235,7 +235,9 @@ class NodeHttpClient implements HttpClient {
       });
 
       abortController.signal.addEventListener("abort", () => {
-        const abortError = new AbortError("The operation was aborted. Rejecting from abort signal callback while making request");
+        const abortError = new AbortError(
+          "The operation was aborted. Rejecting from abort signal callback while making request",
+        );
         req.destroy(abortError);
         reject(abortError);
       });

--- a/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
@@ -88,7 +88,7 @@ class NodeHttpClient implements HttpClient {
     let abortListener: ((event: any) => void) | undefined;
     if (request.abortSignal) {
       if (request.abortSignal.aborted) {
-        throw new AbortError("The operation was aborted.");
+        throw new AbortError("The operation was aborted. Request has already been canceled");
       }
 
       abortListener = (event: Event) => {
@@ -235,7 +235,7 @@ class NodeHttpClient implements HttpClient {
       });
 
       abortController.signal.addEventListener("abort", () => {
-        const abortError = new AbortError("The operation was aborted.");
+        const abortError = new AbortError("The operation was aborted. Rejecting from abort signal callback while making request");
         req.destroy(abortError);
         reject(abortError);
       });

--- a/sdk/core/ts-http-runtime/src/xhrHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/xhrHttpClient.ts
@@ -39,7 +39,7 @@ class XhrHttpClient implements HttpClient {
     const abortSignal = request.abortSignal;
     if (abortSignal) {
       if (abortSignal.aborted) {
-        throw new AbortError("The operation was aborted.");
+        throw new AbortError("The operation was aborted. Request has already been canceled");
       }
 
       const listener = (): void => {

--- a/sdk/test-utils/test-utils/src/xhrHttpClient.ts
+++ b/sdk/test-utils/test-utils/src/xhrHttpClient.ts
@@ -54,7 +54,7 @@ class XhrHttpClient implements HttpClient {
     const abortSignal = request.abortSignal;
     if (abortSignal) {
       if (abortSignal.aborted) {
-        throw new AbortError("The operation was aborted.");
+        throw new AbortError("The operation was aborted. Request has already been canceled");
       }
 
       const listener = (): void => {


### PR DESCRIPTION
for the two AbortErrors thrown in nodeHttpClient to make customer issue
investigation easier.