### PR TITLE
[Docs] tell copilot to run `rush update`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@ You are a highly experienced engineer with expertise in
 
 ## Behavior
 
+- Always run `rush update` at least once before running other `rush` or `rushx` commands.
 - Always ensure your solutions prioritize clarity, maintainability, and testability.
 - Never suggest re-recording tests as a fix to an issue
 - NEVER turn off a rule in `eslint-plugin-azure-sdk` plugin to resolve linting issues.

--- a/documentation/linting.md
+++ b/documentation/linting.md
@@ -4,7 +4,7 @@ In this document, we describe how to address common linting issues for a package
 
 # Azure SDK eslint plugin
 
-Our custom linting rules and recommended configurations is hosted in the `eslint-plugin-azure-sdk` package. This package needs to be built first before linting any SDK packages.
+Our custom linting rules and recommended configurations is hosted in the `eslint-plugin-azure-sdk` package. You MUST build it first before linting any SDK packages.
 
 - `rush update`
 - `rush build -t eslint-plugin-azure-sdk`


### PR DESCRIPTION
before running other rush commands.  This helps copilot in a fresh workspace.
