### PR TITLE
Handle PR changes in the root of the repository

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -75,8 +75,10 @@ function Get-javascript-AdditionalValidationPackagesFromPackageSet {
       $changedServices += $pathComponents[1]
     }
 
-    # handle any changes under sdk/<file>.<extension>
-    if ($pathComponents.Length -eq 2 -and $pathComponents[0] -eq "sdk") {
+    # handle any changes under sdk/<file>.<extension> or in the root of
+    # the repository
+    if (($pathComponents.Length -eq 2 -and $pathComponents[0] -eq "sdk") -or
+        ($pathComponents.Length -eq 1)) {
       $changedServices += "template"
     }
   }


### PR DESCRIPTION
Similar changes are being made to Java, Net and Python. 

When splitting on the directory separator for a file in the repo root, $pathComponents.Length -eq 1.