### PR TITLE
[App Config] Support For AAD Token Audience

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Features Added
 
-- Add `audience` in `AppConfigurationClientOptions` and `KnownAppConfigurationAudience` to support specifying the token credential's Microsoft Entra audience when creating a client. When unspecified, the SDK will check the resource endpoint to determine the correct audience.
+- Add `audience` in `AppConfigurationClientOptions` and `KnownAppConfigurationAudience` to support specifying the token credential's Microsoft Entra audience when creating a client. When unspecified, the SDK will default to Azure Public Cloud.
 
 ### Breaking Changes
 

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Features Added
 
-- Add `audience` in `AppConfigurationClientOptions` and `KnownAppConfigurationAudience` to support specifying the token credential's Microsoft Entra audience when creating a client. When unspecified, the SDK will default to Azure Public Cloud.
+- Add the `audience` param to `AppConfigurationClientOptions` and `KnownAppConfigurationAudience` to allow specifying the Microsoft Entra audience for the token credential when creating a client. If not specified, the SDK will default to Azure Public Cloud.
 
 ### Breaking Changes
 

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features Added
 
+- Add `audience` in `AppConfigurationClientOptions` and `KnownAppConfigurationAudience` to support specifying the token credential's Microsoft Entra audience when creating a client. When unspecified, the SDK will check the resource endpoint to determine the correct audience.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Release History
 
-## 1.8.1 (Unreleased)
+## 1.9.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -93,7 +93,7 @@ const client = new AppConfigurationClient(
 );
 ```
 
-Note: When `audience` property is not defined, the SDK will check the resource endpoint to determine the correct audience.
+Note: When `audience` property is not defined, the SDK will default to Azure Public Cloud.
 
 #### Authenticating with a connection string
 

--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -75,22 +75,25 @@ More information about `@azure/identity` can be found [here](https://github.com/
 
 #### Sovereign Clouds
 
-To authenticate with a resource in a [Sovereign Cloud](https://learn.microsoft.com/azure/active-directory/develop/authentication-national-cloud), you will need to set the `authorityHost` in the credential options or via the `AZURE_AUTHORITY_HOST` environment variable.
+To authenticate with a resource in a [Sovereign Cloud](https://learn.microsoft.com/azure/active-directory/develop/authentication-national-cloud), you will need to set the `audience` in the `AppConfigurationClient` constructor options.
 
 ```ts snippet:AuthenticatingWithAzureSovereignCloud
 import { AppConfigurationClient } from "@azure/app-configuration";
