### PR TITLE
Increased test timeout values from 10 to 20 seconds

### DIFF
--- a/sdk/healthdataaiservices/azure-health-deidentification/test/public/realtimeOperationsTest.spec.ts
+++ b/sdk/healthdataaiservices/azure-health-deidentification/test/public/realtimeOperationsTest.spec.ts
@@ -63,7 +63,7 @@ describe("Realtime", () => {
       output.outputText,
       "Expected output text to be different from input text.",
     );
-  }, 10000);
+  }, 20000);
 
   it("tag returns expected", async () => {
     const content: DeidentificationContent = {
@@ -101,5 +101,5 @@ describe("Realtime", () => {
       output.taggerResult!.entities[0].length.utf8 === 10,
       "Expected first tag to be 10 characters long.",
     );
-  }, 10000);
+  }, 20000);
 });


### PR DESCRIPTION
### Packages impacted by this PR
sdk/healthdataaiservices/azure-health-deidentification

### Issues associated with this PR
Increased test timeouts from 10 to 20 seconds to address the DeID test failures.

### Describe the problem that is addressed by this PR
Random timeouts caused by slow response time during tests. Increased times solved the issues.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Increased resource availability. Chose to increase timeout time as tests are low priority versus other tasks

### Are there test cases added in this PR? _(If not, why?)_
None, time increase only

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
