### PR TITLE
[EngSys] Remove out-of-date code to copy mocha multi reporter

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -427,13 +427,6 @@ async function main(argv) {
     return;
   }
   await replaceSourceReferences(targetPackagePath, targetPackage.packageName, testFolder);
-  await copyRepoFile(
-    repoRoot,
-    "common/tools",
-    "mocha-multi-reporter.js",
-    targetPackagePath,
-    testFolder,
-  );
   await updateRushConfig(repoRoot, targetPackage, testFolder);
   outputTestPath(targetPackage.projectFolder, sourceDir, testFolder);
 }


### PR DESCRIPTION
As mocha-multi-reporter.js has been deleted from the repo.