### PR TITLE
[EngSys] add a special CI pipeline for dev-tool

### DIFF
--- a/common/tools/dev-tool/ci.yml
+++ b/common/tools/dev-tool/ci.yml
@@ -1,0 +1,53 @@
+trigger:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+  paths:
+    include:
+      - common/tools/dev-tool/
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+
+  paths:
+    include:
+      - common/tools/dev-tool/
+
+jobs:
+  - job: 'DevTool'
+    displayName: 'Dev-tool validation'
+
+    variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+
+    pool:
+      vmImage: 'Ubuntu 20.04'
+
+    steps:
+      - template: /eng/pipelines/templates/steps/common.yml
+
+      - script: |
+          node common/scripts/install-run-rush.js install
+        displayName: "Install library dependencies"
+
+      - script: |
+          node common/scripts/install-run-rush.js build -t @azure/dev-tool
+        displayName: "Build dev-tool"
+
+      - script: |
+          node common/scripts/install-run-rush.js check-format -t @azure/dev-tool
+        displayName: "Check format for dev-tool"
+
+      - script: |
+          node common/scripts/install-run-rush.js lint -t @azure/dev-tool
+        displayName: "linting dev-tool"
+
+      - script: |
+          node common/scripts/install-run-rush.js unit-test:node -t @azure/dev-tool
+        displayName: "running dev-tool unit tests"

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -11,7 +11,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc && npm run lint && npm run check-format",
+    "build": "tsc",
     "build:samples": "echo Skipped.",
     "build:test": "echo Skipped.",
     "check-format": "prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",


### PR DESCRIPTION
Currently analyze pipeline won't do anything for dev-tool so we rely on the
"build" NPM script to lint and check format. However, that adds unnecessary work
every time dev-tool is built.

This PR adds a special CI pipeline for dev-tool so that any issue caught in pull requests. Now we can remove linting and checking format from "build" NPM script.

We already have prior art of special pipeline for eslint-plugin-azure-sdk.