### PR TITLE
[test] use custom vitest reporter

### DIFF
--- a/common/tools/dev-tool/vitest.config.mts
+++ b/common/tools/dev-tool/vitest.config.mts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 
 export default defineConfig({
   test: {
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.xml",
     },

--- a/common/tools/eslint-plugin-azure-sdk/vitest.config.ts
+++ b/common/tools/eslint-plugin-azure-sdk/vitest.config.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 
 export default defineConfig({
   test: {
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.xml",
     },

--- a/eng/tools/rush-runner/vitest.config.mjs
+++ b/eng/tools/rush-runner/vitest.config.mjs
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 
 export default defineConfig({
   test: {
     testTimeout: 18000,
-    reporters: ["verbose"],
+    reporters: [new AzureSDKReporter()],
     watch: false,
     include: ["test/**/*.spec.js"],
     coverage: {

--- a/sdk/apimanagement/api-management-custom-widgets-tools/vitest.browser.config.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/vitest.browser.config.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 
 export default defineConfig({
   test: {
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/sdk/eventhub/event-hubs/vitest.browser.config.ts
+++ b/sdk/eventhub/event-hubs/vitest.browser.config.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
 import inject from "@rollup/plugin-inject";
 import { resolve } from "node:path";
@@ -24,7 +25,7 @@ export default defineConfig({
     include: ["dist-test/browser/**/*.spec.js"],
     globalSetup: ["./test/utils/setup.ts"],
     setupFiles: ["./test/utils/logging.ts"],
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/sdk/test-utils/recorder/vitest.browser.config.ts
+++ b/sdk/test-utils/recorder/vitest.browser.config.ts
@@ -4,6 +4,7 @@
 import { defineConfig } from "vitest/config";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
 import { relativeRecordingsPath } from "./src";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
@@ -13,7 +14,7 @@ export default defineConfig({
   },
   plugins: [browserMap()],
   test: {
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/sdk/test-utils/test-utils-vitest/vitest.browser.config.ts
+++ b/sdk/test-utils/test-utils-vitest/vitest.browser.config.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { AzureSDKReporter } from "../../../vitest.shared.config.js";
 
 export default defineConfig({
   test: {
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/vitest.browser.base.config.ts
+++ b/vitest.browser.base.config.ts
@@ -3,6 +3,7 @@
 
 import { defineConfig } from "vitest/config";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
+import { AzureSDKReporter } from "./vitest.shared.config.js";
 
 export default defineConfig({
   define: {
@@ -13,7 +14,7 @@ export default defineConfig({
       enabled: true,
     },
     testTimeout: 18000,
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/vitest.browser.shared.config.ts
+++ b/vitest.browser.shared.config.ts
@@ -3,6 +3,7 @@
 
 import { defineConfig } from "vitest/config";
 import { relativeRecordingsPath } from "@azure-tools/test-recorder";
+import { AzureSDKReporter } from "./vitest.shared.config.js";
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
 
@@ -15,7 +16,7 @@ export default defineConfig({
   },
   test: {
     testTimeout: 18000,
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.browser.xml",
     },

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -2,11 +2,23 @@
 // Licensed under the MIT License.
 
 import { defineConfig } from "vitest/config";
+import { VerboseReporter } from "vitest/reporters";
+
+/**
+ * vitest reporter that does not output "serialized error" to console which may contain secrets
+ */
+export class AzureSDKReporter extends VerboseReporter {
+  /**
+   * the `verbose` flag is used by VerboseReporter solely to control whether the serialized error should be output, so all we need to do
+   * is set it to false
+   */
+  protected verbose = false;
+}
 
 export default defineConfig({
   test: {
     testTimeout: 18000,
-    reporters: ["verbose", "junit"],
+    reporters: [new AzureSDKReporter(), "junit"],
     outputFile: {
       junit: "test-results.xml",
     },


### PR DESCRIPTION
### Packages impacted by this PR

- all packages using vitest

### Describe the problem that is addressed by this PR

The vitest `verbose` reporter outputs to console a JSON-serialized version of any error thrown during a test run. In the case a `RestError` is thrown, this results in the request and response objects being output, including any secrets that may be present. This may lead to secrets being leaked in CI logs. [I thought](https://github.com/Azure/azure-sdk-for-js/pull/29737#issuecomment-2179047796) that vitest turned off this behavior by default, but it turns out that they left it on for the verbose reporter specifically for whatever reason, so [when we changed over](https://github.com/Azure/azure-sdk-for-js/pull/30581) to it from the basic reporter back in July we inadvertently turned it back on.

So that we can still get the benefits of the verbose reporter while not having vitest leak secrets, this PR updates our config to use a custom reporter which updates a field on the verbose reporter to disable outputting the serialized error.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

We could use another reporter, e.g. the default reporter, which doesn't log the serialized error. But we updated to use the verbose reporter because we find the output useful so why change back if we don't have to? If this custom reporter proves to be annoying then maybe we can do that instead.
