### PR TITLE
[EngSys] clean up some dev dependencies

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -115,15 +115,15 @@
     "@typescript-eslint/parser": "~8.26.0",
     "@typescript-eslint/rule-tester": "~8.26.0",
     "@typescript-eslint/utils": "~8.26.0",
-    "@vitest/browser": "^3.0.3",
-    "@vitest/coverage-istanbul": "^3.0.3",
+    "@vitest/browser": "^3.0.9",
+    "@vitest/coverage-istanbul": "^3.0.9",
     "eslint": "^9.9.0",
     "eslint-plugin-markdown": "^5.0.0",
     "playwright": "^1.49.1",
     "prettier": "^3.3.3",
     "rimraf": "^5.0.5",
     "tshy": "^2.0.0",
-    "vitest": "^3.0.3"
+    "vitest": "^3.0.9"
   },
   "tshy": {
     "exports": {

--- a/sdk/databasewatcher/arm-databasewatcher/package.json
+++ b/sdk/databasewatcher/arm-databasewatcher/package.json
@@ -74,7 +74,6 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "@vitest/browser": "^3.0.9",
     "@vitest/coverage-istanbul": "^3.0.9",

--- a/sdk/deviceregistry/arm-deviceregistry/package.json
+++ b/sdk/deviceregistry/arm-deviceregistry/package.json
@@ -74,7 +74,6 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "@vitest/browser": "^3.0.9",
     "@vitest/coverage-istanbul": "^3.0.9",

--- a/sdk/impactreporting/arm-impactreporting/package.json
+++ b/sdk/impactreporting/arm-impactreporting/package.json
@@ -74,7 +74,6 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.7.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "@vitest/browser": "^3.0.9",
     "@vitest/coverage-istanbul": "^3.0.9",


### PR DESCRIPTION
- remove api-extractor from individual packages

- bump vitest to ^3.0.9, same as rest of the repository