### PR TITLE
[Monitor OpenTelemetry Exporter] Fix Reporting the Attach Type on Statsbeat Records

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.29 (2025-03-03)
+## 1.0.0-beta.29 (2025-03-04)
 
 ### Features Added
 
@@ -12,6 +12,7 @@
 
 - Removed faulty span exception exporting logic.
 - Remove applying cloud.* tags to statsbeat telemetry.
+- Correctly capture attach type on statsbeat metrics.
 
 ## 1.0.0-beta.28 (2025-01-28)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -22,6 +22,7 @@ import type {
 } from "./types.js";
 import { StatsbeatCounter, STATSBEAT_LANGUAGE, StatsbeatFeatureType } from "./types.js";
 import { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
+import { getAttachType } from "../../utils/metricUtils.js";
 
 let instance: LongIntervalStatsbeatMetrics | null = null;
 
@@ -36,7 +37,7 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
   private runtimeVersion: string;
   private language: string;
   private version: string;
-  private attach: string = "Manual";
+  private attach: string = getAttachType();
 
   private commonProperties: CommonStatsbeatProperties;
   private attachProperties: AttachStatsbeatProperties;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -21,6 +21,7 @@ import type {
 import { StatsbeatCounter, STATSBEAT_LANGUAGE, NetworkStatsbeat } from "./types.js";
 import { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
 import { ENV_DISABLE_STATSBEAT } from "../../Declarations/Constants.js";
+import { getAttachType } from "../../utils/metricUtils.js";
 
 export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
   private disableNonEssentialStatsbeat: boolean = !!process.env[ENV_DISABLE_STATSBEAT];
@@ -40,7 +41,7 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
   private runtimeVersion: string;
   private language: string;
   private version: string;
-  private attach: string = "Manual";
+  private attach: string = getAttachType();
 
   // Observable Gauges
   private successCountGauge: ObservableGauge;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -55,6 +55,8 @@ export class NetworkStatsbeat {
 
 export const STATSBEAT_LANGUAGE = "node";
 
+export const AZURE_MONITOR_AUTO_ATTACH = "AZURE_MONITOR_AUTO_ATTACH";
+
 export const MAX_STATSBEAT_FAILURES = 3;
 
 export const StatsbeatResourceProvider = {
@@ -64,6 +66,11 @@ export const StatsbeatResourceProvider = {
   vm: "vm",
   unknown: "unknown",
 };
+
+export enum AttachTypeName {
+  INTEGRATED_AUTO = "IntegratedAuto",
+  MANUAL = "Manual",
+}
 
 export enum StatsbeatCounter {
   SUCCESS_COUNT = "Request_Success_Count",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
@@ -22,6 +22,7 @@ import {
   ENV_AZURE_MONITOR_AUTO_ATTACH,
   ENV_APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED,
 } from "../Declarations/Constants.js";
+import { AttachTypeName, AZURE_MONITOR_AUTO_ATTACH } from "../export/statsbeat/types.js";
 
 const breezePerformanceCountersMap = new Map<string, string>([
   [OTelPerformanceCounterNames.PRIVATE_BYTES, BreezePerformanceCounterNames.PRIVATE_BYTES],
@@ -153,4 +154,11 @@ export function isStandardMetric(
   dataPoint: DataPoint<number> | DataPoint<Histogram> | DataPoint<ExponentialHistogram>,
 ): boolean {
   return dataPoint.attributes?.["_MS.IsAutocollected"] === "True";
+}
+
+export function getAttachType(): AttachTypeName {
+  if (process.env[AZURE_MONITOR_AUTO_ATTACH] === "true") {
+    return AttachTypeName.INTEGRATED_AUTO;
+  }
+  return AttachTypeName.MANUAL;
 }

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.9.0 (2025-03-03)
+## 1.9.0 (2025-03-04)
 
 ### Features Added
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR

Attach type should be reported on all statsbeat records.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
