### PR TITLE
[Monitor OpenTelemetry Exporter] Do not filter out standard metrics property

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Filter OpenTelemetry semantic attributes from being double recorded as custom dimensions.
 - Add support for detecting the Application Insights shim on internal verison.
+- Do not filter out `_MS.ProcessedByMetricExtractors` value on envelopes.
 
 ## 1.0.0-beta.29 (2025-03-04)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
@@ -197,3 +197,9 @@ export const httpSemanticValues = [
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
 ];
+
+/**
+ * Internal Microsoft attributes
+ * @internal
+ */
+export const internalMicrosoftAttributes = ["_MS.ProcessedByMetricExtractors"];

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -136,8 +136,9 @@ function createPropertiesFromSpanAttributes(attributes?: Attributes): {
     for (const key of Object.keys(attributes)) {
       // Avoid duplication ignoring fields already mapped.
       if (
+        // We need to not ignore the _MS.ProcessedByMetricExtractors key as it's used to identify standard metrics
         !(
-          key.startsWith("_MS.") ||
+          (key.startsWith("_MS.") && key !== "_MS.ProcessedByMetricExtractors") ||
           key.startsWith("microsoft.") ||
           legacySemanticValues.includes(key) ||
           httpSemanticValues.includes(key as any) ||

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -56,7 +56,12 @@ import {
   serializeAttribute,
 } from "./common.js";
 import type { Tags, Properties, MSLink, Measurements } from "../types.js";
-import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "../types.js";
+import {
+  httpSemanticValues,
+  internalMicrosoftAttributes,
+  legacySemanticValues,
+  MaxPropertyLengths,
+} from "../types.js";
 import { parseEventHubSpan } from "./eventhub.js";
 import {
   AzureMonitorSampleRate,
@@ -138,7 +143,7 @@ function createPropertiesFromSpanAttributes(attributes?: Attributes): {
       if (
         // We need to not ignore the _MS.ProcessedByMetricExtractors key as it's used to identify standard metrics
         !(
-          (key.startsWith("_MS.") && key !== "_MS.ProcessedByMetricExtractors") ||
+          (key.startsWith("_MS.") && !internalMicrosoftAttributes.includes(key as any)) ||
           key.startsWith("microsoft.") ||
           legacySemanticValues.includes(key) ||
           httpSemanticValues.includes(key as any) ||


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
We should not filter out a value used to tell ingestion that a standard metric was processed.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
