### PR TITLE
[Monitor OpenTelemetry][Monitor OpenTelemetry Exporter] Hide iKey in Debug Logs

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Filter OpenTelemetry semantic attributes from being double recorded as custom dimensions.
 - Add support for detecting the Application Insights shim on internal verison.
 - Do not filter out `_MS.ProcessedByMetricExtractors` value on envelopes.
+- Hide iKey in debug logs.
 
 ## 1.0.0-beta.29 (2025-03-04)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
@@ -32,9 +32,7 @@ export class ConnectionStringParser {
         return { ...fields, [key]: value };
       }
       diag.error(
-        `Connection string key-value pair is invalid: ${kv}`,
-        `Entire connection string will be discarded`,
-        connectionString,
+        "Connection string key-value pair is invalid: Entire connection string will be discarded"
       );
       isValid = false;
       return fields;
@@ -60,13 +58,12 @@ export class ConnectionStringParser {
         : Constants.DEFAULT_LIVEMETRICS_ENDPOINT;
       if (result.authorization && result.authorization.toLowerCase() !== "ikey") {
         diag.warn(
-          `Connection String contains an unsupported 'Authorization' value: ${result.authorization}. Defaulting to 'Authorization=ikey'. Instrumentation Key ${result.instrumentationkey!}`,
+          `Connection String contains an unsupported 'Authorization' value. Defaulting to 'Authorization=ikey'`,
         );
       }
     } else {
       diag.error(
         "An invalid connection string was passed in. There may be telemetry loss",
-        connectionString,
       );
     }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/connectionStringParser.ts
@@ -32,7 +32,7 @@ export class ConnectionStringParser {
         return { ...fields, [key]: value };
       }
       diag.error(
-        "Connection string key-value pair is invalid: Entire connection string will be discarded"
+        "Connection string key-value pair is invalid: Entire connection string will be discarded",
       );
       isValid = false;
       return fields;
@@ -62,9 +62,7 @@ export class ConnectionStringParser {
         );
       }
     } else {
-      diag.error(
-        "An invalid connection string was passed in. There may be telemetry loss",
-      );
+      diag.error("An invalid connection string was passed in. There may be telemetry loss");
     }
 
     return result;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -21,7 +21,7 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import type { Measurements, Properties, Tags } from "../types.js";
 import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "../types.js";
-import type { Attributes} from "@opentelemetry/api";
+import type { Attributes } from "@opentelemetry/api";
 import { diag } from "@opentelemetry/api";
 import {
   ApplicationInsightsAvailabilityBaseType,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -21,7 +21,8 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import type { Measurements, Properties, Tags } from "../types.js";
 import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "../types.js";
-import { Attributes, diag } from "@opentelemetry/api";
+import type { Attributes} from "@opentelemetry/api";
+import { diag } from "@opentelemetry/api";
 import {
   ApplicationInsightsAvailabilityBaseType,
   ApplicationInsightsAvailabilityName,

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add support for detecting the Application Insights shim on internal verison.
 - Native ESM support has been added, and this package will now emit both CommonJS and ESM. [#32819](https://github.com/Azure/azure-sdk-for-js/pull/32819)
 - Add undefined checks for document filtering functions.
+- Hide iKey in debug logs.
 
 ## 1.9.0 (2025-03-04)
 

--- a/sdk/monitor/monitor-opentelemetry/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/connectionStringParser.ts
@@ -62,9 +62,7 @@ export class ConnectionStringParser {
         );
       }
     } else {
-      diag.error(
-        "An invalid connection string was passed in. There may be telemetry loss",
-      );
+      diag.error("An invalid connection string was passed in. There may be telemetry loss");
     }
 
     return result;

--- a/sdk/monitor/monitor-opentelemetry/src/utils/connectionStringParser.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/connectionStringParser.ts
@@ -32,9 +32,7 @@ export class ConnectionStringParser {
         return { ...fields, [key]: value };
       }
       diag.error(
-        `Connection string key-value pair is invalid: ${kv}`,
-        `Entire connection string will be discarded`,
-        connectionString,
+        `Connection string key-value pair is invalid: Entire connection string will be discarded`,
       );
       isValid = false;
       return fields;
@@ -60,13 +58,12 @@ export class ConnectionStringParser {
         : DEFAULT_LIVEMETRICS_ENDPOINT;
       if (result.authorization && result.authorization.toLowerCase() !== "ikey") {
         diag.warn(
-          `Connection String contains an unsupported 'Authorization' value: ${result.authorization}. Defaulting to 'Authorization=ikey'. Instrumentation Key ${result.instrumentationkey!}`,
+          `Connection String contains an unsupported 'Authorization' value. Defaulting to 'Authorization=ikey'.`,
         );
       }
     } else {
       diag.error(
         "An invalid connection string was passed in. There may be telemetry loss",
-        connectionString,
       );
     }
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
We should hide iKey in debug logs.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
