### PR TITLE
[core-lro] Relaxed status transformation

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Other Changes
 
+- Logs the status in the polling response before it is being transformed.
+
 ## 3.1.0 (2024-09-12)
 
 ### Features Added

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -138,7 +138,7 @@ function transformStatus(inputs: { status: unknown; statusCode: number }): Opera
       `Polling was unsuccessful. Expected status to have a string value or no value but it has instead: ${status}. This doesn't necessarily indicate the operation has failed. Check your Azure subscription or resource status for more information.`,
     );
   }
-  logger.verbose(`Transforming status: ${status} with status code: ${statusCode}.`);
+  logger.verbose(`LRO: Transforming status: ${status} with status code: ${statusCode}.`);
   const lowerCaseStatus = status?.toLocaleLowerCase();
   if (!lowerCaseStatus) {
     return toOperationStatus(statusCode);
@@ -149,7 +149,7 @@ function transformStatus(inputs: { status: unknown; statusCode: number }): Opera
   if (lowerCaseStatus.includes("fail")) {
     return "failed";
   }
-  if (lowerCaseStatus.includes("cancel") && lowerCaseStatus.includes("led")) {
+  if (["canceled", "cancelled"].includes(lowerCaseStatus)) {
     return "canceled";
   }
   return "running";

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -143,7 +143,7 @@ function transformStatus(inputs: { status: unknown; statusCode: number }): Opera
   if (!lowerCaseStatus) {
     return toOperationStatus(statusCode);
   }
-  if (lowerCaseStatus.includes("succe")) {
+  if (lowerCaseStatus.includes("succeeded")) {
     return "succeeded";
   }
   if (lowerCaseStatus.includes("fail")) {

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -138,27 +138,21 @@ function transformStatus(inputs: { status: unknown; statusCode: number }): Opera
       `Polling was unsuccessful. Expected status to have a string value or no value but it has instead: ${status}. This doesn't necessarily indicate the operation has failed. Check your Azure subscription or resource status for more information.`,
     );
   }
-  switch (status?.toLocaleLowerCase()) {
-    case undefined:
-      return toOperationStatus(statusCode);
-    case "succeeded":
-      return "succeeded";
-    case "failed":
-      return "failed";
-    case "running":
-    case "accepted":
-    case "started":
-    case "canceling":
-    case "cancelling":
-      return "running";
-    case "canceled":
-    case "cancelled":
-      return "canceled";
-    default: {
-      logger.verbose(`LRO: unrecognized operation status: ${status}`);
-      return status as OperationStatus;
-    }
+  logger.verbose(`Transforming status: ${status} with status code: ${statusCode}.`);
+  const lowerCaseStatus = status?.toLocaleLowerCase();
+  if (!lowerCaseStatus) {
+    return toOperationStatus(statusCode);
   }
+  if (lowerCaseStatus.includes("succe")) {
+    return "succeeded";
+  }
+  if (lowerCaseStatus.includes("fail")) {
+    return "failed";
+  }
+  if (lowerCaseStatus.includes("cancel") && lowerCaseStatus.includes("led")) {
+    return "canceled";
+  }
+  return "running";
 }
 
 function getStatus(rawResponse: RawResponse): OperationStatus {

--- a/sdk/core/core-lro/test/public/lro.spec.ts
+++ b/sdk/core/core-lro/test/public/lro.spec.ts
@@ -3153,6 +3153,55 @@ matrix(
           assert.isNotNull(poller.operationState);
           assert.equal(poller.operationState!.status, "running");
         });
+        it("handles polling response with unknown success status", async () => {
+          const poller = createTestPoller({
+            routes: [
+              {
+                method: "POST",
+                status: 200,
+              },
+              {
+                method: "GET",
+                status: 200,
+                body: `{ "status": "unknown" }`,
+              },
+              {
+                method: "GET",
+                status: 200,
+                body: `{ "status": "partially_succeeded" }`,
+              },
+            ],
+            implName,
+            throwOnNon2xxResponse,
+          });
+          const result = await poller.pollUntilDone();
+          assert.equal(result.statusCode, 200);
+        });
+
+        it("handles polling response with unknown fail status", async () => {
+          const poller = createTestPoller({
+            routes: [
+              {
+                method: "POST",
+                status: 200,
+              },
+              {
+                method: "GET",
+                status: 200,
+                body: `{ "status": "unknown" }`,
+              },
+              {
+                method: "GET",
+                status: 200,
+                body: `{ "status": "VerificationFailed" }`,
+              },
+            ],
+            implName,
+            throwOnNon2xxResponse,
+          });
+          const result = await poller.pollUntilDone();
+          assert.equal(result.statusCode, 200);
+        });
       });
 
       describe("promise poller", () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/core-lro

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
Polling responses may contain a status field, this PR logs it before it transforms it to the set of known statuses. It also relaxes the termination checking to be able to handle statuses that are not exactly "succeeded" or "failed" but still contain some variation of these words. This enables polling for many non-conforming LRO APIs without having to create dedicated custom pollers for them.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

- Add an option that specifies the set of terminal statuses to check for, this set has to be specified either by the user or by code gen. This doesn't work in cases where this set is not part of the spec or the user is not familiar with it
- Do nothing and let the user/code gen build custom pollers but that feels a lot more expensive than it should be

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
