### PR TITLE
Add user_security_context optional Azure param in openai

### DIFF
--- a/sdk/openai/openai/CHANGELOG.md
+++ b/sdk/openai/openai/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features Added
 
 - Adds support for `ungrounded_material` in `ContentFilterResultsForChoiceOutput`.
+- Adds support for `user_security_context` in `ChatCompletionCreateParamsNonStreaming` and `ChatCompletionCreateParamsStreaming`.
 
 ### Breaking Changes
 

--- a/sdk/openai/openai/src/types/index.ts
+++ b/sdk/openai/openai/src/types/index.ts
@@ -38,6 +38,7 @@ declare module "openai/resources/index" {
      *   This additional specification is only compatible with Azure OpenAI.
      */
     data_sources?: Array<AzureChatExtensionConfiguration>;
+    user_security_context?: AzureUserSecurityContext;
   }
 
   interface ChatCompletionCreateParamsStreaming {
@@ -46,6 +47,7 @@ declare module "openai/resources/index" {
      *   This additional specification is only compatible with Azure OpenAI.
      */
     data_sources?: Array<AzureChatExtensionConfiguration>;
+    user_security_context?: AzureUserSecurityContext;
   }
 
   interface ChatCompletion {
@@ -135,6 +137,28 @@ declare module "openai/resources/index" {
      * been filtered and its id.
      */
     prompt_filter_results?: ImageGenerationPromptFilterResults;
+  }
+
+  export interface AzureUserSecurityContext {
+    /**
+     * Azure-only field. User security context contains several parameters that describe the
+     * application itself, and the end user that interacts with the application. These fields assist
+     * your security operations teams to investigate and mitigate security incidents by providing
+     * a comprehensive approach to protecting your AI applications.
+     * [Learn more](https://aka.ms/TP4AI/Documentation/EndUserContext) about protecting AI applications using
+     * Microsoft Defender for Cloud. The name of the application. Sensitive personal information should not be
+     * included in this field.
+     */
+    application_name?: string;
+
+    /** This identifier is the Microsoft Entra ID (formerly Azure Active Directory) user object ID used to authenticate end-users within the generative AI application. Sensitive personal information should not be included in this field. */
+    end_user_id?: string;
+
+    /** The Microsoft 365 tenant ID the end user belongs to. It's required when the generative AI application is multitenant. */
+    end_user_tenant_id?: string;
+
+    /** Captures the original client's IP address. */
+    source_ip?: string;
   }
 
   export interface UploadPart {

--- a/sdk/openai/openai/test/public/chatCompletions.spec.ts
+++ b/sdk/openai/openai/test/public/chatCompletions.spec.ts
@@ -55,8 +55,7 @@ describe.shuffle.each(APIMatrix)("Chat Completions [%s]", (apiVersion: APIVersio
   const byodMessages = [
     {
       role: "user",
-      content:
-        "What's the most common feedback we received from our customers about the product?",
+      content: "What's the most common feedback we received from our customers about the product?",
     } as const,
   ];
   const getCurrentWeather = {
@@ -78,229 +77,365 @@ describe.shuffle.each(APIMatrix)("Chat Completions [%s]", (apiVersion: APIVersio
     },
   };
 
-  describe("chat.completions.create", () => {
-
-    describe("return non-streaming", () => {
-      it("returns completions across all models", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          (client, deploymentName) =>
-            client.chat.completions.create({
-              model: deploymentName,
-              messages: pirateMessages,
-            }),
-          assertChatCompletions,
-        );
-      });
-
-      it("calls functions", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          async (client, deploymentName) => {
-            const weatherMessages: ChatCompletionMessageParam[] = [
-              { role: "user", content: "What's the weather like in Boston?" },
-            ];
-            const result = await client.chat.completions.create({
-              model: deploymentName,
-              messages: weatherMessages,
-              functions: [getCurrentWeather],
-            });
-            assertChatCompletions(result, { functions: true });
-            const responseMessage = result.choices[0].message;
-            if (!responseMessage?.function_call) {
-              assert.fail("Undefined function call");
-            }
-            const functionArgs = JSON.parse(responseMessage.function_call.arguments);
-            weatherMessages.push(responseMessage);
-            weatherMessages.push({
-              role: "function",
-              name: responseMessage.function_call.name,
-              content: JSON.stringify({
-                location: functionArgs.location,
-                temperature: "72",
-                unit: functionArgs.unit,
-                forecast: ["sunny", "windy"],
-              }),
-            });
-            return client.chat.completions.create({
-              model: deploymentName,
-              messages: weatherMessages,
-            });
-          },
-          (result) => assertChatCompletions(result, { functions: true }),
-          functionCallModelsToSkip,
-        );
-      });
-
-      it("doesn't call tools if toolChoice is set to none", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          (client, deploymentName) =>
-            client.chat.completions.create({
-              model: deploymentName,
-              messages: [{ role: "user", content: "What's the weather like in Boston?" }],
-              tool_choice: "none",
-              tools: [{ type: "function", function: getCurrentWeather }],
-            }),
-          (res) => {
-            assertChatCompletions(res, { functions: false });
-            assert.isUndefined(res.choices[0].message?.tool_calls);
-          },
-        );
-      });
-
-      it("calls a specific tool if its name is specified", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          (client, deploymentName) =>
-            client.chat.completions.create({
-              model: deploymentName,
-              messages: [{ role: "user", content: "What's the weather like in Boston?" }],
-
-              tool_choice: {
-                type: "function",
-                function: { name: getCurrentWeather.name },
-              },
-              tools: [
-                { type: "function", function: getCurrentWeather },
-                {
-                  type: "function",
-                  function: {
-                    name: "get_current_weather2",
-                    description: "Get the current weather in a given location in the US",
-                    parameters: {
-                      type: "object",
-                      properties: {
-                        location: {
-                          type: "string",
-                          description: "The city and state, e.g. San Francisco, CA",
-                        },
-                        unit: {
-                          type: "string",
-                          enum: ["celsius", "fahrenheit"],
-                        },
-                      },
-                      required: ["location"],
-                    },
-                  },
-                },
-              ],
-            }),
-          (res) => {
-            assertChatCompletions(res, { functions: true });
-            const toolCalls = res.choices[0].message?.tool_calls;
-            if (!toolCalls) {
-              throw new Error("toolCalls should be defined here");
-            }
-            assert.equal(toolCalls[0].function.name, getCurrentWeather.name);
-            assert.isUndefined(res.choices[0].message?.function_call);
-          },
-        );
-      });
-
-      it("ensures schema name is not transformed with snake case", async () => {
-        const getAssetInfo = {
-          name: "getAssetInfo",
-          description: "Returns information about an asset",
-          parameters: {
-            type: "object",
-            properties: {
-              assetName: {
-                type: "string",
-                description: "The asset name. This is a required parameter.",
-              },
-            },
-            required: ["assetName"],
-          },
-        };
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          (client, deploymentName) =>
-            client.chat.completions.create({
-              model: deploymentName,
-              messages: [{ role: "user", content: "Give me information about Asset No1" }],
-              tools: [{ type: "function", function: getAssetInfo }],
-            }),
-          (res) => {
-            assertChatCompletions(res, { functions: true });
-            const toolCalls = res.choices[0].message?.tool_calls;
-            if (!toolCalls) {
-              throw new Error("toolCalls should be defined here");
-            }
-            const argument = toolCalls[0].function.arguments;
-            assert.isTrue(argument?.includes("assetName"));
-          },
-          functionCallModelsToSkip,
-        );
-      });
-
-      it("respects json_object responseFormat", async () => {
-        await withDeployments(
-          filterClientsAndDeployments(clientsAndDeploymentsInfo, {
-            jsonObjectResponse: "true",
+  describe("chat.completions.create non-streaming", () => {
+    it("returns completions across all models", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        (client, deploymentName) =>
+          client.chat.completions.create({
+            model: deploymentName,
+            messages: pirateMessages,
           }),
-          (client, deploymentName) =>
-            client.chat.completions.create({
-              model: deploymentName,
-              messages: [
-                {
-                  role: "user",
-                  content:
-                    "Answer the following question in JSON format: What are the capital cities in Africa?",
-                },
-              ],
-              response_format: { type: "json_object" },
-            }),
-          (res) => {
-            assertChatCompletions(res, { functions: false });
-            const content = res.choices[0].message?.content;
-            if (!content) assert.fail("Undefined content");
-            try {
-              JSON.parse(content);
-            } catch {
-              assert.fail(`Invalid JSON: ${ content }`);
-            }
-          },
-        );
-      });
+        assertChatCompletions,
+      );
+    });
 
-      describe.concurrent.each(createAzureSearchExtensions())(
-        "works with data sources [%o]",
-        async (config) => {
-          await testWithDeployments({
-            clientsAndDeploymentsInfo,
-            run: (client, model) =>
-              client.chat.completions.create({
-                model: model,
-                messages: byodMessages,
-                data_sources: [config],
-              }),
-            validate: assertChatCompletions,
-            modelsListToSkip: [
-              { name: "gpt-35-turbo-0613" }, // Unsupported model
-              { name: "gpt-4-32k" }, // Managed identity is not enabled
-              { name: "o1-preview" }, // o-series models are not supported with OYD.
-              { name: "o1-mini" },
-              { name: "gpt-4", version: "vision-preview" },
-            ],
-            acceptableErrors: {
-              messageSubstring: [
-                "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
-                "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
-              ],
-            },
+    it("calls functions", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        async (client, deploymentName) => {
+          const weatherMessages: ChatCompletionMessageParam[] = [
+            { role: "user", content: "What's the weather like in Boston?" },
+          ];
+          const result = await client.chat.completions.create({
+            model: deploymentName,
+            messages: weatherMessages,
+            functions: [getCurrentWeather],
+          });
+          assertChatCompletions(result, { functions: true });
+          const responseMessage = result.choices[0].message;
+          if (!responseMessage?.function_call) {
+            assert.fail("Undefined function call");
+          }
+          const functionArgs = JSON.parse(responseMessage.function_call.arguments);
+          weatherMessages.push(responseMessage);
+          weatherMessages.push({
+            role: "function",
+            name: responseMessage.function_call.name,
+            content: JSON.stringify({
+              location: functionArgs.location,
+              temperature: "72",
+              unit: functionArgs.unit,
+              forecast: ["sunny", "windy"],
+            }),
+          });
+          return client.chat.completions.create({
+            model: deploymentName,
+            messages: weatherMessages,
           });
         },
+        (result) => assertChatCompletions(result, { functions: true }),
+        functionCallModelsToSkip,
       );
-      describe.concurrent.each(createAzureSearchExtensions())(
-        "works with data sources and user security context [%o]",
-        async (config) => {
-          await testWithDeployments({
-            clientsAndDeploymentsInfo,
-            run: (client, model) =>
-              client.chat.completions.create({
+    });
+
+    it("doesn't call tools if toolChoice is set to none", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        (client, deploymentName) =>
+          client.chat.completions.create({
+            model: deploymentName,
+            messages: [{ role: "user", content: "What's the weather like in Boston?" }],
+            tool_choice: "none",
+            tools: [{ type: "function", function: getCurrentWeather }],
+          }),
+        (res) => {
+          assertChatCompletions(res, { functions: false });
+          assert.isUndefined(res.choices[0].message?.tool_calls);
+        },
+      );
+    });
+
+    it("calls a specific tool if its name is specified", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        (client, deploymentName) =>
+          client.chat.completions.create({
+            model: deploymentName,
+            messages: [{ role: "user", content: "What's the weather like in Boston?" }],
+
+            tool_choice: {
+              type: "function",
+              function: { name: getCurrentWeather.name },
+            },
+            tools: [
+              { type: "function", function: getCurrentWeather },
+              {
+                type: "function",
+                function: {
+                  name: "get_current_weather2",
+                  description: "Get the current weather in a given location in the US",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      location: {
+                        type: "string",
+                        description: "The city and state, e.g. San Francisco, CA",
+                      },
+                      unit: {
+                        type: "string",
+                        enum: ["celsius", "fahrenheit"],
+                      },
+                    },
+                    required: ["location"],
+                  },
+                },
+              },
+            ],
+          }),
+        (res) => {
+          assertChatCompletions(res, { functions: true });
+          const toolCalls = res.choices[0].message?.tool_calls;
+          if (!toolCalls) {
+            throw new Error("toolCalls should be defined here");
+          }
+          assert.equal(toolCalls[0].function.name, getCurrentWeather.name);
+          assert.isUndefined(res.choices[0].message?.function_call);
+        },
+      );
+    });
+
+    it("ensures schema name is not transformed with snake case", async () => {
+      const getAssetInfo = {
+        name: "getAssetInfo",
+        description: "Returns information about an asset",
+        parameters: {
+          type: "object",
+          properties: {
+            assetName: {
+              type: "string",
+              description: "The asset name. This is a required parameter.",
+            },
+          },
+          required: ["assetName"],
+        },
+      };
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        (client, deploymentName) =>
+          client.chat.completions.create({
+            model: deploymentName,
+            messages: [{ role: "user", content: "Give me information about Asset No1" }],
+            tools: [{ type: "function", function: getAssetInfo }],
+          }),
+        (res) => {
+          assertChatCompletions(res, { functions: true });
+          const toolCalls = res.choices[0].message?.tool_calls;
+          if (!toolCalls) {
+            throw new Error("toolCalls should be defined here");
+          }
+          const argument = toolCalls[0].function.arguments;
+          assert.isTrue(argument?.includes("assetName"));
+        },
+        functionCallModelsToSkip,
+      );
+    });
+
+    it("respects json_object responseFormat", async () => {
+      await withDeployments(
+        filterClientsAndDeployments(clientsAndDeploymentsInfo, {
+          jsonObjectResponse: "true",
+        }),
+        (client, deploymentName) =>
+          client.chat.completions.create({
+            model: deploymentName,
+            messages: [
+              {
+                role: "user",
+                content:
+                  "Answer the following question in JSON format: What are the capital cities in Africa?",
+              },
+            ],
+            response_format: { type: "json_object" },
+          }),
+        (res) => {
+          assertChatCompletions(res, { functions: false });
+          const content = res.choices[0].message?.content;
+          if (!content) assert.fail("Undefined content");
+          try {
+            JSON.parse(content);
+          } catch {
+            assert.fail(`Invalid JSON: ${content}`);
+          }
+        },
+      );
+    });
+
+    describe.concurrent.each(createAzureSearchExtensions())(
+      "works with data sources [%o]",
+      async (config) => {
+        await testWithDeployments({
+          clientsAndDeploymentsInfo,
+          run: (client, model) =>
+            client.chat.completions.create({
+              model: model,
+              messages: byodMessages,
+              data_sources: [config],
+            }),
+          validate: assertChatCompletions,
+          modelsListToSkip: [
+            { name: "gpt-35-turbo-0613" }, // Unsupported model
+            { name: "gpt-4-32k" }, // Managed identity is not enabled
+            { name: "o1-preview" }, // o-series models are not supported with OYD.
+            { name: "o1-mini" },
+            { name: "gpt-4", version: "vision-preview" },
+          ],
+          acceptableErrors: {
+            messageSubstring: [
+              "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
+              "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
+            ],
+          },
+        });
+      },
+    );
+    describe.concurrent.each(createAzureSearchExtensions())(
+      "works with data sources and user security context [%o]",
+      async (config) => {
+        await testWithDeployments({
+          clientsAndDeploymentsInfo,
+          run: (client, model) =>
+            client.chat.completions.create({
+              model: model,
+              messages: byodMessages,
+              data_sources: [config],
+              user_security_context: {
+                application_name: "my_app",
+                end_user_id: "user123",
+                end_user_tenant_id: "tenant123",
+                source_ip: "unittest",
+              },
+            }),
+          validate: assertChatCompletions,
+          modelsListToSkip: [
+            { name: "gpt-35-turbo-0613" }, // Unsupported model
+            { name: "gpt-4-32k" }, // Managed identity is not enabled
+            { name: "o1-preview" }, // o-series models are not supported with OYD.
+            { name: "o1-mini" },
+            { name: "gpt-4", version: "vision-preview" },
+          ],
+          acceptableErrors: {
+            messageSubstring: [
+              "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
+              "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
+            ],
+          },
+        });
+      },
+    );
+  });
+
+  describe("chat.completions.create stream", () => {
+    it("returns completions across all models", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        async (client, deploymentName) =>
+          bufferAsyncIterable(
+            await client.chat.completions.create({
+              model: deploymentName,
+              messages: pirateMessages,
+              stream: true,
+            }),
+          ),
+        (res) =>
+          assertChatCompletionsList(res, {
+            // The API returns an empty choice in the first event for some
+            // reason. This should be fixed in the API.
+            allowEmptyChoices: true,
+            // The API returns an empty ID in the first event for some
+            // reason. This should be fixed in the API.
+            allowEmptyId: true,
+          }),
+      );
+    });
+
+    it("calls functions", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        async (client, deploymentName) =>
+          bufferAsyncIterable(
+            await client.chat.completions.create({
+              model: deploymentName,
+              messages: [{ role: "user", content: "What's the weather like in Boston?" }],
+              stream: true,
+              functions: [getCurrentWeather],
+            }),
+          ),
+        (res) =>
+          assertChatCompletionsList(res, {
+            functions: true,
+            // The API returns an empty choice in the first event for some
+            // reason. This should be fixed in the API.
+            allowEmptyChoices: true,
+          }),
+      );
+    });
+
+    it("calls toolCalls", async () => {
+      await withDeployments(
+        clientsAndDeploymentsInfo,
+        async (client, deploymentName) =>
+          bufferAsyncIterable(
+            await client.chat.completions.create({
+              model: deploymentName,
+              messages: [{ role: "user", content: "What's the weather like in Boston?" }],
+              stream: true,
+              tools: [{ type: "function", function: getCurrentWeather }],
+            }),
+          ),
+        (res) =>
+          assertChatCompletionsList(res, {
+            functions: true,
+            // The API returns an empty choice in the first event for some
+            // reason. This should be fixed in the API.
+            allowEmptyChoices: true,
+          }),
+      );
+    });
+
+    describe.concurrent.each(createAzureSearchExtensions())(
+      "works with data sources [%o]",
+      async (config) => {
+        await testWithDeployments({
+          clientsAndDeploymentsInfo,
+          run: async (client, model) =>
+            bufferAsyncIterable(
+              await client.chat.completions.create({
                 model: model,
                 messages: byodMessages,
+                stream: true,
+                data_sources: [config],
+              }),
+            ),
+          validate: assertChatCompletionsList,
+          modelsListToSkip: [
+            { name: "gpt-35-turbo-0613" }, // Unsupported model
+            { name: "gpt-4-32k" }, // Managed identity is not enabled
+            { name: "o1-preview" }, // o-series models are not supported with OYD.
+            { name: "o1-mini" },
+            { name: "gpt-4", version: "vision-preview" },
+          ],
+          acceptableErrors: {
+            messageSubstring: [
+              "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
+              "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
+            ],
+          },
+        });
+      },
+    );
+
+    describe.concurrent.each(createAzureSearchExtensions())(
+      "works with data sources and user security context [%o])",
+      async (config) => {
+        await testWithDeployments({
+          clientsAndDeploymentsInfo,
+          run: async (client, model) =>
+            bufferAsyncIterable(
+              await client.chat.completions.create({
+                model: model,
+                messages: byodMessages,
+                stream: true,
                 data_sources: [config],
                 user_security_context: {
                   application_name: "my_app",
@@ -309,203 +444,61 @@ describe.shuffle.each(APIMatrix)("Chat Completions [%s]", (apiVersion: APIVersio
                   source_ip: "unittest",
                 },
               }),
-            validate: assertChatCompletions,
-            modelsListToSkip: [
-              { name: "gpt-35-turbo-0613" }, // Unsupported model
-              { name: "gpt-4-32k" }, // Managed identity is not enabled
-              { name: "o1-preview" }, // o-series models are not supported with OYD.
-              { name: "o1-mini" },
-              { name: "gpt-4", version: "vision-preview" },
-            ],
-            acceptableErrors: {
-              messageSubstring: [
-                "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
-                "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
-              ],
-            },
-          });
-        },
-      );
-
-    });
-
-    describe("return stream", () => {
-      it("returns completions across all models", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          async (client, deploymentName) =>
-            bufferAsyncIterable(
-              await client.chat.completions.create({
-                model: deploymentName,
-                messages: pirateMessages,
-                stream: true,
-              }),
             ),
-          (res) =>
-            assertChatCompletionsList(res, {
-              // The API returns an empty choice in the first event for some
-              // reason. This should be fixed in the API.
-              allowEmptyChoices: true,
-              // The API returns an empty ID in the first event for some
-              // reason. This should be fixed in the API.
-              allowEmptyId: true,
-            }),
-        );
-      });
-
-      it("calls functions", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          async (client, deploymentName) =>
-            bufferAsyncIterable(
-              await client.chat.completions.create({
-                model: deploymentName,
-                messages: [{ role: "user", content: "What's the weather like in Boston?" }],
-                stream: true,
-                functions: [getCurrentWeather],
-              }),
-            ),
-          (res) =>
-            assertChatCompletionsList(res, {
-              functions: true,
-              // The API returns an empty choice in the first event for some
-              // reason. This should be fixed in the API.
-              allowEmptyChoices: true,
-            }),
-        );
-      });
-
-      it("calls toolCalls", async () => {
-        await withDeployments(
-          clientsAndDeploymentsInfo,
-          async (client, deploymentName) =>
-            bufferAsyncIterable(
-              await client.chat.completions.create({
-                model: deploymentName,
-                messages: [{ role: "user", content: "What's the weather like in Boston?" }],
-                stream: true,
-                tools: [{ type: "function", function: getCurrentWeather }],
-              }),
-            ),
-          (res) =>
-            assertChatCompletionsList(res, {
-              functions: true,
-              // The API returns an empty choice in the first event for some
-              // reason. This should be fixed in the API.
-              allowEmptyChoices: true,
-            }),
-        );
-      });
-
-      describe.concurrent.each(createAzureSearchExtensions())(
-        "works with data sources [%o])",
-        async (config) => {
-          await testWithDeployments({
-            clientsAndDeploymentsInfo,
-            run: async (client, model) =>
-              bufferAsyncIterable(
-                await client.chat.completions.create({
-                  model: model,
-                  messages: byodMessages,
-                  stream: true,
-                  data_sources: [config],
-                }),
-              ),
-            validate: assertChatCompletionsList,
-            modelsListToSkip: [
-              { name: "gpt-35-turbo-0613" }, // Unsupported model
-              { name: "gpt-4-32k" }, // Managed identity is not enabled
-              { name: "o1-preview" }, // o-series models are not supported with OYD.
-              { name: "o1-mini" },
-              { name: "gpt-4", version: "vision-preview" },
+          validate: assertChatCompletionsList,
+          modelsListToSkip: [
+            { name: "gpt-35-turbo-0613" }, // Unsupported model
+            { name: "gpt-4-32k" }, // Managed identity is not enabled
+            { name: "o1-preview" }, // o-series models are not supported with OYD.
+            { name: "o1-mini" },
+            { name: "gpt-4", version: "vision-preview" },
+          ],
+          acceptableErrors: {
+            messageSubstring: [
+              "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
+              "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
             ],
-            acceptableErrors: {
-              messageSubstring: [
-                "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
-                "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
+          },
+        });
+      },
+    );
+
+    describe("chat.completions.parse", () => {
+      describe("structured output for chat completions", async () => {
+        await testWithDeployments({
+          clientsAndDeploymentsInfo: filterClientsAndDeployments(clientsAndDeploymentsInfo, {
+            jsonSchemaResponse: "true",
+          }),
+          run: async (client, deploymentName) => {
+            const step = z.object({
+              explanation: z.string(),
+              output: z.string(),
+            });
+
+            const mathResponse = z.object({
+              steps: z.array(step),
+              final_answer: z.string(),
+            });
+
+            return client.beta.chat.completions.parse({
+              model: deploymentName,
+              messages: [
+                {
+                  role: "system",
+                  content: "You are a helpful math tutor. Only use the schema for math responses.",
+                },
+                { role: "user", content: "solve 8x + 3 = 21" },
               ],
-            },
-          });
-        },
-      );
-
-      describe.concurrent.each(createAzureSearchExtensions())(
-        "works with data sources and user security context [%o])",
-        async (config) => {
-          await testWithDeployments({
-            clientsAndDeploymentsInfo,
-            run: async (client, model) =>
-              bufferAsyncIterable(
-                await client.chat.completions.create({
-                  model: model,
-                  messages: byodMessages,
-                  stream: true,
-                  data_sources: [config],
-                  user_security_context: {
-                    application_name: "my_app",
-                    end_user_id: "user123",
-                    end_user_tenant_id: "tenant123",
-                    source_ip: "unittest",
-                  },
-                }),
-              ),
-            validate: assertChatCompletionsList,
-            modelsListToSkip: [
-              { name: "gpt-35-turbo-0613" }, // Unsupported model
-              { name: "gpt-4-32k" }, // Managed identity is not enabled
-              { name: "o1-preview" }, // o-series models are not supported with OYD.
-              { name: "o1-mini" },
-              { name: "gpt-4", version: "vision-preview" },
-            ],
-            acceptableErrors: {
-              messageSubstring: [
-                "Invalid AzureCognitiveSearch configuration detected", // gpt-4-1106-preview and others
-                "Managed Identity (MI) is not set for this account while the encryption key source is 'Microsoft.KeyVault', customer managed storage or Network Security Perimeter is used.",
-              ],
-            },
-          });
-        },
-      );
-
-      describe("chat.completions.parse", () => {
-        describe("structured output for chat completions", async () => {
-          await testWithDeployments({
-            clientsAndDeploymentsInfo: filterClientsAndDeployments(clientsAndDeploymentsInfo, {
-              jsonSchemaResponse: "true",
-            }),
-            run: async (client, deploymentName) => {
-              const step = z.object({
-                explanation: z.string(),
-                output: z.string(),
-              });
-
-              const mathResponse = z.object({
-                steps: z.array(step),
-                final_answer: z.string(),
-              });
-
-              return client.beta.chat.completions.parse({
-                model: deploymentName,
-                messages: [
-                  {
-                    role: "system",
-                    content:
-                      "You are a helpful math tutor. Only use the schema for math responses.",
-                  },
-                  { role: "user", content: "solve 8x + 3 = 21" },
-                ],
-                response_format: zodResponseFormat(mathResponse, "mathResponse"),
-              });
-            },
-            validate: (result) => {
-              assertParsedChatCompletion<MathResponse>(result, assertMathResponseOutput, {
-                allowEmptyChoices: true,
-              });
-            },
-          });
+              response_format: zodResponseFormat(mathResponse, "mathResponse"),
+            });
+          },
+          validate: (result) => {
+            assertParsedChatCompletion<MathResponse>(result, assertMathResponseOutput, {
+              allowEmptyChoices: true,
+            });
+          },
         });
       });
     });
-
   });
 });

