### PR TITLE
[engSys] Use common OIDC token env vars for live tests

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -45,6 +45,9 @@ parameters:
 - name: UseFederatedAuth
   type: boolean
   default: false
+- name: PersistOidcToken
+  type: boolean
+  default: false
 
 jobs:
   - job:
@@ -99,6 +102,7 @@ jobs:
               SubscriptionConfiguration: $(SubscriptionConfiguration)
               ArmTemplateParameters: $(ArmTemplateParameters)
               UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              PersistOidcToken: ${{ parameters.PersistOidcToken }}
               ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
               SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
               EnvVars:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests-isolated.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests-isolated.yml
@@ -67,6 +67,9 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: true
+  - name: PersistOidcToken
+    type: boolean
+    default: false
 
 stages:
   - ${{ each cloud in parameters.CloudConfig }}:
@@ -95,6 +98,7 @@ stages:
                 TestResourceDirectories: ${{ parameters.TestResourceDirectories }}
                 PublishCodeCoverage: ${{ parameters.PublishCodeCoverage }}
                 UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+                PersistOidcToken: ${{ parameters.PersistOidcToken }}
                 PreSteps:
                   - ${{ parameters.PreSteps }}
                 PostSteps:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -67,6 +67,9 @@ parameters:
   - name: UseFederatedAuth
     type: boolean
     default: true
+  - name: PersistOidcToken
+    type: boolean
+    default: false
 
 
 extends:
@@ -87,6 +90,7 @@ extends:
           SupportedClouds: ${{ parameters.SupportedClouds }}
           UnsupportedClouds: ${{ parameters.UnsupportedClouds }}
           UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+          PersistOidcToken: ${{ parameters.PersistOidcToken }}
           PreSteps:
             - ${{ parameters.PreSteps }}
           PostSteps:

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -4,22 +4,6 @@ extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       Location: westus2
-      # PreSteps:
-      # - task: AzureCLI@2
-      #   displayName: Set OIDC variables
-      #   env:
-      #     ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
-      #     ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-      #     ARM_TENANT_ID: $(ARM_TENANT_ID)
-      #   inputs:
-      #     azureSubscription: azure-sdk-tests
-      #     scriptType: pscore
-      #     scriptLocation: inlineScript
-      #     addSpnToEnvironment: true
-      #     inlineScript: |
-      #       Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
-      #       Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
-      #       Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
       PackageName: "@azure/identity"
       ServiceDirectory: identity
       TimeoutInMinutes: 120
@@ -40,8 +24,4 @@ extends:
         - OSVmImage=.*LINUXNEXTVMIMAGE.*/azsdk-pool-mms-ubuntu-2204-1espt
       EnvVars:
         AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
-        # AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
         AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
-        # ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
-        # ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-        # ARM_TENANT_ID: $(ARM_TENANT_ID)

--- a/sdk/identity/identity/tests.yml
+++ b/sdk/identity/identity/tests.yml
@@ -4,25 +4,26 @@ extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       Location: westus2
-      PreSteps:
-      - task: AzureCLI@2
-        displayName: Set OIDC variables
-        env:
-          ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
-          ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-          ARM_TENANT_ID: $(ARM_TENANT_ID)
-        inputs:
-          azureSubscription: azure-sdk-tests
-          scriptType: pscore
-          scriptLocation: inlineScript
-          addSpnToEnvironment: true
-          inlineScript: |
-            Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
-            Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
-            Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
+      # PreSteps:
+      # - task: AzureCLI@2
+      #   displayName: Set OIDC variables
+      #   env:
+      #     ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
+      #     ARM_CLIENT_ID: $(ARM_CLIENT_ID)
+      #     ARM_TENANT_ID: $(ARM_TENANT_ID)
+      #   inputs:
+      #     azureSubscription: azure-sdk-tests
+      #     scriptType: pscore
+      #     scriptLocation: inlineScript
+      #     addSpnToEnvironment: true
+      #     inlineScript: |
+      #       Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
+      #       Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
+      #       Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
       PackageName: "@azure/identity"
       ServiceDirectory: identity
       TimeoutInMinutes: 120
+      PersistOidcToken: true
       CloudConfig:
         Public:
           SubscriptionConfigurations:
@@ -39,8 +40,8 @@ extends:
         - OSVmImage=.*LINUXNEXTVMIMAGE.*/azsdk-pool-mms-ubuntu-2204-1espt
       EnvVars:
         AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
+        # AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
         AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
