### PR TITLE
[Monitor OpenTelemetry Exporter] Add Synthetic Source Support in the Exporter

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support setting the AiLocationIp on logs and events.
 - Add support for performance counters.
+- Support `syntheticSource` from `user_agent.synthetic.type` semantic convention.
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
@@ -170,6 +170,14 @@ export const legacySemanticValues = [
 ];
 
 /**
+ * Experimental OpenTelemetry semantic convention values
+ * @internal
+ */
+export enum experimentalOpenTelemetryValues {
+  SYNTHETIC_TYPE = "user_agent.synthetic.type",
+}
+
+/**
  * HTTP semantic convention values
  * @internal
  */
@@ -196,7 +204,14 @@ export const httpSemanticValues = [
   ATTR_EXCEPTION_TYPE,
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
+  experimentalOpenTelemetryValues.SYNTHETIC_TYPE,
 ];
+
+/**
+ * Synthetic source values
+ * @internal
+ */
+export const syntheticSourceValues = ["bot", "test"];
 
 /**
  * Internal Microsoft attributes

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -30,7 +30,7 @@ import {
   ATTR_TELEMETRY_SDK_NAME,
   DBSYSTEMVALUES_H2,
 } from "@opentelemetry/semantic-conventions";
-import type { Tags } from "../types.js";
+import { experimentalOpenTelemetryValues, syntheticSourceValues, type Tags } from "../types.js";
 import { getInstance } from "../platform/index.js";
 import type { TelemetryItem as Envelope, MetricsData } from "../generated/index.js";
 import { KnownContextTagKeys } from "../generated/index.js";
@@ -286,4 +286,11 @@ export function serializeAttribute(value: AnyValue): string {
 
 export function shouldCreateResourceMetric(): boolean {
   return !(process.env[ENV_OPENTELEMETRY_RESOURCE_METRIC_DISABLED]?.toLowerCase() === "true");
+}
+
+export function isSyntheticSource(attributes: Attributes): boolean {
+  const syntheticType: string = attributes[
+    experimentalOpenTelemetryValues.SYNTHETIC_TYPE
+  ] as string;
+  return syntheticSourceValues.includes(syntheticType?.toLowerCase());
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -12,7 +12,12 @@ import type {
   TelemetryExceptionDetails,
 } from "../generated/index.js";
 import { KnownContextTagKeys, KnownSeverityLevel } from "../generated/index.js";
-import { createTagsFromResource, hrTimeToDate, serializeAttribute } from "./common.js";
+import {
+  createTagsFromResource,
+  hrTimeToDate,
+  isSyntheticSource,
+  serializeAttribute,
+} from "./common.js";
 import type { ReadableLogRecord } from "@opentelemetry/sdk-logs";
 import {
   ATTR_EXCEPTION_MESSAGE,
@@ -21,7 +26,8 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import type { Measurements, Properties, Tags } from "../types.js";
 import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "../types.js";
-import { Attributes, diag } from "@opentelemetry/api";
+import type { Attributes } from "@opentelemetry/api";
+import { diag } from "@opentelemetry/api";
 import {
   ApplicationInsightsAvailabilityBaseType,
   ApplicationInsightsAvailabilityName,
@@ -144,6 +150,9 @@ function createTagsFromLog(log: ReadableLogRecord): Tags {
     tags[KnownContextTagKeys.AiOperationName] = log.attributes[
       KnownContextTagKeys.AiOperationName
     ] as string;
+  }
+  if (isSyntheticSource(log.attributes as Attributes)) {
+    tags[KnownContextTagKeys.AiOperationSyntheticSource] = "True";
   }
   getLocationIp(tags, log.attributes as Attributes);
   return tags;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -53,6 +53,7 @@ import {
   getUrl,
   hrTimeToDate,
   isSqlDB,
+  isSyntheticSource,
   serializeAttribute,
 } from "./common.js";
 import type { Tags, Properties, MSLink, Measurements } from "../types.js";
@@ -94,6 +95,9 @@ function createTagsFromSpan(span: ReadableSpan): Tags {
   if (httpUserAgent) {
     // TODO: Not exposed in Swagger, need to update def
     tags["ai.user.userAgent"] = String(httpUserAgent);
+  }
+  if (isSyntheticSource(span.attributes)) {
+    tags[KnownContextTagKeys.AiOperationSyntheticSource] = "True";
   }
   if (span.kind === SpanKind.SERVER) {
     const httpMethod = getHttpMethod(span.attributes);

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -16,7 +16,7 @@ import {
   SEMATTRS_HTTP_CLIENT_IP,
 } from "@opentelemetry/semantic-conventions";
 import type { Tags, Properties, Measurements } from "../../src/types.js";
-import { MaxPropertyLengths } from "../../src/types.js";
+import { experimentalOpenTelemetryValues, MaxPropertyLengths } from "../../src/types.js";
 import { getInstance } from "../../src/platform/index.js";
 import type {
   AvailabilityData,
@@ -73,6 +73,7 @@ function assertEnvelope(
   assert.deepStrictEqual(envelope?.tags, {
     ...context.tags,
     ...expectedServiceTags,
+    [KnownContextTagKeys.AiOperationSyntheticSource]: "True",
   });
   assert.deepStrictEqual((envelope?.data?.baseData as any).properties, expectedProperties);
   assert.deepStrictEqual((envelope?.data?.baseData as any).measurements, expectedMeasurements);
@@ -98,6 +99,7 @@ describe("logUtils.ts", () => {
     attributes: {
       "some-attribute": "some attribute value",
       [ATTR_CLIENT_ADDRESS]: "127.0.0.1",
+      [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
     },
     severityNumber: SeverityNumber.INFO,
     severityText: "Information",
@@ -118,6 +120,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [ATTR_NETWORK_PEER_ADDRESS]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "test",
       };
       const expectedProperties = {
         "extra.attribute": "foo",
@@ -155,6 +158,7 @@ describe("logUtils.ts", () => {
         [SEMATTRS_EXCEPTION_MESSAGE]: "test exception message",
         [SEMATTRS_EXCEPTION_STACKTRACE]: "test exception stack",
         [SEMATTRS_NET_PEER_IP]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       const expectedProperties = {
         "extra.attribute": "foo",
@@ -201,6 +205,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [ATTR_CLIENT_ADDRESS]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = data;
 
@@ -245,6 +250,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [ATTR_CLIENT_ADDRESS]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = data;
 
@@ -295,6 +301,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = data;
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
@@ -345,6 +352,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = data;
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
@@ -391,6 +399,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = data;
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
@@ -432,6 +441,7 @@ describe("logUtils.ts", () => {
         "extra.attribute": "foo",
         [SEMATTRS_MESSAGE_TYPE]: "test message type",
         [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       testLogRecord.body = data;
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
@@ -464,6 +474,7 @@ describe("logUtils.ts", () => {
         "microsoft.custom_event.name": "testing name",
         "extra.attribute": "foo",
         [ATTR_CLIENT_ADDRESS]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
       };
       const expectedTime = hrTimeToDate(testLogRecord.hrTime);
       const expectedProperties = {
@@ -496,6 +507,7 @@ describe("logUtils.ts", () => {
       "extra.attribute": "foo",
       [SEMATTRS_MESSAGE_TYPE]: "test message type",
       [SEMATTRS_HTTP_CLIENT_IP]: "127.0.0.1",
+      [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
     };
     testLogRecord.body = {
       message: { nested: { nested2: { test: "test" } } },

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.spec.ts
@@ -41,7 +41,7 @@ import {
 } from "@opentelemetry/semantic-conventions";
 
 import type { Tags, Properties, Measurements } from "../../src/types.js";
-import { MaxPropertyLengths } from "../../src/types.js";
+import { experimentalOpenTelemetryValues, MaxPropertyLengths } from "../../src/types.js";
 import { Context, getInstance } from "../../src/platform/index.js";
 import { readableSpanToEnvelope, spanEventsToEnvelopes } from "../../src/utils/spanUtils.js";
 import type {
@@ -139,6 +139,7 @@ describe("spanUtils.ts", () => {
           "extra.attribute": "foo",
           [SEMATTRS_RPC_GRPC_STATUS_CODE]: 123,
           [SEMATTRS_RPC_SYSTEM]: "test rpc system",
+          [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "test",
         });
         span.setStatus({
           code: SpanStatusCode.OK,
@@ -148,6 +149,7 @@ describe("spanUtils.ts", () => {
           [KnownContextTagKeys.AiOperationId]: "traceid",
           [KnownContextTagKeys.AiOperationParentId]: "parentSpanId",
           [KnownContextTagKeys.AiOperationName]: "parent span",
+          [KnownContextTagKeys.AiOperationSyntheticSource]: "True",
         };
         const expectedProperties = {
           "extra.attribute": "foo",
@@ -290,6 +292,7 @@ describe("spanUtils.ts", () => {
           [SEMATTRS_RPC_GRPC_STATUS_CODE]: 123,
           [SEMATTRS_RPC_SYSTEM]: "test rpc system",
           [SEMATTRS_PEER_SERVICE]: "test peer service",
+          [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
         });
         span.setStatus({
           code: SpanStatusCode.OK,
@@ -298,6 +301,7 @@ describe("spanUtils.ts", () => {
         const expectedTags: Tags = {
           [KnownContextTagKeys.AiOperationId]: "traceid",
           [KnownContextTagKeys.AiOperationParentId]: "parentSpanId",
+          [KnownContextTagKeys.AiOperationSyntheticSource]: "True",
         };
         const expectedProperties = {
           "extra.attribute": "foo",


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Adds support for the synthetic source semantic conventions to the OpenTelemetry Exporter.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
