### PR TITLE
[Identity] Update workered exports order

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Bugs Fixed
 
-- Update the order for conditional exports so that the most specific conditions are listed first
-- Fix a bug in which `self.location` is undefined in specific environment
+- Update the order for conditional exports so that the most specific conditions are listed first. [#33914](https://github.com/Azure/azure-sdk-for-js/pull/33914)
+- Fix a bug in which `self.location` is undefined in specific environment. [#33914](https://github.com/Azure/azure-sdk-for-js/pull/33914)
 
 ### Other Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Update the order for conditional exports so that the most specific conditions are listed first
+- Fix a bug in which `self.location` is undefined in specific environment
+
 ### Other Changes
 
 ## 4.9.0 (2025-04-16)

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -123,21 +123,21 @@
       "commonjs"
     ],
     "esmDialects": [
-      "browser",
-      "workerd"
+      "workerd",
+      "browser"
     ],
     "selfLink": false
   },
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
-      },
       "workerd": {
         "types": "./dist/workerd/index.d.ts",
         "default": "./dist/workerd/index.js"
+      },
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
       },
       "import": {
         "types": "./dist/esm/index.d.ts",

--- a/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
@@ -49,7 +49,7 @@ function generateMsalBrowserConfiguration(
       // If the users picked redirect as their login style,
       // but they didn't provide a redirectUri,
       // we can try to use the current page we're in as a default value.
-      redirectUri: options.redirectUri || isLocationDefined ? self.location.origin : undefined,
+      redirectUri: options.redirectUri || (isLocationDefined ? self.location.origin : undefined),
     },
     cache: {
       cacheLocation: "sessionStorage",

--- a/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
+++ b/sdk/identity/identity/src/msal/browserFlows/msalBrowserCommon.ts
@@ -28,6 +28,10 @@ import {
 } from "../../util/tenantIdUtils.js";
 import { DefaultTenantId } from "../../constants.js";
 
+// We keep a copy of the redirect hash.
+// Check if self and location object is defined.
+const isLocationDefined = typeof self !== "undefined" && self.location !== undefined;
+
 /**
  * Generates a MSAL configuration that generally works for browsers
  * @internal
@@ -45,7 +49,7 @@ function generateMsalBrowserConfiguration(
       // If the users picked redirect as their login style,
       // but they didn't provide a redirectUri,
       // we can try to use the current page we're in as a default value.
-      redirectUri: options.redirectUri || self.location.origin,
+      redirectUri: options.redirectUri || isLocationDefined ? self.location.origin : undefined,
     },
     cache: {
       cacheLocation: "sessionStorage",
@@ -71,7 +75,7 @@ export interface MsalBrowserClient {
 }
 
 // We keep a copy of the redirect hash.
-const redirectHash = self.location.hash;
+const redirectHash = isLocationDefined ? self.location.hash : undefined;
 
 /**
  * Uses MSAL Browser 2.X for browser authentication,


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
- `self.location` is not defined in all environments so it's necessary to add a type guard to ensure we can access the property.
- `exports` have order significance and the most specific ones should be listed first. Refer to [Node conditional exports](https://nodejs.org/api/packages.html#conditional-exports) guide.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
