### PR TITLE
Revert "[core] Support NodeJS stream cancellation (#33341)"

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Features Added
 
-- `asNodeStream` now returns a `NodeJSReadableStream` which can be canceled by calling the `destroy` method.
-
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-client-rest/review/core-client.api.md
+++ b/sdk/core/core-client-rest/review/core-client.api.md
@@ -8,7 +8,6 @@ import type { AbortSignalLike } from '@azure/abort-controller';
 import type { HttpClient } from '@azure/core-rest-pipeline';
 import type { KeyCredential } from '@azure/core-auth';
 import type { LogPolicyOptions } from '@azure/core-rest-pipeline';
-import type { NodeJSReadableStream } from '@azure/core-rest-pipeline';
 import type { OperationTracingOptions } from '@azure/core-tracing';
 import type { Pipeline } from '@azure/core-rest-pipeline';
 import type { PipelineOptions } from '@azure/core-rest-pipeline';
@@ -99,7 +98,7 @@ export type HttpBrowserStreamResponse = HttpResponse & {
 
 // @public
 export type HttpNodeStreamResponse = HttpResponse & {
-    body?: NodeJSReadableStream;
+    body?: NodeJS.ReadableStream;
 };
 
 // @public

--- a/sdk/core/core-client-rest/src/common.ts
+++ b/sdk/core/core-client-rest/src/common.ts
@@ -4,7 +4,6 @@
 import type {
   HttpClient,
   LogPolicyOptions,
-  NodeJSReadableStream,
   Pipeline,
   PipelineOptions,
   PipelinePolicy,
@@ -225,7 +224,7 @@ export type HttpNodeStreamResponse = HttpResponse & {
   /**
    * Streamable body
    */
-  body?: NodeJSReadableStream;
+  body?: NodeJS.ReadableStream;
 };
 
 /**

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Features Added
 
-- `PipelineResponse.readableStreamBody` is now typed as `NodeJSReadableStream` which can be canceled by calling the `destroy` method.
-
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -232,11 +232,6 @@ export function ndJsonPolicy(): PipelinePolicy;
 export const ndJsonPolicyName = "ndJsonPolicy";
 
 // @public
-export interface NodeJSReadableStream extends NodeJS.ReadableStream {
-    destroy(error?: Error): void;
-}
-
-// @public
 export interface Pipeline {
     addPolicy(policy: PipelinePolicy, options?: AddPipelineOptions): void;
     clone(): Pipeline;
@@ -322,7 +317,7 @@ export interface PipelineResponse {
     bodyAsText?: string | null;
     browserStreamBody?: ReadableStream<Uint8Array>;
     headers: HttpHeaders;
-    readableStreamBody?: NodeJSReadableStream;
+    readableStreamBody?: NodeJS.ReadableStream;
     request: PipelineRequest;
     status: number;
 }

--- a/sdk/core/core-rest-pipeline/src/index.ts
+++ b/sdk/core/core-rest-pipeline/src/index.ts
@@ -30,7 +30,6 @@ export type {
   SendRequest,
   TlsSettings,
   TransferProgressEvent,
-  NodeJSReadableStream,
 } from "./interfaces.js";
 export {
   type AddPolicyOptions as AddPipelineOptions,

--- a/sdk/core/core-rest-pipeline/src/interfaces.ts
+++ b/sdk/core/core-rest-pipeline/src/interfaces.ts
@@ -49,18 +49,6 @@ export interface HttpHeaders extends Iterable<[string, string]> {
 }
 
 /**
- * A Node.js Readable stream that also has a `destroy` method.
- */
-export interface NodeJSReadableStream extends NodeJS.ReadableStream {
-  /**
-   * Destroy the stream. Optionally emit an 'error' event, and emit a
-   * 'close' event (unless emitClose is set to false). After this call,
-   * internal resources will be released.
-   */
-  destroy(error?: Error): void;
-}
-
-/**
  * A part of the request body in a multipart request.
  */
 export interface BodyPart {
@@ -298,7 +286,7 @@ export interface PipelineResponse {
    * The response body as a node.js Readable stream.
    * Always undefined in the browser.
    */
-  readableStreamBody?: NodeJSReadableStream;
+  readableStreamBody?: NodeJS.ReadableStream;
 }
 
 /**

--- a/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
+++ b/sdk/core/core-rest-pipeline/src/nodeHttpClient.ts
@@ -9,7 +9,6 @@ import { AbortError } from "@azure/abort-controller";
 import type {
   HttpClient,
   HttpHeaders,
-  NodeJSReadableStream,
   PipelineRequest,
   PipelineResponse,
   RequestBodyType,
@@ -24,11 +23,11 @@ import { Sanitizer } from "./util/sanitizer.js";
 
 const DEFAULT_TLS_SETTINGS = {};
 
-function isReadableStream(body: any): body is NodeJSReadableStream {
+function isReadableStream(body: any): body is NodeJS.ReadableStream {
   return body && typeof body.pipe === "function";
 }
 
-function isStreamComplete(stream: NodeJSReadableStream): Promise<void> {
+function isStreamComplete(stream: NodeJS.ReadableStream): Promise<void> {
   if (stream.readable === false) {
     return Promise.resolve();
   }
@@ -122,7 +121,7 @@ class NodeHttpClient implements HttpClient {
       }
     }
 
-    let responseStream: NodeJSReadableStream | undefined;
+    let responseStream: NodeJS.ReadableStream | undefined;
     try {
       if (body && request.onUploadProgress) {
         const onUploadProgress = request.onUploadProgress;
@@ -333,7 +332,7 @@ function getResponseHeaders(res: IncomingMessage): HttpHeaders {
 function getDecodedResponseStream(
   stream: IncomingMessage,
   headers: HttpHeaders,
-): NodeJSReadableStream {
+): NodeJS.ReadableStream {
   const contentEncoding = headers.get("Content-Encoding");
   if (contentEncoding === "gzip") {
     const unzip = zlib.createGunzip();
@@ -348,7 +347,7 @@ function getDecodedResponseStream(
   return stream;
 }
 
-function streamToText(stream: NodeJSReadableStream): Promise<string> {
+function streamToText(stream: NodeJS.ReadableStream): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const buffer: Buffer[] = [];
 

--- a/sdk/core/core-sse/CHANGELOG.md
+++ b/sdk/core/core-sse/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Features Added
 
-- `createSseStream` now supports NodeJS streams as input.
-
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-sse/review/core-sse.api.md
+++ b/sdk/core/core-sse/review/core-sse.api.md
@@ -13,9 +13,6 @@ export function createSseStream(chunkStream: ReadableStream<Uint8Array>): EventM
 export function createSseStream(chunkStream: IncomingMessage): EventMessageStream;
 
 // @public
-export function createSseStream(chunkStream: NodeJSReadableStream): EventMessageStream;
-
-// @public
 export interface EventMessage {
     data: string;
     event: string;
@@ -25,11 +22,6 @@ export interface EventMessage {
 
 // @public
 export interface EventMessageStream extends ReadableStream<EventMessage>, AsyncDisposable, AsyncIterable<EventMessage> {
-}
-
-// @public
-export interface NodeJSReadableStream extends NodeJS.ReadableStream {
-    destroy(error?: Error): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/core/core-sse/src/index.ts
+++ b/sdk/core/core-sse/src/index.ts
@@ -2,4 +2,4 @@
 // Licensed under the MIT License.
 
 export { createSseStream } from "./sse.js";
-export { EventMessage, EventMessageStream, NodeJSReadableStream } from "./models.js";
+export { EventMessage, EventMessageStream } from "./models.js";

--- a/sdk/core/core-sse/src/models.ts
+++ b/sdk/core/core-sse/src/models.ts
@@ -25,15 +25,3 @@ export interface EventMessageStream
     AsyncIterable<EventMessage> {}
 
 export type PartialSome<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
-/**
- * A Node.js Readable stream that also has a `destroy` method.
- */
-export interface NodeJSReadableStream extends NodeJS.ReadableStream {
-  /**
-   * Destroy the stream. Optionally emit an 'error' event, and emit a
-   * 'close' event (unless emitClose is set to false). After this call,
-   * internal resources will be released.
-   */
-  destroy(error?: Error): void;
-}

--- a/sdk/core/core-sse/src/sse.ts
+++ b/sdk/core/core-sse/src/sse.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT License.
 
 import type { IncomingMessage } from "node:http";
-import type {
-  EventMessage,
-  EventMessageStream,
-  NodeJSReadableStream,
-  PartialSome,
-} from "./models.js";
+import type { EventMessage, EventMessageStream, PartialSome } from "./models.js";
 import { createStream, ensureAsyncIterable } from "./utils.js";
 
 enum ControlChars {
@@ -20,23 +15,17 @@ enum ControlChars {
 /**
  * Processes a response stream into a stream of events.
  * @param chunkStream - A stream of Uint8Array chunks
- * @returns A stream of EventMessage objects
+ * @returns An async iterable of EventMessage objects
  */
 export function createSseStream(chunkStream: ReadableStream<Uint8Array>): EventMessageStream;
 /**
  * Processes a response stream into a stream of events.
- * @param chunkStream - A NodeJS HTTP response
- * @returns A stream of EventMessage objects
+ * @param chunkStream - An async iterable of Uint8Array chunks
+ * @returns An async iterable of EventMessage objects
  */
 export function createSseStream(chunkStream: IncomingMessage): EventMessageStream;
-/**
- * Processes a response stream into a stream of events.
- * @param chunkStream - A NodeJS Readable stream
- * @returns A stream of EventMessage objects
- */
-export function createSseStream(chunkStream: NodeJSReadableStream): EventMessageStream;
 export function createSseStream(
-  chunkStream: IncomingMessage | NodeJSReadableStream | ReadableStream<Uint8Array>,
+  chunkStream: IncomingMessage | ReadableStream<Uint8Array>,
 ): EventMessageStream {
   const { cancel, iterable } = ensureAsyncIterable(chunkStream);
   const asyncIter = toMessage(toLine(iterable));

--- a/sdk/core/core-sse/test/public/node/util.ts
+++ b/sdk/core/core-sse/test/public/node/util.ts
@@ -10,5 +10,6 @@ export function createStream(
   const stream = new PassThrough();
   cb((c) => stream.write(c));
   stream.end();
-  return createSseStream(stream);
+  // This is a mock test that doesn't need a true IncomingMessage object
+  return createSseStream(stream as any);
 }

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -489,15 +489,14 @@ index 30dac33..66ea99c 100644
    if (!cachedHttpClient) {
      cachedHttpClient = createDefaultHttpClient();
 diff --git a/src/client/common.ts b/src/client/common.ts
-index f9b6c48..a45e87d 100644
+index 609878a..da6742a 100644
 --- a/src/client/common.ts
 +++ b/src/client/common.ts
-@@ -3,20 +3,18 @@
+@@ -3,19 +3,17 @@
  
  import type {
    HttpClient,
 -  LogPolicyOptions,
--  NodeJSReadableStream,
 -  Pipeline,
 -  PipelineOptions,
 -  PipelinePolicy,
@@ -511,7 +510,6 @@ index f9b6c48..a45e87d 100644
 -import type { AbortSignalLike } from "@azure/abort-controller";
 -import type { OperationTracingOptions } from "@azure/core-tracing";
 +  RawHttpHeadersInput,
-+  NodeJSReadableStream,
 +} from "../interfaces.js";
 +import type { Pipeline, PipelinePolicy } from "../pipeline.js";
 +import type { AbortSignalLike } from "../abort-controller/AbortSignalLike.js";
@@ -520,7 +518,7 @@ index f9b6c48..a45e87d 100644
  
  /**
   * Shape of the default request parameters, this may be overridden by the specific
-@@ -75,11 +73,6 @@ export type RequestParameters = {
+@@ -74,11 +72,6 @@ export type RequestParameters = {
     */
    abortSignal?: AbortSignalLike;
  
@@ -532,7 +530,7 @@ index f9b6c48..a45e87d 100644
    /**
     * A function to be called each time a response is received from the server
     * while performing the requested operation.
-@@ -92,16 +85,9 @@ export type RequestParameters = {
+@@ -91,16 +84,9 @@ export type RequestParameters = {
   * A function to be called each time a response is received from the server
   * while performing the requested operation.
   * May be called multiple times.
@@ -551,7 +549,7 @@ index f9b6c48..a45e87d 100644
  
  /**
   * Wrapper object for http request and response. Deserialized object is stored in
-@@ -136,11 +122,6 @@ export interface OperationOptions {
+@@ -135,11 +121,6 @@ export interface OperationOptions {
     * Options used when creating and sending HTTP requests for this operation.
     */
    requestOptions?: OperationRequestOptions;
@@ -563,7 +561,7 @@ index f9b6c48..a45e87d 100644
    /**
     * A function to be called each time a response is received from the server
     * while performing the requested operation.
-@@ -202,8 +183,8 @@ export interface Client {
+@@ -201,8 +182,8 @@ export interface Client {
     * This method will be used to send request that would check the path to provide
     * strong types. When used by the codegen this type gets overridden with the generated
     * types. For example:
@@ -574,7 +572,7 @@ index f9b6c48..a45e87d 100644
     *
     * type MyClient = Client & {
     *   path: Routes;
-@@ -334,11 +315,9 @@ export type ClientOptions = PipelineOptions & {
+@@ -333,11 +314,9 @@ export type ClientOptions = PipelineOptions & {
       */
      apiKeyHeaderName?: string;
    };
@@ -917,10 +915,10 @@ index ad162e3..ae5349c 100644
    HttpClient,
    HttpHeaders as PipelineHeaders,
 diff --git a/src/index.ts b/src/index.ts
-index 5fd69af..f28ac83 100644
+index 92a7ee9..65e7734 100644
 --- a/src/index.ts
 +++ b/src/index.ts
-@@ -9,117 +9,72 @@ declare global {
+@@ -9,116 +9,71 @@ declare global {
    interface TransformStream<I = any, O = any> {}
  }
  
@@ -965,7 +963,6 @@ index 5fd69af..f28ac83 100644
 +  ProxySettings,
 +  RawHttpHeadersInput,
 +  PipelineRetryOptions,
-   NodeJSReadableStream,
  } from "./interfaces.js";
 -export {
 -  type AddPolicyOptions as AddPipelineOptions,
@@ -1094,7 +1091,7 @@ index 5fd69af..f28ac83 100644
 +export type { RedirectPolicyOptions } from "./policies/redirectPolicy.js";
 +export type { UserAgentPolicyOptions } from "./policies/userAgentPolicy.js";
 diff --git a/src/interfaces.ts b/src/interfaces.ts
-index 8466f08..58ad06c 100644
+index 26b806d..5d790ad 100644
 --- a/src/interfaces.ts
 +++ b/src/interfaces.ts
 @@ -1,9 +1,7 @@
@@ -1108,7 +1105,7 @@ index 8466f08..58ad06c 100644
  
  /**
   * A HttpHeaders collection represented as a simple JSON object.
-@@ -216,11 +214,6 @@ export interface PipelineRequest {
+@@ -204,11 +202,6 @@ export interface PipelineRequest {
     */
    abortSignal?: AbortSignalLike;
  
@@ -1120,7 +1117,7 @@ index 8466f08..58ad06c 100644
    /**
     * Callback which fires upon upload progress.
     */
-@@ -327,6 +320,21 @@ export type TransferProgressEvent = {
+@@ -315,6 +308,21 @@ export type TransferProgressEvent = {
    loadedBytes: number;
  };
  
@@ -1340,7 +1337,7 @@ index 3e33a3b..3654566 100644
 +  return TYPESPEC_RUNTIME_LOG_LEVELS.includes(logLevel as any);
  }
 diff --git a/src/nodeHttpClient.ts b/src/nodeHttpClient.ts
-index 2d7bf00..1e415cb 100644
+index 264a28e..2b974db 100644
 --- a/src/nodeHttpClient.ts
 +++ b/src/nodeHttpClient.ts
 @@ -5,7 +5,7 @@ import * as http from "node:http";

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -159,7 +159,7 @@ export type HttpMethods = "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "HEAD" |
 
 // @public
 export type HttpNodeStreamResponse = HttpResponse & {
-    body?: NodeJSReadableStream;
+    body?: NodeJS.ReadableStream;
 };
 
 // @public
@@ -201,11 +201,6 @@ export interface LogPolicyOptions {
 export interface MultipartRequestBody {
     boundary?: string;
     parts: BodyPart[];
-}
-
-// @public
-export interface NodeJSReadableStream extends NodeJS.ReadableStream {
-    destroy(error?: Error): void;
 }
 
 // @public
@@ -331,7 +326,7 @@ export interface PipelineResponse {
     bodyAsText?: string | null;
     browserStreamBody?: ReadableStream<Uint8Array>;
     headers: HttpHeaders;
-    readableStreamBody?: NodeJSReadableStream;
+    readableStreamBody?: NodeJS.ReadableStream;
     request: PipelineRequest;
     status: number;
 }

--- a/sdk/core/ts-http-runtime/src/client/common.ts
+++ b/sdk/core/ts-http-runtime/src/client/common.ts
@@ -9,7 +9,6 @@ import type {
   RequestBodyType,
   TransferProgressEvent,
   RawHttpHeadersInput,
-  NodeJSReadableStream,
 } from "../interfaces.js";
 import type { Pipeline, PipelinePolicy } from "../pipeline.js";
 import type { AbortSignalLike } from "../abort-controller/AbortSignalLike.js";
@@ -206,7 +205,7 @@ export type HttpNodeStreamResponse = HttpResponse & {
   /**
    * Streamable body
    */
-  body?: NodeJSReadableStream;
+  body?: NodeJS.ReadableStream;
 };
 
 /**

--- a/sdk/core/ts-http-runtime/src/index.ts
+++ b/sdk/core/ts-http-runtime/src/index.ts
@@ -38,7 +38,6 @@ export type {
   ProxySettings,
   RawHttpHeadersInput,
   PipelineRetryOptions,
-  NodeJSReadableStream,
 } from "./interfaces.js";
 export { createHttpHeaders } from "./httpHeaders.js";
 export { isKeyCredential, type KeyCredential } from "./auth/keyCredential.js";

--- a/sdk/core/ts-http-runtime/src/interfaces.ts
+++ b/sdk/core/ts-http-runtime/src/interfaces.ts
@@ -47,18 +47,6 @@ export interface HttpHeaders extends Iterable<[string, string]> {
 }
 
 /**
- * A Node.js Readable stream that also has a `destroy` method.
- */
-export interface NodeJSReadableStream extends NodeJS.ReadableStream {
-  /**
-   * Destroy the stream. Optionally emit an 'error' event, and emit a
-   * 'close' event (unless emitClose is set to false). After this call,
-   * internal resources will be released.
-   */
-  destroy(error?: Error): void;
-}
-
-/**
  * A part of the request body in a multipart request.
  */
 export interface BodyPart {
@@ -291,7 +279,7 @@ export interface PipelineResponse {
    * The response body as a node.js Readable stream.
    * Always undefined in the browser.
    */
-  readableStreamBody?: NodeJSReadableStream;
+  readableStreamBody?: NodeJS.ReadableStream;
 }
 
 /**

--- a/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
@@ -9,7 +9,6 @@ import { AbortError } from "./abort-controller/AbortError.js";
 import type {
   HttpClient,
   HttpHeaders,
-  NodeJSReadableStream,
   PipelineRequest,
   PipelineResponse,
   RequestBodyType,
@@ -24,11 +23,11 @@ import { Sanitizer } from "./util/sanitizer.js";
 
 const DEFAULT_TLS_SETTINGS = {};
 
-function isReadableStream(body: any): body is NodeJSReadableStream {
+function isReadableStream(body: any): body is NodeJS.ReadableStream {
   return body && typeof body.pipe === "function";
 }
 
-function isStreamComplete(stream: NodeJSReadableStream): Promise<void> {
+function isStreamComplete(stream: NodeJS.ReadableStream): Promise<void> {
   if (stream.readable === false) {
     return Promise.resolve();
   }
@@ -122,7 +121,7 @@ class NodeHttpClient implements HttpClient {
       }
     }
 
-    let responseStream: NodeJSReadableStream | undefined;
+    let responseStream: NodeJS.ReadableStream | undefined;
     try {
       if (body && request.onUploadProgress) {
         const onUploadProgress = request.onUploadProgress;
@@ -333,7 +332,7 @@ function getResponseHeaders(res: IncomingMessage): HttpHeaders {
 function getDecodedResponseStream(
   stream: IncomingMessage,
   headers: HttpHeaders,
-): NodeJSReadableStream {
+): NodeJS.ReadableStream {
   const contentEncoding = headers.get("Content-Encoding");
   if (contentEncoding === "gzip") {
     const unzip = zlib.createGunzip();
@@ -348,7 +347,7 @@ function getDecodedResponseStream(
   return stream;
 }
 
-function streamToText(stream: NodeJSReadableStream): Promise<string> {
+function streamToText(stream: NodeJS.ReadableStream): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const buffer: Buffer[] = [];
 


### PR DESCRIPTION
This reverts commit 4967916d8fbadad8a209a20783142573c053ddf6.

Storage still uses test-recorder v3 which pulls in incompatible core-rest-pipeline version from npmjs and
leads to test build failure. This RP reverts the change for now to unblock storage March release and PR 
validation pipelines