### PR TITLE
[identity] Fix error message for AZD

### DIFF
--- a/sdk/identity/identity/src/credentials/azureDeveloperCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureDeveloperCliCredential.ts
@@ -29,7 +29,7 @@ export const developerCliCredentialInternals = {
       let systemRoot = process.env.SystemRoot || process.env["SYSTEMROOT"];
       if (!systemRoot) {
         logger.getToken.warning(
-          "The SystemRoot environment variable is not set. This may cause issues when using the Azure CLI credential.",
+          "The SystemRoot environment variable is not set. This may cause issues when using the Azure Developer CLI credential.",
         );
 
         systemRoot = "C:\\Windows";


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/identity

### Issues associated with this PR

- #33176


### Describe the problem that is addressed by this PR

Fixes the error message for AZD to `"The SystemRoot environment variable is not set. This may cause issues when using the Azure Developer CLI credential.",` where previously it omitted the word Developer.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
