### PR TITLE
[dev-tool] fix `migrate-package` to not format empty test directory

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-package.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-package.ts
@@ -10,7 +10,7 @@ import { basename, dirname, resolve } from "node:path";
 import { run } from "../../util/run";
 import stripJsonComments from "strip-json-comments";
 import { codemods } from "../../util/admin/migrate-package/codemods";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { isWindows } from "../../util/platform";
 
 const log = createPrinter("migrate-package");
@@ -315,10 +315,15 @@ async function upgradePackageJson(
   // Set files
   setFilesSection(packageJson);
 
+  const testDirectoryPath = resolve(projectFolder, "test");
+  const emptyTestDirectory =
+    !existsSync(testDirectoryPath) || readdirSync(testDirectoryPath).length === 0;
+
   // Set scripts
   setScriptsSection(packageJson.scripts, {
     ...options,
     isArm: packageJson.name.includes("@azure/arm-"),
+    formatTests: !emptyTestDirectory,
   });
 
   // Rename files and rewrite browser field
@@ -338,7 +343,7 @@ async function upgradePackageJson(
 
 function setScriptsSection(
   scripts: PackageJson["scripts"],
-  options: { browser: boolean; isArm: boolean },
+  options: { browser: boolean; isArm: boolean; formatTests: boolean },
 ): void {
   scripts["build"] = "npm run clean && dev-tool run build-package && dev-tool run extract-api";
 
@@ -352,6 +357,12 @@ function setScriptsSection(
   if (options.isArm) {
     scripts["unit-test:browser"] = "echo skipped";
     scripts["integration-test:node"] = "dev-tool run test:vitest --esm";
+  }
+
+  if (!options.formatTests) {
+    scripts["format"] = scripts["format"]
+      .replaceAll(`"test/**/*.{ts,cts,mts}" `, "")
+      .replaceAll(`"test/**/*.ts" `, "");
   }
 
   for (const script of Object.keys(scripts)) {


### PR DESCRIPTION
Part of SDK automation in specs repo PR check is to generate JS SDK packages for
spec changes and build them. The dev-tool `migrate-package` is executed on the
generated package before building it. There are case where the generated package
doesn't include a `test` directory, which causes "npm run format" to fail.

This PR checks whether the `test` directory exists or is empty. If either is
true test file patterns are removed from the `"format"` NPM script of the
package.