### PR TITLE
[cosmos] Correct documentation for enableBackgroundEndpointRefreshing default value

### DIFF
--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
@@ -27,7 +27,7 @@ export interface ConnectionPolicy {
   useMultipleWriteLocations?: boolean;
   /** Rate in milliseconds at which the client will refresh the endpoints list in the background */
   endpointRefreshRateInMs?: number;
-  /** Flag to enable/disable background refreshing of endpoints. Defaults to false.
+  /** Flag to enable/disable background refreshing of endpoints. Defaults to true.
    * Endpoint discovery using `enableEndpointsDiscovery` will still work for failed requests. */
   enableBackgroundEndpointRefreshing?: boolean;
 }


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/cosmos`

### Issues associated with this PR


### Describe the problem that is addressed by this PR
JSDoc comment and [documentation](https://learn.microsoft.com/en-us/javascript/api/@azure/cosmos/connectionpolicy?view=azure-node-latest#@azure-cosmos-connectionpolicy-enablebackgroundendpointrefreshing) incorrectly state that `enableBackgroundEndpointRefreshing` defaults to false, when the actual default value is true as shown in the `defaultConnectionPolicy` object:
https://github.com/Azure/azure-sdk-for-js/blob/fe306bcfe7f1ce7673bd90475c39e6a62a6d1215/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts#L50

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_
#15781 (implemented this parameter)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)