### PR TITLE
[EngSys] exclude d.*ts.map from packing

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -57,6 +57,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/advisor/arm-advisor/package.json
+++ b/sdk/advisor/arm-advisor/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/agrifood/arm-agrifood/package.json
+++ b/sdk/agrifood/arm-agrifood/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/ai/ai-inference-rest/package.json
+++ b/sdk/ai/ai-inference-rest/package.json
@@ -44,6 +44,7 @@
   "type": "module",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -35,7 +35,8 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "files": [
-    "dist",
+    "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/analysisservices/arm-analysisservices/package.json
+++ b/sdk/analysisservices/arm-analysisservices/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/apicenter/arm-apicenter/package.json
+++ b/sdk/apicenter/arm-apicenter/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
@@ -25,6 +25,7 @@
   "sideEffects": false,
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "bin/",
     "LICENSE"
   ],

--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -23,6 +23,7 @@
   "sideEffects": false,
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "LICENSE",
     "README.md"
   ],

--- a/sdk/apimanagement/arm-apimanagement/package.json
+++ b/sdk/apimanagement/arm-apimanagement/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/appconfiguration/arm-appconfiguration/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/appconfiguration/perf-tests/app-configuration/package.json
+++ b/sdk/appconfiguration/perf-tests/app-configuration/package.json
@@ -62,6 +62,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/appcontainers/arm-appcontainers/package.json
+++ b/sdk/appcontainers/arm-appcontainers/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/applicationinsights/arm-appinsights/package.json
+++ b/sdk/applicationinsights/arm-appinsights/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/appplatform/arm-appplatform/package.json
+++ b/sdk/appplatform/arm-appplatform/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/appservice/arm-appservice-rest/package.json
+++ b/sdk/appservice/arm-appservice-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/*",

--- a/sdk/appservice/arm-appservice/package.json
+++ b/sdk/appservice/arm-appservice/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/astro/arm-astro/package.json
+++ b/sdk/astro/arm-astro/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/attestation/arm-attestation/package.json
+++ b/sdk/attestation/arm-attestation/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/authorization/arm-authorization/package.json
+++ b/sdk/authorization/arm-authorization/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/automanage/arm-automanage/package.json
+++ b/sdk/automanage/arm-automanage/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/automation/arm-automation/package.json
+++ b/sdk/automation/arm-automation/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/avs/arm-avs/package.json
+++ b/sdk/avs/arm-avs/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/azurestack/arm-azurestack/package.json
+++ b/sdk/azurestack/arm-azurestack/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/azurestackhci/arm-azurestackhci/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/package.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/batch/arm-batch/package.json
+++ b/sdk/batch/arm-batch/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/batch/batch-rest/package.json
+++ b/sdk/batch/batch-rest/package.json
@@ -35,7 +35,8 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "files": [
-    "dist",
+    "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/billing/arm-billing/package.json
+++ b/sdk/billing/arm-billing/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/billingbenefits/arm-billingbenefits/package.json
+++ b/sdk/billingbenefits/arm-billingbenefits/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/botservice/arm-botservice/package.json
+++ b/sdk/botservice/arm-botservice/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/cdn/arm-cdn/package.json
+++ b/sdk/cdn/arm-cdn/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/changeanalysis/arm-changeanalysis/package.json
+++ b/sdk/changeanalysis/arm-changeanalysis/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/changes/arm-changes/package.json
+++ b/sdk/changes/arm-changes/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/chaos/arm-chaos/package.json
+++ b/sdk/chaos/arm-chaos/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/cognitivelanguage/ai-language-conversations/package.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/cognitivelanguage/ai-language-text/package.json
+++ b/sdk/cognitivelanguage/ai-language-text/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/cognitivelanguage/ai-language-textauthoring/package.json
+++ b/sdk/cognitivelanguage/ai-language-textauthoring/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/cognitivelanguage/perf-tests/ai-language-text/package.json
+++ b/sdk/cognitivelanguage/perf-tests/ai-language-text/package.json
@@ -58,6 +58,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/cognitiveservices/arm-cognitiveservices/package.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/commerce/arm-commerce/package.json
+++ b/sdk/commerce/arm-commerce/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/communication/arm-communication/package.json
+++ b/sdk/communication/arm-communication/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/communication/communication-alpha-ids/package.json
+++ b/sdk/communication/communication-alpha-ids/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -70,6 +70,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-job-router-rest/package.json
+++ b/sdk/communication/communication-job-router-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-messages-rest/package.json
+++ b/sdk/communication/communication-messages-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-recipient-verification/package.json
+++ b/sdk/communication/communication-recipient-verification/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-rooms/package.json
+++ b/sdk/communication/communication-rooms/package.json
@@ -57,6 +57,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-tiering/package.json
+++ b/sdk/communication/communication-tiering/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/communication/communication-toll-free-verification/package.json
+++ b/sdk/communication/communication-toll-free-verification/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/compute/arm-compute-rest/package.json
+++ b/sdk/compute/arm-compute-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/*",

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/computefleet/arm-computefleet/package.json
+++ b/sdk/computefleet/arm-computefleet/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/computeschedule/arm-computeschedule/package.json
+++ b/sdk/computeschedule/arm-computeschedule/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/confidentialledger/arm-confidentialledger/package.json
+++ b/sdk/confidentialledger/arm-confidentialledger/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/confluent/arm-confluent/package.json
+++ b/sdk/confluent/arm-confluent/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/connectedcache/arm-connectedcache/package.json
+++ b/sdk/connectedcache/arm-connectedcache/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/connectedvmware/arm-connectedvmware/package.json
+++ b/sdk/connectedvmware/arm-connectedvmware/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/consumption/arm-consumption/package.json
+++ b/sdk/consumption/arm-consumption/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/containerinstance/arm-containerinstance/package.json
+++ b/sdk/containerinstance/arm-containerinstance/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/containerregistry/arm-containerregistry/package.json
+++ b/sdk/containerregistry/arm-containerregistry/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/containerregistry/container-registry-perf-tests/package.json
+++ b/sdk/containerregistry/container-registry-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/containerservice/arm-containerservice-rest/package.json
+++ b/sdk/containerservice/arm-containerservice-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/containerservice/arm-containerservice/package.json
+++ b/sdk/containerservice/arm-containerservice/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/containerservice/arm-containerservicefleet/package.json
+++ b/sdk/containerservice/arm-containerservicefleet/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/contentsafety/ai-content-safety-rest/package.json
+++ b/sdk/contentsafety/ai-content-safety-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/cosmosdb/arm-cosmosdb/package.json
+++ b/sdk/cosmosdb/arm-cosmosdb/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/package.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/cost-management/arm-costmanagement/package.json
+++ b/sdk/cost-management/arm-costmanagement/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/customer-insights/arm-customerinsights/package.json
+++ b/sdk/customer-insights/arm-customerinsights/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/dashboard/arm-dashboard/package.json
+++ b/sdk/dashboard/arm-dashboard/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/databasewatcher/arm-databasewatcher/package.json
+++ b/sdk/databasewatcher/arm-databasewatcher/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/databoundaries/arm-databoundaries/package.json
+++ b/sdk/databoundaries/arm-databoundaries/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/databox/arm-databox/package.json
+++ b/sdk/databox/arm-databox/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/databoxedge/arm-databoxedge/package.json
+++ b/sdk/databoxedge/arm-databoxedge/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/databricks/arm-databricks/package.json
+++ b/sdk/databricks/arm-databricks/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/datacatalog/arm-datacatalog/package.json
+++ b/sdk/datacatalog/arm-datacatalog/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/datadog/arm-datadog/package.json
+++ b/sdk/datadog/arm-datadog/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/datafactory/arm-datafactory/package.json
+++ b/sdk/datafactory/arm-datafactory/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/datalake-analytics/arm-datalake-analytics/package.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/datamigration/arm-datamigration/package.json
+++ b/sdk/datamigration/arm-datamigration/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/dataprotection/arm-dataprotection/package.json
+++ b/sdk/dataprotection/arm-dataprotection/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/defendereasm/arm-defendereasm/package.json
+++ b/sdk/defendereasm/arm-defendereasm/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/deploymentmanager/arm-deploymentmanager/package.json
+++ b/sdk/deploymentmanager/arm-deploymentmanager/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/package.json
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/devcenter/arm-devcenter/package.json
+++ b/sdk/devcenter/arm-devcenter/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/devcenter/developer-devcenter-rest/package.json
+++ b/sdk/devcenter/developer-devcenter-rest/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/devhub/arm-devhub/package.json
+++ b/sdk/devhub/arm-devhub/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/deviceregistry/arm-deviceregistry/package.json
+++ b/sdk/deviceregistry/arm-deviceregistry/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/deviceupdate/arm-deviceupdate/package.json
+++ b/sdk/deviceupdate/arm-deviceupdate/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/deviceupdate/iot-device-update-rest/package.json
+++ b/sdk/deviceupdate/iot-device-update-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/devspaces/arm-devspaces/package.json
+++ b/sdk/devspaces/arm-devspaces/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/devtestlabs/arm-devtestlabs/package.json
+++ b/sdk/devtestlabs/arm-devtestlabs/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/digitaltwins/arm-digitaltwins/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -37,6 +37,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/dns/arm-dns/package.json
+++ b/sdk/dns/arm-dns/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/dnsresolver/arm-dnsresolver/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/documentintelligence/ai-document-intelligence-rest/package.json
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/package.json
@@ -34,6 +34,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/domainservices/arm-domainservices/package.json
+++ b/sdk/domainservices/arm-domainservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/dynatrace/arm-dynatrace/package.json
+++ b/sdk/dynatrace/arm-dynatrace/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/easm/defender-easm-rest/package.json
+++ b/sdk/easm/defender-easm-rest/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/edgezones/arm-edgezones/package.json
+++ b/sdk/edgezones/arm-edgezones/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/education/arm-education/package.json
+++ b/sdk/education/arm-education/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/elastic/arm-elastic/package.json
+++ b/sdk/elastic/arm-elastic/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/elasticsans/arm-elasticsan/package.json
+++ b/sdk/elasticsans/arm-elasticsan/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/entra/functions-authentication-events/package.json
+++ b/sdk/entra/functions-authentication-events/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventgrid/arm-eventgrid/package.json
+++ b/sdk/eventgrid/arm-eventgrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/eventgrid/eventgrid-namespaces/package.json
+++ b/sdk/eventgrid/eventgrid-namespaces/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventgrid/eventgrid-perf-tests/package.json
+++ b/sdk/eventgrid/eventgrid-perf-tests/package.json
@@ -45,6 +45,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventgrid/eventgrid-systemevents/package.json
+++ b/sdk/eventgrid/eventgrid-systemevents/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/eventhub/arm-eventhub/package.json
+++ b/sdk/eventhub/arm-eventhub/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/eventhub/event-hubs-perf-tests/package.json
+++ b/sdk/eventhub/event-hubs-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -26,6 +26,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -44,6 +44,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "License"
   ],

--- a/sdk/extendedlocation/arm-extendedlocation/package.json
+++ b/sdk/extendedlocation/arm-extendedlocation/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/fabric/arm-fabric/package.json
+++ b/sdk/fabric/arm-fabric/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/face/ai-vision-face-rest/package.json
+++ b/sdk/face/ai-vision-face-rest/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/fluidrelay/arm-fluidrelay/package.json
+++ b/sdk/fluidrelay/arm-fluidrelay/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/perf-tests/ai-form-recognizer/package.json
@@ -58,6 +58,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/frontdoor/arm-frontdoor/package.json
+++ b/sdk/frontdoor/arm-frontdoor/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/graphservices/arm-graphservices/package.json
+++ b/sdk/graphservices/arm-graphservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/guestconfiguration/arm-guestconfiguration/package.json
+++ b/sdk/guestconfiguration/arm-guestconfiguration/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hanaonazure/arm-hanaonazure/package.json
+++ b/sdk/hanaonazure/arm-hanaonazure/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hdinsight/arm-hdinsight/package.json
+++ b/sdk/hdinsight/arm-hdinsight/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hdinsight/arm-hdinsightcontainers/package.json
+++ b/sdk/hdinsight/arm-hdinsightcontainers/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/healthbot/arm-healthbot/package.json
+++ b/sdk/healthbot/arm-healthbot/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/healthcareapis/arm-healthcareapis/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/healthdataaiservices/azure-health-deidentification/package.json
+++ b/sdk/healthdataaiservices/azure-health-deidentification/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/healthinsights/health-insights-cancerprofiling-rest/package.json
+++ b/sdk/healthinsights/health-insights-cancerprofiling-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/healthinsights/health-insights-clinicalmatching-rest/package.json
+++ b/sdk/healthinsights/health-insights-clinicalmatching-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/healthinsights/health-insights-radiologyinsights-rest/package.json
+++ b/sdk/healthinsights/health-insights-radiologyinsights-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/hybridcompute/arm-hybridcompute/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/package.json
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/hybridnetwork/arm-hybridnetwork/package.json
+++ b/sdk/hybridnetwork/arm-hybridnetwork/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/identity/identity-perf-tests/package.json
+++ b/sdk/identity/identity-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -45,6 +45,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/imagebuilder/arm-imagebuilder/package.json
+++ b/sdk/imagebuilder/arm-imagebuilder/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/impactreporting/arm-impactreporting/package.json
+++ b/sdk/impactreporting/arm-impactreporting/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/informatica/arm-informaticadatamanagement/package.json
+++ b/sdk/informatica/arm-informaticadatamanagement/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -43,6 +43,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/iotcentral/arm-iotcentral/package.json
+++ b/sdk/iotcentral/arm-iotcentral/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/iothub/arm-iothub/package.json
+++ b/sdk/iothub/arm-iothub/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/iotoperations/arm-iotoperations/package.json
+++ b/sdk/iotoperations/arm-iotoperations/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/keyvault/arm-keyvault/package.json
+++ b/sdk/keyvault/arm-keyvault/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-certificates-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-certificates-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-keys-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-keys-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-secrets-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-secrets-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/kusto/arm-kusto/package.json
+++ b/sdk/kusto/arm-kusto/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/labservices/arm-labservices/package.json
+++ b/sdk/labservices/arm-labservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/largeinstance/arm-largeinstance/package.json
+++ b/sdk/largeinstance/arm-largeinstance/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/liftrqumulo/arm-qumulo/package.json
+++ b/sdk/liftrqumulo/arm-qumulo/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/loadtesting/arm-loadtesting/package.json
+++ b/sdk/loadtesting/arm-loadtesting/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/loadtesting/load-testing-rest/package.json
+++ b/sdk/loadtesting/load-testing-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/logic/arm-logic/package.json
+++ b/sdk/logic/arm-logic/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/machinelearning/arm-commitmentplans/package.json
+++ b/sdk/machinelearning/arm-commitmentplans/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/machinelearning/arm-machinelearning/package.json
+++ b/sdk/machinelearning/arm-machinelearning/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/machinelearning/arm-webservices/package.json
+++ b/sdk/machinelearning/arm-webservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/machinelearning/arm-workspaces/package.json
+++ b/sdk/machinelearning/arm-workspaces/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/maintenance/arm-maintenance/package.json
+++ b/sdk/maintenance/arm-maintenance/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/package.json
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/managementgroups/arm-managementgroups/package.json
+++ b/sdk/managementgroups/arm-managementgroups/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/managementpartner/arm-managementpartner/package.json
+++ b/sdk/managementpartner/arm-managementpartner/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/maps/arm-maps/package.json
+++ b/sdk/maps/arm-maps/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/maps/maps-common/package.json
+++ b/sdk/maps/maps-common/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/maps/maps-geolocation-rest/package.json
+++ b/sdk/maps/maps-geolocation-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/maps/maps-render-rest/package.json
+++ b/sdk/maps/maps-render-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/maps/maps-route-rest/package.json
+++ b/sdk/maps/maps-route-rest/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/maps/maps-search-rest/package.json
+++ b/sdk/maps/maps-search-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/maps/maps-timezone-rest/package.json
+++ b/sdk/maps/maps-timezone-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/mariadb/arm-mariadb/package.json
+++ b/sdk/mariadb/arm-mariadb/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/marketplaceordering/arm-marketplaceordering/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/mediaservices/arm-mediaservices/package.json
+++ b/sdk/mediaservices/arm-mediaservices/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/metricsadvisor/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/package.json
+++ b/sdk/metricsadvisor/perf-tests/ai-metrics-advisor/package.json
@@ -56,6 +56,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/migrate/arm-migrate/package.json
+++ b/sdk/migrate/arm-migrate/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/package.json
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/mixedreality/arm-mixedreality/package.json
+++ b/sdk/mixedreality/arm-mixedreality/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/mixedreality/mixed-reality-authentication/package.json
+++ b/sdk/mixedreality/mixed-reality-authentication/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/mobilenetwork/arm-mobilenetwork/package.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/mongocluster/arm-mongocluster/package.json
+++ b/sdk/mongocluster/arm-mongocluster/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/monitor/arm-monitor/package.json
+++ b/sdk/monitor/arm-monitor/package.json
@@ -53,6 +53,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/monitor/monitor-ingestion-perf-tests/package.json
+++ b/sdk/monitor/monitor-ingestion-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/monitor/monitor-query-perf-tests/package.json
+++ b/sdk/monitor/monitor-query-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/monitor/monitor-query/package.json
+++ b/sdk/monitor/monitor-query/package.json
@@ -64,6 +64,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/msi/arm-msi/package.json
+++ b/sdk/msi/arm-msi/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/mysql/arm-mysql-flexible/package.json
+++ b/sdk/mysql/arm-mysql-flexible/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/mysql/arm-mysql/package.json
+++ b/sdk/mysql/arm-mysql/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/neonpostgres/arm-neonpostgres/package.json
+++ b/sdk/neonpostgres/arm-neonpostgres/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/netapp/arm-netapp/package.json
+++ b/sdk/netapp/arm-netapp/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/network/arm-network-rest/package.json
+++ b/sdk/network/arm-network-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/networkcloud/arm-networkcloud/package.json
+++ b/sdk/networkcloud/arm-networkcloud/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/networkfunction/arm-networkfunction/package.json
+++ b/sdk/networkfunction/arm-networkfunction/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/newrelicobservability/arm-newrelicobservability/package.json
+++ b/sdk/newrelicobservability/arm-newrelicobservability/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/nginx/arm-nginx/package.json
+++ b/sdk/nginx/arm-nginx/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/notificationhubs/arm-notificationhubs/package.json
+++ b/sdk/notificationhubs/arm-notificationhubs/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -40,6 +40,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/oep/arm-oep/package.json
+++ b/sdk/oep/arm-oep/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/operationalinsights/arm-operationalinsights/package.json
+++ b/sdk/operationalinsights/arm-operationalinsights/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/operationsmanagement/arm-operations/package.json
+++ b/sdk/operationsmanagement/arm-operations/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/oracledatabase/arm-oracledatabase/package.json
+++ b/sdk/oracledatabase/arm-oracledatabase/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/orbital/arm-orbital/package.json
+++ b/sdk/orbital/arm-orbital/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/peering/arm-peering/package.json
+++ b/sdk/peering/arm-peering/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/pineconevectordb/arm-pineconevectordb/package.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/playwrighttesting/arm-playwrighttesting/package.json
+++ b/sdk/playwrighttesting/arm-playwrighttesting/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/playwrighttesting/create-microsoft-playwright-testing/package.json
+++ b/sdk/playwrighttesting/create-microsoft-playwright-testing/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/playwrighttesting/microsoft-playwright-testing/package.json
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/package.json
@@ -66,6 +66,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/policyinsights/arm-policyinsights/package.json
+++ b/sdk/policyinsights/arm-policyinsights/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/portal/arm-portal/package.json
+++ b/sdk/portal/arm-portal/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/postgresql/arm-postgresql-flexible/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/postgresql/arm-postgresql/package.json
+++ b/sdk/postgresql/arm-postgresql/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/powerbidedicated/arm-powerbidedicated/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/powerbiembedded/arm-powerbiembedded/package.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/privatedns/arm-privatedns/package.json
+++ b/sdk/privatedns/arm-privatedns/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/purview/arm-purview/package.json
+++ b/sdk/purview/arm-purview/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/purview/purview-administration-rest/package.json
+++ b/sdk/purview/purview-administration-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/purview/purview-datamap-rest/package.json
+++ b/sdk/purview/purview-datamap-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/purview/purview-scanning-rest/package.json
+++ b/sdk/purview/purview-scanning-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/purview/purview-sharing-rest/package.json
+++ b/sdk/purview/purview-sharing-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/purview/purview-workflow-rest/package.json
+++ b/sdk/purview/purview-workflow-rest/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/quantum/arm-quantum/package.json
+++ b/sdk/quantum/arm-quantum/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/quantum/quantum-jobs/package.json
+++ b/sdk/quantum/quantum-jobs/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/quota/arm-quota/package.json
+++ b/sdk/quota/arm-quota/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/recoveryservices/arm-recoveryservices/package.json
+++ b/sdk/recoveryservices/arm-recoveryservices/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/redhatopenshift/arm-redhatopenshift/package.json
+++ b/sdk/redhatopenshift/arm-redhatopenshift/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/redis/arm-rediscache/package.json
+++ b/sdk/redis/arm-rediscache/package.json
@@ -50,6 +50,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/redisenterprise/arm-redisenterprisecache/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/relay/arm-relay/package.json
+++ b/sdk/relay/arm-relay/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/remoterendering/mixed-reality-remote-rendering/package.json
+++ b/sdk/remoterendering/mixed-reality-remote-rendering/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/reservations/arm-reservations/package.json
+++ b/sdk/reservations/arm-reservations/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resourceconnector/arm-resourceconnector/package.json
+++ b/sdk/resourceconnector/arm-resourceconnector/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resourcegraph/arm-resourcegraph/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resourcehealth/arm-resourcehealth/package.json
+++ b/sdk/resourcehealth/arm-resourcehealth/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resourcemover/arm-resourcemover/package.json
+++ b/sdk/resourcemover/arm-resourcemover/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/package.json
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/schemaregistry/perf-tests/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/perf-tests/schema-registry-avro/package.json
@@ -59,6 +59,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/schemaregistry/schema-registry-json/package.json
+++ b/sdk/schemaregistry/schema-registry-json/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/scvmm/arm-scvmm/package.json
+++ b/sdk/scvmm/arm-scvmm/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/search/arm-search/package.json
+++ b/sdk/search/arm-search/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/search/search-documents-perf-tests/package.json
+++ b/sdk/search/search-documents-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/security/arm-security/package.json
+++ b/sdk/security/arm-security/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/securitydevops/arm-securitydevops/package.json
+++ b/sdk/securitydevops/arm-securitydevops/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/securityinsight/arm-securityinsight/package.json
+++ b/sdk/securityinsight/arm-securityinsight/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/selfhelp/arm-selfhelp/package.json
+++ b/sdk/selfhelp/arm-selfhelp/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/serialconsole/arm-serialconsole/package.json
+++ b/sdk/serialconsole/arm-serialconsole/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/service-map/arm-servicemap/package.json
+++ b/sdk/service-map/arm-servicemap/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicebus/arm-servicebus/package.json
+++ b/sdk/servicebus/arm-servicebus/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicebus/service-bus-perf-tests/package.json
+++ b/sdk/servicebus/service-bus-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/servicefabric/arm-servicefabric-rest/package.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicefabric/arm-servicefabric/package.json
+++ b/sdk/servicefabric/arm-servicefabric/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicelinker/arm-servicelinker/package.json
+++ b/sdk/servicelinker/arm-servicelinker/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/servicenetworking/arm-servicenetworking/package.json
+++ b/sdk/servicenetworking/arm-servicenetworking/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/signalr/arm-signalr/package.json
+++ b/sdk/signalr/arm-signalr/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/sphere/arm-sphere/package.json
+++ b/sdk/sphere/arm-sphere/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/springappdiscovery/arm-springappdiscovery/package.json
+++ b/sdk/springappdiscovery/arm-springappdiscovery/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/standbypool/arm-standbypool/package.json
+++ b/sdk/standbypool/arm-standbypool/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storage/arm-storage/package.json
+++ b/sdk/storage/arm-storage/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storage/storage-blob-perf-tests/package.json
+++ b/sdk/storage/storage-blob-perf-tests/package.json
@@ -37,6 +37,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/storage/storage-file-datalake-perf-tests/package.json
+++ b/sdk/storage/storage-file-datalake-perf-tests/package.json
@@ -37,6 +37,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/storage/storage-file-share-perf-tests/package.json
+++ b/sdk/storage/storage-file-share-perf-tests/package.json
@@ -37,6 +37,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/storageactions/arm-storageactions/package.json
+++ b/sdk/storageactions/arm-storageactions/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storagecache/arm-storagecache/package.json
+++ b/sdk/storagecache/arm-storagecache/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storageimportexport/arm-storageimportexport/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storagemover/arm-storagemover/package.json
+++ b/sdk/storagemover/arm-storagemover/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storagesync/arm-storagesync/package.json
+++ b/sdk/storagesync/arm-storagesync/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storsimple1200series/arm-storsimple1200series/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/storsimple8000series/arm-storsimple8000series/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/streamanalytics/arm-streamanalytics/package.json
+++ b/sdk/streamanalytics/arm-streamanalytics/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/subscription/arm-subscriptions/package.json
+++ b/sdk/subscription/arm-subscriptions/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/support/arm-support/package.json
+++ b/sdk/support/arm-support/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/synapse/arm-synapse/package.json
+++ b/sdk/synapse/arm-synapse/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/synapse/synapse-access-control-rest/package.json
+++ b/sdk/synapse/synapse-access-control-rest/package.json
@@ -59,6 +59,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -63,6 +63,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -53,6 +53,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -63,6 +63,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -62,6 +62,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/tables/data-tables-perf-tests/package.json
+++ b/sdk/tables/data-tables-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/template/template-dpg/package.json
+++ b/sdk/template/template-dpg/package.json
@@ -91,6 +91,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/template/template-perf-tests/package.json
+++ b/sdk/template/template-perf-tests/package.json
@@ -37,6 +37,7 @@
   ],
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -59,6 +59,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/templatespecs/arm-templatespecs/package.json
+++ b/sdk/templatespecs/arm-templatespecs/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/terraform/arm-terraform/package.json
+++ b/sdk/terraform/arm-terraform/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/test-utils/perf/package.json
+++ b/sdk/test-utils/perf/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -33,6 +33,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/test-utils/test-utils-vitest/package.json
+++ b/sdk/test-utils/test-utils-vitest/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/test-utils/test-utils/package.json
+++ b/sdk/test-utils/test-utils/package.json
@@ -33,6 +33,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/textanalytics/perf-tests/ai-text-analytics/package.json
+++ b/sdk/textanalytics/perf-tests/ai-text-analytics/package.json
@@ -59,6 +59,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
@@ -52,6 +52,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/trafficmanager/arm-trafficmanager/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/translation/ai-translation-document-rest/package.json
+++ b/sdk/translation/ai-translation-document-rest/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/translation/ai-translation-text-rest/package.json
+++ b/sdk/translation/ai-translation-text-rest/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/trustedsigning/arm-trustedsigning/package.json
+++ b/sdk/trustedsigning/arm-trustedsigning/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/vision/ai-vision-image-analysis-rest/package.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/visualstudio/arm-visualstudio/package.json
+++ b/sdk/visualstudio/arm-visualstudio/package.json
@@ -48,6 +48,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/voiceservices/arm-voiceservices/package.json
+++ b/sdk/voiceservices/arm-voiceservices/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/web-pubsub/arm-webpubsub/package.json
+++ b/sdk/web-pubsub/arm-webpubsub/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
@@ -41,6 +41,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/web-pubsub/web-pubsub-client/package.json
+++ b/sdk/web-pubsub/web-pubsub-client/package.json
@@ -34,6 +34,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE"
   ],

--- a/sdk/workloads/arm-workloads/package.json
+++ b/sdk/workloads/arm-workloads/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",

--- a/sdk/workloads/arm-workloadssapvirtualinstance/package.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "dist/",
+    "!dist/**/*.d.*ts.map",
     "README.md",
     "LICENSE",
     "review/",


### PR DESCRIPTION
They are not only used in IDE when we develop Azure SDK and won't benefit customers because they need to work with source which we don't pack.

This PR excludes them from packing for packages that have been migrated to ESM.

***NO_CI***

