### PR TITLE
[core] core-rest-pipeline: fix ts-http-runtime dependency version

### DIFF
--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -97,7 +97,7 @@
     "@azure/core-tracing": "^1.0.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.0.0",
-    "@typespec/ts-http-runtime": "^0.2.1",
+    "@typespec/ts-http-runtime": "^0.2.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-rest-pipeline`

### Describe the problem that is addressed by this PR

Bump minimum version of ts-http-runtime to latest to prevent nightly failures (forgot to do it before merging #33948). See https://github.com/Azure/azure-sdk-for-js/pull/33994.
