### PR TITLE
[core-rest-pipeline] remove `[custom]` from RestError members

### DIFF
--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline.api.md
@@ -376,8 +376,6 @@ export type RequestBodyType = NodeJS.ReadableStream | (() => NodeJS.ReadableStre
 // @public
 export class RestError extends Error {
     constructor(message: string, options?: RestErrorOptions);
-    // (undocumented)
-    [x: symbol]: () => string;
     code?: string;
     details?: unknown;
     static readonly PARSE_ERROR: string;

--- a/sdk/core/core-rest-pipeline/src/restError.ts
+++ b/sdk/core/core-rest-pipeline/src/restError.ts
@@ -82,20 +82,21 @@ export class RestError extends Error {
     Object.defineProperty(this, "request", { value: options.request, enumerable: false });
     Object.defineProperty(this, "response", { value: options.response, enumerable: false });
 
-    Object.setPrototypeOf(this, RestError.prototype);
-  }
+    // Logging method for util.inspect in Node
+    Object.defineProperty(this, custom, {
+      value: () => {
+        // Extract non-enumerable properties and add them back. This is OK since in this output the request and
+        // response get sanitized.
+        return `RestError: ${this.message} \n ${errorSanitizer.sanitize({
+          ...this,
+          request: this.request,
+          response: this.response,
+        })}`;
+      },
+      enumerable: false,
+    });
 
-  /**
-   * Logging method for util.inspect in Node
-   */
-  [custom](): string {
-    // Extract non-enumerable properties and add them back. This is OK since in this output the request and
-    // response get sanitized.
-    return `RestError: ${this.message} \n ${errorSanitizer.sanitize({
-      ...this,
-      request: this.request,
-      response: this.response,
-    })}`;
+    Object.setPrototypeOf(this, RestError.prototype);
   }
 }
 

--- a/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
+++ b/sdk/core/ts-http-runtime/review/azure-core-comparison.diff
@@ -2189,7 +2189,7 @@ index 4f54b0d..0000000
 -  }
 -}
 diff --git a/src/restError.ts b/src/restError.ts
-index 0b2e69f..bc09e78 100644
+index a3d36bc..722db2a 100644
 --- a/src/restError.ts
 +++ b/src/restError.ts
 @@ -1,7 +1,7 @@

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime.api.md
@@ -403,8 +403,6 @@ export interface ResourceMethods<TResponse = PromiseLike<PathUncheckedResponse>>
 // @public
 export class RestError extends Error {
     constructor(message: string, options?: RestErrorOptions);
-    // (undocumented)
-    [x: symbol]: () => string;
     code?: string;
     details?: unknown;
     static readonly PARSE_ERROR: string;

--- a/sdk/core/ts-http-runtime/src/restError.ts
+++ b/sdk/core/ts-http-runtime/src/restError.ts
@@ -82,20 +82,21 @@ export class RestError extends Error {
     Object.defineProperty(this, "request", { value: options.request, enumerable: false });
     Object.defineProperty(this, "response", { value: options.response, enumerable: false });
 
-    Object.setPrototypeOf(this, RestError.prototype);
-  }
+    // Logging method for util.inspect in Node
+    Object.defineProperty(this, custom, {
+      value: () => {
+        // Extract non-enumerable properties and add them back. This is OK since in this output the request and
+        // response get sanitized.
+        return `RestError: ${this.message} \n ${errorSanitizer.sanitize({
+          ...this,
+          request: this.request,
+          response: this.response,
+        })}`;
+      },
+      enumerable: false,
+    });
 
-  /**
-   * Logging method for util.inspect in Node
-   */
-  [custom](): string {
-    // Extract non-enumerable properties and add them back. This is OK since in this output the request and
-    // response get sanitized.
-    return `RestError: ${this.message} \n ${errorSanitizer.sanitize({
-      ...this,
-      request: this.request,
-      response: this.response,
-    })}`;
+    Object.setPrototypeOf(this, RestError.prototype);
   }
 }
 


### PR DESCRIPTION
TypeScript version v5.8 and later generate a type declaration for `RestError` that is incompatible with
previous versions of TypeScript, which means our d.ts generated by TypeScript v5.8+ will cause compilation
error when being consumed by earlier versions of TypeScript.

The `[util.custom]()` member of `RestError` is used to override the behavior of `util.inspec` on `RestError`
instances and not meant to be used directly. This PR removes the method from the class members and instead
assign to the `util.custom` property in the constructor.