### PR TITLE
[core-amqp] Mark more network errors as retryable

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Designates `EAI_AGAIN` and `EADDRNOTAVAIL` errors as timeout errors to be retryable.
+
 ### Other Changes
 
 ## 4.3.5 (2025-02-06)

--- a/sdk/core/core-amqp/review/core-amqp.api.md
+++ b/sdk/core/core-amqp/review/core-amqp.api.md
@@ -573,6 +573,10 @@ export const StandardAbortMessage = "The operation was aborted.";
 // @public
 export enum SystemErrorConditionMapper {
     // (undocumented)
+    EADDRNOTAVAIL = "com.microsoft:timeout",
+    // (undocumented)
+    EAI_AGAIN = "com.microsoft:timeout",
+    // (undocumented)
     EBUSY = "com.microsoft:server-busy",
     // (undocumented)
     ECONNREFUSED = "amqp:connection:forced",

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -595,6 +595,8 @@ export enum SystemErrorConditionMapper {
   ENETRESET = "com.microsoft:timeout",
   ENETUNREACH = "com.microsoft:timeout",
   ENONET = "com.microsoft:timeout",
+  EADDRNOTAVAIL = "com.microsoft:timeout",
+  EAI_AGAIN = "com.microsoft:timeout",
   /* eslint-enable @typescript-eslint/no-duplicate-enum-values */
 }
 

--- a/sdk/core/core-amqp/test/errors.spec.ts
+++ b/sdk/core/core-amqp/test/errors.spec.ts
@@ -185,6 +185,18 @@ describe("Errors", function () {
         message: "code: ENOTFOUND, errno: ENOTFOUND, syscall: read",
       },
       {
+        code: "EADDRNOTAVAIL",
+        errno: "EADDRNOTAVAIL",
+        syscall: "read",
+        message: "code: EADDRNOTAVAIL, errno: EADDRNOTAVAIL, syscall: read",
+      },
+      {
+        code: "EAI_AGAIN",
+        errno: "EAI_AGAIN",
+        syscall: "read",
+        message: "code: EAI_AGAIN, errno: EAI_AGAIN, syscall: read",
+      },
+      {
         code: "ESOMETHINGRANDOM",
         errno: "ESOMETHINGRANDOM",
         syscall: "read",
@@ -197,7 +209,11 @@ describe("Errors", function () {
           const translatedError = Errors.translate(mapping as any) as Errors.MessagingError;
           assert.equal(translatedError.name, "MessagingError");
           assert.equal(translatedError.code, mapping.code);
-          if (["ECONNRESET", "ECONNREFUSED", "EBUSY"].indexOf(mapping.code) !== -1) {
+          if (
+            ["ECONNRESET", "ECONNREFUSED", "EBUSY", "EAI_AGAIN", "EADDRNOTAVAIL"].indexOf(
+              mapping.code,
+            ) !== -1
+          ) {
             assert.isTrue(translatedError.retryable);
           } else {
             assert.isFalse(translatedError.retryable);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-amqp

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/33205

### Describe the problem that is addressed by this PR
Some network errors are not being retried.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
It makes sense to retry network errors.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
