### PR TITLE
[Monitor OpenTelemetry] Update AKS Detection

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for stable OpenTelemetry semantic conventions.
 
+### Other Changes
+
+- Added support for detecting AKS when `KUBERNETES_SERVICE_HOST` is set.
+
 ## 1.8.1 (2025-01-28)
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
@@ -66,7 +66,7 @@ export const isFunctionApp = (): boolean => {
 };
 
 export const isAks = (): boolean => {
-  return process.env.AKS_ARM_NAMESPACE_ID ? true : false;
+  return process.env.AKS_ARM_NAMESPACE_ID || process.env.KUBERNETES_SERVICE_HOST ? true : false;
 };
 
 /**

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -282,6 +282,20 @@ describe("Main functions", () => {
     assert.strictEqual(process.env["AZURE_MONITOR_PREFIX"], `k${os}m_`);
   });
 
+  it("should capture the AKS SDK prefix correctly", () => {
+    const os = getOsPrefix();
+    const env = <{ [id: string]: string }>{};
+    env.KUBERNETES_SERVICE_HOST = "test-AKS";
+    process.env = env;
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+    };
+    useAzureMonitor(config);
+    assert.strictEqual(process.env["AZURE_MONITOR_PREFIX"], `k${os}m_`);
+  });
+
   it("should prioritize resource detectors in env var OTEL_NODE_RESOURCE_DETECTORS", () => {
     const expectedResourceAttributeNamespaces = new Set(["os", "service", "telemetry"]);
     const env = <{ [id: string]: string }>{};


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
The original env var being used will only detect AKS environments when auto-attach occurs. The new env var being checked will add support for when manual attach is used.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