-import { DefaultAzureCredential, AzureAuthorityHosts } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 // The endpoint for your App Configuration resource
 const endpoint = "https://example.azconfig.azure.cn";
 // Create an AppConfigurationClient that will authenticate through AAD in the China cloud
 const client = new AppConfigurationClient(
   endpoint,
-  new DefaultAzureCredential({ authorityHost: AzureAuthorityHosts.AzureChina }),
+  new DefaultAzureCredential(),
+  {
+    audience: KnownAppConfigurationAudience.AzureChina
+  }
 );
 ```
 
-More information about `@azure/identity` can be found [here](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/README.md)
+Note: When `audience` property is not defined, the SDK will check the resource endpoint to determine the correct audience.
 
 #### Authenticating with a connection string
 

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "sdk-type": "client",
   "keywords": [
     "node",

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -48,6 +48,7 @@ export class AppConfigurationClient {
 // @public
 export interface AppConfigurationClientOptions extends CommonClientOptions {
     apiVersion?: string;
+    audience?: string;
 }
 
 // @public
@@ -196,6 +197,13 @@ export function isFeatureFlag(setting: ConfigurationSetting): setting is Configu
 
 // @public
 export function isSecretReference(setting: ConfigurationSetting): setting is ConfigurationSetting & Required<Pick<ConfigurationSetting, "value">>;
+
+// @public
+export enum KnownAppConfigurationAudience {
+    AzureChina = "https://appconfig.azure.cn",
+    AzureGovernment = "https://appconfig.azure.us",
+    AzurePublicCloud = "https://appconfig.azure.com"
+}
 
 // @public
 export enum KnownConfigurationSnapshotStatus {

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -199,7 +199,7 @@ export function isFeatureFlag(setting: ConfigurationSetting): setting is Configu
 export function isSecretReference(setting: ConfigurationSetting): setting is ConfigurationSetting & Required<Pick<ConfigurationSetting, "value">>;
 
 // @public
-export enum KnownAppConfigurationAudience {
+export enum KnownAppConfigAudience {
     AzureChina = "https://appconfig.azure.cn",
     AzureGovernment = "https://appconfig.azure.us",
     AzurePublicCloud = "https://appconfig.azure.com"

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -4,41 +4,42 @@
 // https://azure.github.io/azure-sdk/typescript_design.html#ts-config-lib
 /// <reference lib="esnext.asynciterable" />
 
-import type {
-  AddConfigurationSettingOptions,
-  AddConfigurationSettingParam,
-  AddConfigurationSettingResponse,
-  AppConfigurationClientOptions,
-  ConfigurationSetting,
-  ConfigurationSettingId,
-  CreateSnapshotOptions,
-  CreateSnapshotResponse,
-  DeleteConfigurationSettingOptions,
-  DeleteConfigurationSettingResponse,
-  GetConfigurationSettingOptions,
-  GetConfigurationSettingResponse,
-  GetSnapshotOptions,
-  GetSnapshotResponse,
-  HttpResponseField,
-  ListConfigurationSettingPage,
-  ListConfigurationSettingsForSnapshotOptions,
-  ListConfigurationSettingsOptions,
-  ListLabelsOptions,
-  ListLabelsPage,
-  ListRevisionsOptions,
-  ListRevisionsPage,
-  ListSnapshotsOptions,
-  ListSnapshotsPage,
-  PageSettings,
-  SetConfigurationSettingOptions,
-  SetConfigurationSettingParam,
-  SetConfigurationSettingResponse,
-  SetReadOnlyOptions,
-  SetReadOnlyResponse,
-  SettingLabel,
-  SnapshotInfo,
-  UpdateSnapshotOptions,
-  UpdateSnapshotResponse,
+import {
+  KnownAppConfigurationAudience as KnownAppConfigAudience,
+  type AddConfigurationSettingOptions,
+  type AddConfigurationSettingParam,
+  type AddConfigurationSettingResponse,
+  type AppConfigurationClientOptions,
+  type ConfigurationSetting,
+  type ConfigurationSettingId,
+  type CreateSnapshotOptions,
+  type CreateSnapshotResponse,
+  type DeleteConfigurationSettingOptions,
+  type DeleteConfigurationSettingResponse,
+  type GetConfigurationSettingOptions,
+  type GetConfigurationSettingResponse,
+  type GetSnapshotOptions,
+  type GetSnapshotResponse,
+  type HttpResponseField,
+  type ListConfigurationSettingPage,
+  type ListConfigurationSettingsForSnapshotOptions,
+  type ListConfigurationSettingsOptions,
+  type ListLabelsOptions,
+  type ListLabelsPage,
+  type ListRevisionsOptions,
+  type ListRevisionsPage,
+  type ListSnapshotsOptions,
+  type ListSnapshotsPage,
+  type PageSettings,
+  type SetConfigurationSettingOptions,
+  type SetConfigurationSettingParam,
+  type SetConfigurationSettingResponse,
+  type SetReadOnlyOptions,
+  type SetReadOnlyResponse,
+  type SettingLabel,
+  type SnapshotInfo,
+  type UpdateSnapshotOptions,
+  type UpdateSnapshotResponse,
 } from "./models.js";
 import type {
   AppConfigurationGetKeyValuesHeaders,
@@ -151,6 +152,7 @@ export class AppConfigurationClient {
     let appConfigCredential: TokenCredential;
     let appConfigEndpoint: string;
     let authPolicy: PipelinePolicy;
+    let scope: string;
 
     if (isTokenCredential(tokenCredentialOrOptions)) {
       appConfigOptions = (options as InternalAppConfigurationClientOptions) || {};
@@ -158,8 +160,19 @@ export class AppConfigurationClient {
       appConfigEndpoint = connectionStringOrEndpoint.endsWith("/")
         ? connectionStringOrEndpoint.slice(0, -1)
         : connectionStringOrEndpoint;
+      // Use audience from options if provided
+      // Otherwise, deduct the scope based on the endpoint
+      if (appConfigOptions.audience) {
+        scope = `${appConfigOptions.audience}/.default`;
+      } else if (appConfigEndpoint.endsWith("azconfig.azure.us") || appConfigEndpoint.endsWith("appconfig.azure.us")) {
+        scope = `${KnownAppConfigAudience.AzureGovernment}/.default`;
+      } else if (appConfigEndpoint.endsWith("azconfig.azure.cn") || appConfigEndpoint.endsWith("appconfig.azure.cn")) {
+        scope = `${KnownAppConfigAudience.AzureChina}/.default`;
+      } else {
+        scope = `${KnownAppConfigAudience.AzurePublicCloud}/.default`;
+      }
       authPolicy = bearerTokenAuthenticationPolicy({
-        scopes: `${appConfigEndpoint}/.default`,
+        scopes: scope,
         credential: appConfigCredential,
       });
     } else {
@@ -171,7 +184,7 @@ export class AppConfigurationClient {
       } else {
         throw new Error(
           `Invalid connection string. Valid connection strings should match the regex '${ConnectionStringRegex.source}'.` +
-            ` To mitigate the issue, please refer to the troubleshooting guide here at https://aka.ms/azsdk/js/app-configuration/troubleshoot.`,
+          ` To mitigate the issue, please refer to the troubleshooting guide here at https://aka.ms/azsdk/js/app-configuration/troubleshoot.`,
         );
       }
     }
