### PR TITLE
[dev-tool] allow `vendored` command to log information  when command fails

### DIFF
--- a/common/tools/dev-tool/src/commands/run/vendored.ts
+++ b/common/tools/dev-tool/src/commands/run/vendored.ts
@@ -64,5 +64,13 @@ export default async (...args: string[]): Promise<boolean> => {
     ),
   );
 
-  return executor(...args);
+  const status = await executor(...args);
+  if (!status) {
+    // opportunity to log recommendations for the commands
+    if (args[0] === "prettier" && args[1] === "--list-different") {
+      log.warn(`Invoke "rushx format" in package directory to fix formatting.`);
+    }
+  }
+
+  return status;
 };

--- a/common/tools/dev-tool/src/commands/run/vendored.ts
+++ b/common/tools/dev-tool/src/commands/run/vendored.ts
@@ -68,7 +68,7 @@ export default async (...args: string[]): Promise<boolean> => {
   if (!status) {
     // opportunity to log recommendations for the commands
     if (args[0] === "prettier" && args[1] === "--list-different") {
-      log.warn(`Invoke "rushx format" in package directory to fix formatting.`);
+      log.warn(`Invoke "npm run format" in package directory to fix formatting.`);
     }
   }
 


### PR DESCRIPTION
This enables us to suggest `npm format` when vendored `prettier --list-different` in
`check-format` NPM script fails.