### PR TITLE
@azure/identity throw environmental credetials exception on constructor

### DIFF
--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -138,7 +138,6 @@ export class EnvironmentCredential implements TokenCredential {
         password,
         newOptions,
       );
-      return;
     }
 
     throw new CredentialUnavailableError(

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -138,7 +138,12 @@ export class EnvironmentCredential implements TokenCredential {
         password,
         newOptions,
       );
+      return;
     }
+
+    throw new CredentialUnavailableError(
+      `${credentialName} is unavailable. No underlying credential could be used. To troubleshoot, visit https://aka.ms/azsdk/js/identity/environmentcredential/troubleshoot.`,
+    );
   }
 
   /**

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -140,6 +140,7 @@ export class EnvironmentCredential implements TokenCredential {
       );
     }
 
+if(!this._credential)
     throw new CredentialUnavailableError(
       `${credentialName} is unavailable. No underlying credential could be used. To troubleshoot, visit https://aka.ms/azsdk/js/identity/environmentcredential/troubleshoot.`,
     );

--- a/sdk/identity/identity/test/public/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/public/node/environmentCredential.spec.ts
@@ -50,6 +50,18 @@ describe("EnvironmentCredential", function () {
 
   const scope = "https://vault.azure.net/.default";
 
+  it("throws an CredentialUnavailable without required environment variables", () => {
+    let error: Error | undefined;
+    try {
+      new EnvironmentCredential(recorder.configureClientOptions({}));
+    }
+    catch (e: any) {
+      error = e;
+    }
+
+    assert.equal(error?.name, "CredentialUnavailableError");
+  });
+
   it("authenticates with a client secret on the environment variables", async function () {
     // The following environment variables must be set for this to work.
     // On TEST_MODE="playback", the recorder automatically fills them with stubbed values.
@@ -168,17 +180,6 @@ describe("EnvironmentCredential", function () {
         // We will focus our test on making sure the underlying getToken was called.
       }
     }).toSupportTracing(["EnvironmentCredential.getToken"]);
-  });
-
-  it("throws an CredentialUnavailable when getToken is called and no credential was configured", async () => {
-    const credential = new EnvironmentCredential(recorder.configureClientOptions({}));
-    const error = await getError(credential.getToken(scope));
-    assert.equal(error.name, "CredentialUnavailableError");
-    assert.ok(
-      error.message.indexOf(
-        "EnvironmentCredential is unavailable. No underlying credential could be used.",
-      ) > -1,
-    );
   });
 
   it("throws an AuthenticationError when getToken is called and EnvironmentCredential authentication failed", async () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR
`EnviromentalCredential` never throws an exception in constructor, but always throw exception in `getToken` inside a `tracingClient.withSpan` (https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/src/credentials/environmentCredential.ts#L151-L168)

When using `DefaultCredentials` the first try to `getToken` is `EnvironmentalCredential` and (e.g in a Managed identity environment) this will throw an exception that will be recorded in the tracing. Our trace is full of errors because of that (see attachment)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Suggested approach will fix the issue, but a better approach IMHO should be to add an `isAvailable` method to `TokenCredential` interface and in `DefaultAzureCredentials` constructor (https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/src/credentials/defaultAzureCredential.ts#L235-L262) use this new method to conditionally add the credentials to `ChainedTokenCredential` constructor.

The issue exists also in the other `ChainedTokenCredential` subclasses

### Are there test cases added in this PR? _(If not, why?)_
- Yes


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)

<img width="1691" alt="image" src="https://github.com/user-attachments/assets/b5d0ac88-f0ce-45c0-8448-2f01f1831fec" />
