### PR TITLE
[dev-tool] Work around two minor issues

### DIFF
--- a/common/tools/dev-tool/jsconfig.json
+++ b/common/tools/dev-tool/jsconfig.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["node_modules/**"]
+}

--- a/common/tools/dev-tool/register.js
+++ b/common/tools/dev-tool/register.js
@@ -26,9 +26,12 @@ const { name: hostPackageName } = main.require("./package.json");
 // If we're bootstrapping a dev-tool command, we need to patch the package from
 // CWD instead.  This will still end up being dev-tool if we end up in a
 // self-hosting situation where dev-tool calls itself from its own scripts.
+const packageJsonPath = path.join(cwd, "package.json");
 const packageNameToPatch =
   hostPackageName === "@azure/dev-tool"
-    ? require(path.join(cwd, "package.json")).name
+    ? (existsSync(packageJsonPath) 
+       ? require(packageJsonPath).name 
+       : hostPackageName)
     : hostPackageName;
 
 if (process.env.DEBUG) {

--- a/common/tools/dev-tool/register.js
+++ b/common/tools/dev-tool/register.js
@@ -29,9 +29,9 @@ const { name: hostPackageName } = main.require("./package.json");
 const packageJsonPath = path.join(cwd, "package.json");
 const packageNameToPatch =
   hostPackageName === "@azure/dev-tool"
-    ? (existsSync(packageJsonPath) 
-       ? require(packageJsonPath).name 
-       : hostPackageName)
+    ? existsSync(packageJsonPath)
+      ? require(packageJsonPath).name
+      : hostPackageName
     : hostPackageName;
 
 if (process.env.DEBUG) {


### PR DESCRIPTION
### Packages impacted by this PR

`dev-tool`

### Describe the problem that is addressed by this PR

One issue is VS Code using up a ton of memory and the TS language service crashing when viewing a `.js` file. This was fixed by adding a `jsconfig.json` file. I figured this out from this comment: https://github.com/microsoft/vscode/issues/235547#issuecomment-2547765610

The other issue is I wanted to be able to run dev-tool from outside of a project folder when using admin commands (like listing all projects, checking migration progress, etc) but `register.js` always tries to load a local `package.json` and throws if you are in a folder without one so I put a simple check to see if the file exists.