### PR TITLE
[monitor-query] fix an issue where `customHeaders` option value is lost

### DIFF
--- a/sdk/monitor/monitor-query/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query/src/logsQueryClient.ts
@@ -126,7 +126,9 @@ export class LogsQueryClient {
           {
             ...updatedOptions,
             requestOptions: {
+              ...updatedOptions.requestOptions,
               customHeaders: {
+                ...updatedOptions.requestOptions?.customHeaders,
                 ...formatPreferHeader(options),
               },
             },
@@ -228,7 +230,9 @@ export class LogsQueryClient {
           {
             ...updatedOptions,
             requestOptions: {
+              ...updatedOptions.requestOptions,
               customHeaders: {
+                ...updatedOptions.requestOptions?.customHeaders,
                 ...formatPreferHeader(options),
               },
             },

--- a/sdk/monitor/monitor-query/test/internal/unit/logsQueryClient.unittest.spec.ts
+++ b/sdk/monitor/monitor-query/test/internal/unit/logsQueryClient.unittest.spec.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Durations, LogsQueryClient } from "../../../src/index.js";
+import { Durations, LogsQueryClient, LogsQueryOptions } from "../../../src/index.js";
 import type { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
 import { describe, it, assert, expect } from "vitest";
 import type { OperationOptions } from "@azure/core-client";
 import { toSupportTracing } from "@azure-tools/test-utils-vitest";
@@ -70,5 +71,90 @@ describe("LogsQueryClient unit tests", () => {
       // We don't care about errors, only that we created (and closed) the appropriate spans.
       await Promise.all(promises.map((p) => p.catch(() => undefined)));
     }).toSupportTracing(["LogsQueryClient.queryWorkspace", "LogsQueryClient.queryBatch"]);
+  });
+
+  it("keeps custom request options in queryWorkspace", async () => {
+    const client = new LogsQueryClient(
+      {
+        getToken: async () => Promise.resolve({ token: "token", expiresOnTimestamp: 1234567890 }),
+      },
+      {
+        endpoint: "https://customEndpoint1",
+      },
+    );
+    const testPipelinePolicy = {
+      name: "testPipelinePolicy",
+      sendRequest: async (request: any) => {
+        assert.equal(request.headers.get("randomHeader"), "4321");
+        assert.equal(request.timeout, "3333");
+        console.dir(request);
+        return {
+          request,
+          status: 200,
+          headers: createHttpHeaders(),
+          bodyAsText: `{ "tables": [] }`,
+        };
+      },
+    };
+    const testOptions: LogsQueryOptions = {
+      requestOptions: {
+        timeout: 3333,
+        customHeaders: {
+          randomHeader: "4321",
+        },
+      },
+    };
+    client["_logAnalytics"].pipeline.addPolicy(testPipelinePolicy, { afterPhase: "Sign" });
+
+    await client.queryWorkspace(
+      "workspaceId",
+      "query",
+      {
+        duration: Durations.fiveMinutes,
+      },
+      testOptions,
+    );
+  });
+
+  it("keeps custom request options in queryResource", async () => {
+    const client = new LogsQueryClient(
+      {
+        getToken: async () => Promise.resolve({ token: "token", expiresOnTimestamp: 1234567890 }),
+      },
+      {
+        endpoint: "https://customEndpoint1",
+      },
+    );
+    const testPipelinePolicy = {
+      name: "testPipelinePolicy",
+      sendRequest: async (request: any) => {
+        assert.equal(request.headers.get("randomHeader"), "4321");
+        assert.equal(request.timeout, "3333");
+        return {
+          request,
+          status: 200,
+          headers: createHttpHeaders(),
+          bodyAsText: `{ "tables": [] }`,
+        };
+      },
+    };
+    const testOptions: LogsQueryOptions = {
+      requestOptions: {
+        timeout: 3333,
+        customHeaders: {
+          randomHeader: "4321",
+        },
+      },
+    };
+    client["_logAnalytics"].pipeline.addPolicy(testPipelinePolicy, { afterPhase: "Sign" });
+
+    await client.queryResource(
+      "workspaceId",
+      "query",
+      {
+        duration: Durations.fiveMinutes,
+      },
+      testOptions,
+    );
   });
 });

--- a/sdk/monitor/monitor-query/vitest.browser.int.config.ts
+++ b/sdk/monitor/monitor-query/vitest.browser.int.config.ts
@@ -8,6 +8,8 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
+      testTimeout: 1200000,
+      hookTimeout: 1200000,
       include: [
         "dist-test/browser/test/internal/**/*.spec.js",
         "dist-test/browser/test/public/**/*.spec.js",

--- a/sdk/monitor/monitor-query/vitest.int.config.ts
+++ b/sdk/monitor/monitor-query/vitest.int.config.ts
@@ -8,6 +8,8 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
+      testTimeout: 1200000,
+      hookTimeout: 1200000,
       include: ["test/internal/**/*.spec.ts", "test/public/**/*.spec.ts"],
       exclude: ["test/snippets.spec.ts"],
     },


### PR DESCRIPTION
We were overriding the `requestOptions` property in the option bag instead of merging. This PR ensures that the original values are carried over.
