### PR TITLE
In AzureCommunicationTokenCredential, use correct route and API version when calling ACS Auth token exchange API

### DIFF
--- a/sdk/communication/communication-common/src/entraTokenCredential.ts
+++ b/sdk/communication/communication-common/src/entraTokenCredential.ts
@@ -17,10 +17,10 @@ import {
 
 const TeamsExtensionScopePrefix = "https://auth.msft.communication.azure.com/";
 const CommunicationClientsScopePrefix = "https://communication.azure.com/clients/";
-const TeamsExtensionEndpoint = "/access/teamsPhone/:exchangeAccessToken";
+const TeamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
 const TeamsExtensionApiVersion = "2025-03-02-preview";
 const CommunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
-const CommunicationClientsApiVersion = "2024-04-01-preview";
+const CommunicationClientsApiVersion = "2025-03-02-preview";
 
 export interface ExchangeTokenResponse {
   identity: string;

--- a/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
+++ b/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
@@ -16,10 +16,10 @@ const entraToken = "entraToken";
 const newEntraToken = "newEntraToken";
 const acsToken = "acsToken";
 const comunicationClientsEndpoint =
-  "/access/entra/:exchangeAccessToken?api-version=2024-04-01-preview";
+  "/access/entra/:exchangeAccessToken?api-version=2025-03-02-preview";
 const communicationClientsScope = "https://communication.azure.com/clients/VoIP";
 const teamsExtensionEndpoint =
-  "/access/teamsPhone/:exchangeAccessToken?api-version=2025-03-02-preview";
+  "/access/teamsExtension/:exchangeAccessToken?api-version=2025-03-02-preview";
 const teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
 
 const tokenCredential: TokenCredential = {


### PR DESCRIPTION
Use Teams Phone Extensibility token exchange API with route according to REST API review. Use correct API version

### Packages impacted by this PR
@azure/communication-common

### Issues associated with this PR

### Describe the problem that is addressed by this PR
Replacing historical route and API version used for calling ACS Auth token exchange API by values approved in REST API review

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_
No, just updated existing ones to verify changed values

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
