### PR TITLE
[ServiceBus] bump dependency `long` version to ^5.3.1

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2737,7 +2737,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-computeschedule@file:projects/arm-computeschedule.tgz':
-    resolution: {integrity: sha512-Xc2JkbgagP65oltPB9A4krmQn4o6YTZ2V6gL6JqJYBfe1ARa/pNWa+bhKY3+u/ImzMpWj+eZ433VGXuTja5EwQ==, tarball: file:projects/arm-computeschedule.tgz}
+    resolution: {integrity: sha512-YE6nJTK/BVAb1nBjvV/qgoJOgtmzrPI3GPW7DOuKyyVO1yNCIZ15X46xdfFgoZysUzTvglU7TgAUYur+STPBYw==, tarball: file:projects/arm-computeschedule.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-confidentialledger@file:projects/arm-confidentialledger.tgz':
@@ -3249,7 +3249,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-pineconevectordb@file:projects/arm-pineconevectordb.tgz':
-    resolution: {integrity: sha512-h4htkOBXb/SsaNfmBHi3B7j8LJGsPAVjXZQJR9dLkg8fhCHT3EWVckIfhLpDNu/+FHPG4yf8EefdcUxdBWrX1g==, tarball: file:projects/arm-pineconevectordb.tgz}
+    resolution: {integrity: sha512-jW914Jzu10EhN3yiXskFA40AOpqHyI/GdT35ak04F3dP0ug5Ouk2R40dYLf//wsxHpkaPF4PBnXOaMtv7Ew5ZA==, tarball: file:projects/arm-pineconevectordb.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-playwrighttesting@file:projects/arm-playwrighttesting.tgz':
@@ -3433,7 +3433,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-servicenetworking@file:projects/arm-servicenetworking.tgz':
-    resolution: {integrity: sha512-arlvJb/ozRYbK5/eX6UKRRFByc5mhGztqsWFR6U9o+wSfu6VAZuksYw2w8rUovVSzWx+LCKhX2uG2nBaYdfxgw==, tarball: file:projects/arm-servicenetworking.tgz}
+    resolution: {integrity: sha512-y41ds59a+CS9sqMVLi7Wdabb4hBxBIi+T7GFQCWDR1MwU68OfVmhlCoYOtgJKZI6dPVMLtoGc62yHXXPeHv4HA==, tarball: file:projects/arm-servicenetworking.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-signalr@file:projects/arm-signalr.tgz':
@@ -3705,7 +3705,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/defender-easm@file:projects/defender-easm.tgz':
-    resolution: {integrity: sha512-12oujwcJZYF2mealed/mFD41GgSez6UE1ICuPTnzoDyW2yaasQKrp5z8RowLVQFmIZz6Y6xcPKPhRUSQ3Optug==, tarball: file:projects/defender-easm.tgz}
+    resolution: {integrity: sha512-jI8Yq+2wjHPEivyY7P7u6aSgf7vh4DhhJATtBjuVYuowO353vHtGL2f1Q05SEZLm4i2zkeRiYfRb6GP0gNbjUQ==, tarball: file:projects/defender-easm.tgz}
     version: 0.0.0
 
   '@rush-temp/dev-tool@file:projects/dev-tool.tgz':
@@ -4029,7 +4029,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/service-bus@file:projects/service-bus.tgz':
-    resolution: {integrity: sha512-3J1MkJ54xTVhUxp6bnqZanWXMwyovz1snfXuAJeO2ieTgnWew28Rbbb//DAYO8saOFyjs15l0ZgXdd5QaKLbbg==, tarball: file:projects/service-bus.tgz}
+    resolution: {integrity: sha512-ICttr5Vkcza3Jpy5WP+rciaUvO8NRkplh7TEOk7RWExZR9GFF0hXTNbH11Id8/OSZ17v/vuWtwt+9GFLBeDsZw==, tarball: file:projects/service-bus.tgz}
     version: 0.0.0
 
   '@rush-temp/storage-blob-changefeed@file:projects/storage-blob-changefeed.tgz':
@@ -4117,7 +4117,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/web-pubsub-client-protobuf@file:projects/web-pubsub-client-protobuf.tgz':
-    resolution: {integrity: sha512-jot7zl1QVeVeMo2nOXEcwwfzOH/wGFQt8cXr0eMNmHU42TVlIjZ5fP/dXbA7UI8JFtUqoukMSd1CFVSeTxs0FA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
+    resolution: {integrity: sha512-vgpru4yp5Ir2l8ofCEQ21GQnZiqSy2JBFwFIgnSZN2hZ7oNbzUgkgx6SaxZOoDH+dSxtfICOPvacCiXkjA1ppA==, tarball: file:projects/web-pubsub-client-protobuf.tgz}
     version: 0.0.0
 
   '@rush-temp/web-pubsub-client@file:projects/web-pubsub-client.tgz':
@@ -6356,6 +6356,9 @@ packages:
 
   long@5.2.5:
     resolution: {integrity: sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==}
+
+  long@5.3.1:
+    resolution: {integrity: sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==}
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -11824,7 +11827,6 @@ snapshots:
 
   '@rush-temp/arm-computeschedule@file:projects/arm-computeschedule.tgz(@types/debug@4.1.12)(msw@2.7.0(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.2)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.49.2(@types/node@18.19.75)
       '@types/node': 18.19.75
       '@vitest/browser': 3.0.5(@types/node@18.19.75)(playwright@1.50.1)(typescript@5.6.3)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5)
       '@vitest/coverage-istanbul': 3.0.5(vitest@3.0.5)
@@ -16187,7 +16189,6 @@ snapshots:
 
   '@rush-temp/arm-pineconevectordb@file:projects/arm-pineconevectordb.tgz(@types/debug@4.1.12)(msw@2.7.0(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.2)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.49.2(@types/node@18.19.75)
       '@types/node': 18.19.75
       '@vitest/browser': 3.0.5(@types/node@18.19.75)(playwright@1.50.1)(typescript@5.6.3)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5)
       '@vitest/coverage-istanbul': 3.0.5(vitest@3.0.5)
@@ -17532,7 +17533,6 @@ snapshots:
 
   '@rush-temp/arm-servicenetworking@file:projects/arm-servicenetworking.tgz(@types/debug@4.1.12)(msw@2.7.0(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.2)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.49.2(@types/node@18.19.75)
       '@types/node': 18.19.75
       '@vitest/browser': 3.0.5(@types/node@18.19.75)(playwright@1.50.1)(typescript@5.6.3)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5)
       '@vitest/coverage-istanbul': 3.0.5(vitest@3.0.5)
@@ -19921,7 +19921,6 @@ snapshots:
 
   '@rush-temp/defender-easm@file:projects/defender-easm.tgz(@types/debug@4.1.12)(msw@2.7.0(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.2)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.49.2(@types/node@18.19.75)
       '@types/node': 18.19.75
       '@vitest/browser': 3.0.5(@types/node@18.19.75)(playwright@1.50.1)(typescript@5.7.3)(vite@6.1.0(@types/node@22.7.9)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5)
       '@vitest/coverage-istanbul': 3.0.5(vitest@3.0.5)
@@ -22396,7 +22395,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-buffer: 2.0.5
       jssha: 3.3.1
-      long: 5.2.5
+      long: 5.3.1
       playwright: 1.50.1
       process: 0.11.10
       rhea-promise: 3.0.3
@@ -23157,7 +23156,7 @@ snapshots:
       cpy-cli: 5.0.0
       dotenv: 16.4.7
       eslint: 9.20.0
-      long: 5.2.5
+      long: 5.3.1
       move-file-cli: 3.0.0
       protobufjs: 7.4.0
       protobufjs-cli: 1.1.3(protobufjs@7.4.0)
@@ -25827,6 +25826,8 @@ snapshots:
 
   long@5.2.5: {}
 
+  long@5.3.1: {}
+
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
@@ -26619,7 +26620,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/node': 18.19.75
-      long: 5.2.5
+      long: 5.3.1
 
   proxy-addr@2.0.7:
     dependencies:

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -99,7 +99,7 @@
     "buffer": "^6.0.0",
     "is-buffer": "^2.0.3",
     "jssha": "^3.3.1",
-    "long": "^5.2.0",
+    "long": "^5.3.1",
     "process": "^0.11.10",
     "rhea-promise": "^3.0.0",
     "tslib": "^2.7.0"

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -11,7 +11,7 @@ import type { CommonClientOptions } from '@azure/core-client';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
 import type { HttpMethods } from '@azure/core-rest-pipeline';
-import Long from 'long';
+import { default as Long_2 } from 'long';
 import { MessagingError } from '@azure/core-amqp';
 import type { NamedKeyCredential } from '@azure/core-auth';
 import { OperationOptions } from '@azure/core-client';
@@ -210,7 +210,7 @@ export function parseServiceBusConnectionString(connectionString: string): Servi
 
 // @public
 export interface PeekMessagesOptions extends OperationOptionsBase {
-    fromSequenceNumber?: Long;
+    fromSequenceNumber?: Long_2;
 }
 
 // @public
@@ -476,7 +476,7 @@ export interface ServiceBusReceivedMessage extends ServiceBusMessage {
     lockedUntilUtc?: Date;
     readonly lockToken?: string;
     readonly _rawAmqpMessage: AmqpAnnotatedMessage;
-    readonly sequenceNumber?: Long;
+    readonly sequenceNumber?: Long_2;
     readonly state: "active" | "deferred" | "scheduled";
 }
 
@@ -500,7 +500,7 @@ export interface ServiceBusReceiver {
     isClosed: boolean;
     peekMessages(maxMessageCount: number, options?: PeekMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
     purgeMessages(options?: PurgeMessagesOptions): Promise<number>;
-    receiveDeferredMessages(sequenceNumbers: Long | Long[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
+    receiveDeferredMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<ServiceBusReceivedMessage[]>;
     receiveMessages(maxMessageCount: number, options?: ReceiveMessagesOptions): Promise<ServiceBusReceivedMessage[]>;
     receiveMode: "peekLock" | "receiveAndDelete";
     renewMessageLock(message: ServiceBusReceivedMessage): Promise<Date>;
@@ -529,13 +529,13 @@ export interface ServiceBusRuleManager {
 
 // @public
 export interface ServiceBusSender {
-    cancelScheduledMessages(sequenceNumbers: Long | Long[], options?: OperationOptionsBase): Promise<void>;
+    cancelScheduledMessages(sequenceNumbers: Long_2 | Long_2[], options?: OperationOptionsBase): Promise<void>;
     close(): Promise<void>;
     createMessageBatch(options?: CreateMessageBatchOptions): Promise<ServiceBusMessageBatch>;
     entityPath: string;
     identifier: string;
     isClosed: boolean;
-    scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long[]>;
+    scheduleMessages(messages: ServiceBusMessage | ServiceBusMessage[] | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], scheduledEnqueueTimeUtc: Date, options?: OperationOptionsBase): Promise<Long_2[]>;
     sendMessages(messages: ServiceBusMessage | ServiceBusMessage[] | ServiceBusMessageBatch | AmqpAnnotatedMessage | AmqpAnnotatedMessage[], options?: OperationOptionsBase): Promise<void>;
 }
 

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@azure/logger": "^1.0.0",
     "@azure/web-pubsub-client": "1.0.0-beta.2",
-    "long": "^5.2.1",
+    "long": "^5.3.1",
     "protobufjs": "^7.4.0",
     "tslib": "^2.6.2"
   },

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.src.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.src.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../../../tsconfig.lib.json",
-  "compilerOptions": {
-    "skipLibCheck": true
-  }
+  "extends": "../../../tsconfig.lib.json"
 }


### PR DESCRIPTION
Typing changes in `long` 5.3.1

https://github.com/dcodeIO/long.js/releases/tag/v5.3.1

leads to trivial changes in Service Bus api.md (due to known api-extractor issue https://github.com/search?q=repo%3Amicrosoft%2Frushstack+api+extractor+_2&type=issues)

This PR bumps the version and updates the api.md

-------

### Packages impacted by this PR
- `@azure/service-bus`
-  `@azure/web-pubsub-client-protobuf`