### PR TITLE
[eventgrid-namespace][test] add "https://" for namespace endpoint

### DIFF
--- a/sdk/eventgrid/test-resources.bicep
+++ b/sdk/eventgrid/test-resources.bicep
@@ -156,4 +156,4 @@ output SERVICE_BUS_FQDN string = replace(
   ''
 )
 output SERVICE_BUS_QUEUE_NAME string = serviceBusQueueName
-output EVENT_GRID_NAMESPACES_ENDPOINT string = egNamespace.properties.topicsConfiguration.hostname
+output EVENT_GRID_NAMESPACES_ENDPOINT string = 'https://${egNamespace.properties.topicsConfiguration.hostname}'


### PR DESCRIPTION
It was missed when we migrated to .bicep for deployment