### PR TITLE
[ServiceBus] fix management client for browser

### DIFF
--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -52,7 +52,7 @@ import {
   throwTypeErrorIfParameterTypeMismatch,
 } from "../util/errors.js";
 import { max32BitNumber } from "../util/constants.js";
-import { Buffer } from "node:buffer";
+import { Buffer } from "buffer";
 import type { OperationOptionsBase } from "./../modelsToBeSharedWithEventHubs.js";
 import type { AbortSignalLike } from "@azure/abort-controller";
 import type { ReceiveMode } from "../models.js";


### PR DESCRIPTION
We used to import from "buffer" and rely on the `buffer` NPM package for browser polyfill. Importing from
"node:buffer" broke the scenario.  This PR reverts back to import from "buffer".