### PR TITLE
[core] address warning with typescript 5.8

### DIFF
--- a/sdk/core/core-rest-pipeline/src/util/inspect.common.ts
+++ b/sdk/core/core-rest-pipeline/src/util/inspect.common.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const custom = {};
+export const custom = Symbol();

--- a/sdk/core/ts-http-runtime/src/util/inspect.common.ts
+++ b/sdk/core/ts-http-runtime/src/util/inspect.common.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const custom = {};
+export const custom = Symbol();


### PR DESCRIPTION
This addresses build warnings seen in TypeScript 5.8 upgrade

>Warning: dist/browser/restError.d.ts:31:5 - (TS2464) A computed property name must be of type 'string', 'number', 'symbol', or 'any'.

We could use some string or number but `Symbol` is more in line with the NodeJS version's `unique symbol`.