--- a/sdk/openai/openai/test/utils/utils.ts
+++ b/sdk/openai/openai/test/utils/utils.ts
@@ -25,12 +25,12 @@ import { logger } from "./logger.js";
 import type { OpenAI } from "openai";
 import type { Sku } from "@azure/arm-cognitiveservices";
 
-export type AcceptableErrors = {
+export type SkippableErrors = {
   messageSubstring: string[];
 };
 
-const GlobalAcceptedErrors: AcceptableErrors = {
-  messageSubstring: ["Rate limit is exceeded"],
+const GlobalSkippableErrors: SkippableErrors = {
+  messageSubstring: ["Rate limit is exceeded", "400 Unsupported Model"],
 };
 
 export const maxRetriesOption = { maxRetries: 0 };
@@ -120,7 +120,7 @@ export type DeploymentTestingParameters<T> = {
   run: (client: OpenAI, model: string) => Promise<T>;
   validate?: (result: T) => void;
   modelsListToSkip?: Partial<ModelInfo>[];
-  acceptableErrors?: AcceptableErrors;
+  acceptableErrors?: SkippableErrors;
 };
 
 /**
@@ -157,7 +157,7 @@ export async function testWithDeployments<T>({
               done.skip(`Skipping due to acceptable error: ${error}`);
             }
             if (
-              GlobalAcceptedErrors.messageSubstring.some((match) => error.message.includes(match))
+              GlobalSkippableErrors.messageSubstring.some((match) => error.message.includes(match))
             ) {
               done.skip(`Skipping due to global acceptable error: ${error}`);
             }


### PR DESCRIPTION
### Packages impacted by this PR
openai

### Describe the problem that is addressed by this PR
This PR adds `user_security_context` as an optional Azure parameter as `AzureUserSecurityContext` in the `openai` package for `ChatCompletionCreateParams` streaming and non-streaming interfaces.

### Are there test cases added in this PR? _(If not, why?)_
yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
