### PR TITLE
[Migration tool] Do not remove subpath exports for modular package.json generation

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -372,7 +372,7 @@ function setFilesSection(packageJson: any): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function addTypeScriptHybridizer(packageJson: any, options: { browser: boolean }): void {
-  // skip exports replacement if pacakge.json already have tshy config
+  // Do not remove subpath exports for modular package's package.json
   if (packageJson["tshy"]) {
     packageJson["tshy"].project = "./tsconfig.src.json";
     return;

--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -372,6 +372,12 @@ function setFilesSection(packageJson: any): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function addTypeScriptHybridizer(packageJson: any, options: { browser: boolean }): void {
+  // skip exports replacement if pacakge.json already have tshy config
+  if (packageJson["tshy"]) {
+    packageJson["tshy"].project = "./tsconfig.src.json";
+    return;
+  }
+
   packageJson["tshy"] = {
     project: "./tsconfig.src.json",
     exports: {
@@ -386,16 +392,6 @@ function addTypeScriptHybridizer(packageJson: any, options: { browser: boolean }
   // Remove the esmDialects for arm packages since we don't support ARM in the browser
   if (!options.browser) {
     delete packageJson["tshy"].esmDialects;
-  }
-
-  // Check if there are subpath exports
-  if (packageJson.exports) {
-    for (const key of Object.keys(packageJson.exports)) {
-      // Don't set for package.json or root
-      if (key !== "." && key !== "./package.json") {
-        packageJson["tshy"].exports[key] = `./src/${key.replace("./", "")}/index.ts`;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Migration tool is a step in JS Automation and it is before build step, So Migration tool will remove subpath exports in tshy configs after the code generation
So create a PR to fix this