### PR TITLE
[core] bump dependency ts-http-runtime version

### DIFF
--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
     "tslib": "^2.6.2",
-    "@typespec/ts-http-runtime": "^0.2.1"
+    "@typespec/ts-http-runtime": "^0.2.2"
   },
   "devDependencies": {
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "tslib": "^2.6.2",
-    "@typespec/ts-http-runtime": "^0.2.1"
+    "@typespec/ts-http-runtime": "^0.2.2"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",


### PR DESCRIPTION
for the new features.  This fixes the `js - core` nightly build.

Our nightly automation updates packages to use dev/nightly versions only when
the min satisfying version numbers are exact match. This ensures dependency
semantic version range is accurate.