### PR TITLE
[eslint] turn off `n/no-unsupported-features/node-builtins` rule for core

### DIFF
--- a/sdk/core/core-amqp/eslint.config.mjs
+++ b/sdk/core/core-amqp/eslint.config.mjs
@@ -2,9 +2,8 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 
 export default azsdkEslint.config([
   {
+    files: ["src/util/hmacSha256.common.ts"],
     rules: {
-      "@azure/azure-sdk/ts-package-json-name": "warn",
-      "@azure/azure-sdk/ts-versioning-semver": "warn",
       "n/no-unsupported-features/node-builtins": "off",
     },
   },

--- a/sdk/core/core-client-rest/eslint.config.mjs
+++ b/sdk/core/core-client-rest/eslint.config.mjs
@@ -1,0 +1,18 @@
+import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
+
+export default azsdkEslint.config([
+  {
+    files: [
+      "src/common.ts",
+      "src/getClient.ts",
+      "src/multipart.ts",
+      "src/sendRequest.ts",
+      "src/helpers/isBinaryBody.ts",
+      "test/multipart.spec.ts",
+      "test/sendRequest.spec.ts",
+    ],
+    rules: {
+      "n/no-unsupported-features/node-builtins": "off",
+    },
+  },
+]);

--- a/sdk/core/core-rest-pipeline/eslint.config.mjs
+++ b/sdk/core/core-rest-pipeline/eslint.config.mjs
@@ -1,0 +1,21 @@
+import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
+
+export default azsdkEslint.config([
+  {
+    files: [
+      "src/fetchHttpClient.ts",
+      "src/interfaces.ts",
+      "src/policies/formDataPolicy.ts",
+      "src/policies/multipartPolicy.ts",
+      "src/util/concat.ts",
+      "src/util/concat.common.ts",
+      "src/util/file.ts",
+      "src/util/typeGuards.ts",
+      "test/formDataPolicy.spec.ts",
+      "test/multipartPolicy.spec.ts",
+    ],
+    rules: {
+      "n/no-unsupported-features/node-builtins": "off",
+    },
+  },
+]);

--- a/sdk/core/core-rest-pipeline/test/agentPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/agentPolicy.spec.ts
@@ -5,10 +5,12 @@ import { describe, it, assert, vi } from "vitest";
 import {
   type PipelineResponse,
   type SendRequest,
+  type Agent,
+} from "../src/index.js";
+import {
   createHttpHeaders,
   createPipelineRequest,
   agentPolicy,
-  Agent,
 } from "../src/index.js";
 
 describe("agentPolicy", function () {

--- a/sdk/core/core-rest-pipeline/test/agentPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/agentPolicy.spec.ts
@@ -2,16 +2,8 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, vi } from "vitest";
-import {
-  type PipelineResponse,
-  type SendRequest,
-  type Agent,
-} from "../src/index.js";
-import {
-  createHttpHeaders,
-  createPipelineRequest,
-  agentPolicy,
-} from "../src/index.js";
+import { type PipelineResponse, type SendRequest, type Agent } from "../src/index.js";
+import { createHttpHeaders, createPipelineRequest, agentPolicy } from "../src/index.js";
 
 describe("agentPolicy", function () {
   it("should set custom agent", async () => {

--- a/sdk/core/core-sse/eslint.config.mjs
+++ b/sdk/core/core-sse/eslint.config.mjs
@@ -2,11 +2,7 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 
 export default azsdkEslint.config([
   {
-    files: [
-      "src/models.ts",
-      "src/sse.ts",
-      "src/utils.ts",
-    ],
+    files: ["src/models.ts", "src/sse.ts", "src/utils.ts"],
     rules: {
       "n/no-unsupported-features/node-builtins": "off",
     },

--- a/sdk/core/core-sse/eslint.config.mjs
+++ b/sdk/core/core-sse/eslint.config.mjs
@@ -2,9 +2,12 @@ import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 
 export default azsdkEslint.config([
   {
+    files: [
+      "src/models.ts",
+      "src/sse.ts",
+      "src/utils.ts",
+    ],
     rules: {
-      "@azure/azure-sdk/ts-package-json-name": "warn",
-      "@azure/azure-sdk/ts-versioning-semver": "warn",
       "n/no-unsupported-features/node-builtins": "off",
     },
   },


### PR DESCRIPTION
Our core code use a style of mixing browser code with NodeJS code in some files.
The `n/no-unsupported-features/node-builtins` complains about experimental Web
features that is not supported yet in NodeJS v18 even though they are only
intended to be used in browsers. for example,

>   87:28  warning  The 'fetch' is still an experimental feature and is not supported until Node.js 21.0.0. The configured version range is '>=18.0.0'     n/no-unsupported-features/node-builtins

This PR suppresses those warnings for core packages.