### PR TITLE
[core-client] Check response body for error details even without default body mapper

### DIFF
--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -268,9 +268,10 @@ function handleErrorResponse(
     throw error;
   }
 
+  const defaultBodyMapper = errorResponseSpec?.bodyMapper;
+  const defaultHeadersMapper = errorResponseSpec?.headersMapper;
+
   try {
-    const defaultBodyMapper = errorResponseSpec?.bodyMapper;
-    const defaultHeadersMapper = errorResponseSpec?.headersMapper;
     // If error response has a body, try to deserialize it using default body mapper.
     // Then try to extract error code & message from it
     if (parsedResponse.parsedBody) {

--- a/sdk/core/core-client/src/deserializationPolicy.ts
+++ b/sdk/core/core-client/src/deserializationPolicy.ts
@@ -259,15 +259,18 @@ function handleErrorResponse(
   });
 
   // If the item failed but there's no error spec or default spec to deserialize the error,
+  // and the parsed body doesn't look like an error object,
   // we should fail so we just throw the parsed response
-  if (!errorResponseSpec) {
+  if (
+    !errorResponseSpec &&
+    !(parsedResponse.parsedBody?.error?.code && parsedResponse.parsedBody?.error?.message)
+  ) {
     throw error;
   }
 
-  const defaultBodyMapper = errorResponseSpec.bodyMapper;
-  const defaultHeadersMapper = errorResponseSpec.headersMapper;
-
   try {
+    const defaultBodyMapper = errorResponseSpec?.bodyMapper;
+    const defaultHeadersMapper = errorResponseSpec?.headersMapper;
     // If error response has a body, try to deserialize it using default body mapper.
     // Then try to extract error code & message from it
     if (parsedResponse.parsedBody) {


### PR DESCRIPTION
Currently, when we receive an error response and there is no default body mapper, we immediately throw a
RestError without further inspecting the response body. It's ideal for operation specifications to define a
default mapper for unexpected responses. However, some services did not implement this leading to issues like
https://github.com/Azure/azure-sdk-for-js/issues/33035 where the error message contains a JSON string of the
error object, and the error code is undefined.

This PR modifies the behavior to look into parsedBody if it has an 'error' property that contains both
'code' and 'message' properties, improving the developer experience in this scenario.