### PR TITLE
[instrumentation] Fix snippets imports for named imports

### DIFF
--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/README.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/README.md
@@ -45,6 +45,7 @@ import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import { createAzureSdkInstrumentation } from "@azure/opentelemetry-instrumentation-azure-sdk";
 import { KeyClient } from "@azure/keyvault-keys";
 import { DefaultAzureCredential } from "@azure/identity";
+import { trace, context } from "@opentelemetry/api";
 
 // Set-up and configure a Node Tracer Provider using OpenTelemetry SDK.
 const provider = new NodeTracerProvider();
@@ -67,9 +68,9 @@ await keyClient.getKey("MyKeyName");
 // If your scenario requires manual span propagation, all Azure client libraries
 // support explicitly passing a parent context via an `options` parameter.
 // Get a tracer from a registered provider, create a span, and get the current context.
-const tracer = opentelemetry.trace.getTracer("my-tracer");
+const tracer = trace.getTracer("my-tracer");
 const span = tracer.startSpan("main");
-const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), span);
+const ctx = trace.setSpan(context.active(), span);
 
 await keyClient.getKey("MyKeyName", {
   tracingOptions: {

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/snippets.spec.ts
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/test/snippets.spec.ts
@@ -4,7 +4,7 @@
 import { describe, it } from "vitest";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import { createAzureSdkInstrumentation } from "@azure/opentelemetry-instrumentation-azure-sdk";
-import opentelemetry from "@opentelemetry/api";
+import { context, trace } from "@opentelemetry/api";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { SimpleSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/tracing";
 import { KeyClient } from "@azure/keyvault-keys";
@@ -35,9 +35,9 @@ describe("snippets", function () {
     // If your scenario requires manual span propagation, all Azure client libraries
     // support explicitly passing a parent context via an `options` parameter.
     // Get a tracer from a registered provider, create a span, and get the current context.
-    const tracer = opentelemetry.trace.getTracer("my-tracer");
+    const tracer = trace.getTracer("my-tracer");
     const span = tracer.startSpan("main");
-    const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), span);
+    const ctx = trace.setSpan(context.active(), span);
     // @ts-preserve-whitespace
     await keyClient.getKey("MyKeyName", {
       tracingOptions: {


### PR DESCRIPTION
### Packages impacted by this PR

- @azure/opentelemetry-instrumentation-azure-sdk

### Issues associated with this PR

- https://github.com/Azure/azure-sdk-for-js/issues/33880

### Describe the problem that is addressed by this PR

Fixes the snippets extraction by using explicit imports instead of default imports.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
