### PR TITLE
[eslint-plugin] remove deprecated dev dependency @types/eslint__js

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -109,7 +109,6 @@
   },
   "devDependencies": {
     "@types/eslint": "^9.6.0",
-    "@types/eslint__js": "8.42.3",
     "@types/eslint-config-prettier": "6.11.3",
     "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "~8.24.1",


### PR DESCRIPTION
Version v9+ of @eslint/js provides its own type definitions, so we do not need
this installed any more.

-------

### Packages impacted by this PR
eslint-plugin-azure-sdk

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/issues/33171