### PR TITLE
[EngSys] pin dev dependency @microsoft/api-extractor version to 7.51.1

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -17,6 +17,7 @@
      */
     // "some-library": "1.2.3"
     "typescript": "~5.7.3",
+    "@microsoft/api-extractor": "7.51.1",
     "vitest": "3.0.7",
     "@vitest/browser": "3.0.7",
     "@vitest/coverage-istanbul": "3.0.7"

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   .:
     dependencies:
+      '@microsoft/api-extractor':
+        specifier: 7.51.1
+        version: 7.51.1(@types/node@22.7.9)
       '@rush-temp/abort-controller':
         specifier: file:./projects/abort-controller.tgz
         version: file:projects/abort-controller.tgz(@types/debug@4.1.12)(msw@2.7.3(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(yaml@2.7.0)
@@ -1877,11 +1880,14 @@ packages:
   '@loaderkit/resolve@1.0.3':
     resolution: {integrity: sha512-oo51csrgEfeHO593bqoPOGwrX093QzDWrc/7y876b/ObDqp2Hbw+rl+3s26WRXIbnhty40T403nwU4UFX3KQCg==}
 
+  '@microsoft/api-extractor-model@7.30.3':
+    resolution: {integrity: sha512-yEAvq0F78MmStXdqz9TTT4PZ05Xu5R8nqgwI5xmUmQjWBQ9E6R2n8HB/iZMRciG4rf9iwI2mtuQwIzDXBvHn1w==}
+
   '@microsoft/api-extractor-model@7.30.4':
     resolution: {integrity: sha512-RobC0gyVYsd2Fao9MTKOfTdBm41P/bCMUmzS5mQ7/MoAKEqy0FOBph3JOYdq4X4BsEnMEiSHc+0NUNmdzxCpjA==}
 
-  '@microsoft/api-extractor@7.52.1':
-    resolution: {integrity: sha512-m3I5uAwE05orsu3D1AGyisX5KxsgVXB+U4bWOOaX/Z7Ftp/2Cy41qsNhO6LPvSxHBaapyser5dVorF1t5M6tig==}
+  '@microsoft/api-extractor@7.51.1':
+    resolution: {integrity: sha512-VoFvIeYXme8QctXDkixy1KIn750kZaFy2snAEOB3nhDFfbBcJNEcvBrpCIQIV09MqI4g9egKUkg+/12WMRC77w==}
     hasBin: true
 
   '@microsoft/applicationinsights-web-snippet@1.2.1':
@@ -4025,6 +4031,14 @@ packages:
     resolution: {integrity: sha512-dJ8JgCJudsdYBEjFv1ADV++H8i26leiclTVoZVMHU6B/H+AHV8YKKyM+ze4x3949srsh5BH6OhBQjFOxPxGJ/A==, tarball: file:projects/web-pubsub.tgz}
     version: 0.0.0
 
+  '@rushstack/node-core-library@5.11.0':
+    resolution: {integrity: sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/node-core-library@5.12.0':
     resolution: {integrity: sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==}
     peerDependencies:
@@ -4036,16 +4050,16 @@ packages:
   '@rushstack/rig-package@0.5.3':
     resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
-  '@rushstack/terminal@0.15.1':
-    resolution: {integrity: sha512-3vgJYwumcjoDOXU3IxZfd616lqOdmr8Ezj4OWgJZfhmiBK4Nh7eWcv8sU8N/HdzXcuHDXCRGn/6O2Q75QvaZMA==}
+  '@rushstack/terminal@0.15.0':
+    resolution: {integrity: sha512-vXQPRQ+vJJn4GVqxkwRe+UGgzNxdV8xuJZY2zem46Y0p3tlahucH9/hPmLGj2i9dQnUBFiRnoM9/KW7PYw8F4Q==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@4.23.6':
-    resolution: {integrity: sha512-7WepygaF3YPEoToh4MAL/mmHkiIImQq3/uAkQX46kVoKTNOOlCtFGyNnze6OYuWw2o9rxsyrHVfIBKxq/am2RA==}
+  '@rushstack/ts-command-line@4.23.5':
+    resolution: {integrity: sha512-jg70HfoK44KfSP3MTiL5rxsZH7X1ktX3cZs9Sl8eDu1/LxJSbPsh0MOFRC710lIuYYSgxWjI5AjbCBAl7u3RxA==}
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -8940,6 +8954,22 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.0
 
+  '@microsoft/api-extractor-model@7.30.3(@types/node@18.19.80)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.11.0(@types/node@18.19.80)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor-model@7.30.3(@types/node@22.7.9)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.11.0(@types/node@22.7.9)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor-model@7.30.4(@types/node@18.19.80)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
@@ -8948,21 +8978,39 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.52.1(@types/node@18.19.80)':
+  '@microsoft/api-extractor@7.51.1(@types/node@18.19.80)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.4(@types/node@18.19.80)
+      '@microsoft/api-extractor-model': 7.30.3(@types/node@18.19.80)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.12.0(@types/node@18.19.80)
+      '@rushstack/node-core-library': 5.11.0(@types/node@18.19.80)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.1(@types/node@18.19.80)
-      '@rushstack/ts-command-line': 4.23.6(@types/node@18.19.80)
+      '@rushstack/terminal': 0.15.0(@types/node@18.19.80)
+      '@rushstack/ts-command-line': 4.23.5(@types/node@18.19.80)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.8.2
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.51.1(@types/node@22.7.9)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.30.3(@types/node@22.7.9)
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+      '@rushstack/node-core-library': 5.11.0(@types/node@22.7.9)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.15.0(@types/node@22.7.9)
+      '@rushstack/ts-command-line': 4.23.5(@types/node@22.7.9)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -12295,7 +12343,7 @@ snapshots:
 
   '@rush-temp/arm-databasewatcher@file:projects/arm-databasewatcher.tgz(@types/debug@4.1.12)(msw@2.7.3(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.52.1(@types/node@18.19.80)
+      '@microsoft/api-extractor': 7.51.1(@types/node@18.19.80)
       '@types/node': 18.19.80
       '@vitest/browser': 3.0.7(@types/node@18.19.80)(playwright@1.51.0)(typescript@5.6.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.7)
       '@vitest/coverage-istanbul': 3.0.7(vitest@3.0.7)
@@ -12918,7 +12966,7 @@ snapshots:
 
   '@rush-temp/arm-deviceregistry@file:projects/arm-deviceregistry.tgz(@types/debug@4.1.12)(msw@2.7.3(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.52.1(@types/node@18.19.80)
+      '@microsoft/api-extractor': 7.51.1(@types/node@18.19.80)
       '@types/node': 18.19.80
       '@vitest/browser': 3.0.7(@types/node@18.19.80)(playwright@1.51.0)(typescript@5.6.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.7)
       '@vitest/coverage-istanbul': 3.0.7(vitest@3.0.7)
@@ -14242,7 +14290,7 @@ snapshots:
 
   '@rush-temp/arm-impactreporting@file:projects/arm-impactreporting.tgz(@types/debug@4.1.12)(msw@2.7.3(@types/node@22.7.9)(typescript@5.7.3))(tsx@4.19.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(yaml@2.7.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.52.1(@types/node@18.19.80)
+      '@microsoft/api-extractor': 7.51.1(@types/node@18.19.80)
       '@types/node': 18.19.80
       '@vitest/browser': 3.0.7(@types/node@18.19.80)(playwright@1.51.0)(typescript@5.6.3)(vite@6.2.1(@types/node@22.7.9)(tsx@4.19.3)(yaml@2.7.0))(vitest@3.0.7)
       '@vitest/coverage-istanbul': 3.0.7(vitest@3.0.7)
@@ -20246,7 +20294,7 @@ snapshots:
       '@arethetypeswrong/cli': 0.17.4
       '@azure/identity': 4.8.0
       '@eslint/js': 9.22.0
-      '@microsoft/api-extractor': 7.52.1(@types/node@18.19.80)
+      '@microsoft/api-extractor': 7.51.1(@types/node@18.19.80)
       '@microsoft/api-extractor-model': 7.30.4(@types/node@18.19.80)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.35.0)
       '@rollup/plugin-inject': 5.0.5(rollup@4.35.0)
@@ -23564,6 +23612,32 @@ snapshots:
       - webdriverio
       - yaml
 
+  '@rushstack/node-core-library@5.11.0(@types/node@18.19.80)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 18.19.80
+
+  '@rushstack/node-core-library@5.11.0(@types/node@22.7.9)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 22.7.9
+
   '@rushstack/node-core-library@5.12.0(@types/node@18.19.80)':
     dependencies:
       ajv: 8.13.0
@@ -23582,16 +23656,32 @@ snapshots:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.15.1(@types/node@18.19.80)':
+  '@rushstack/terminal@0.15.0(@types/node@18.19.80)':
     dependencies:
-      '@rushstack/node-core-library': 5.12.0(@types/node@18.19.80)
+      '@rushstack/node-core-library': 5.11.0(@types/node@18.19.80)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 18.19.80
 
-  '@rushstack/ts-command-line@4.23.6(@types/node@18.19.80)':
+  '@rushstack/terminal@0.15.0(@types/node@22.7.9)':
     dependencies:
-      '@rushstack/terminal': 0.15.1(@types/node@18.19.80)
+      '@rushstack/node-core-library': 5.11.0(@types/node@22.7.9)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 22.7.9
+
+  '@rushstack/ts-command-line@4.23.5(@types/node@18.19.80)':
+    dependencies:
+      '@rushstack/terminal': 0.15.0(@types/node@18.19.80)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@rushstack/ts-command-line@4.23.5(@types/node@22.7.9)':
+    dependencies:
+      '@rushstack/terminal': 0.15.0(@types/node@22.7.9)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -24183,7 +24273,7 @@ snapshots:
 
   ajv-formats@3.0.1:
     dependencies:
-      ajv: 8.13.0
+      ajv: 8.17.1
 
   ajv@6.12.6:
     dependencies:


### PR DESCRIPTION
Later versions bundles typescript 5.8.2 which cause incompatibility issue with
current typescript 5.7.3 that we are using.

It will be unpinned as part of upgrade to typescript v5.8.