### PR TITLE
Filter ExcludePaths out of the targetedFiles

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -61,6 +61,12 @@ function Get-javascript-AdditionalValidationPackagesFromPackageSet {
     $targetedFiles += $diff.DeletedFiles
   }
 
+  # The targetedFiles needs to filter out anything in the ExcludePaths
+  # otherwise it'll end up processing things below that it shouldn't be.
+  foreach ($excludePath in $diffObj.ExcludePaths) {
+    $targetedFiles = $targetedFiles | Where-Object { -not $_.StartsWith($excludePath.TrimEnd("/") + "/") }
+  }
+
   $changedServices = @()
   foreach ($file in $targetedFiles) {
     $pathComponents = $file -split "/"


### PR DESCRIPTION
This is the same change that was made in Python, is in my testing code for Java and will be made for Rust.

The targetedFiles list needs to remove anything that's in the ExcludePaths otherwise, it will end up trying to process them if they're in the ChangedFiles or DeletedFiles. The scenario is this, something changes in the root of path being excluded, the code on line 74 would end up adding additional packages for validation for something that should be being excluded.