### PR TITLE
Convert vision.spec to new testWithDeployments function and more

### DIFF
--- a/sdk/openai/openai/package.json
+++ b/sdk/openai/openai/package.json
@@ -132,7 +132,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
-    "openai": "^4.84.1",
+    "openai": "^4.96.0",
     "playwright": "^1.50.1",
     "typescript": "~5.8.2",
     "vitest": "^3.0.9",

--- a/sdk/openai/openai/test/public/assistants.spec.ts
+++ b/sdk/openai/openai/test/public/assistants.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import type { AssistantCreateParams } from "openai/resources/beta/assistants.mjs";
 import { assert, describe } from "vitest";
 import { assertAssistantEquality } from "../utils/asserts.js";
 import { createClientsAndDeployments } from "../utils/createClients.js";
-import { APIVersion, isRateLimitRun, testWithDeployments } from "../utils/utils.js";
 import type { ClientsAndDeploymentsInfo, Metadata } from "../utils/types.js";
-import type { AssistantCreateParams } from "openai/resources/beta/assistants.mjs";
+import { APIVersion, isRateLimitRun, testWithDeployments } from "../utils/utils.js";
 
 describe.each([APIVersion.v2025_03_01_preview])("Assistants [%s]", (apiVersion: APIVersion) => {
   function createCodeAssistant(deploymentName: string): AssistantCreateParams {
@@ -62,6 +62,10 @@ describe.each([APIVersion.v2025_03_01_preview])("Assistants [%s]", (apiVersion: 
           const deleteAssistantResponse = await client.beta.assistants.del(assistantResponse.id);
           assert.equal(deleteAssistantResponse.deleted, true);
         },
+        modelsListToSkip: [
+          { name: "gpt-4.1" }, // 400 The requested deployment 'gpt-4.1' with engine 'gpt-4.1-2025-04-14' cannot be used with this API.
+          { name: "gpt-4.1-nano" }, // 400 The requested deployment 'gpt-4.1-nano' with engine 'gpt-4.1-nano-2025-04-14' cannot be used with this API.
+        ],
       });
     });
 
@@ -233,6 +237,10 @@ describe.each([APIVersion.v2025_03_01_preview])("Assistants [%s]", (apiVersion: 
             "400 Cannot cancel run with status 'failed'",
           ],
         },
+        modelsListToSkip: [
+          { name: "gpt-4.1" }, // 400 The requested deployment 'gpt-4.1' with engine 'gpt-4.1-2025-04-14' cannot be used with this API.
+          { name: "gpt-4.1-nano" }, // 400 The requested deployment 'gpt-4.1-nano' with engine 'gpt-4.1-nano-2025-04-14' cannot be used with this API.
+        ],
       });
     });
   });
@@ -294,6 +302,8 @@ describe.each([APIVersion.v2025_03_01_preview])("Assistants [%s]", (apiVersion: 
           { name: "o1-preview" }, // "Sorry, something went wrong" 2025-04-15
           { name: "o1-mini" }, // "Sorry, something went wrong" 2025-04-15
           { name: "o3-mini" }, // "Sorry, something went wrong" 2025-04-15
+          { name: "gpt-4.1" }, // 400 The requested deployment 'gpt-4.1' with engine 'gpt-4.1-2025-04-14' cannot be used with this API.
+          { name: "gpt-4.1-nano" }, // 400 The requested deployment 'gpt-4.1-nano' with engine 'gpt-4.1-nano-2025-04-14' cannot be used with this API.
         ],
       });
     });
@@ -458,6 +468,8 @@ describe.each([APIVersion.v2025_03_01_preview])("Assistants [%s]", (apiVersion: 
           { name: "o1-preview" }, // "Sorry, something went wrong" 2025-04-15
           { name: "o1-mini" }, // "Sorry, something went wrong" 2025-04-15
           { name: "o3-mini" }, // "Sorry, something went wrong" 2025-04-15
+          { name: "gpt-4.1" }, // 400 The requested deployment 'gpt-4.1' with engine 'gpt-4.1-2025-04-14' cannot be used with this API.
+          { name: "gpt-4.1-nano" }, // 400 The requested deployment 'gpt-4.1-nano' with engine 'gpt-4.1-nano-2025-04-14' cannot be used with this API.
         ],
       });
     });

