### PR TITLE
[Monitor OpenTelemetry Exporter] Don't Apply Cloud Tags to Statsbeat Telemetry

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Other Changes
 
 - Removed faulty span exception exporting logic.
+- Remove applying cloud.* tags to statsbeat telemetry.
 
 ## 1.0.0-beta.28 (2025-01-28)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
@@ -15,7 +15,7 @@ import type {
   MetricDataPoint,
 } from "../generated/index.js";
 import { createTagsFromResource } from "./common.js";
-import { BreezePerformanceCounterNames, OTelPerformanceCounterNames } from "../types.js";
+import { BreezePerformanceCounterNames, OTelPerformanceCounterNames, Tags } from "../types.js";
 import {
   ENV_OTEL_METRICS_EXPORTER,
   ENV_OTLP_METRICS_ENDPOINT,
@@ -56,13 +56,14 @@ export function resourceMetricsToEnvelope(
   const envelopes: Envelope[] = [];
   const time = new Date();
   const instrumentationKey = ikey;
-  const tags = createTagsFromResource(metrics.resource);
+  let tags: Tags;
   let envelopeName: string;
 
   if (isStatsbeat) {
     envelopeName = "Microsoft.ApplicationInsights.Statsbeat";
   } else {
     envelopeName = "Microsoft.ApplicationInsights.Metric";
+    tags = createTagsFromResource(metrics.resource);
   }
 
   metrics.scopeMetrics.forEach((scopeMetric) => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.spec.ts
@@ -28,6 +28,7 @@ import { BreezePerformanceCounterNames, OTelPerformanceCounterNames } from "../.
 import { Context, getInstance } from "../../src/platform/index.js";
 import { describe, it, assert } from "vitest";
 import { ENV_APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED } from "../../src/Declarations/Constants.js";
+import { StatsbeatCounter } from "../../src/export/statsbeat/types.js";
 
 const context = getInstance();
 const packageJsonPath = path.resolve(__dirname, "../../", "./package.json");
@@ -86,6 +87,22 @@ function assertEnvelope(
   if (expectedProperties) {
     assert.deepStrictEqual(envelope.data?.baseData?.properties, expectedProperties);
   }
+}
+
+function assertStatsbeatEnvelope(
+  envelope: Envelope,
+  name: string,
+  sampleRate: number,
+  baseType: string,
+): void {
+  assert.ok(envelope);
+  assert.strictEqual(envelope.name, name);
+  assert.strictEqual(envelope.sampleRate, sampleRate);
+  assert.deepStrictEqual(envelope.data?.baseType, baseType);
+
+  assert.strictEqual(envelope.instrumentationKey, "ikey");
+
+  assert.deepStrictEqual(envelope.tags, undefined);
 }
 
 describe("metricUtil.ts", () => {
@@ -532,6 +549,34 @@ describe("metricUtil.ts", () => {
         expectedProperties,
       );
       process.env = originalEnv;
+    });
+    it("should add not attach tags to statsbeat telemetry", async () => {
+      const provider = new MeterProvider({
+        resource: new Resource({
+          [SemanticResourceAttributes.SERVICE_NAME]: "basic-service",
+        }),
+      });
+      const exporter = new TestExporter({
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      });
+      const metricReaderOptions: PeriodicExportingMetricReaderOptions = {
+        exporter: exporter,
+      };
+      const metricReader = new PeriodicExportingMetricReader(metricReaderOptions);
+      provider.addMetricReader(metricReader);
+      const meter = provider.getMeter("example-meter-node");
+      // Create Counter instrument with the meter
+      const counter = meter.createCounter(StatsbeatCounter.SUCCESS_COUNT);
+      counter.add(1);
+      provider.forceFlush();
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      const envelope = resourceMetricsToEnvelope(testMetrics, "ikey", true);
+      assertStatsbeatEnvelope(
+        envelope[0],
+        "Microsoft.ApplicationInsights.Statsbeat",
+        100,
+        "MetricData",
+      );
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
We shouldn't apply the cloud tags to our statsbeat telemetry as it isn't needed.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
