### PR TITLE
[ServiceBus] add message batch size limit

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bugs Fixed
 
+- `MessageSender.createBatch()` now report error if `maxSizeInBytes` option is greater than maximum batch size.
+
 ### Other Changes
 
 - Upgrade dependency `@azure/abort-controller` version to `^2.1.2`.

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -27,6 +27,16 @@ export const receiveDrainTimeoutInMs = 200;
 export const max32BitNumber = Math.pow(2, 31) - 1;
 
 /**
+ * @internal
+ */
+export const maxBatchSizeStandard = 256 * 1024;
+
+/**
+ * @internal
+ */
+export const maxBatchSizePremium = 1024 * 1024;
+
+/**
  * Queue name identifier
  * @internal
  */

--- a/sdk/servicebus/service-bus/test/internal/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/sendBatch.spec.ts
@@ -16,6 +16,7 @@ import { delay } from "@azure/core-util";
 import { createTestCredential } from "@azure-tools/test-credential";
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { assert, should } from "../public/utils/chai.js";
+import { maxBatchSizeStandard } from "../../src/util/constants.js";
 
 describe("Send Batch", () => {
   let sender: ServiceBusSender;
@@ -407,10 +408,9 @@ describe("Send Batch", () => {
       try {
         await sender.createMessageBatch({ maxSizeInBytes });
       } catch (error: any) {
-        const maxSize = await (sender as ServiceBusSenderImpl)["_sender"].getMaxMessageSize();
         should.equal(
           error.message,
-          `Max message size (${maxSizeInBytes} bytes) is greater than maximum message size (${maxSize} bytes) on the AMQP sender link.`,
+          `Max message size (${maxSizeInBytes} bytes) is greater than maximum batch size (${maxBatchSizeStandard} bytes).`,
           "Unexpected error message when tried to create a batch of size > maximum message size.",
         );
         errorIsThrown = true;


### PR DESCRIPTION
Even though Service Bus Premium namespaces support large messages up to 100 MB, batching of large messages is
not supported.

https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#large-messages-support

Currently we use the max message size as the max allowed batch size. This allows customers to add large
messages into the batch only to get a cryptic "link **** is force detached" error from the service after
sending the batch, as reported in

https://github.com/Azure/azure-sdk-for-js/issues/33278

This PR updates `createBatch` to use two pre-defined maximum batch sizes, for Standard and Premium
respectively, as the batch limits when creating batches, thus enforcing the proper limits on messages being
added into the batch.

-------

### Packages impacted by this PR
`@azure/service-bus`

### Related PR

https://github.com/Azure/azure-sdk-for-python/pull/38313