### PR TITLE
[doc] fix broken link to purview catalog

### DIFF
--- a/documentation/Quickstart-on-how-to-write-tests.md
+++ b/documentation/Quickstart-on-how-to-write-tests.md
@@ -52,7 +52,7 @@ To be able to leverage the asset-sync workflow
 
 # How to run test
 
-This section describes how to run the SDK tests. If you want to run the tests of a specific project, go to that project's folder and execute `rushx test`. All of the tests will automatically run both in NodeJS and in the browser. To target these environments individually, you can run `rushx test:node` and `rushx test:browser`. Let's take `purview-catalog-rest` as an example.
+This section describes how to run the SDK tests. If you want to run the tests of a specific project, go to that project's folder and execute `rushx test`. All of the tests will automatically run both in NodeJS and in the browser. To target these environments individually, you can run `rushx test:node` and `rushx test:browser`. Let's take `purview-scanning-rest` as an example.
 
 If you have no concepts of `recording`, `playback` or [TEST_MODE](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/README.md#test_mode) we'll highly recommand you to read this [doc](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/README.md#key-concepts). We'll touch upon these concepts in below content.
 
@@ -71,7 +71,7 @@ _Note: the structure of the `test` folder has slight differences between high-le
 ```
 sdk/
 ├─ purview/
-│  ├─ purview-catalog-rest/
+│  ├─ purview-scanning-rest/
 │  │  ├─ src/
 │  │  │  ├─ ...
 │  │  ├─ recordings/
@@ -90,14 +90,14 @@ Before running tests, it's advised to update the dependencises and build our pro
 
 ```Shell
 > rush update
-> rush build -t @azure-rest/purview-catalog
+> rush build -t @azure-rest/purview-scanning
 ```
 
 Then, we could go to the project folder to run the tests. By default, if you don't specify `TEST_MODE`, it will run previously recorded tests.
 
 ```Shell
-> cd sdk/purview/purview-catalog-rest
-sdk/purview/purview-catalog-rest> rushx test
+> cd sdk/purview/purview-scanning-rest
+sdk/purview/purview-scanning-rest> rushx test
 ```
 
 If you are the first time to run tests you may fail with below message because there is no any recordings found.
@@ -124,7 +124,7 @@ To record or update our recordings, we need to set the environment variable `TES
 > rushx test
 ```
 
-This time we could get following similar logs. Go to the folder `purview-catalog-rest/recordings` to view recording files.
+This time we could get following similar logs. Go to the folder `purview-scanning-rest/recordings` to view recording files.
 
 ```
 [test-info] ===TEST_MODE="record"===
@@ -302,7 +302,7 @@ API key authentication would hit the service's endpoint directly so these traffi
 
 At the code structure [section](#code-structure), we described we'll generate sample file for you. If you are the first time to write test cases, you could grow up your own based on them.
 
-This simple test creates a resource and checks that the service handles it correctly in the project `purview-catalog-rest`. Below are the steps:
+This simple test creates a resource and checks that the service handles it correctly in the project `purview-scanning-rest`. Below are the steps:
 
 - Step 1: Create your test file and add one test case with resource creation, here we have purview catalog glossary test file `glossary.spec.ts` and one case named `Should create a glossary`. Or rename the `sampleTest.spec.ts` file and its case `sample test`.
 - Step 2: Add the utility method `createClient` in `public/utils/recordedClient.ts` to share the `PurviewCatalogClient` creation.

--- a/sdk/purview/purview-administration-rest/README.md
+++ b/sdk/purview/purview-administration-rest/README.md
@@ -161,7 +161,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 
 [account_product_documentation]: https://azure.microsoft.com/services/purview/
 [rest_client]: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/rest-clients.md
-[source_code]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-catalog-rest
+[source_code]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/purview/purview-administration-rest
 [account_npm]: https://www.npmjs.com/org/azure-rest
 [account_ref_docs]: https://azure.github.io/azure-sdk-for-js
 [azure_subscription]: https://azure.microsoft.com/free/


### PR DESCRIPTION
This PR replaces references to purview-catalog with ones to purview-scanning
because the former has been deprecated and removed.