### PR TITLE
[ServiceBus][Test] fix browser test

### DIFF
--- a/sdk/servicebus/service-bus/vitest.browser.config.ts
+++ b/sdk/servicebus/service-bus/vitest.browser.config.ts
@@ -6,7 +6,7 @@ import viteConfig from "../../../vitest.browser.shared.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
 import inject from "@rollup/plugin-inject";
 
-export default mergeConfig(
+const config = mergeConfig(
   viteConfig,
   defineConfig({
     define: {
@@ -27,3 +27,7 @@ export default mergeConfig(
     },
   }),
 );
+
+delete config.test.fakeTimers;
+
+export default config;


### PR DESCRIPTION
After vitest.browser.config.ts was refactored to merge with shared browser config, some tests started failing likely due to the fakeTimers settings.  This PR restores the behavior prior to the refactoring.
