### PR TITLE
[SchemaRegistry][doc] update link to schema-registry-json

### DIFF
--- a/sdk/schemaregistry/README.md
+++ b/sdk/schemaregistry/README.md
@@ -4,4 +4,4 @@ We have two client libraries for Azure Schema Registry
 
 - `@azure/schema-registry` - The Schema Registry client for storing and retrieving schemas. You can find more info over [here](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/schemaregistry/schema-registry).
 - `@azure/schema-registry-avro` - The Avro-based serializer that leverages Schema Registry. You can find more info over [here](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/schemaregistry/schema-registry-avro).
-- `@azure/schema-registry-json` - The JSON-based serializer that leverages Schema Registry. You can find more info over [here](https://github.com/Azure/azure-sdk-for-js/tree/schemaregistryjson-init/sdk/schemaregistry/schema-registry-json).
+- `@azure/schema-registry-json` - The JSON-based serializer that leverages Schema Registry. You can find more info over [here](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/schemaregistry/schema-registry-json).


### PR DESCRIPTION
The old branch is probably deleted.  We should link to main branch now anyway.


