### PR TITLE
[monitor] Re-enable traceHandler tests

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -231,8 +231,7 @@ describe("Library/TraceHandler", () => {
       );
     });
 
-    // TODO: these tests pass in isolation but not as a group due to test pollution. Resolve the test pollution separately
-    it.todo("should not track dependencies if configured off", async () => {
+    it("should not track dependencies if configured off", async () => {
       const httpConfig: HttpInstrumentationConfig = {
         enabled: true,
         ignoreOutgoingRequestHook: () => true,
@@ -246,7 +245,7 @@ describe("Library/TraceHandler", () => {
       assert.deepStrictEqual(spans[0].kind, 1, "Span Kind"); // Incoming only
     });
 
-    it.todo("should not track requests if configured off", async () => {
+    it("should not track requests if configured off", async () => {
       const httpConfig: HttpInstrumentationConfig = {
         enabled: true,
         ignoreIncomingRequestHook: () => true,
@@ -260,7 +259,7 @@ describe("Library/TraceHandler", () => {
       assert.deepStrictEqual(spans[0].kind, 2, "Span Kind"); // Outgoing only
     });
 
-    it.todo("http should not track if instrumentations are disabled", async () => {
+    it("http should not track if instrumentations are disabled", async () => {
       createHandler({ enabled: false });
       await makeHttpRequest();
       await makeHttpRequest();

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -4,7 +4,10 @@
 import { TraceHandler } from "../../../../src/traces/index.js";
 import { MetricHandler } from "../../../../src/metrics/index.js";
 import { InternalConfig } from "../../../../src/shared/index.js";
-import type { HttpInstrumentationConfig } from "@opentelemetry/instrumentation-http";
+import {
+  HttpInstrumentation,
+  type HttpInstrumentationConfig,
+} from "@opentelemetry/instrumentation-http";
 import type { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import type { ProxyTracerProvider, Span } from "@opentelemetry/api";
 import { metrics, trace } from "@opentelemetry/api";
@@ -83,6 +86,14 @@ describe("Library/TraceHandler", () => {
     handler = new TraceHandler(_config, metricHandler);
     tracerProvider.addSpanProcessor(handler.getAzureMonitorSpanProcessor());
     tracerProvider.addSpanProcessor(handler.getBatchSpanProcessor());
+
+    // Because the instrumentation is registered globally, its config is not updated
+    // when the handler is created. We need to mock the getConfig method to return
+    // the updated config.
+    vi.spyOn(HttpInstrumentation.prototype, "getConfig").mockImplementation(() => {
+      return httpConfig;
+    });
+
     exportSpy = vi
       .spyOn(handler["_azureExporter"], "export")
       .mockImplementation((spans: any, resultCallback: any) => {
@@ -236,6 +247,7 @@ describe("Library/TraceHandler", () => {
         enabled: true,
         ignoreOutgoingRequestHook: () => true,
       };
+
       createHandler(httpConfig);
       await makeHttpRequest();
       await tracerProvider.forceFlush();
@@ -250,6 +262,7 @@ describe("Library/TraceHandler", () => {
         enabled: true,
         ignoreIncomingRequestHook: () => true,
       };
+
       createHandler(httpConfig);
       await makeHttpRequest();
       await tracerProvider.forceFlush();
@@ -259,12 +272,10 @@ describe("Library/TraceHandler", () => {
       assert.deepStrictEqual(spans[0].kind, 2, "Span Kind"); // Outgoing only
     });
 
-    it("http should not track if instrumentations are disabled", async () => {
+    it("http should not track if instrumentations are disabled", () => {
       createHandler({ enabled: false });
-      await makeHttpRequest();
-      await makeHttpRequest();
-      await tracerProvider.forceFlush();
-      expect(exportSpy).not.toHaveBeenCalled();
+      // No HTTP instrumentation should be created
+      expect(handler.getInstrumentations()).toHaveLength(0);
     });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -109,7 +109,6 @@ describe("Library/TraceHandler", () => {
         });
       });
 
-    vi.resetModules();
     // Load Http modules, HTTP instrumentation hook will be created in OpenTelemetry
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require("http");


### PR DESCRIPTION
### Packages impacted by this PR

@azure/monitor-opentelemetry

### Issues associated with this PR

N/A - followup for #32819

### Describe the problem that is addressed by this PR

The move to ESM and Vitest uncovered some test-pollution that needs to be
addressed. To get the PR merged, I temporarily skipped those tests. 

This PR re-enables those tests to the best we can do given the constraints in
place and OTel's usage of globals.

A few changes were made:

1. OTel require hook will fire only once so instead of passing the config to a
new instrumentation, we can spy on the initialized instrumentation and update
its config via a spy. That allows it to always get a fresh config.
2. For ensuring disable works, we don't need to check on any spies and it's
sufficient to ensure that no http instrumentation was created.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

IMO this entire test suite can be simplified to only test the business logic of
the handler. When we initialize a handler, did it pass the correct configuration
to OTel? That will continue to test at the unit level with some integration
level coverage loss.


....

After finally finding an acceptable solution

![image](https://github.com/user-attachments/assets/be1bbd74-b92e-4cdf-bebd-862a241c87b8)
