### PR TITLE
Maorleger/cosmos refactor

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1101,17 +1101,7 @@ export class EncryptionQueryBuilder {
     // (undocumented)
     addNumericParameter(name: string, value: number, dbType: "float" | "double", path: string): void;
     // (undocumented)
-    addParameter(name: string, value: boolean, path: string): void;
-    // (undocumented)
-    addParameter(name: string, value: string, path: string): void;
-    // (undocumented)
-    addParameter(name: string, value: JSONArray, path: string): void;
-    // (undocumented)
-    addParameter(name: string, value: JSONObject, path: string): void;
-    // (undocumented)
-    addParameter(name: string, value: Date, path: string): void;
-    // (undocumented)
-    addParameter(name: string, value: null, path: string): void;
+    addParameter(name: string, value: boolean | string | JSONArray | JSONObject | Date | null, path: string): void;
     addUnencryptedParameter(name: string, value: JSONValue, path: string): void;
 }
 

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1099,9 +1099,19 @@ export class EncryptionKeyWrapMetadata {
 export class EncryptionQueryBuilder {
     constructor(query: string);
     // (undocumented)
-    addParameter(name: string, value: boolean | string | JSONArray | JSONObject | Date | null, path: string): void;
+    addNumericParameter(name: string, value: number, dbType: "float" | "double", path: string): void;
     // (undocumented)
-    addParameter(name: string, value: number, dbType: "long" | "double", path: string): void;
+    addParameter(name: string, value: boolean, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: string, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: JSONArray, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: JSONObject, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: Date, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: null, path: string): void;
     addUnencryptedParameter(name: string, value: JSONValue, path: string): void;
 }
 

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1098,14 +1098,10 @@ export class EncryptionKeyWrapMetadata {
 // @public
 export class EncryptionQueryBuilder {
     constructor(query: string);
-    addArrayParameter(name: string, value: JSONArray, path: string): void;
-    addBooleanParameter(name: string, value: boolean, path: string): void;
-    addDateParameter(name: string, value: Date, path: string): void;
-    addFloatParameter(name: string, value: number, path: string): void;
-    addIntegerParameter(name: string, value: number, path: string): void;
-    addNullParameter(name: string, path: string): void;
-    addObjectParameter(name: string, value: JSONObject, path: string): void;
-    addStringParameter(name: string, value: string, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: boolean | string | JSONArray | JSONObject | Date | null, path: string): void;
+    // (undocumented)
+    addParameter(name: string, value: number, dbType: "long" | "double", path: string): void;
     addUnencryptedParameter(name: string, value: JSONValue, path: string): void;
 }
 

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
@@ -26,44 +26,51 @@ export class EncryptionQueryBuilder {
     this.query = query;
     this.parameters = [];
   }
-  /** Adds boolean parameter to the query */
-  public addBooleanParameter(name: string, value: boolean, path: string): void {
-    this.parameters.push({ name: name, value: value, type: TypeMarker.Boolean, path: path });
-  }
-  /** Adds integer parameter to query  */
-  public addIntegerParameter(name: string, value: number, path: string): void {
-    this.parameters.push({ name: name, value: value, type: TypeMarker.Long, path: path });
-  }
-  /** Adds float parameter to query */
-  public addFloatParameter(name: string, value: number, path: string): void {
-    this.parameters.push({ name: name, value: value, type: TypeMarker.Double, path: path });
-  }
-  /** Adds string parameter to query */
-  public addStringParameter(name: string, value: string, path: string): void {
-    this.parameters.push({ name: name, value: value, type: TypeMarker.String, path: path });
-  }
-  /** Adds array parameter to query */
-  public addArrayParameter(name: string, value: JSONArray, path: string): void {
-    this.parameters.push({ name: name, value: value, path: path });
-  }
-  /** Adds object parameter to query */
-  public addObjectParameter(name: string, value: JSONObject, path: string): void {
-    this.parameters.push({ name: name, value: value, path: path });
-  }
-  /** Adds date parameter to query */
-  public addDateParameter(name: string, value: Date, path: string): void {
-    const date = value.toISOString();
-    this.parameters.push({
-      name: name,
-      value: date,
-      type: TypeMarker.String,
-      path: path,
-    });
-  }
 
-  /** Adds null parameter to query */
-  public addNullParameter(name: string, path: string): void {
-    this.parameters.push({ name: name, value: null, path: path });
+  public addParameter(
+    name: string,
+    value: boolean | string | JSONArray | JSONObject | Date | null,
+    path: string,
+  ): void;
+  public addParameter(name: string, value: number, dbType: "long" | "double", path: string): void;
+  public addParameter(
+    name: string,
+    value: boolean | string | JSONArray | JSONObject | Date | null | number,
+    kindOrPath: string,
+    pathOrUndefined?: string,
+  ): void {
+    const path = pathOrUndefined === undefined ? kindOrPath : pathOrUndefined;
+    const kind = pathOrUndefined === undefined ? undefined : kindOrPath;
+    if (path === undefined) {
+      throw new Error("Path is required");
+    }
+
+    switch (typeof value) {
+      case "boolean":
+        this.parameters?.push({ name, value, type: TypeMarker.Boolean, path });
+        break;
+      case "number":
+        if (kind === "double") {
+          this.parameters?.push({ name, value, type: TypeMarker.Double, path });
+        } else {
+          this.parameters?.push({ name, value, type: TypeMarker.Long, path });
+        }
+        break;
+      case "string":
+        this.parameters?.push({ name, value, type: TypeMarker.String, path });
+        break;
+      case "object":
+        if (value instanceof Date) {
+          const date = value.toISOString();
+          this.parameters?.push({ name, value: date, type: TypeMarker.String, path });
+        } else if (value === null) {
+          this.parameters?.push({ name, value: null, path });
+        }
+        break;
+      default:
+        this.parameters?.push({ name, value, path });
+        break;
+    }
   }
 
   /** Adds unencrypted parameter to query */

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
@@ -27,49 +27,53 @@ export class EncryptionQueryBuilder {
     this.parameters = [];
   }
 
-  public addParameter(name: string, value: number, dbType: "long" | "double", path: string): void;
+  public addNumericParameter(
+    name: string,
+    value: number,
+    dbType: "float" | "double",
+    path: string,
+  ): void {
+    this.parameters?.push({
+      name,
+      value,
+      type: dbType === "float" ? TypeMarker.Double : TypeMarker.Long,
+      path,
+    });
+  }
+
+  // Alternatively you can remove all overloads (except for last one) and expose a single method
+  // with a union type for the value parameter (comment out this block and see how it impacts the experience)
   public addParameter(name: string, value: boolean, path: string): void;
   public addParameter(name: string, value: string, path: string): void;
   public addParameter(name: string, value: JSONArray, path: string): void;
   public addParameter(name: string, value: JSONObject, path: string): void;
   public addParameter(name: string, value: Date, path: string): void;
   public addParameter(name: string, value: null, path: string): void;
+
   public addParameter(
     name: string,
-    value: boolean | string | JSONArray | JSONObject | Date | null | number,
-    kindOrPath: string,
-    pathOrUndefined?: string,
+    value: boolean | string | JSONArray | JSONObject | Date | null,
+    path: string,
   ): void {
-    const path = pathOrUndefined === undefined ? kindOrPath : pathOrUndefined;
-    const kind = pathOrUndefined === undefined ? undefined : kindOrPath;
-    if (path === undefined) {
-      throw new Error("Path is required");
-    }
-
     switch (typeof value) {
       case "boolean":
         this.parameters?.push({ name, value, type: TypeMarker.Boolean, path });
-        break;
-      case "number":
-        if (kind === "double") {
-          this.parameters?.push({ name, value, type: TypeMarker.Double, path });
-        } else {
-          this.parameters?.push({ name, value, type: TypeMarker.Long, path });
-        }
         break;
       case "string":
         this.parameters?.push({ name, value, type: TypeMarker.String, path });
         break;
       case "object":
         if (value instanceof Date) {
+          // convenience for dates
           const date = value.toISOString();
           this.parameters?.push({ name, value: date, type: TypeMarker.String, path });
         } else if (value === null) {
+          // typeof null === object
           this.parameters?.push({ name, value: null, path });
         }
         break;
       default:
-        this.parameters?.push({ name, value, path });
+        this.parameters?.push({ name, value, path }); // for JSONObject, JSONArray, unencrypted etc
         break;
     }
   }

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
@@ -41,15 +41,6 @@ export class EncryptionQueryBuilder {
     });
   }
 
-  // Alternatively you can remove all overloads (except for last one) and expose a single method
-  // with a union type for the value parameter (comment out this block and see how it impacts the experience)
-  public addParameter(name: string, value: boolean, path: string): void;
-  public addParameter(name: string, value: string, path: string): void;
-  public addParameter(name: string, value: JSONArray, path: string): void;
-  public addParameter(name: string, value: JSONObject, path: string): void;
-  public addParameter(name: string, value: Date, path: string): void;
-  public addParameter(name: string, value: null, path: string): void;
-
   public addParameter(
     name: string,
     value: boolean | string | JSONArray | JSONObject | Date | null,

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionQueryBuilder.ts
@@ -27,12 +27,13 @@ export class EncryptionQueryBuilder {
     this.parameters = [];
   }
 
-  public addParameter(
-    name: string,
-    value: boolean | string | JSONArray | JSONObject | Date | null,
-    path: string,
-  ): void;
   public addParameter(name: string, value: number, dbType: "long" | "double", path: string): void;
+  public addParameter(name: string, value: boolean, path: string): void;
+  public addParameter(name: string, value: string, path: string): void;
+  public addParameter(name: string, value: JSONArray, path: string): void;
+  public addParameter(name: string, value: JSONObject, path: string): void;
+  public addParameter(name: string, value: Date, path: string): void;
+  public addParameter(name: string, value: null, path: string): void;
   public addParameter(
     name: string,
     value: boolean | string | JSONArray | JSONObject | Date | null | number,

--- a/sdk/cosmosdb/cosmos/test/public/functional/clientSideEncryption.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/clientSideEncryption.spec.ts
@@ -545,27 +545,29 @@ describe("ClientSideEncryption", function (this: Suite) {
         " AND c.sensitive_NestedObjectFormatL1.sensitive_NestedObjectFormatL2.sensitive_DecimalFormatL2 = @sensitive_DecimalFormatL2",
     );
     // null parameters should also work with other add methods
-    queryBuilder.addStringParameter(
+    queryBuilder.addParameter(
       "@sensitive_StringFormat",
       testDoc.sensitive_StringFormat,
       "/sensitive_StringFormat",
     );
-    queryBuilder.addNullParameter("@sensitive_ArrayFormat", "/sensitive_ArrayFormat");
-    queryBuilder.addIntegerParameter(
+    queryBuilder.addParameter("@sensitive_ArrayFormat", null, "/sensitive_ArrayFormat");
+    queryBuilder.addParameter(
       "@sensitive_IntFormat",
       testDoc.sensitive_IntFormat,
+      "double",
       "/sensitive_IntFormat",
     );
-    queryBuilder.addStringParameter(
+    queryBuilder.addParameter(
       "@sensitive_StringFormatL2",
       testDoc.sensitive_NestedObjectFormatL1.sensitive_NestedObjectFormatL2
         .sensitive_StringFormatL2,
       "/sensitive_NestedObjectFormatL1",
     );
-    queryBuilder.addFloatParameter(
+    queryBuilder.addParameter(
       "@sensitive_DecimalFormatL2",
       testDoc.sensitive_NestedObjectFormatL1.sensitive_NestedObjectFormatL2
         .sensitive_DecimalFormatL2,
+      "double",
       "/sensitive_NestedObjectFormatL1",
     );
 
@@ -588,8 +590,8 @@ describe("ClientSideEncryption", function (this: Suite) {
       "select * from c where c.id = @theId and c.PK = @thePK",
     );
 
-    queryBuilder.addStringParameter("@theId", expectedDoc.id, "/id");
-    queryBuilder.addStringParameter("@thePK", expectedDoc.PK, "/PK");
+    queryBuilder.addParameter("@theId", expectedDoc.id, "/id");
+    queryBuilder.addParameter("@thePK", expectedDoc.PK, "/PK");
 
     await validateQueryResults(encryptionContainer, queryBuilder, expectedDocList);
 
@@ -631,12 +633,12 @@ describe("ClientSideEncryption", function (this: Suite) {
     queryBuilder = new EncryptionQueryBuilder(
       "SELECT * FROM c where array_contains(@sensitive_StringFormat, c.sensitive_StringFormat) AND c.sensitive_NestedObjectFormatL1 = @sensitive_NestedObjectFormatL1",
     );
-    queryBuilder.addArrayParameter(
+    queryBuilder.addParameter(
       "@sensitive_StringFormat",
       arrayOfStringValues,
       "/sensitive_StringFormat",
     );
-    queryBuilder.addObjectParameter(
+    queryBuilder.addParameter(
       "@sensitive_NestedObjectFormatL1",
       testDoc1.sensitive_NestedObjectFormatL1,
       "/sensitive_NestedObjectFormatL1",
@@ -646,14 +648,15 @@ describe("ClientSideEncryption", function (this: Suite) {
     queryBuilder = new EncryptionQueryBuilder(
       "SELECT * FROM c where c.sensitive_BoolFormat = @sensitive_BoolFormat and c.sensitive_FloatFormat = @sensitive_FloatFormat",
     );
-    queryBuilder.addBooleanParameter(
+    queryBuilder.addParameter(
       "@sensitive_BoolFormat",
       testDoc1.sensitive_BoolFormat,
       "/sensitive_BoolFormat",
     );
-    queryBuilder.addFloatParameter(
+    queryBuilder.addParameter(
       "@sensitive_FloatFormat",
       testDoc1.sensitive_FloatFormat,
+      "double",
       "/sensitive_FloatFormat",
     );
     await validateQueryResults(
@@ -669,10 +672,11 @@ describe("ClientSideEncryption", function (this: Suite) {
     queryBuilder = new EncryptionQueryBuilder(
       "SELECT * FROM c where c.nonsensitive = @nonsensitive and c.sensitive_IntFormat = @sensitive_IntFormat",
     );
-    queryBuilder.addStringParameter("@nonsensitive", testDoc4.nonsensitive, "/nonsensitive");
-    queryBuilder.addIntegerParameter(
+    queryBuilder.addParameter("@nonsensitive", testDoc4.nonsensitive, "/nonsensitive");
+    queryBuilder.addParameter(
       "@sensitive_IntFormat",
       testDoc4.sensitive_IntFormat,
+      "long",
       "/sensitive_IntFormat",
     );
     await validateQueryResults(encryptionQueryContainer, queryBuilder, [testDoc4]);
@@ -1135,14 +1139,15 @@ describe("ClientSideEncryption", function (this: Suite) {
     const queryBuilder = new EncryptionQueryBuilder(
       `SELECT * FROM c where c.sensitive_StringFormat = @sensitive_StringFormat AND c.sensitive_IntFormat = @sensitive_IntFormat`,
     );
-    queryBuilder.addStringParameter(
+    queryBuilder.addParameter(
       "@sensitive_StringFormat",
       testDoc.sensitive_StringFormat,
       "/sensitive_StringFormat",
     );
-    queryBuilder.addIntegerParameter(
+    queryBuilder.addParameter(
       "@sensitive_IntFormat",
       testDoc.sensitive_IntFormat,
+      "long",
       "/sensitive_IntFormat",
     );
     const expectedDocList = [testDoc];
@@ -1985,7 +1990,7 @@ describe("ClientSideEncryption", function (this: Suite) {
       `SELECT COUNT(c.id), c.PK FROM c WHERE c.PK = @PK GROUP BY c.PK`,
     );
 
-    query.addStringParameter("@PK", partitionKey, "/PK");
+    query.addParameter("@PK", partitionKey, "/PK");
     let iterator = await encryptionContainer.items.getEncryptionQueryIterator(query);
     while (iterator.hasMoreResults()) {
       const response = await iterator.fetchNext();
@@ -1996,9 +2001,16 @@ describe("ClientSideEncryption", function (this: Suite) {
       "SELECT COUNT(c.id), c.sensitive_IntFormat FROM c WHERE c.sensitive_IntFormat = @Sensitive_IntFormat GROUP BY c.sensitive_IntFormat",
     );
 
-    withEncryptedParameter.addIntegerParameter(
+    withEncryptedParameter.addParameter(
+      "@sensitive",
+      testDoc1.sensitive_IntFormat,
+      "long",
+      "/sensitive_IntFormat",
+    );
+    withEncryptedParameter.addParameter(
       "@Sensitive_IntFormat",
       testDoc1.sensitive_IntFormat,
+      "long",
       "/sensitive_IntFormat",
     );
 
@@ -2108,7 +2120,7 @@ describe("ClientSideEncryption", function (this: Suite) {
     query = new EncryptionQueryBuilder(
       "SELECT * FROM c WHERE c.sensitive_StringFormat= @sensitive_StringFormat",
     );
-    query.addStringParameter(
+    query.addParameter(
       "@sensitive_StringFormat",
       testDoc.sensitive_StringFormat,
       "/sensitive_StringFormat",
@@ -2121,9 +2133,10 @@ describe("ClientSideEncryption", function (this: Suite) {
     query = new EncryptionQueryBuilder(
       "SELECT * FROM c WHERE c.sensitive_LongFormat= @sensitive_LongFormat",
     );
-    query.addIntegerParameter(
+    query.addParameter(
       "@sensitive_LongFormat",
       testDoc.sensitive_LongFormat,
+      "long",
       "/sensitive_LongFormat",
     );
     iterator = await container.items.getEncryptionQueryIterator(query);
@@ -2134,7 +2147,7 @@ describe("ClientSideEncryption", function (this: Suite) {
     query = new EncryptionQueryBuilder(
       "SELECT * FROM c WHERE c.sensitive_NestedObjectFormatL1= @sensitive_NestedObjectFormatL1",
     );
-    query.addObjectParameter(
+    query.addParameter(
       "@sensitive_NestedObjectFormatL1",
       testDoc.sensitive_NestedObjectFormatL1,
       "/sensitive_NestedObjectFormatL1",

--- a/sdk/cosmosdb/cosmos/test/public/functional/clientSideEncryption.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/clientSideEncryption.spec.ts
@@ -550,8 +550,9 @@ describe("ClientSideEncryption", function (this: Suite) {
       testDoc.sensitive_StringFormat,
       "/sensitive_StringFormat",
     );
+    queryBuilder.addNumericParameter("foo", 4.4, "float", "/something");
     queryBuilder.addParameter("@sensitive_ArrayFormat", null, "/sensitive_ArrayFormat");
-    queryBuilder.addParameter(
+    queryBuilder.addNumericParameter(
       "@sensitive_IntFormat",
       testDoc.sensitive_IntFormat,
       "double",
@@ -563,7 +564,7 @@ describe("ClientSideEncryption", function (this: Suite) {
         .sensitive_StringFormatL2,
       "/sensitive_NestedObjectFormatL1",
     );
-    queryBuilder.addParameter(
+    queryBuilder.addNumericParameter(
       "@sensitive_DecimalFormatL2",
       testDoc.sensitive_NestedObjectFormatL1.sensitive_NestedObjectFormatL2
         .sensitive_DecimalFormatL2,
@@ -653,7 +654,7 @@ describe("ClientSideEncryption", function (this: Suite) {
       testDoc1.sensitive_BoolFormat,
       "/sensitive_BoolFormat",
     );
-    queryBuilder.addParameter(
+    queryBuilder.addNumericParameter(
       "@sensitive_FloatFormat",
       testDoc1.sensitive_FloatFormat,
       "double",
@@ -673,10 +674,10 @@ describe("ClientSideEncryption", function (this: Suite) {
       "SELECT * FROM c where c.nonsensitive = @nonsensitive and c.sensitive_IntFormat = @sensitive_IntFormat",
     );
     queryBuilder.addParameter("@nonsensitive", testDoc4.nonsensitive, "/nonsensitive");
-    queryBuilder.addParameter(
+    queryBuilder.addNumericParameter(
       "@sensitive_IntFormat",
       testDoc4.sensitive_IntFormat,
-      "long",
+      "double",
       "/sensitive_IntFormat",
     );
     await validateQueryResults(encryptionQueryContainer, queryBuilder, [testDoc4]);
@@ -1144,10 +1145,10 @@ describe("ClientSideEncryption", function (this: Suite) {
       testDoc.sensitive_StringFormat,
       "/sensitive_StringFormat",
     );
-    queryBuilder.addParameter(
+    queryBuilder.addNumericParameter(
       "@sensitive_IntFormat",
       testDoc.sensitive_IntFormat,
-      "long",
+      "double",
       "/sensitive_IntFormat",
     );
     const expectedDocList = [testDoc];
@@ -2001,16 +2002,16 @@ describe("ClientSideEncryption", function (this: Suite) {
       "SELECT COUNT(c.id), c.sensitive_IntFormat FROM c WHERE c.sensitive_IntFormat = @Sensitive_IntFormat GROUP BY c.sensitive_IntFormat",
     );
 
-    withEncryptedParameter.addParameter(
+    withEncryptedParameter.addNumericParameter(
       "@sensitive",
       testDoc1.sensitive_IntFormat,
-      "long",
+      "double",
       "/sensitive_IntFormat",
     );
-    withEncryptedParameter.addParameter(
+    withEncryptedParameter.addNumericParameter(
       "@Sensitive_IntFormat",
       testDoc1.sensitive_IntFormat,
-      "long",
+      "double",
       "/sensitive_IntFormat",
     );
 
@@ -2133,10 +2134,10 @@ describe("ClientSideEncryption", function (this: Suite) {
     query = new EncryptionQueryBuilder(
       "SELECT * FROM c WHERE c.sensitive_LongFormat= @sensitive_LongFormat",
     );
-    query.addParameter(
+    query.addNumericParameter(
       "@sensitive_LongFormat",
       testDoc.sensitive_LongFormat,
-      "long",
+      "double",
       "/sensitive_LongFormat",
     );
     iterator = await container.items.getEncryptionQueryIterator(query);


### PR DESCRIPTION
Just a few options to resolve https://spa.apiview.dev/review/78434da7bab841c583864e3a27d3c043?activeApiRevisionId=6de9f9740782489f85b4861c3a837da7&nId=@azure%2Fcosmos!EncryptionKeyWrapMetadata%23value:member 

Helpful to review each option separately:

- [option 1](https://github.com/Azure/azure-sdk-for-js/compare/main...4a7521a016a16d495824fd507044c1778fc05bb7) shows one possibility. From a usage perspective, the intellisense is not great when adding a number without the dbType param but it's worth exploring
- [option 2](https://github.com/Azure/azure-sdk-for-js/compare/main...b236f0322c19baf59499dcea2974233e56c724b1) shows a hybrid of overloads and a separate function for numeric parameters that need to be disambiguated
- [option 3](https://github.com/Azure/azure-sdk-for-js/compare/main...6857b494998f94575ff34c069020cc780e3f481e) removes the overloads and exposes the union type directly

@amanrao23 a few options for you to review. I prefer the second (overload for "normal" parameters)

@joheredi would love your take on this as well sometime today - is one better from a JS / idiomatic perspective? They're trying to ship by friday 