### PR TITLE
Set python version before calling verify-readmes

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -29,6 +29,11 @@ steps:
       pwsh: true
     displayName: Spell check public API
 
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.11'
+    inputs:
+      versionSpec: '3.11'
+
   - template: /eng/common/pipelines/templates/steps/verify-readmes.yml
     parameters:
       PackagePropertiesFolder: $(Build.ArtifactStagingDirectory)/PackageInfo


### PR DESCRIPTION
To avoid an issue with python and readme verification, set the python version first