### PR TITLE
[identity] proof-of-concept: broker auto-load

### DIFF
--- a/sdk/identity/identity/src/msal/nodeFlows/brokerLoader-cjs.cts
+++ b/sdk/identity/identity/src/msal/nodeFlows/brokerLoader-cjs.cts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is the CommonJS version of the file that uses the built-in `require`
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export function tryLoadNativeBrokerPlugin():
+  | import("@azure/msal-node").INativeBrokerPlugin
+  | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { nativeBrokerPlugin } = require("@azure/identity-broker");
+    console.log("Loaded native broker plugin");
+    return nativeBrokerPlugin;
+  } catch (e) {
+    // do nothing
+    console.log("Failed to load native broker plugin");
+    console.error(e);
+    return undefined;
+  }
+}

--- a/sdk/identity/identity/src/msal/nodeFlows/brokerLoader.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/brokerLoader.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is the ESM version of the file. We want to use createRequire to load the broker plugin synchronously.
+// A better solution would be to use dynamic import, but that would require making the whole code-path async.
+// Definitely something we should do, but this helps us get a working solution out the door.
+
+import { createRequire } from "module";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore ESM only output
+const require = createRequire(import.meta.url);
+
+export function tryLoadNativeBrokerPlugin():
+  | import("@azure/msal-node").INativeBrokerPlugin
+  | undefined {
+  try {
+    const { nativeBrokerPlugin } = require("@azure/identity-broker");
+    console.log("Loaded native broker plugin");
+    return nativeBrokerPlugin;
+  } catch (e) {
+    // do nothing
+    console.log("Failed to load native broker plugin");
+    console.error(e);
+    return undefined;
+  }
+}


### PR DESCRIPTION
Demos one way we can auto-load the broker plugin. Of course, there are other
approaches but hopefully this provides a starting point that works in both CJS
and ESM context.

See https://github.com/maorleger/identity-broker-loader for usage example
