### PR TITLE
 Update live test job display names

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -217,7 +217,7 @@ jobs:
 
               node ../../../common/scripts/install-run-rushx.js integration-test:$(TestType)
               exit $LASTEXITCODE
-          displayName: "Integration test libraries"
+          displayName: "Integration test libraries - PackagePath"
           condition: and(succeededOrFailed(),ne(variables['TestType'],'sample'),eq(variables['DependencyVersion'],''))
           env:
             TEST_MODE: "live"
@@ -238,7 +238,7 @@ jobs:
 
               node $(Build.SourcesDirectory)/common/scripts/install-run-rushx.js integration-test:$(TestType)
               exit $LASTEXITCODE
-          displayName: "Integration test libraries"
+          displayName: "Integration test libraries - PackageTestPath"
           condition: and(succeeded(),ne(variables['TestType'],'sample'),ne(variables['DependencyVersion'],''))
           env:
             TEST_MODE: "live"
@@ -274,7 +274,7 @@ jobs:
       - ${{ else }}:
         - script: |
             node ../../../common/scripts/install-run-rushx.js integration-test:$(TestType)
-          displayName: "Integration test libraries"
+          displayName: "Integration test libraries - PackagePath"
           workingDirectory: $(PackagePath)
           condition: and(succeededOrFailed(),ne(variables['TestType'],'sample'),eq(variables['DependencyVersion'],''))
           env:
@@ -284,7 +284,7 @@ jobs:
 
         - script: |
             node $(Build.SourcesDirectory)/common/scripts/install-run-rushx.js integration-test:$(TestType)
-          displayName: "Integration test libraries"
+          displayName: "Integration test libraries - PackageTestPath"
           workingDirectory: $(PackageTestPath)
           condition: and(succeeded(),ne(variables['TestType'],'sample'),ne(variables['DependencyVersion'],''))
           env:


### PR DESCRIPTION
I'm not sure what the difference is here, or why we want the main tests to run on `succeededOrFailed()`. At the very least the duplicate display names was confusing me, so figured I'd throw up a quick fix.