### PR TITLE
Add Get-PackageInfoNameOverride function to Language-Settings

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -181,9 +181,8 @@ function Get-PackageInfoNameOverride {
   if ($PkgProps.ArtifactName) {
     return $PkgProps.ArtifactName
   }
-  else {
-    LogError "In Get-PackageInfoNameOverride-PkgProps, PkgProps with name $($PkgProps.Name) did not contain an ArtifactName"
-  }
+  LogError "In Get-PackageInfoNameOverride-PkgProps, PkgProps with name $($PkgProps.Name) did not contain an ArtifactName"
+  exit 1
 }
 
 # Returns the npm publish status of a package id and version.

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -173,6 +173,19 @@ function Get-javascript-PackageInfoFromRepo ($pkgPath, $serviceDirectory) {
   return $packageProps
 }
 
+function Get-PackageInfoNameOverride {
+  param(
+    [Parameter(Mandatory = $true)]
+    [PackageProps] $PkgProps
+  )
+  if ($PkgProps.ArtifactName) {
+    return $PkgProps.ArtifactName
+  }
+  else {
+    LogError "In Get-PackageInfoNameOverride-PkgProps, PkgProps with name $($PkgProps.Name) did not contain an ArtifactName"
+  }
+}
+
 # Returns the npm publish status of a package id and version.
 function IsNPMPackageVersionPublished ($pkgId, $pkgVersion) {
   Confirm-NodeInstallation


### PR DESCRIPTION
There's an [eng/common change](https://github.com/Azure/azure-sdk-tools/pull/10096) that's going to be pushed out very soon that will need this function.

eng/common/scripts/Save-Package-Properties.ps1 had the following code which was only for JS. 
```
    if ($pkg.ArtifactName)
    {
      $configFilePrefix = $pkg.ArtifactName
    }
```
The $configFilePrefix is actually the name of the packageInfo file. The problem is the above code was always causing the PackageInfo file names to be set to the ArtifactName if it was set, preventing me from making necessary changes. The solution was to define Get-PackageInfoNameOverride in Language-Settings.ps1 and have it return what the PackageInfo name should be set to. For JS this is the ArtifactName. I've already tested these changes locally generating all PackageInfo files for the repository before and after my changes and diffed them. This just gets things ready for when the eng/common change is merged.