### PR TITLE
[monitor] Migrate monitor projects to use snippets extraction

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -27,8 +27,8 @@ See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUP
 
 > _Important:_ `useAzureMonitor` must be called _before_ you import anything else. There may be resulting telemetry loss if other libraries are imported first.
 
-```typescript
-import { useAzureMonitor, AzureMonitorOpenTelemetryOptions } from "@azure/monitor-opentelemetry";
+```ts snippet:ReadmeSampleUseAzureMonitor
+import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
 
 const options: AzureMonitorOpenTelemetryOptions = {
   azureMonitorExporterOptions: {
@@ -43,9 +43,9 @@ useAzureMonitor(options);
 
 ## Configuration
 
-```typescript
-import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
+```ts snippet:ReadmeSampleConfiguration
 import { Resource } from "@opentelemetry/resources";
+import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
 
 const resource = new Resource({ testAttribute: "testValue" });
 const options: AzureMonitorOpenTelemetryOptions = {
@@ -82,23 +82,22 @@ const options: AzureMonitorOpenTelemetryOptions = {
   logRecordProcessors: [],
   spanProcessors: [],
 };
-
 useAzureMonitor(options);
 ```
 
-|Property|Description|Default|
-| ------------------------------- |------------------------------------------------------------------------------------------------------------|-------|
-| azureMonitorExporterOptions     | Azure Monitor OpenTelemetry Exporter Configuration. [More info here](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/monitor-opentelemetry-exporter) | | | |
-| samplingRatio              | Sampling ratio must take a value in the range [0,1], 1 meaning all data will sampled and 0 all Tracing data will be sampled out. | 1|
-| instrumentationOptions| Allow configuration of OpenTelemetry Instrumentations. |  {"http": { enabled: true },"azureSdk": { enabled: false },"mongoDb": { enabled: false },"mySql": { enabled: false },"postgreSql": { enabled: false },"redis": { enabled: false },"bunyan": { enabled: false }, "winston": { enabled: false } }|
-| browserSdkLoaderOptions| Allow configuration of Web Instrumentations. | { enabled: false, connectionString: "" } |
-| resource       | Opentelemetry Resource. [More info here](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources) ||
-| samplingRatio              | Sampling ratio must take a value in the range [0,1], 1 meaning all data will sampled and 0 all Tracing data will be sampled out. |1|
-| enableLiveMetrics          | Enable/Disable Live Metrics. |true|
-| enableStandardMetrics      | Enable/Disable Standard Metrics. |true|
-| logRecordProcessors        | Array of log record processors to register to the global logger provider. ||
-| spanProcessors             | Array of span processors to register to the global tracer provider. ||
-| enableTraceBasedSamplingForLogs  | Enable log sampling based on trace. |false|                                                                                                                                                                                                                                      |
+| Property                        | Description                                                                                                                                                          | Default                                                                                                                                                                                                                                        |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | --- |
+| azureMonitorExporterOptions     | Azure Monitor OpenTelemetry Exporter Configuration. [More info here](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/monitor-opentelemetry-exporter) |                                                                                                                                                                                                                                                |     |     |
+| samplingRatio                   | Sampling ratio must take a value in the range [0,1], 1 meaning all data will sampled and 0 all Tracing data will be sampled out.                                     | 1                                                                                                                                                                                                                                              |
+| instrumentationOptions          | Allow configuration of OpenTelemetry Instrumentations.                                                                                                               | {"http": { enabled: true },"azureSdk": { enabled: false },"mongoDb": { enabled: false },"mySql": { enabled: false },"postgreSql": { enabled: false },"redis": { enabled: false },"bunyan": { enabled: false }, "winston": { enabled: false } } |
+| browserSdkLoaderOptions         | Allow configuration of Web Instrumentations.                                                                                                                         | { enabled: false, connectionString: "" }                                                                                                                                                                                                       |
+| resource                        | Opentelemetry Resource. [More info here](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources)                              |                                                                                                                                                                                                                                                |
+| samplingRatio                   | Sampling ratio must take a value in the range [0,1], 1 meaning all data will sampled and 0 all Tracing data will be sampled out.                                     | 1                                                                                                                                                                                                                                              |
+| enableLiveMetrics               | Enable/Disable Live Metrics.                                                                                                                                         | true                                                                                                                                                                                                                                           |
+| enableStandardMetrics           | Enable/Disable Standard Metrics.                                                                                                                                     | true                                                                                                                                                                                                                                           |
+| logRecordProcessors             | Array of log record processors to register to the global logger provider.                                                                                            |                                                                                                                                                                                                                                                |
+| spanProcessors                  | Array of span processors to register to the global tracer provider.                                                                                                  |                                                                                                                                                                                                                                                |
+| enableTraceBasedSamplingForLogs | Enable log sampling based on trace.                                                                                                                                  | false                                                                                                                                                                                                                                          |     |
 
 Options could be set using configuration file `applicationinsights.json` located under root folder of @azure/monitor-opentelemetry package installation folder, Ex: `node_modules/@azure/monitor-opentelemetry`. These configuration values will be applied to all AzureMonitorOpenTelemetryClient instances.
 
@@ -118,11 +117,8 @@ Options could be set using configuration file `applicationinsights.json` located
 
 Custom JSON file could be provided using `APPLICATIONINSIGHTS_CONFIGURATION_FILE` environment variable.
 
-```javascript
-process.env.APPLICATIONINSIGHTS_CONFIGURATION_FILE =
-  "C:/applicationinsights/config/customConfig.json";
-
-// Application Insights SDK setup....
+```ts snippet:ReadmeSampleCustomConfig
+process.env["APPLICATIONINSIGHTS_CONFIGURATION_FILE"] = "path/to/customConfig.json";
 ```
 
 ## Instrumentation libraries
@@ -153,18 +149,17 @@ The following OpenTelemetry Instrumentation libraries are included as part of Az
 
 Other OpenTelemetry Instrumentations are available [here](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node) and could be added using TracerProvider in AzureMonitorOpenTelemetryClient.
 
-```typescript
+```ts snippet:ReadmeSampleCustomInstrumentation
 import { useAzureMonitor } from "@azure/monitor-opentelemetry";
-import { metrics, trace } from "@opentelemetry/api";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import { trace, metrics } from "@opentelemetry/api";
 import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
 
 useAzureMonitor();
-const instrumentations = [new ExpressInstrumentation()];
 registerInstrumentations({
   tracerProvider: trace.getTracerProvider(),
   meterProvider: metrics.getMeterProvider(),
-  instrumentations: instrumentations,
+  instrumentations: [new ExpressInstrumentation()],
 });
 ```
 
@@ -184,18 +179,22 @@ Further information on usage of the browser SDK loader can be found [here](https
 
 You might set the Cloud Role Name and the Cloud Role Instance via [OpenTelemetry Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#resource-sdk) attributes.
 
-```typescript
-import { useAzureMonitor, AzureMonitorOpenTelemetryOptions } from "@azure/monitor-opentelemetry";
+```ts snippet:ReadmeSampleSetRoleNameAndInstance
 import { Resource } from "@opentelemetry/resources";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import {
+  ATTR_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+} from "@opentelemetry/semantic-conventions";
+import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
 
 // ----------------------------------------
 // Setting role name and role instance
 // ----------------------------------------
 const customResource = Resource.EMPTY;
-customResource.attributes[SemanticResourceAttributes.SERVICE_NAME] = "my-helloworld-service";
-customResource.attributes[SemanticResourceAttributes.SERVICE_NAMESPACE] = "my-namespace";
-customResource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID] = "my-instance";
+customResource.attributes[ATTR_SERVICE_NAME] = "my-helloworld-service";
+customResource.attributes[SEMRESATTRS_SERVICE_NAMESPACE] = "my-namespace";
+customResource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID] = "my-instance";
 
 const options: AzureMonitorOpenTelemetryOptions = { resource: customResource };
 useAzureMonitor(options);
@@ -224,23 +223,24 @@ Any [attributes](#add-span-attributes) you add to spans are exported as custom p
 
 Use a custom processor:
 
-```typescript
-import { useAzureMonitor, AzureMonitorOpenTelemetryOptions } from "@azure/monitor-opentelemetry";
-import { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+```ts snippet:ReadmeSampleAddCustomProperty
+import { SpanProcessor, ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { Span } from "@opentelemetry/api";
+import { SEMATTRS_HTTP_CLIENT_IP } from "@opentelemetry/semantic-conventions";
+import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
 
 class SpanEnrichingProcessor implements SpanProcessor {
-  forceFlush(): Promise<void> {
-    return Promise.resolve();
+  async forceFlush(): Promise<void> {
+    // Flush code here
   }
-  shutdown(): Promise<void> {
-    return Promise.resolve();
+  async shutdown(): Promise<void> {
+    // shutdown code here
   }
   onStart(_span: Span): void {}
-  onEnd(span: ReadableSpan) {
+  onEnd(span: ReadableSpan): void {
     span.attributes["CustomDimension1"] = "value1";
     span.attributes["CustomDimension2"] = "value2";
-    span.attributes[SemanticAttributes.HTTP_CLIENT_IP] = "<IP Address>";
+    span.attributes[SEMATTRS_HTTP_CLIENT_IP] = "<IP Address>";
   }
 }
 
@@ -249,6 +249,7 @@ const options: AzureMonitorOpenTelemetryOptions = {
   // Add the SpanEnrichingProcessor
   spanProcessors: [new SpanEnrichingProcessor()],
 };
+
 useAzureMonitor(options);
 ```
 
@@ -256,43 +257,42 @@ useAzureMonitor(options);
 
 Use a custom span processor and log record processor in order to attach and correlate operation name from requests to dependencies and logs.
 
-```typescript
-import { useAzureMonitor, AzureMonitorOpenTelemetryOptions } from "@azure/monitor-opentelemetry";
-import { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { LogRecordProcessor } from "@opentelemetry/sdk-logs";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+```ts snippet:ReadmeSampleAddOperationName
+import { SpanProcessor, ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { Span, Context, trace } from "@opentelemetry/api";
 import { AI_OPERATION_NAME } from "@azure/monitor-opentelemetry-exporter";
-import { Context, trace } from "@opentelemetry/api";
+import { LogRecordProcessor, LogRecord } from "@opentelemetry/sdk-logs";
+import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
 
 class SpanEnrichingProcessor implements SpanProcessor {
-  forceFlush(): Promise<void> {
-    return Promise.resolve();
+  async forceFlush(): Promise<void> {
+    // Flush code here
   }
-  shutdown(): Promise<void> {
-    return Promise.resolve();
+  async shutdown(): Promise<void> {
+    // shutdown code here
   }
   onStart(_span: Span, _context: Context): void {
     const parentSpan = trace.getSpan(_context);
     if (parentSpan && "name" in parentSpan) {
       // If the parent span has a name we can assume it is a ReadableSpan and cast it.
-      _span.attributes[AI_OPERATION_NAME] = (parentSpan as unknown as ReadableSpan).name;
+      _span.setAttribute(AI_OPERATION_NAME, (parentSpan as unknown as ReadableSpan).name);
     }
   }
-  onEnd(span: ReadableSpan) {}
+  onEnd(_span: ReadableSpan): void {}
 }
 
 class LogRecordEnrichingProcessor implements LogRecordProcessor {
-  forceFlush(): Promise<void> {
-    return Promise.resolve();
+  async forceFlush(): Promise<void> {
+    // Flush code here
   }
-  shutdown(): Promise<void> {
-    return Promise.resolve();
+  async shutdown(): Promise<void> {
+    // shutdown code here
   }
-  onEmit(_logRecord, _context): void {
+  onEmit(_logRecord: LogRecord, _context: Context): void {
     const parentSpan = trace.getSpan(_context);
     if (parentSpan && "name" in parentSpan) {
       // If the parent span has a name we can assume it is a ReadableSpan and cast it.
-      _logRecord.attributes[AI_OPERATION_NAME] = (parentSpan as unknown as ReadableSpan).name;
+      _logRecord.setAttribute(AI_OPERATION_NAME, (parentSpan as unknown as ReadableSpan).name);
     }
   }
 }
@@ -303,6 +303,7 @@ const options: AzureMonitorOpenTelemetryOptions = {
   spanProcessors: [new SpanEnrichingProcessor()],
   logRecordProcessors: [new LogRecordEnrichingProcessor()],
 };
+
 useAzureMonitor(options);
 ```
 
@@ -314,14 +315,10 @@ You might use the following ways to filter out telemetry before it leaves your a
 
     The following example shows how to exclude a certain URL from being tracked by using the [HTTP/HTTPS instrumentation library](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http):
 
-    ```typescript
-    import {
-      useAzureMonitor,
-      AzureMonitorOpenTelemetryOptions,
-    } from "@azure/monitor-opentelemetry";
-    import { IncomingMessage } from "http";
-    import { RequestOptions } from "https";
+    ```ts snippet:ReadmeSampleExcludeUrl
     import { HttpInstrumentationConfig } from "@opentelemetry/instrumentation-http";
+    import { IncomingMessage, RequestOptions } from "node:http";
+    import { AzureMonitorOpenTelemetryOptions, useAzureMonitor } from "@azure/monitor-opentelemetry";
 
     const httpInstrumentationConfig: HttpInstrumentationConfig = {
       enabled: true,
@@ -340,30 +337,38 @@ You might use the following ways to filter out telemetry before it leaves your a
         return false;
       },
     };
+
     const options: AzureMonitorOpenTelemetryOptions = {
       instrumentationOptions: {
         http: httpInstrumentationConfig,
       },
     };
+
     useAzureMonitor(options);
     ```
 
 1.  Use a custom processor. You can use a custom span processor to exclude certain spans from being exported. To mark spans to not be exported, set `TraceFlag` to `DEFAULT`.
     Use the add [custom property example](#add-a-custom-property-to-a-trace), but replace the following lines of code:
 
-        ```typescript
-        ...
-        import { SpanKind, TraceFlags } from "@opentelemetry/api";
-        import { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+        ```ts snippet:ReadmeSampleCustomProcessor
+        import { SpanProcessor, ReadableSpan } from "@opentelemetry/sdk-trace-base";
+        import { Span, Context, SpanKind, TraceFlags } from "@opentelemetry/api";
 
         class SpanEnrichingProcessor implements SpanProcessor {
-            ...
-
-            onEnd(span: ReadableSpan) {
-                if(span.kind == SpanKind.INTERNAL){
-                    span.spanContext().traceFlags = TraceFlags.NONE;
-                }
+          async forceFlush(): Promise<void> {
+            // Force flush code here
+          }
+          onStart(_span: Span, _parentContext: Context): void {
+            // Normal code here
+          }
+          async shutdown(): Promise<void> {
+            // Shutdown code here
+          }
+          onEnd(span: ReadableSpan): void {
+            if (span.kind === SpanKind.INTERNAL) {
+              span.spanContext().traceFlags = TraceFlags.NONE;
             }
+          }
         }
         ```
 
@@ -393,18 +398,18 @@ The following table shows the recommended aggregation types] for each of the Ope
 The [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument)
 describes the instruments and provides examples of when you might use each one.
 
-```typescript
+```ts snippet:ReadmeSampleCustomMetrics
 import { useAzureMonitor } from "@azure/monitor-opentelemetry";
-import { ObservableResult, metrics } from "@opentelemetry/api";
+import { metrics, ObservableResult } from "@opentelemetry/api";
 
 useAzureMonitor();
 const meter = metrics.getMeter("testMeter");
 
-let histogram = meter.createHistogram("histogram");
-let counter = meter.createCounter("counter");
-let gauge = meter.createObservableGauge("gauge");
+const histogram = meter.createHistogram("histogram");
+const counter = meter.createCounter("counter");
+const gauge = meter.createObservableGauge("gauge");
 gauge.addCallback((observableResult: ObservableResult) => {
-  let randomNumber = Math.floor(Math.random() * 100);
+  const randomNumber = Math.floor(Math.random() * 100);
   observableResult.observe(randomNumber, { testKey: "testValue" });
 });
 
@@ -424,14 +429,14 @@ However, you may want to manually report exceptions beyond what instrumention li
 For instance, exceptions caught by your code are _not_ ordinarily not reported, and you may wish to report them
 and thus draw attention to them in relevant experiences including the failures blade and end-to-end transaction view.
 
-```typescript
+```ts snippet:ReadmeSampleCustomExceptions
 import { useAzureMonitor } from "@azure/monitor-opentelemetry";
 import { trace, Exception } from "@opentelemetry/api";
 
 useAzureMonitor();
 const tracer = trace.getTracer("testMeter");
 
-let span = tracer.startSpan("hello");
+const span = tracer.startSpan("hello");
 try {
   throw new Error("Test Error");
 } catch (error) {
@@ -445,13 +450,12 @@ try {
 
 Azure Monitor OpenTelemetry uses the OpenTelemetry API Logger for internal logs. To enable it, use the following code:
 
-```typescript
+```ts snippet:ReadmeSampleSelfDiagnostics
 import { useAzureMonitor } from "@azure/monitor-opentelemetry";
-import { DiagLogLevel } from "@opentelemetry/api";
 
-process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "VERBOSE";
-process.env.APPLICATIONINSIGHTS_LOG_DESTINATION = "file";
-process.env.APPLICATIONINSIGHTS_LOGDIR = "C:/applicationinsights/logs";
+process.env["APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL"] = "VERBOSE";
+process.env["APPLICATIONINSIGHTS_LOG_DESTINATION"] = "file";
+process.env["APPLICATIONINSIGHTS_LOGDIR"] = "path/to/logs";
 
 useAzureMonitor();
 ```

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -33,7 +33,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "dev-tool run test:node-tsx-ts --no-test-proxy -- --timeout 1200000 \"test/internal/unit/**/*.test.ts\"",
-    "update-snippets": "echo skipped"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/sdk/monitor/monitor-opentelemetry/test/snippets.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/snippets.spec.ts
@@ -1,0 +1,266 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Resource } from "@opentelemetry/resources";
+import { useAzureMonitor, AzureMonitorOpenTelemetryOptions } from "../src";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import {
+  Context,
+  Exception,
+  metrics,
+  ObservableResult,
+  Span,
+  SpanKind,
+  trace,
+  TraceFlags,
+} from "@opentelemetry/api";
+// @ts-ignore
+import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
+import {
+  ATTR_SERVICE_NAME,
+  SEMATTRS_HTTP_CLIENT_IP,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+} from "@opentelemetry/semantic-conventions";
+import { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { LogRecord, LogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { AI_OPERATION_NAME } from "@azure/monitor-opentelemetry-exporter";
+import { HttpInstrumentationConfig } from "@opentelemetry/instrumentation-http";
+import { IncomingMessage, RequestOptions } from "node:http";
+
+describe("snippets", () => {
+  it("ReadmeSampleUseAzureMonitor", () => {
+    const options: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString:
+          process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"] || "<your connection string>",
+      },
+    };
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleConfiguration", () => {
+    const resource = new Resource({ testAttribute: "testValue" });
+    const options: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        // Offline storage
+        storageDirectory: "c://azureMonitor",
+        // Automatic retries
+        disableOfflineStorage: false,
+        // Application Insights Connection String
+        connectionString:
+          process.env["APPLICATIONINSIGHTS_CONNECTION_STRING"] || "<your connection string>",
+      },
+      samplingRatio: 1,
+      instrumentationOptions: {
+        // Instrumentations generating traces
+        azureSdk: { enabled: true },
+        http: { enabled: true },
+        mongoDb: { enabled: true },
+        mySql: { enabled: true },
+        postgreSql: { enabled: true },
+        redis: { enabled: true },
+        redis4: { enabled: true },
+        // Instrumentations generating logs
+        bunyan: { enabled: true },
+        winston: { enabled: true },
+      },
+      enableLiveMetrics: true,
+      enableStandardMetrics: true,
+      browserSdkLoaderOptions: {
+        enabled: false,
+        connectionString: "",
+      },
+      resource: resource,
+      logRecordProcessors: [],
+      spanProcessors: [],
+    };
+
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleCustomConfig", () => {
+    process.env["APPLICATIONINSIGHTS_CONFIGURATION_FILE"] = "path/to/customConfig.json";
+    // @ts-preserve-whitespace
+    // Application Insights SDK setup....
+  });
+
+  it("ReadmeSampleCustomInstrumentation", () => {
+    useAzureMonitor();
+    registerInstrumentations({
+      tracerProvider: trace.getTracerProvider(),
+      meterProvider: metrics.getMeterProvider(),
+      instrumentations: [new ExpressInstrumentation()],
+    });
+  });
+
+  it("ReadmeSampleSetRoleNameAndInstance", () => {
+    // ----------------------------------------
+    // Setting role name and role instance
+    // ----------------------------------------
+    const customResource = Resource.EMPTY;
+    customResource.attributes[ATTR_SERVICE_NAME] = "my-helloworld-service";
+    customResource.attributes[SEMRESATTRS_SERVICE_NAMESPACE] = "my-namespace";
+    customResource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID] = "my-instance";
+    // @ts-preserve-whitespace
+    const options: AzureMonitorOpenTelemetryOptions = { resource: customResource };
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleAddCustomProperty", () => {
+    class SpanEnrichingProcessor implements SpanProcessor {
+      async forceFlush(): Promise<void> {
+        // Flush code here
+      }
+      async shutdown(): Promise<void> {
+        // shutdown code here
+      }
+      onStart(_span: Span): void {}
+      onEnd(span: ReadableSpan): void {
+        span.attributes["CustomDimension1"] = "value1";
+        span.attributes["CustomDimension2"] = "value2";
+        span.attributes[SEMATTRS_HTTP_CLIENT_IP] = "<IP Address>";
+      }
+    }
+    // @ts-preserve-whitespace
+    // Enable Azure Monitor integration.
+    const options: AzureMonitorOpenTelemetryOptions = {
+      // Add the SpanEnrichingProcessor
+      spanProcessors: [new SpanEnrichingProcessor()],
+    };
+    // @ts-preserve-whitespace
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleAddOperationName", () => {
+    class SpanEnrichingProcessor implements SpanProcessor {
+      async forceFlush(): Promise<void> {
+        // Flush code here
+      }
+      async shutdown(): Promise<void> {
+        // shutdown code here
+      }
+      onStart(_span: Span, _context: Context): void {
+        const parentSpan = trace.getSpan(_context);
+        if (parentSpan && "name" in parentSpan) {
+          // If the parent span has a name we can assume it is a ReadableSpan and cast it.
+          _span.setAttribute(AI_OPERATION_NAME, (parentSpan as unknown as ReadableSpan).name);
+        }
+      }
+      onEnd(_span: ReadableSpan): void {}
+    }
+    // @ts-preserve-whitespace
+    class LogRecordEnrichingProcessor implements LogRecordProcessor {
+      async forceFlush(): Promise<void> {
+        // Flush code here
+      }
+      async shutdown(): Promise<void> {
+        // shutdown code here
+      }
+      onEmit(_logRecord: LogRecord, _context: Context): void {
+        const parentSpan = trace.getSpan(_context);
+        if (parentSpan && "name" in parentSpan) {
+          // If the parent span has a name we can assume it is a ReadableSpan and cast it.
+          _logRecord.setAttribute(AI_OPERATION_NAME, (parentSpan as unknown as ReadableSpan).name);
+        }
+      }
+    }
+    // @ts-preserve-whitespace
+    // Enable Azure Monitor integration.
+    const options: AzureMonitorOpenTelemetryOptions = {
+      // Add the SpanEnrichingProcessor
+      spanProcessors: [new SpanEnrichingProcessor()],
+      logRecordProcessors: [new LogRecordEnrichingProcessor()],
+    };
+    // @ts-preserve-whitespace
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleExcludeUrl", () => {
+    const httpInstrumentationConfig: HttpInstrumentationConfig = {
+      enabled: true,
+      ignoreIncomingRequestHook: (request: IncomingMessage) => {
+        // Ignore OPTIONS incoming requests
+        if (request.method === "OPTIONS") {
+          return true;
+        }
+        return false;
+      },
+      ignoreOutgoingRequestHook: (options: RequestOptions) => {
+        // Ignore outgoing requests with /test path
+        if (options.path === "/test") {
+          return true;
+        }
+        return false;
+      },
+    };
+    // @ts-preserve-whitespace
+    const options: AzureMonitorOpenTelemetryOptions = {
+      instrumentationOptions: {
+        http: httpInstrumentationConfig,
+      },
+    };
+    // @ts-preserve-whitespace
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleCustomProcessor", () => {
+    class SpanEnrichingProcessor implements SpanProcessor {
+      async forceFlush(): Promise<void> {
+        // Force flush code here
+      }
+      onStart(_span: Span, _parentContext: Context): void {
+        // Normal code here
+      }
+      async shutdown(): Promise<void> {
+        // Shutdown code here
+      }
+      onEnd(span: ReadableSpan): void {
+        if (span.kind === SpanKind.INTERNAL) {
+          span.spanContext().traceFlags = TraceFlags.NONE;
+        }
+      }
+    }
+  });
+
+  it("ReadmeSampleCustomMetrics", () => {
+    useAzureMonitor();
+    const meter = metrics.getMeter("testMeter");
+    // @ts-preserve-whitespace
+    const histogram = meter.createHistogram("histogram");
+    const counter = meter.createCounter("counter");
+    const gauge = meter.createObservableGauge("gauge");
+    gauge.addCallback((observableResult: ObservableResult) => {
+      const randomNumber = Math.floor(Math.random() * 100);
+      observableResult.observe(randomNumber, { testKey: "testValue" });
+    });
+    // @ts-preserve-whitespace
+    histogram.record(1, { testKey: "testValue" });
+    histogram.record(30, { testKey: "testValue2" });
+    histogram.record(100, { testKey2: "testValue" });
+    // @ts-preserve-whitespace
+    counter.add(1, { testKey: "testValue" });
+    counter.add(5, { testKey2: "testValue" });
+    counter.add(3, { testKey: "testValue2" });
+  });
+
+  it("ReadmeSampleCustomExceptions", () => {
+    useAzureMonitor();
+    const tracer = trace.getTracer("testMeter");
+    // @ts-preserve-whitespace
+    const span = tracer.startSpan("hello");
+    try {
+      throw new Error("Test Error");
+    } catch (error) {
+      span.recordException(error as Exception);
+    }
+  });
+
+  it("ReadmeSampleSelfDiagnostics", () => {
+    process.env["APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL"] = "VERBOSE";
+    process.env["APPLICATIONINSIGHTS_LOG_DESTINATION"] = "file";
+    process.env["APPLICATIONINSIGHTS_LOGDIR"] = "path/to/logs";
+    // @ts-preserve-whitespace
+    useAzureMonitor();
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/monitor-opentelemetry

### Issues associated with this PR

- #32416

### Describe the problem that is addressed by this PR

Uses snippets extraction for old mocha/karma for snippets versus the modern system.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
