### PR TITLE
[dev-tool] Remove env-paths dependency

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@_ts/max": "npm:typescript@latest",
     "@_ts/min": "npm:typescript@~4.2.4",
+    "@arethetypeswrong/cli": "^0.17.0",
     "@azure/identity": "^4.4.1",
     "@microsoft/api-extractor": "^7.49.1",
     "@microsoft/api-extractor-model": "^7.30.2",
@@ -55,7 +56,6 @@
     "chalk": "^4.1.1",
     "concurrently": "^8.2.2",
     "dotenv": "^16.0.0",
-    "env-paths": "^2.2.1",
     "express": "^4.19.2",
     "fs-extra": "^11.2.0",
     "memfs": "^4.14.1",
@@ -73,7 +73,6 @@
     "tsx": "^4.0.0",
     "typescript": "~5.7.2",
     "yaml": "^2.3.4",
-    "@arethetypeswrong/cli": "^0.17.0",
     "tar": "^7.4.3",
     "unzipper": "~0.12.3"
   },

--- a/common/tools/dev-tool/src/util/testProxyUtils.ts
+++ b/common/tools/dev-tool/src/util/testProxyUtils.ts
@@ -8,14 +8,33 @@ import fs from "fs-extra";
 import path from "node:path";
 import { extract } from "tar";
 import * as unzipper from "unzipper";
-import envPaths from "env-paths";
 import { promisify } from "node:util";
 import { PassThrough } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { delay } from "./checkWithTimeout";
+import process from "node:process";
+import os from "node:os";
 
 const log = createPrinter("test-proxy");
-const downloadLocation = path.join(envPaths("azsdk-dev-tool").cache, "test-proxy");
+const downloadLocation = getTestProxyDownloadLocation();
+
+export function getTestProxyDownloadLocation(): string {
+  const homedir = os.homedir();
+  const downloadPath = "azsdk-dev-tool";
+  switch (process.platform) {
+    case "win32":
+      return path.join(
+        process.env["LOCALAPPDATA"] || path.join(homedir, "AppData", "Local"),
+        downloadPath,
+        "Cache",
+      );
+    case "darwin":
+      return path.join(path.join(homedir, "Library"), "Caches", downloadPath);
+    default:
+      // Assume Linux
+      return path.join(process.env["XDG_CACHE_HOME"] || path.join(homedir, ".cache"), downloadPath);
+  }
+}
 
 /**
  * Represents a test proxy binary artifact archive that is built against a specific platform and architecture.


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/dev-tool

### Issues associated with this PR

- #32939

### Describe the problem that is addressed by this PR

Removes the `env-paths` dependency from the @azure/dev-tool project and only uses the logic we needed to get the cache location.  Removed dependency due to ESM only nature and the little benefit we got from it.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