@@ -383,53 +396,53 @@ export class AppConfigurationClient {
     const pageEtags = options.pageEtags ? [...options.pageEtags] : undefined;
     delete options.pageEtags;
     const pagedResult: PagedResult<ListConfigurationSettingPage, PageSettings, string | undefined> =
-      {
-        firstPageLink: undefined,
-        getPage: async (pageLink: string | undefined) => {
-          const etag = pageEtags?.shift();
-          try {
-            const response = await this.sendConfigurationSettingsRequest(
-              { ...options, etag },
-              pageLink,
+    {
+      firstPageLink: undefined,
+      getPage: async (pageLink: string | undefined) => {
+        const etag = pageEtags?.shift();
+        try {
+          const response = await this.sendConfigurationSettingsRequest(
+            { ...options, etag },
+            pageLink,
+          );
+          const currentResponse: ListConfigurationSettingPage = {
+            ...response,
+            items: response.items != null ? response.items?.map(transformKeyValue) : [],
+            continuationToken: response.nextLink
+              ? extractAfterTokenFromNextLink(response.nextLink)
+              : undefined,
+            _response: response._response,
+          };
+          return {
+            page: currentResponse,
+            nextPageLink: currentResponse.continuationToken,
+          };
+        } catch (error) {
+          const err = error as RestError;
+
+          const link = err.response?.headers?.get("link");
+          const continuationToken = link ? extractAfterTokenFromLinkHeader(link) : undefined;
+
+          if (err.statusCode === 304) {
+            err.message = `Status 304: No updates for this page`;
+            logger.info(
+              `[listConfigurationSettings] No updates for this page. The current etag for the page is ${etag}`,
             );
-            const currentResponse: ListConfigurationSettingPage = {
-              ...response,
-              items: response.items != null ? response.items?.map(transformKeyValue) : [],
-              continuationToken: response.nextLink
-                ? extractAfterTokenFromNextLink(response.nextLink)
-                : undefined,
-              _response: response._response,
-            };
             return {
-              page: currentResponse,
-              nextPageLink: currentResponse.continuationToken,
+              page: {
+                items: [],
+                etag,
+                _response: { ...err.response, status: 304 },
+              } as unknown as ListConfigurationSettingPage,
+              nextPageLink: continuationToken,
             };
-          } catch (error) {
-            const err = error as RestError;
-
-            const link = err.response?.headers?.get("link");
-            const continuationToken = link ? extractAfterTokenFromLinkHeader(link) : undefined;
-
-            if (err.statusCode === 304) {
-              err.message = `Status 304: No updates for this page`;
-              logger.info(
-                `[listConfigurationSettings] No updates for this page. The current etag for the page is ${etag}`,
-              );
-              return {
-                page: {
-                  items: [],
-                  etag,
-                  _response: { ...err.response, status: 304 },
-                } as unknown as ListConfigurationSettingPage,
-                nextPageLink: continuationToken,
-              };
-            }
-
-            throw err;
           }
-        },
-        toElements: (page) => page.items,
-      };
+
+          throw err;
+        }
+      },
+      toElements: (page) => page.items,
+    };
     return getPagedAsyncIterator(pagedResult);
   }
 
@@ -458,27 +471,27 @@ export class AppConfigurationClient {
     options: ListConfigurationSettingsForSnapshotOptions = {},
   ): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage, PageSettings> {
     const pagedResult: PagedResult<ListConfigurationSettingPage, PageSettings, string | undefined> =
-      {
-        firstPageLink: undefined,
-        getPage: async (pageLink: string | undefined) => {
-          const response = await this.sendConfigurationSettingsRequest(
-            { snapshotName, ...options },
-            pageLink,
-          );
-          const currentResponse = {
-            ...response,
-            items: response.items != null ? response.items?.map(transformKeyValue) : [],
-            continuationToken: response.nextLink
-              ? extractAfterTokenFromNextLink(response.nextLink)
-              : undefined,
-          };
-          return {
-            page: currentResponse,
-            nextPageLink: currentResponse.continuationToken,
-          };
-        },
-        toElements: (page) => page.items,
-      };
+    {
+      firstPageLink: undefined,
+      getPage: async (pageLink: string | undefined) => {
+        const response = await this.sendConfigurationSettingsRequest(
+          { snapshotName, ...options },
+          pageLink,
+        );
+        const currentResponse = {
+          ...response,
+          items: response.items != null ? response.items?.map(transformKeyValue) : [],
+          continuationToken: response.nextLink
+            ? extractAfterTokenFromNextLink(response.nextLink)
+            : undefined,
+        };
+        return {
+          page: currentResponse,
+          nextPageLink: currentResponse.continuationToken,
+        };
+      },
+      toElements: (page) => page.items,
+    };
     return getPagedAsyncIterator(pagedResult);
   }
 

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -5,7 +5,6 @@
 /// <reference lib="esnext.asynciterable" />
 
 import {
-  KnownAppConfigurationAudience as KnownAppConfigAudience,
   type AddConfigurationSettingOptions,
   type AddConfigurationSettingParam,
   type AddConfigurationSettingResponse,
@@ -75,6 +74,7 @@ import {
   formatFiltersAndSelect,
   formatLabelsFiltersAndSelect,
   formatSnapshotFiltersAndSelect,
+  getScope,
   makeConfigurationSettingEmpty,
   serializeAsConfigurationSettingParam,
   transformKeyValue,
@@ -127,7 +127,6 @@ export class AppConfigurationClient {
 
   /**
    * Initializes a new instance of the AppConfigurationClient class.
-   * @param connectionString - Connection string needed for a client to connect to Azure.
    * @param options - Options for the AppConfigurationClient.
    */
   constructor(connectionString: string, options?: AppConfigurationClientOptions);
@@ -160,23 +159,7 @@ export class AppConfigurationClient {
       appConfigEndpoint = connectionStringOrEndpoint.endsWith("/")
         ? connectionStringOrEndpoint.slice(0, -1)
         : connectionStringOrEndpoint;
-      // Use audience from options if provided
-      // Otherwise, deduct the scope based on the endpoint
-      if (appConfigOptions.audience) {
-        scope = `${appConfigOptions.audience}/.default`;
-      } else if (
-        appConfigEndpoint.endsWith("azconfig.azure.us") ||
-        appConfigEndpoint.endsWith("appconfig.azure.us")
-      ) {
-        scope = `${KnownAppConfigAudience.AzureGovernment}/.default`;
-      } else if (
-        appConfigEndpoint.endsWith("azconfig.azure.cn") ||
-        appConfigEndpoint.endsWith("appconfig.azure.cn")
-      ) {
-        scope = `${KnownAppConfigAudience.AzureChina}/.default`;
-      } else {
-        scope = `${KnownAppConfigAudience.AzurePublicCloud}/.default`;
-      }
+      scope = getScope(appConfigEndpoint, appConfigOptions.audience);
       authPolicy = bearerTokenAuthenticationPolicy({
         scopes: scope,
         credential: appConfigCredential,

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -164,9 +164,15 @@ export class AppConfigurationClient {
       // Otherwise, deduct the scope based on the endpoint
       if (appConfigOptions.audience) {
         scope = `${appConfigOptions.audience}/.default`;
-      } else if (appConfigEndpoint.endsWith("azconfig.azure.us") || appConfigEndpoint.endsWith("appconfig.azure.us")) {
+      } else if (
+        appConfigEndpoint.endsWith("azconfig.azure.us") ||
+        appConfigEndpoint.endsWith("appconfig.azure.us")
+      ) {
         scope = `${KnownAppConfigAudience.AzureGovernment}/.default`;
-      } else if (appConfigEndpoint.endsWith("azconfig.azure.cn") || appConfigEndpoint.endsWith("appconfig.azure.cn")) {
+      } else if (
+        appConfigEndpoint.endsWith("azconfig.azure.cn") ||
+        appConfigEndpoint.endsWith("appconfig.azure.cn")
+      ) {
         scope = `${KnownAppConfigAudience.AzureChina}/.default`;
       } else {
         scope = `${KnownAppConfigAudience.AzurePublicCloud}/.default`;
@@ -184,7 +190,7 @@ export class AppConfigurationClient {
       } else {
         throw new Error(
           `Invalid connection string. Valid connection strings should match the regex '${ConnectionStringRegex.source}'.` +
-          ` To mitigate the issue, please refer to the troubleshooting guide here at https://aka.ms/azsdk/js/app-configuration/troubleshoot.`,
+            ` To mitigate the issue, please refer to the troubleshooting guide here at https://aka.ms/azsdk/js/app-configuration/troubleshoot.`,
         );
       }
     }
@@ -396,53 +402,53 @@ export class AppConfigurationClient {
     const pageEtags = options.pageEtags ? [...options.pageEtags] : undefined;
     delete options.pageEtags;
     const pagedResult: PagedResult<ListConfigurationSettingPage, PageSettings, string | undefined> =
-    {
-      firstPageLink: undefined,
-      getPage: async (pageLink: string | undefined) => {
-        const etag = pageEtags?.shift();
-        try {
-          const response = await this.sendConfigurationSettingsRequest(
-            { ...options, etag },
-            pageLink,
-          );
-          const currentResponse: ListConfigurationSettingPage = {
-            ...response,
-            items: response.items != null ? response.items?.map(transformKeyValue) : [],
-            continuationToken: response.nextLink
-              ? extractAfterTokenFromNextLink(response.nextLink)
-              : undefined,
-            _response: response._response,
-          };
-          return {
-            page: currentResponse,
-            nextPageLink: currentResponse.continuationToken,
-          };
-        } catch (error) {
-          const err = error as RestError;
-
-          const link = err.response?.headers?.get("link");
-          const continuationToken = link ? extractAfterTokenFromLinkHeader(link) : undefined;
-
-          if (err.statusCode === 304) {
-            err.message = `Status 304: No updates for this page`;
-            logger.info(
-              `[listConfigurationSettings] No updates for this page. The current etag for the page is ${etag}`,
+      {
+        firstPageLink: undefined,
+        getPage: async (pageLink: string | undefined) => {
+          const etag = pageEtags?.shift();
+          try {
+            const response = await this.sendConfigurationSettingsRequest(
+              { ...options, etag },
+              pageLink,
             );
-            return {
-              page: {
-                items: [],
-                etag,
-                _response: { ...err.response, status: 304 },
-              } as unknown as ListConfigurationSettingPage,
-              nextPageLink: continuationToken,
+            const currentResponse: ListConfigurationSettingPage = {
+              ...response,
+              items: response.items != null ? response.items?.map(transformKeyValue) : [],
+              continuationToken: response.nextLink
+                ? extractAfterTokenFromNextLink(response.nextLink)
+                : undefined,
+              _response: response._response,
             };
-          }
+            return {
+              page: currentResponse,
+              nextPageLink: currentResponse.continuationToken,
+            };
+          } catch (error) {
+            const err = error as RestError;
 
-          throw err;
-        }
-      },
-      toElements: (page) => page.items,
-    };
+            const link = err.response?.headers?.get("link");
+            const continuationToken = link ? extractAfterTokenFromLinkHeader(link) : undefined;
+
+            if (err.statusCode === 304) {
+              err.message = `Status 304: No updates for this page`;
+              logger.info(
+                `[listConfigurationSettings] No updates for this page. The current etag for the page is ${etag}`,
+              );
+              return {
+                page: {
+                  items: [],
+                  etag,
+                  _response: { ...err.response, status: 304 },
+                } as unknown as ListConfigurationSettingPage,
+                nextPageLink: continuationToken,
+              };
+            }
+
+            throw err;
+          }
+        },
+        toElements: (page) => page.items,
+      };
     return getPagedAsyncIterator(pagedResult);
   }
 
@@ -471,27 +477,27 @@ export class AppConfigurationClient {
     options: ListConfigurationSettingsForSnapshotOptions = {},
   ): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage, PageSettings> {
     const pagedResult: PagedResult<ListConfigurationSettingPage, PageSettings, string | undefined> =
-    {
-      firstPageLink: undefined,
-      getPage: async (pageLink: string | undefined) => {
-        const response = await this.sendConfigurationSettingsRequest(
-          { snapshotName, ...options },
-          pageLink,
-        );
-        const currentResponse = {
-          ...response,
-          items: response.items != null ? response.items?.map(transformKeyValue) : [],
-          continuationToken: response.nextLink
-            ? extractAfterTokenFromNextLink(response.nextLink)
-            : undefined,
-        };
-        return {
-          page: currentResponse,
-          nextPageLink: currentResponse.continuationToken,
-        };
-      },
-      toElements: (page) => page.items,
-    };
+      {
+        firstPageLink: undefined,
+        getPage: async (pageLink: string | undefined) => {
+          const response = await this.sendConfigurationSettingsRequest(
+            { snapshotName, ...options },
+            pageLink,
+          );
+          const currentResponse = {
+            ...response,
+            items: response.items != null ? response.items?.map(transformKeyValue) : [],
+            continuationToken: response.nextLink
+              ? extractAfterTokenFromNextLink(response.nextLink)
+              : undefined,
+          };
+          return {
+            page: currentResponse,
+            nextPageLink: currentResponse.continuationToken,
+          };
+        },
+        toElements: (page) => page.items,
+      };
     return getPagedAsyncIterator(pagedResult);
   }
 

--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfiguration.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfiguration.ts
@@ -112,7 +112,7 @@ export class AppConfiguration extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-app-configuration/1.8.1`;
+    const packageDetails = `azsdk-js-app-configuration/1.9.0`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/appconfiguration/app-configuration/src/internal/constants.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/constants.ts
@@ -4,7 +4,7 @@
 /**
  * @internal
  */
-export const packageVersion = "1.8.1";
+export const packageVersion = "1.9.0";
 
 /**
  * @internal

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -471,9 +471,9 @@ export function hasUnderscoreResponse<T extends object>(
 export function getScope(appConfigEndpoint: string, appConfigAudience?: string): string {
   if (appConfigAudience) {
     return `${appConfigAudience}/.default`;
-  } else if (appConfigEndpoint.includes("azconfig.azure.us") || appConfigEndpoint.includes("appconfig.azure.us")) {
+  } else if (appConfigEndpoint.endsWith("azconfig.azure.us") || appConfigEndpoint.endsWith("appconfig.azure.us")) {
     return `${KnownAppConfigAudience.AzureGovernment}/.default`;
-  } else if (appConfigEndpoint.includes("azconfig.azure.cn") || appConfigEndpoint.includes("appconfig.azure.cn")) {
+  } else if (appConfigEndpoint.endsWith("azconfig.azure.cn") || appConfigEndpoint.endsWith("appconfig.azure.cn")) {
     return `${KnownAppConfigAudience.AzureChina}/.default`;
   } else {
     return `${KnownAppConfigAudience.AzurePublicCloud}/.default`;

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -471,9 +471,9 @@ export function hasUnderscoreResponse<T extends object>(
 export function getScope(appConfigEndpoint: string, appConfigAudience?: string): string {
   if (appConfigAudience) {
     return `${appConfigAudience}/.default`;
-  } else if (appConfigEndpoint.includes("azure.us")) {
+  } else if (appConfigEndpoint.includes("azconfig.azure.us") || appConfigEndpoint.includes("appconfig.azure.us")) {
     return `${KnownAppConfigAudience.AzureGovernment}/.default`;
-  } else if (appConfigEndpoint.includes("azure.cn")) {
+  } else if (appConfigEndpoint.includes("azconfig.azure.cn") || appConfigEndpoint.includes("appconfig.azure.cn")) {
     return `${KnownAppConfigAudience.AzureChina}/.default`;
   } else {
     return `${KnownAppConfigAudience.AzurePublicCloud}/.default`;

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type {
-  ConfigurationSetting,
-  ConfigurationSettingParam,
-  HttpOnlyIfChangedField,
-  HttpOnlyIfUnchangedField,
-  HttpResponseField,
-  HttpResponseFields,
-  ListRevisionsOptions,
-  ListSettingsOptions,
-  ListSnapshotsOptions,
-  ConfigurationSnapshot,
-  SnapshotResponse,
-  EtagEntity,
-  ListLabelsOptions,
+import {
+  type ConfigurationSetting,
+  type ConfigurationSettingParam,
+  type HttpOnlyIfChangedField,
+  type HttpOnlyIfUnchangedField,
+  type HttpResponseField,
+  type HttpResponseFields,
+  type ListRevisionsOptions,
+  type ListSettingsOptions,
+  type ListSnapshotsOptions,
+  type ConfigurationSnapshot,
+  type SnapshotResponse,
+  type EtagEntity,
+  type ListLabelsOptions,
+  KnownAppConfigAudience,
 } from "../models.js";
 import type { FeatureFlagValue } from "../featureFlag.js";
 import { FeatureFlagHelper, featureFlagContentType } from "../featureFlag.js";
@@ -458,4 +459,23 @@ export function hasUnderscoreResponse<T extends object>(
   result: T,
 ): result is T & HttpResponseField<any> {
   return Object.prototype.hasOwnProperty.call(result, "_response");
+}
+
+/**
+ * Get the scope for the App Configuration service based on the endpoint and audience.
+ * If the audience is provided, it will be used as the scope.
+ * If not, the scope is defaulted to Azure Public Cloud when not specified.
+ *
+ * @internal
+ */
+export function getScope(appConfigEndpoint: string, appConfigAudience?: string): string {
+  if (appConfigAudience) {
+    return `${appConfigAudience}/.default`;
+  } else if (appConfigEndpoint.includes("azure.us")) {
+    return `${KnownAppConfigAudience.AzureGovernment}/.default`;
+  } else if (appConfigEndpoint.includes("azure.cn")) {
+    return `${KnownAppConfigAudience.AzureChina}/.default`;
+  } else {
+    return `${KnownAppConfigAudience.AzurePublicCloud}/.default`;
+  }
 }

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -471,9 +471,15 @@ export function hasUnderscoreResponse<T extends object>(
 export function getScope(appConfigEndpoint: string, appConfigAudience?: string): string {
   if (appConfigAudience) {
     return `${appConfigAudience}/.default`;
-  } else if (appConfigEndpoint.endsWith("azconfig.azure.us") || appConfigEndpoint.endsWith("appconfig.azure.us")) {
+  } else if (
+    appConfigEndpoint.endsWith("azconfig.azure.us") ||
+    appConfigEndpoint.endsWith("appconfig.azure.us")
+  ) {
     return `${KnownAppConfigAudience.AzureGovernment}/.default`;
-  } else if (appConfigEndpoint.endsWith("azconfig.azure.cn") || appConfigEndpoint.endsWith("appconfig.azure.cn")) {
+  } else if (
+    appConfigEndpoint.endsWith("azconfig.azure.cn") ||
+    appConfigEndpoint.endsWith("appconfig.azure.cn")
+  ) {
     return `${KnownAppConfigAudience.AzureChina}/.default`;
   } else {
     return `${KnownAppConfigAudience.AzurePublicCloud}/.default`;

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -25,7 +25,7 @@ export interface AppConfigurationClientOptions extends CommonClientOptions {
 
   /**
    * The Audience to use for authentication with Azure Active Directory (AAD).
-   * {@link KnownAppConfigurationAudience} can be used interchangeably with audience.
+   * {@link KnownAppConfigAudience} can be used interchangeably with audience.
    * If not specified, the default audience will be set to Azure Public Cloud.
    */
   audience?: string;
@@ -34,7 +34,7 @@ export interface AppConfigurationClientOptions extends CommonClientOptions {
 /**
  * Known values for Azure App Configuration Audience
  */
-export enum KnownAppConfigurationAudience {
+export enum KnownAppConfigAudience {
   /**
    * Audience for Azure China
    */

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -22,6 +22,31 @@ export interface AppConfigurationClientOptions extends CommonClientOptions {
    * Note that overriding this default value may result in unsupported behavior.
    */
   apiVersion?: string;
+
+  /**
+   * The Audience to use for authentication with Azure Active Directory (AAD).
+   * {@link KnownAppConfigurationAudience} can be used interchangeably with audience.
+   * If not specified, the default audience will be set to Azure Public Cloud.
+   */
+  audience?: string;
+}
+
+/**
+ * Known values for Azure App Configuration Audience
+ */
+export enum KnownAppConfigurationAudience {
+  /**
+   * Audience for Azure China
+   */
+  AzureChina = "https://appconfig.azure.cn",
+  /**
+   * Audience for Azure Government
+   */
+  AzureGovernment = "https://appconfig.azure.us",
+  /**
+   * Audience for Azure Public
+   */
+  AzurePublicCloud = "https://appconfig.azure.com",
 }
 
 /**

--- a/sdk/appconfiguration/app-configuration/swagger/swagger.md
+++ b/sdk/appconfiguration/app-configuration/swagger/swagger.md
@@ -4,7 +4,7 @@
 
 ```yaml
 package-name: app-configuration
-package-version: "1.8.1"
+package-version: "1.9.0"
 title: AppConfiguration
 description: App Configuration client
 enable-xml: true

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -173,7 +173,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", async (ctx) => {
+    it.skip("accepts operation options", async (ctx) => {
       if (isPlaybackMode()) ctx.skip();
       const key = recorder.variable(
         "addConfigTestTwice",

--- a/sdk/appconfiguration/app-configuration/test/snippets.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/snippets.spec.ts
@@ -18,13 +18,9 @@ describe("snippets", () => {
     // The endpoint for your App Configuration resource
     const endpoint = "https://example.azconfig.azure.cn";
     // Create an AppConfigurationClient that will authenticate through AAD in the China cloud
-    const client = new AppConfigurationClient(
-      endpoint,
-      new DefaultAzureCredential(),
-      {
-        audience: KnownAppConfigurationAudience.AzureChina
-      }
-    );
+    const client = new AppConfigurationClient(endpoint, new DefaultAzureCredential(), {
+      audience: KnownAppConfigurationAudience.AzureChina,
+    });
   });
 
   it("ReadmeSampleCreateClientWithConnectionString", async () => {

--- a/sdk/appconfiguration/app-configuration/test/snippets.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/snippets.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, it } from "vitest";
 import { AzureAuthorityHosts, DefaultAzureCredential } from "@azure/identity";
-import { AppConfigurationClient } from "@azure/app-configuration";
+import { AppConfigurationClient, KnownAppConfigurationAudience } from "@azure/app-configuration";
 import { setLogLevel } from "@azure/logger";
 
 describe("snippets", () => {
@@ -20,7 +20,10 @@ describe("snippets", () => {
     // Create an AppConfigurationClient that will authenticate through AAD in the China cloud
     const client = new AppConfigurationClient(
       endpoint,
-      new DefaultAzureCredential({ authorityHost: AzureAuthorityHosts.AzureChina }),
+      new DefaultAzureCredential(),
+      {
+        audience: KnownAppConfigurationAudience.AzureChina
+      }
     );
   });
 

--- a/sdk/appconfiguration/app-configuration/test/snippets.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/snippets.spec.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import { describe, it } from "vitest";
-import { AzureAuthorityHosts, DefaultAzureCredential } from "@azure/identity";
-import { AppConfigurationClient, KnownAppConfigurationAudience } from "@azure/app-configuration";
+import { DefaultAzureCredential } from "@azure/identity";
+import { AppConfigurationClient, KnownAppConfigAudience } from "@azure/app-configuration";
 import { setLogLevel } from "@azure/logger";
 
 describe("snippets", () => {
@@ -19,7 +19,7 @@ describe("snippets", () => {
     const endpoint = "https://example.azconfig.azure.cn";
     // Create an AppConfigurationClient that will authenticate through AAD in the China cloud
     const client = new AppConfigurationClient(endpoint, new DefaultAzureCredential(), {
-      audience: KnownAppConfigurationAudience.AzureChina,
+      audience: KnownAppConfigAudience.AzureChina,
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/app-configuration

### Issues associated with this PR


### Describe the problem that is addressed by this PR
This PR adds support for specifying the Microsoft Entra audience to use when forming authorization scopes in token authentication. Add `audience` property to `AppConfigurationClientOptions` with `KnownAppConfigAudience` to specify the token audience. The SDK will default to public cloud when no audience is supplied.