### PR TITLE
[core-lro] Add support for `skipFinalGet`

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Supports a `baseUrl` option that can be used to rewrite the polling URL to use that base URL instead. This makes sure that polling works for operations that live behind proxies or API gateways.
+- Added `skipFinalGet` option to skip the final GET request when polling is complete, optimizing scenarios where the final resource state is not needed. [#33286](https://github.com/Azure/azure-sdk-for-js/pull/33286)
 
 ### Breaking Changes
 

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -20,6 +20,7 @@ export interface CreateHttpPollerOptions<TResult, TState> {
     resolveOnUnsuccessful?: boolean;
     resourceLocationConfig?: ResourceLocationConfig;
     restoreFrom?: string;
+    skipFinalGet?: boolean;
     updateState?: (state: TState, response: OperationResponse) => void;
     withOperationLocation?: (operationLocation: string) => void;
 }

--- a/sdk/core/core-lro/src/http/models.ts
+++ b/sdk/core/core-lro/src/http/models.ts
@@ -124,4 +124,8 @@ export interface CreateHttpPollerOptions<TResult, TState> {
    * Control whether to throw an exception if the operation failed or was canceled.
    */
   resolveOnUnsuccessful?: boolean;
+  /**
+   * A flag to skip the final GET request that would normally fetch the final resource
+   */
+  skipFinalGet?: boolean;
 }

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -45,8 +45,15 @@ function findResourceLocation(inputs: {
   location?: string;
   requestPath?: string;
   resourceLocationConfig?: ResourceLocationConfig;
+  skipFinalGet?: boolean;
 }): string | undefined {
-  const { location, requestMethod, requestPath, resourceLocationConfig } = inputs;
+  const { location, requestMethod, requestPath, resourceLocationConfig, skipFinalGet } = inputs;
+
+  // If skipFinalGet is true, return undefined to skip the final GET request
+  if (skipFinalGet) {
+    return undefined;
+  }
+
   switch (requestMethod) {
     case "PUT": {
       return requestPath;
@@ -82,6 +89,7 @@ function findResourceLocation(inputs: {
 export function inferLroMode(
   rawResponse: RawResponse,
   resourceLocationConfig?: ResourceLocationConfig,
+  skipFinalGet?: boolean,
 ): (OperationConfig & { mode: HttpOperationMode }) | undefined {
   const requestPath = rawResponse.request.url;
   const requestMethod = rawResponse.request.method;
@@ -99,6 +107,7 @@ export function inferLroMode(
         location,
         requestPath,
         resourceLocationConfig,
+        skipFinalGet,
       }),
       initialRequestUrl: requestPath,
       requestMethod,

--- a/sdk/core/core-lro/src/http/poller.ts
+++ b/sdk/core/core-lro/src/http/poller.ts
@@ -36,6 +36,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
     withOperationLocation,
     resolveOnUnsuccessful = false,
     baseUrl,
+    skipFinalGet,
   } = options || {};
   return buildCreatePoller<OperationResponse, TResult, TState>({
     getStatusFromInitialResponse,
@@ -50,7 +51,7 @@ export function createHttpPoller<TResult, TState extends OperationState<TResult>
     {
       init: async () => {
         const response = await lro.sendInitialRequest();
-        const config = inferLroMode(response.rawResponse, resourceLocationConfig);
+        const config = inferLroMode(response.rawResponse, resourceLocationConfig, skipFinalGet);
         return {
           response,
           operationLocation: rewriteUrl({ url: config?.operationLocation, baseUrl }),

--- a/sdk/core/core-lro/test/utils/router.ts
+++ b/sdk/core/core-lro/test/utils/router.ts
@@ -140,6 +140,7 @@ export function createTestPoller(
     routes: LroResponseSpec[];
     implName?: ImplementationName;
     throwOnNon2xxResponse?: boolean;
+    skipFinalGet?: boolean;
   },
 ): PollerLike<State, Result> {
   const {
@@ -147,6 +148,7 @@ export function createTestPoller(
     implName = "createPoller",
     throwOnNon2xxResponse = true,
     restoreFrom,
+    skipFinalGet = false,
     ...rest
   } = settings;
   const client = createClient({ routes: toLroProcessors(routes), throwOnNon2xxResponse });
@@ -170,6 +172,7 @@ export function createTestPoller(
         intervalInMs: 0,
         resolveOnUnsuccessful: !throwOnNon2xxResponse,
         restoreFrom,
+        skipFinalGet,
         ...rest,
       });
     }
@@ -186,6 +189,7 @@ async function runLro(
     updateState?: (state: State, lastResponse: RawResponse) => void;
     implName?: ImplementationName;
     throwOnNon2xxResponse?: boolean;
+    skipFinalGet?: boolean;
   },
 ): Promise<Result> {
   const {
@@ -194,6 +198,7 @@ async function runLro(
     updateState,
     implName = "createPoller",
     throwOnNon2xxResponse = true,
+    skipFinalGet,
     ...rest
   } = settings;
   const poller = createTestPoller({
@@ -201,6 +206,7 @@ async function runLro(
     updateState: (state, { rawResponse }) => updateState?.(state, rawResponse),
     implName,
     throwOnNon2xxResponse,
+    skipFinalGet,
     ...rest,
   });
   if (onProgress !== undefined) {
@@ -217,5 +223,6 @@ export const createRunLroWith =
     resourceLocationConfig?: ResourceLocationConfig;
     processResult?: (result: unknown, state: State) => Promise<Result>;
     updateState?: (state: State, lastResponse: RawResponse) => void;
+    skipFinalGet?: boolean;
   }): Promise<Result> =>
     runLro({ ...settings, ...variables });


### PR DESCRIPTION
### Packages impacted by this PR

@azure/keyvault-admin 
@azure/core-lro

### Issues associated with this PR

Contributes to #32142

### Describe the problem that is addressed by this PR

Adds `skipFinalGet` as an optimization and proper support for LROs where fetching the final resource is unnecessary for various reasons. 

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Naming mostly! I think `skipFinalGet` is the best I could land on, but maybe `skipFetchResource` or something like that?

### Are there test cases added in this PR? _(If not, why?)_

Yes

### Command used to generate this PR: _(Applicable only to SDK release request PRs)_

Entire feature was written by GH Copilot in Agent mode with my help! 