-        ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
-        ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-        ARM_TENANT_ID: $(ARM_TENANT_ID)
+        # ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
+        # ARM_CLIENT_ID: $(ARM_CLIENT_ID)
+        # ARM_TENANT_ID: $(ARM_TENANT_ID)

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -4,18 +4,11 @@
 # IMPORTANT: Do not invoke this file directly. Please instead run eng/New-TestResources.ps1 from the repository root.
 
 param (
-  [Parameter(ValueFromRemainingArguments = $true)]
-  $RemainingArguments,
-
   [Parameter()]
   [hashtable] $DeploymentOutputs,
 
   [Parameter()]
   [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
-
-  [Parameter()]
-  [hashtable] $AdditionalParameters = @{},
-
 
   [Parameter(Mandatory = $true)]
   [ValidateNotNullOrEmpty()]
@@ -31,7 +24,11 @@ param (
 
   [Parameter(Mandatory = $true)]
   [ValidateNotNullOrEmpty()]
-  [string] $Environment
+  [string] $Environment,
+
+  # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+  [Parameter(ValueFromRemainingArguments = $true)]
+  $RemainingArguments
 )
 
 if (!$AdditionalParameters['deployMIResources']) {

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -56,12 +56,6 @@ Write-Host "Working directory: $workingFolder"
 
 if ($CI) {
   Write-Host "Logging in to service principal"
-  Write-Host "$TestApplicationId exists? $($TestApplicationId -ne $null)"
-  # log if $env:TenantId, $SubscriptionId, and $env:ARM_OIDC_TOKEN are set
-  Write-Host "$TenantId exists? $($TenantId -ne $null)"
-  Write-Host "$SubscriptionId exists? $($SubscriptionId -ne $null)"
-  Write-Host "$env:ARM_OIDC_TOKEN exists? $($env:ARM_OIDC_TOKEN -ne $null)"
-
   az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
   az account set --subscription $SubscriptionId
 }

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -56,7 +56,7 @@ Write-Host "Working directory: $workingFolder"
 
 if ($CI) {
   Write-Host "Logging in to service principal"
-  Write-Host "$env:TestApplicationId exists? $($env:TestApplicationId -ne $null)"
+  Write-Host "$TestApplicationId exists? $($TestApplicationId -ne $null)"
   # log if $env:TenantId, $SubscriptionId, and $env:ARM_OIDC_TOKEN are set
   Write-Host "$TenantId exists? $($TenantId -ne $null)"
   Write-Host "$SubscriptionId exists? $($SubscriptionId -ne $null)"

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -14,7 +14,24 @@ param (
   [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
 
   [Parameter()]
-  [hashtable] $AdditionalParameters = @{}
+  [hashtable] $AdditionalParameters = @{},
+
+
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string] $SubscriptionId,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string] $TenantId,
+
+  [Parameter()]
+  [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+  [string] $TestApplicationId,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string] $Environment
 )
 
 if (!$AdditionalParameters['deployMIResources']) {
@@ -39,8 +56,14 @@ Write-Host "Working directory: $workingFolder"
 
 if ($CI) {
   Write-Host "Logging in to service principal"
-  az login --service-principal -u $env:ARM_CLIENT_ID --tenant $env:ARM_TENANT_ID --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
-  az account set --subscription $DeploymentOutputs['IDENTITY_SUBSCRIPTION_ID']
+  Write-Host "$env:TestApplicationId exists? $($env:TestApplicationId -ne $null)"
+  # log if $env:TenantId, $SubscriptionId, and $env:ARM_OIDC_TOKEN are set
+  Write-Host "$TenantId exists? $($TenantId -ne $null)"
+  Write-Host "$SubscriptionId exists? $($SubscriptionId -ne $null)"
+  Write-Host "$env:ARM_OIDC_TOKEN exists? $($env:ARM_OIDC_TOKEN -ne $null)"
+
+  az login --service-principal -u $TestApplicationId --tenant $TenantId --allow-no-subscriptions --federated-token $env:ARM_OIDC_TOKEN
+  az account set --subscription $SubscriptionId
 }
 
 # Azure Functions app deployment

--- a/sdk/keyvault/keyvault-admin/tests.yml
+++ b/sdk/keyvault/keyvault-admin/tests.yml
@@ -10,6 +10,7 @@ extends:
       # instances per region per subscription) so we're only running
       # live tests against a single instance.
       Location: eastus2
+      PersistOidcToken: true
       MatrixConfigs:
         - Name: Keyvault_live_test_base
           Path: sdk/keyvault/keyvault-admin/platform-matrix.json

--- a/sdk/keyvault/keyvault-keys/tests.yml
+++ b/sdk/keyvault/keyvault-keys/tests.yml
@@ -6,6 +6,7 @@ extends:
       PackageName: "@azure/keyvault-keys"
       ServiceDirectory: keyvault
       TimeoutInMinutes: 90
+      PersistOidcToken: true
       CloudConfig:
         Public:
           Location: 'eastus2'

--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -31,6 +31,8 @@ param (
     [ValidateNotNullOrEmpty()]
     [string] $Environment,
 
+    [Parameter()]
+    [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
 
     # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
     [Parameter(ValueFromRemainingArguments = $true)]

--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -126,9 +126,8 @@ if ($CI) {
                       -TenantId $TenantId `
                       -ApplicationId $TestApplicationId `
                       -FederatedToken $env:ARM_OIDC_TOKEN `
-                      -AllowNoSubscriptions
 
-    Select-AzSubscription -SubscriptionId $SubscriptionId
+    Select-AzSubscription -Subscription $SubscriptionId
 }
 
 Export-AzKeyVaultSecurityDomain -Name $hsmName -Quorum 2 -Certificates $wrappingFiles -OutputPath $sdPath -ErrorAction SilentlyContinue -Verbose

--- a/sdk/keyvault/test-resources-post.ps1
+++ b/sdk/keyvault/test-resources-post.ps1
@@ -116,11 +116,6 @@ if (Test-Path $sdpath) {
 
 if ($CI) {
     Log "Logging in to service principal"
-    Log "$TestApplicationId exists? $($TestApplicationId -ne $null)"
-    # log if $env:TenantId, $SubscriptionId, and $env:ARM_OIDC_TOKEN are set
-    Log "$TenantId exists? $($TenantId -ne $null)"
-    Log "$SubscriptionId exists? $($SubscriptionId -ne $null)"
-    Log "$env:ARM_OIDC_TOKEN exists? $($env:ARM_OIDC_TOKEN -ne $null)"
 
     Connect-AzAccount -ServicePrincipal `
                       -TenantId $TenantId `


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/identity`
`@azure/keyvault-admin`
`@azure/keyvault-keys`

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Builds on previous work in https://github.com/Azure/azure-sdk-for-js/pull/31335
This PR adds support for `PersistOidcToken` parameter passing, allowing one to 
refresh their credential using `Connect-AzAccount` or `az login`

