### PR TITLE
[Recorder] Exclude Origin header

### DIFF
--- a/eng/tools/rush-runner/src/helpers.js
+++ b/eng/tools/rush-runner/src/helpers.js
@@ -18,7 +18,6 @@ export const reducedDependencyTestMatrix = {
     "@azure/template",
   ],
   "test-utils": [
-    "@azure-tests/perf-storage-blob",
     "@azure/arm-eventgrid",
     "@azure/ai-text-analytics",
     "@azure/identity",

--- a/eng/tools/rush-runner/src/helpers.js
+++ b/eng/tools/rush-runner/src/helpers.js
@@ -24,12 +24,10 @@ export const reducedDependencyTestMatrix = {
     "@azure/template",
   ],
   identity: [
-    "@azure-tests/perf-storage-blob",
     "@azure/ai-text-analytics",
     "@azure/arm-resources",
     "@azure/identity-cache-persistence",
     "@azure/identity-vscode",
-    "@azure/storage-blob",
     "@azure/template",
   ],
 };

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -12,6 +12,7 @@
     - `HeaderSanitizers` that redact sensitive information in the headers of the requests.
 - Added support for the TestProxy/addSanitizers API, which improves the recording of tests by reducing flakiness and timeouts caused by concurrent requests. This helps to speed up the recording process and reduces the burden on the test proxy.
 - Adds `removeCentralSanitizers` option to the `RecorderStartOptions` to allow users pass in the central sanitizer ids to skip the specific santiizers at the test proxy level.
+- Ignore `Origin` header for browsers in Playback mode, to address [#32851](https://github.com/Azure/azure-sdk-for-js/issues/32851).
 
 ### Bugs Fixed
 

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -446,8 +446,9 @@ export class Recorder {
       // Ideally this should be handled by the test-proxy.  However, it was suggested that
       // there may be scenarios where it is desired to include these headers.
       // Thus we are ignoring Accept-Language and Accept-Encountered headers in recorder for browser.
+      // Origin header - https://github.com/Azure/azure-sdk-for-js/issues/32851
       const excludedHeaders = isBrowser
-        ? (options.excludedHeaders ?? []).concat("Accept-Language", "Accept-Encoding")
+        ? (options.excludedHeaders ?? []).concat("Accept-Language", "Accept-Encoding", "Origin")
         : options.excludedHeaders;
 
       const updatedOptions = {

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -445,7 +445,7 @@ export class Recorder {
       // See discussion in https://github.com/Azure/azure-sdk-tools/pull/6152
       // Ideally this should be handled by the test-proxy.  However, it was suggested that
       // there may be scenarios where it is desired to include these headers.
-      // Thus we are ignoring Accept-Language and Accept-Encountered headers in recorder for browser.
+      // Thus we are ignoring Accept-Language and Accept-Encoding headers in recorder for browser.
       // Origin header - https://github.com/Azure/azure-sdk-for-js/issues/32851
       const excludedHeaders = isBrowser
         ? (options.excludedHeaders ?? []).concat("Accept-Language", "Accept-Encoding", "Origin")


### PR DESCRIPTION
### Packages impacted by this PR
Browser tests in all the packages

### Issues associated with this PR
#32851 

### Describe the problem that is addressed by this PR
Ignore `Origin` header for browsers in Playback mode