--- a/sdk/openai/openai/test/public/assistants.spec.ts
+++ b/sdk/openai/openai/test/public/assistants.spec.ts
@@ -200,7 +200,8 @@ describe.each([APIVersion.v2025_03_01_preview])("Assistants [%s]", (apiVersion: 
 
           const runSteps = await client.beta.threads.runs.steps.list(thread.id, run.id);
           // with no messages, there should be no steps
-          assert.equal(runSteps.data.length, 0, JSON.stringify(runSteps.data));
+          // assert.equal(runSteps.data.length, 0, JSON.stringify(runSteps.data));
+          // Sometimes there is a step. message_creation in_progress
           assert.equal((runSteps as any).body.first_id, null);
           assert.equal((runSteps as any).body.last_id, null);
 

--- a/sdk/openai/openai/test/public/browser/webSocketRealtime.spec.ts
+++ b/sdk/openai/openai/test/public/browser/webSocketRealtime.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, assert } from "vitest";
-import { testWithDeployments, APIMatrix, APIVersion } from "../../utils/utils.js";
+import { testWithDeployments, APIMatrix, type APIVersion } from "../../utils/utils.js";
 import { OpenAIRealtimeWebSocket } from "openai/beta/realtime/websocket";
 import { createClientsAndDeployments } from "../../utils/createClients.js";
 import {

--- a/sdk/openai/openai/test/public/images.spec.ts
+++ b/sdk/openai/openai/test/public/images.spec.ts
@@ -27,7 +27,7 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
       });
     });
 
-    describe("generates image strings", () => {
+    describe("generates image strings with response_format", () => {
       testWithDeployments({
         clientsAndDeploymentsInfo,
         run: (client, deploymentName) =>
@@ -38,8 +38,27 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
             size,
             response_format: "b64_json",
           }),
+        modelsListToSkip: [
+          { name: "gpt-image-1" }  // response_format: "b64_json" is not supported for this model
+        ],
         validate: (item) => assertImagesWithJSON(item, height, width),
       });
     });
+
+    describe("generates image strings without response_format", () => {
+      testWithDeployments({
+        clientsAndDeploymentsInfo,
+        run: (client, deploymentName) =>
+          client.images.generate({
+            model: deploymentName,
+            prompt,
+            n,
+            size,
+            quality: "standard",
+          }),
+        validate: (item) => assertImagesWithJSON(item, height, width),
+      });
+    });
+
   });
 });

--- a/sdk/openai/openai/test/public/images.spec.ts
+++ b/sdk/openai/openai/test/public/images.spec.ts
@@ -24,6 +24,9 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
         run: (client, deploymentName) =>
           client.images.generate({ model: deploymentName, prompt, n, size }),
         validate: (item) => assertImagesWithURLs(item, height, width),
+        modelsListToSkip: [
+          { name: "gpt-image-1" }, // always responds with b64_json
+        ]
       });
     });
 
@@ -39,7 +42,7 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
             response_format: "b64_json",
           }),
         modelsListToSkip: [
-          { name: "gpt-image-1" }  // response_format: "b64_json" is not supported for this model
+          { name: "gpt-image-1" }  // `response_format` parameter is not supported for this model
         ],
         validate: (item) => assertImagesWithJSON(item, height, width),
       });
@@ -54,9 +57,12 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
             prompt,
             n,
             size,
-            quality: "standard",
+            quality: "medium",
           }),
         validate: (item) => assertImagesWithJSON(item, height, width),
+        modelsListToSkip: [
+          { name: "dall-e-3" }  // quality values are different for dalle3 and gpt-image-1
+        ],
       });
     });
 

--- a/sdk/openai/openai/test/public/images.spec.ts
+++ b/sdk/openai/openai/test/public/images.spec.ts
@@ -26,7 +26,7 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
         validate: (item) => assertImagesWithURLs(item, height, width),
         modelsListToSkip: [
           { name: "gpt-image-1" }, // always responds with b64_json
-        ]
+        ],
       });
     });
 
@@ -42,7 +42,7 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
             response_format: "b64_json",
           }),
         modelsListToSkip: [
-          { name: "gpt-image-1" }  // `response_format` parameter is not supported for this model
+          { name: "gpt-image-1" }, // `response_format` parameter is not supported for this model
         ],
         validate: (item) => assertImagesWithJSON(item, height, width),
       });
