### PR TITLE
Adjustment to `sparse-checkout` settings for Create-PRJobMatrix

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -81,7 +81,7 @@ jobs:
           MatrixFilters: ${{ parameters.MatrixFilters }}
           MatrixReplace: ${{ parameters.MatrixReplace }}
           ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-            SparseCheckoutPaths: [ "**/package.json", "**/ci*.yml"]
+            SparseCheckoutPaths: [ "/*" ]"
           CloudConfig:
             Cloud: Public
           AdditionalParameters:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -81,7 +81,7 @@ jobs:
           MatrixFilters: ${{ parameters.MatrixFilters }}
           MatrixReplace: ${{ parameters.MatrixReplace }}
           ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-            SparseCheckoutPaths: [ "/*" ]"
+            SparseCheckoutPaths: [ "/*" ]
           CloudConfig:
             Cloud: Public
           AdditionalParameters:


### PR DESCRIPTION
@jeremymeng reached out about this pr that looked [wonky.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4693084&view=logs&j=2a01393f-ea32-556d-315a-d0f84478d58d&t=2dcd174d-08bd-5b06-32f6-08c9530e78f7)

The issue is that we need the triggeringPath files to exist when we are checking whether or not to trigger a package based on them.

The lack of `common/config` presence was causing `azure-core` packages to NOT resolve when generating the targeted packages, so we were falling back to `template` packages. Rather than adding `common/config` to the sparse checkout, I'm just enhancing it to pull all the files. We lose 10 to 15 seconds, it's nbd.