### PR TITLE
[Monitor OpenTelemetry Exporter] Removing Cloud Attributes Should Not Also Remove sdkVersion

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/metricUtils.ts
@@ -23,6 +23,7 @@ import {
   ENV_APPLICATIONINSIGHTS_METRICS_TO_LOGANALYTICS_ENABLED,
 } from "../Declarations/Constants.js";
 import { AttachTypeName, AZURE_MONITOR_AUTO_ATTACH } from "../export/statsbeat/types.js";
+import { getInstance } from "../platform/index.js";
 
 const breezePerformanceCountersMap = new Map<string, string>([
   [OTelPerformanceCounterNames.PRIVATE_BYTES, BreezePerformanceCounterNames.PRIVATE_BYTES],
@@ -62,6 +63,8 @@ export function resourceMetricsToEnvelope(
 
   if (isStatsbeat) {
     envelopeName = "Microsoft.ApplicationInsights.Statsbeat";
+    const context = getInstance();
+    tags = { ...context.tags };
   } else {
     envelopeName = "Microsoft.ApplicationInsights.Metric";
     tags = createTagsFromResource(metrics.resource);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.spec.ts
@@ -102,7 +102,7 @@ function assertStatsbeatEnvelope(
 
   assert.strictEqual(envelope.instrumentationKey, "ikey");
 
-  assert.deepStrictEqual(envelope.tags, undefined);
+  assert.deepStrictEqual(Object.keys(envelope.tags || {}).length, 2);
 }
 
 describe("metricUtil.ts", () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -12,6 +12,7 @@ import nock from "nock";
 import { NetworkStatsbeatMetrics } from "../../src/export/statsbeat/networkStatsbeatMetrics.js";
 import { AZURE_MONITOR_AUTO_ATTACH, StatsbeatCounter } from "../../src/export/statsbeat/types.js";
 import { getInstance } from "../../src/export/statsbeat/longIntervalStatsbeatMetrics.js";
+import { getInstance as getContext } from "../../src/platform/nodejs/context/context.js";
 import { AzureMonitorTraceExporter } from "../../src/export/trace.js";
 import { diag } from "@opentelemetry/api";
 import { describe, it, assert, expect, vi, beforeAll, afterAll } from "vitest";
@@ -151,6 +152,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
         // Ensure network statsbeat attributes are populated
         assert.strictEqual(statsbeat["attach"], "IntegratedAuto");
+        assert.ok(getContext().tags["ai.internal.sdkVersion"]);
         process.env = originalEnv;
       });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR


### Describe the problem that is addressed by this PR
From #33229 when removing the cloud attributes, the sdkVersion is also removed unintentionally. This PR fixes that mistake and adds a test case to ensure this is not possible in the future.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