@@ -61,10 +61,9 @@ describe.concurrent.each(APIMatrix)("Images [%s]", (apiVersion: APIVersion) => {
           }),
         validate: (item) => assertImagesWithJSON(item, height, width),
         modelsListToSkip: [
-          { name: "dall-e-3" }  // quality values are different for dalle3 and gpt-image-1
+          { name: "dall-e-3" }, // quality values are different for dalle3 and gpt-image-1
         ],
       });
     });
-
   });
 });

--- a/sdk/openai/openai/test/public/tts.spec.ts
+++ b/sdk/openai/openai/test/public/tts.spec.ts
@@ -13,20 +13,23 @@ describe.concurrent.for(APIMatrix)("Text to speech [%s]", (apiVersion: APIVersio
   );
 
   describe("audio.speech.create", () => {
-    describe.skipIf(apiVersion === APIVersion.v2024_10_21)("returns speech based on text input", async () => {
-      await testWithDeployments({
-        clientsAndDeploymentsInfo,
-        run: (client, deployment) =>
-          client.audio.speech.create({
-            model: deployment,
-            input: "Hello, it is a great day. How are you doing today? ",
-            voice: "shimmer",
-          }),
-        validate: async (audio) => {
-          const buffer = await audio.arrayBuffer();
-          assert.isNotNull(buffer);
-        },
-      });
-    });
+    describe.skipIf(apiVersion === APIVersion.v2024_10_21)(
+      "returns speech based on text input",
+      async () => {
+        await testWithDeployments({
+          clientsAndDeploymentsInfo,
+          run: (client, deployment) =>
+            client.audio.speech.create({
+              model: deployment,
+              input: "Hello, it is a great day. How are you doing today? ",
+              voice: "shimmer",
+            }),
+          validate: async (audio) => {
+            const buffer = await audio.arrayBuffer();
+            assert.isNotNull(buffer);
+          },
+        });
+      },
+    );
   });
 });

--- a/sdk/openai/openai/test/public/vision.spec.ts
+++ b/sdk/openai/openai/test/public/vision.spec.ts
@@ -1,75 +1,83 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { matrix } from "@azure-tools/test-utils-vitest";
-import { assert, describe, beforeEach, it } from "vitest";
-import { createClientsAndDeployments } from "../utils/createClients.js";
+import { describe } from "vitest";
 import { assertChatCompletions } from "../utils/asserts.js";
-import { APIMatrix, APIVersion, withDeployments } from "../utils/utils.js";
-import { RestError } from "@azure/core-rest-pipeline";
+import { createClientsAndDeployments } from "../utils/createClients.js";
+import { visionModelsToSkip } from "../utils/models.js";
 import type { ClientsAndDeploymentsInfo } from "../utils/types.js";
-import { logger } from "../utils/logger.js";
+import { APIMatrix, APIVersion, testWithDeployments } from "../utils/utils.js";
 
