### PR TITLE
[playwrighttesting] Migrate playwrighttesting projects to use snippet extraction

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/package.json
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/package.json
@@ -65,7 +65,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "dev-tool run test:node-ts-input --no-test-proxy -- --timeout 12000 'test/**/*.spec.ts' --exit",
-    "update-snippets": "echo skipped"
+    "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
     "@azure/core-rest-pipeline": "^1.16.3",

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/snippets.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/snippets.spec.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+describe("snippets", () => {});

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/clInfoProvider.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/clInfoProvider.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { expect } from "@azure-tools/test-utils";
 import { CIInfoProvider, CI_PROVIDERS } from "../../src/utils/cIInfoProvider";
 import sinon from "sinon";

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/packageManager.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/packageManager.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { expect } from "@azure-tools/test-utils";
 import sinon from "sinon";
 import { getPackageManager } from "../../src/utils/packageManager";

--- a/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/reporterUtils.spec.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/test/utils/reporterUtils.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { expect } from "@azure-tools/test-utils";
 import ReporterUtils from "../../src/utils/reporterUtils";
 import { TestResult as MPTTestResult } from "../../src/model/testResult";


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/microsoft-playwright-testing

### Issues associated with this PR

- https://github.com/Azure/azure-sdk-for-js/issues/32416

### Describe the problem that is addressed by this PR

Updates all projects under `playwrighttesting` to use snippets extraction.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
