### PR TITLE
Fix/codeql regex vulnarability

### DIFF
--- a/sdk/core/logger/src/debug.ts
+++ b/sdk/core/logger/src/debug.ts
@@ -65,18 +65,22 @@ export interface Debugger {
   extend: (namespace: string) => Debugger;
 }
 
+function sanitizeEnvVariable(envValue: string): string {
+  return envValue.replace(/[^a-zA-Z0-9,.*:-]/g, ''); // Allow only safe characters
+}
+
 const debugEnvVariable =
-  (typeof process !== "undefined" && process.env && process.env.DEBUG) || undefined;
+  (typeof process !== "undefined" && process.env && process.env.DEBUG)
+    ? sanitizeEnvVariable(process.env.DEBUG)
+    : undefined;
 
 let enabledString: string | undefined;
-let debugEnvVariableEscaped: string;
 let enabledNamespaces: RegExp[] = [];
 let skippedNamespaces: RegExp[] = [];
 const debuggers: Debugger[] = [];
 
 if (debugEnvVariable) {
-  debugEnvVariableEscaped = debugEnvVariable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape special characters
-  enable(debugEnvVariableEscaped);
+  enable(debugEnvVariable);
 }
 
 const debugObj: Debug = Object.assign(

--- a/sdk/core/logger/src/debug.ts
+++ b/sdk/core/logger/src/debug.ts
@@ -69,12 +69,14 @@ const debugEnvVariable =
   (typeof process !== "undefined" && process.env && process.env.DEBUG) || undefined;
 
 let enabledString: string | undefined;
+let debugEnvVariableEscaped: string;
 let enabledNamespaces: RegExp[] = [];
 let skippedNamespaces: RegExp[] = [];
 const debuggers: Debugger[] = [];
 
 if (debugEnvVariable) {
-  enable(debugEnvVariable);
+  debugEnvVariableEscaped = debugEnvVariable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape special characters
+  enable(debugEnvVariableEscaped);
 }
 
 const debugObj: Debug = Object.assign(

--- a/sdk/core/ts-http-runtime/src/logger/debug.ts
+++ b/sdk/core/ts-http-runtime/src/logger/debug.ts
@@ -65,18 +65,22 @@ export interface Debugger {
   extend: (namespace: string) => Debugger;
 }
 
+function sanitizeEnvVariable(envValue: string): string {
+  return envValue.replace(/[^a-zA-Z0-9,.*:-]/g, ''); // Allow only safe characters
+}
+
 const debugEnvVariable =
-  (typeof process !== "undefined" && process.env && process.env.DEBUG) || undefined;
+  (typeof process !== "undefined" && process.env && process.env.DEBUG)
+    ? sanitizeEnvVariable(process.env.DEBUG)
+    : undefined;
 
 let enabledString: string | undefined;
-let debugEnvVariableEscaped: string;
 let enabledNamespaces: RegExp[] = [];
 let skippedNamespaces: RegExp[] = [];
 const debuggers: Debugger[] = [];
 
 if (debugEnvVariable) {
-  debugEnvVariableEscaped = debugEnvVariable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape special characters
-  enable(debugEnvVariableEscaped);
+  enable(debugEnvVariable);
 }
 
 const debugObj: Debug = Object.assign(

--- a/sdk/core/ts-http-runtime/src/logger/debug.ts
+++ b/sdk/core/ts-http-runtime/src/logger/debug.ts
@@ -65,14 +65,8 @@ export interface Debugger {
   extend: (namespace: string) => Debugger;
 }
 
-function sanitizeEnvVariable(envValue: string): string {
-  return envValue.replace(/[^a-zA-Z0-9,.*:-]/g, ''); // Allow only safe characters
-}
-
 const debugEnvVariable =
-  (typeof process !== "undefined" && process.env && process.env.DEBUG)
-    ? sanitizeEnvVariable(process.env.DEBUG)
-    : undefined;
+  (typeof process !== "undefined" && process.env && process.env.DEBUG) || undefined;
 
 let enabledString: string | undefined;
 let enabledNamespaces: RegExp[] = [];

--- a/sdk/core/ts-http-runtime/src/logger/debug.ts
+++ b/sdk/core/ts-http-runtime/src/logger/debug.ts
@@ -69,12 +69,14 @@ const debugEnvVariable =
   (typeof process !== "undefined" && process.env && process.env.DEBUG) || undefined;
 
 let enabledString: string | undefined;
+let debugEnvVariableEscaped: string;
 let enabledNamespaces: RegExp[] = [];
 let skippedNamespaces: RegExp[] = [];
 const debuggers: Debugger[] = [];
 
 if (debugEnvVariable) {
-  enable(debugEnvVariable);
+  debugEnvVariableEscaped = debugEnvVariable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape special characters
+  enable(debugEnvVariableEscaped);
 }
 
 const debugObj: Debug = Object.assign(


### PR DESCRIPTION
### Packages impacted by this PR
All the package that uses `core/logger/src/debug.ts` and `core/ts-http-runtime/src/logger/debug.ts`

### Describe the problem that is addressed by this PR
GitHub [CodeQL Scan](https://github.com/chathurangakw/nodejs-app/pull/2/checks?check_run_id=37272964920) detected a high-severity vulnerability in the `@azure/storage-blob` npm package (CWE-400, CWE-730). This is due to the construction of a regular expression with an unsanitized environment variable.

In this PR, `debugEnvVariable` is sanitized before being passed to the `enable` function.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
