### PR TITLE
[EngSys] update outdated test:node-ts-input usage

### DIFF
--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -27,7 +27,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "dev-tool run test:vitest -- --test-timeout 300000",
-    "unit-test:manual": "dev-tool run test:node-ts-input -- --timeout 300000 'test/manual/node/popTokenSupport.spec.ts'",
+    "unit-test:manual": "dev-tool run test:vitest -- --timeout 300000 'test/manual/node/popTokenSupport.spec.ts'",
     "update-snippets": "dev-tool run update-snippets"
   },
   "files": [

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -19,7 +19,7 @@
     "generate:client": "autorest --typescript ./swagger/README.md",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "integration-test:browser": "echo skipped",
-    "integration-test:node": "dev-tool run test:node-ts-input --no-test-proxy -- \"test/internal/functional/**/*.test.ts\"",
+    "integration-test:node": "dev-tool run test:vitest --esm --no-test-proxy -- \"test/internal/functional/*.test.ts\"",
     "lint": "eslint package.json api-extractor.json src test",
     "lint:fix": "eslint package.json api-extractor.json src test --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",


### PR DESCRIPTION
as the dev-tool command has been removed.