### PR TITLE
[App Config] Skip flaky tests in live mode

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.readonlytests.spec.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import type { Recorder } from "@azure-tools/test-recorder";
-import { isPlaybackMode } from "@azure-tools/test-recorder";
 import {
   assertThrowsAbortError,
   assertThrowsRestError,
@@ -71,7 +70,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
   });
 
   // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-  it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+  it.skip("accepts operation options", async () => {
     // Recorder checks for the recording and complains before core-rest-pipeline could throw the AbortError (Recorder v2 should help here)
     await client.getConfigurationSetting({
       key: testConfigSetting.key,

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -173,8 +173,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts operation options", async (ctx) => {
-      ctx.skip();
+    it.skip("accepts operation options", async () => {
       const key = recorder.variable(
         "addConfigTestTwice",
         `addConfigTestTwice${Math.floor(Math.random() * 1000)}`,

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -174,7 +174,7 @@ describe("AppConfigurationClient", () => {
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
     it.skip("accepts  operation options", async (ctx) => {
-      if (isPlaybackMode()) ctx.skip();
+      ctx.skip();
       const key = recorder.variable(
         "addConfigTestTwice",
         `addConfigTestTwice${Math.floor(Math.random() * 1000)}`,
@@ -327,7 +327,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts  operation options", async () => {
       // Recorder checks for the recording and complains before core-rest-pipeline could throw the AbortError (Recorder v2 should help here)
       const key = recorder.variable(
         "deleteConfigTest",
@@ -455,7 +455,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts  operation options", async () => {
       const key = recorder.variable(
         "getConfigTest",
         `getConfigTest${Math.floor(Math.random() * 1000)}`,
@@ -1134,7 +1134,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts  operation options", async () => {
       await assertThrowsAbortError(async () => {
         const settingsIterator = client.listConfigurationSettings({
           requestOptions: { timeout: 1 },
@@ -1310,7 +1310,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts  operation options", async () => {
       await assertThrowsAbortError(async () => {
         const iter = client.listRevisions({ labelFilter: labelA, requestOptions: { timeout: 1 } });
         await iter.next();
@@ -1582,7 +1582,7 @@ describe("AppConfigurationClient", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts  operation options", async () => {
       const key = recorder.variable(
         `setConfigTestNA`,
         `setConfigTestNA${Math.floor(Math.random() * 1000)}`,

--- a/sdk/appconfiguration/app-configuration/test/public/snapshot.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/snapshot.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import type { Recorder } from "@azure-tools/test-recorder";
-import { isPlaybackMode, testPollingOptions } from "@azure-tools/test-recorder";
+import { testPollingOptions } from "@azure-tools/test-recorder";
 import type { AppConfigurationClient } from "../../src/appConfigurationClient.js";
 import type {
   ConfigurationSnapshot,
@@ -110,7 +110,7 @@ describe("AppConfigurationClient snapshot", () => {
     });
 
     // Skipping all "accepts operation options flaky tests" https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts  operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts  operation options", async () => {
       await assertThrowsAbortError(async () => {
         await client.beginCreateSnapshotAndWait(snapshot1, {
           requestOptions: {
@@ -175,7 +175,7 @@ describe("AppConfigurationClient snapshot", () => {
       );
     });
 
-    it.skip("accepts operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts operation options", async () => {
       await assertThrowsAbortError(async () => {
         await client.archiveSnapshot(newSnapshot.name, {
           requestOptions: {
@@ -201,7 +201,7 @@ describe("AppConfigurationClient snapshot", () => {
       await client.archiveSnapshot(newSnapshot.name);
     });
 
-    it.skip("accepts operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts operation options", async () => {
       await assertThrowsAbortError(async () => {
         await client.recoverSnapshot(newSnapshot.name, {
           requestOptions: {
@@ -223,7 +223,7 @@ describe("AppConfigurationClient snapshot", () => {
     });
 
     // Check issue https://github.com/Azure/azure-sdk-for-js/issues/26447
-    it.skip("accepts operation options", { skip: isPlaybackMode() }, async () => {
+    it.skip("accepts operation options", async () => {
       newSnapshot = await client.beginCreateSnapshotAndWait(snapshot1, testPollingOptions);
       await assertThrowsAbortError(async () => {
         await client.getSnapshot(newSnapshot.name, {


### PR DESCRIPTION
- "accepts operation options" tests are testing options passed into core than specific App Configuration features. Some of these tests have been flaky in live test pipeline only in windows environment. Skipping for now and we have created an issue to track this.