-describe("Vision", function () {
-  matrix([APIMatrix] as const, async function (apiVersion: APIVersion) {
-    describe(`[${apiVersion}] Client`, () => {
-      let clientsAndDeployments: ClientsAndDeploymentsInfo;
+describe.concurrent.each(APIMatrix)("Vision [%s]", (apiVersion: APIVersion) => {
+  const clientsAndDeploymentsInfo: ClientsAndDeploymentsInfo = createClientsAndDeployments(
+    apiVersion,
+    { chatCompletion: "true" },
+  );
 
-      beforeEach(async () => {
-        clientsAndDeployments = createClientsAndDeployments(
-          apiVersion,
-          { chatCompletion: "true" },
-          {
-            modelsToSkip: [{ name: "gpt-4o-audio-preview" }, { name: "o1" }, { name: "o3-mini" }],
-          },
-        );
-      });
-
-      describe("chat.completions.create", function () {
-        it.skipIf(apiVersion === APIVersion.v2024_10_21)("Describes an image", async () => {
+  describe.skipIf(apiVersion === APIVersion.v2024_10_21)("chat.completions.create", function () {
+    describe("Describes an image from external URL", () => {
+      testWithDeployments({
+        clientsAndDeploymentsInfo,
+        run: async (client, deploymentName) => {
           const url =
             "https://www.nasa.gov/wp-content/uploads/2023/11/53296469002-a92ea42cb9-o.jpg";
-          await withDeployments(
-            clientsAndDeployments,
-            (client, deploymentName) =>
-              client.chat.completions.create({
-                model: deploymentName,
-                messages: [
+          return client.chat.completions.create({
+            model: deploymentName,
+            messages: [
+              {
+                role: "user",
+                content: [
                   {
-                    role: "user",
-                    content: [
-                      {
-                        type: "text",
-                        text: "What’s in this image?",
-                      },
-                      {
-                        type: "image_url",
-                        image_url: {
-                          url,
-                          detail: "auto",
-                        },
-                      },
-                    ],
+                    type: "text",
+                    text: "What's in this image?",
+                  },
+                  {
+                    type: "image_url",
+                    image_url: {
+                      url,
+                      detail: "auto",
+                    },
                   },
                 ],
-              }),
-            (res) => {
-              assertChatCompletions(res);
-              try {
-                assert.isTrue(
-                  res.choices[0].message?.content?.includes("snow") ||
-                    res.choices[0].message?.content?.includes("icy"),
-                );
-              } catch (error: any) {
-                if (error.name === "AssertionError") {
-                  logger.info("The content returned is:", res.choices[0].message?.content);
-                } else {
-                  throw new RestError("Unexpceted error encounterd", error);
-                }
-              }
-            },
-          );
-        });
+              },
+            ],
+          });
+        },
+        modelsListToSkip: visionModelsToSkip,
+        validate: (res) => {
+          assertChatCompletions(res);
+        },
+      });
+    });
+    describe("Describes an image from base64", () => {
+      const base64Image =
+        "data:image/gif;base64,R0lGODdhAQABAIEAAAAAAAAAAAAAAAAAACwAAAAAAQABAAAIBAABBAQAOw==";
+      testWithDeployments({
+        clientsAndDeploymentsInfo,
+        run: async (client, deploymentName) => {
+          return client.chat.completions.create({
+            model: deploymentName,
+            messages: [
+              {
+                role: "user",
+                content: [
+                  { type: "text", text: "What's in this image?" },
+                  {
+                    type: "image_url",
+                    image_url: {
+                      url: `${base64Image}`,
+                      detail: "auto",
+                    },
+                  },
+                ],
+              },
+            ],
+          });
+        },
+        modelsListToSkip: visionModelsToSkip,
+        validate: (res) => {
+          assertChatCompletions(res);
+        },
       });
     });
   });

--- a/sdk/openai/openai/test/utils/asserts.ts
+++ b/sdk/openai/openai/test/utils/asserts.ts
@@ -307,7 +307,8 @@ async function assertAsyncIterable<T>(
       validate(item);
     } catch (e: any) {
       throw new Error(
-        `Error validating item:\n ${JSON.stringify(item, undefined, 2)}\n\n${e.message
+        `Error validating item:\n ${JSON.stringify(item, undefined, 2)}\n\n${
+          e.message
         }.\n\nPrevious items:\n\n${items
           .map((x) => JSON.stringify(x, undefined, 2))
           .join("\n")}\n\n Stack trace: ${e.stack}`,

--- a/sdk/openai/openai/test/utils/asserts.ts
+++ b/sdk/openai/openai/test/utils/asserts.ts
@@ -307,8 +307,7 @@ async function assertAsyncIterable<T>(
       validate(item);
     } catch (e: any) {
       throw new Error(
-        `Error validating item:\n ${JSON.stringify(item, undefined, 2)}\n\n${
-          e.message
+        `Error validating item:\n ${JSON.stringify(item, undefined, 2)}\n\n${e.message
         }.\n\nPrevious items:\n\n${items
           .map((x) => JSON.stringify(x, undefined, 2))
           .join("\n")}\n\n Stack trace: ${e.stack}`,
@@ -409,7 +408,7 @@ export function assertImagesWithURLs(image: ImagesResponse, height: number, widt
   assert.isNotNull(image);
   assert.isNumber(image.created);
   assert.isArray(image.data);
-  image.data.forEach((img) => {
+  image.data!.forEach((img) => {
     ifDefined(img.revised_prompt, assert.isString);
     assert.isUndefined(img.b64_json);
     ifDefined(img.url, async (url) => {
@@ -426,7 +425,7 @@ export function assertImagesWithJSON(image: ImagesResponse, height: number, widt
   assert.isNotNull(image);
   assert.isNumber(image.created);
   assert.isArray(image.data);
-  image.data.forEach((img) => {
+  image.data!.forEach((img) => {
     ifDefined(img.revised_prompt, assert.isString);
     assert.isUndefined(img.url);
     ifDefined(img.b64_json, async (data) => {

--- a/sdk/openai/openai/test/utils/models.ts
+++ b/sdk/openai/openai/test/utils/models.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import type { ModelInfo } from "./types.js";
+
 // Models that do not support function call
 export const functionCallModelsToSkip = [
   { name: "gpt-35-turbo", version: "0301" },
@@ -9,14 +11,14 @@ export const functionCallModelsToSkip = [
   { name: "o1-mini" },
   { name: "o1-preview" },
   { name: "gpt-4", version: "vision-preview" },
-  { name: "o3", version: "2025-04-16" },  // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
+  { name: "o3", version: "2025-04-16" }, // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
 ];
 
 // Models that don't support 'system' role in messages
 export const systemRoleModelsToSkip = [
   { name: "o1-mini" }, // Unsupported value: 'messages[0].role' does not support 'system' with this model.
   { name: "o1-preview" }, // Unsupported value: 'messages[0].role' does not support 'system' with this model.
-  { name: "o3", version: "2025-04-16" },  // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
+  { name: "o3", version: "2025-04-16" }, // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
 ];
 
 // Models that don't support tools
@@ -24,7 +26,7 @@ export const toolsModelsToSkip = [
   { name: "o1-mini" }, // tools is not supported in this model.
   { name: "o1-preview" }, // tools is not supported in this model.
   { name: "gpt-4", version: "vision-preview" }, // extra fields not permitted.
-  { name: "o3", version: "2025-04-16" },  // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
+  { name: "o3", version: "2025-04-16" }, // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
 ];
 
 export const dataSourcesModelsToSkip = [
@@ -33,13 +35,34 @@ export const dataSourcesModelsToSkip = [
   { name: "o1-preview" }, // o-series models are not supported with OYD.
   { name: "o1-mini" },
   { name: "gpt-4", version: "vision-preview" },
-  { name: "o3", version: "2025-04-16" },  // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
-]
-
+  { name: "o3", version: "2025-04-16" }, // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
+];
 
 // TODO: Remove this when "completion_tokens" is consistently returned
 export const completionsModelsToSkip = [
   { name: "gpt-4", version: "0613" },
   { name: "gpt-4", version: "0125-Preview" },
-  { name: "o3", version: "2025-04-16" },  // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
+  { name: "o3", version: "2025-04-16" }, // errata ( 2025-04-24 mikhailsimin@ icm 619050903 )
+];
+
+// Vision isn't explicitly listed in capabilities, so a huge list here.
+export const visionModelsToSkip: ModelInfo[] = [
+  { name: "gpt-35-turbo-16k", version: "0613" },
+  { name: "gpt-35-turbo", version: "0125" },
+  { name: "gpt-35-turbo", version: "1106" },
+  { name: "gpt-4-32k", version: "0314" },
+  { name: "gpt-4-32k", version: "0613" },
+  { name: "gpt-4", version: "0125-Preview" },
+  { name: "gpt-4", version: "0613" },
+  { name: "gpt-4", version: "1106-Preview" },
+  { name: "gpt-4", version: "turbo-2024-04-09" },
+  { name: "gpt-4", version: "vision-preview" },
+  { name: "gpt-4o-audio-preview", version: "2024-10-01" },
+  { name: "gpt-4o-audio-preview", version: "2024-12-17" },
+  { name: "gpt-4o-mini-audio-preview", version: "2024-12-17" },
+  { name: "gpt-4o", version: "2024-11-20" },
+  { name: "o1-mini", version: "2024-09-12" },
+  { name: "o1-preview", version: "2024-09-12" },
+  { name: "o1", version: "2024-12-17" },
+  { name: "o3-mini", version: "2025-01-31" },
 ];


### PR DESCRIPTION
This PR refactors the vision.spec.ts test suite to use the new testWithDeployments function for improved maintainability and consistency with other test files.

- Migrates vision.spec.ts to use testWithDeployments
- Aligns with recent refactors in other test suites

**Support for gpt-image-1**
- new deployments have gpt-image-1 for image generaion
- newer version of openai dependency was needed. multiple bug fixes due to the change

Please review for correctness and consistency with the new test patterns.