### PR TITLE
[schema-registry-avro][test] fix browser integration tests

### DIFF
--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -17,7 +17,7 @@
     "extract-api": "dev-tool run build-package && dev-tool run extract-api",
     "format": "dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"samples-dev/**/*.ts\" \"*.{js,json}\"",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "integration-test:browser": "npm run build:test && dev-tool run test:vitest --browser --no-test-proxy",
+    "integration-test:browser": "dev-tool run build-test && dev-tool run test:vitest --browser --no-test-proxy",
     "integration-test:node": "dev-tool run test:vitest --no-test-proxy --esm",
     "lint": "eslint package.json api-extractor.json README.md src test",
     "lint:fix": "eslint package.json api-extractor.json README.md src test --fix --fix-type [problem,suggestion]",


### PR DESCRIPTION
We updated "build:test" to just echo, but didn't update the
"integration-test:browser" script to really build the test. This PR adds the
command to build browser tests in "integration-test:browser" script.