### PR TITLE
[identity] deprecation warning of user name password usage in env cred

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Added deprecation warnings for username password usage in `EnvironmentCredential` constructor to warn the users. `UsernamePassword` authentication doesn't support Multi-Factor Authentication (MFA), and MFA will enabled soon on all tenants.  For more details, see [Planning for mandatory MFA](https://aka.ms/mfaforazure).
+
 ## 4.9.1 (2025-04-17)
 
 ### Bugs Fixed

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -74,7 +74,7 @@ export class EnvironmentCredential implements TokenCredential {
    * - `AZURE_CLIENT_CERTIFICATE_PASSWORD`: (optional) password for the certificate file.
    * - `AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`: (optional) indicates that the certificate chain should be set in x5c header to support subject name / issuer based authentication.
    *
-   * The username and password authentication is deprecated, since it doesn't support multifactor authentication (MFA). See https://aka.ms/azsdk/identity/mfa for more details. Though users can still provide environment variables for this authentication:
+   * Username and password authentication is deprecated, since it doesn't support multifactor authentication (MFA). See https://aka.ms/azsdk/identity/mfa for more details. Users can still provide environment variables for this authentication method:
    * - `AZURE_USERNAME`: Username to authenticate with.
    * - `AZURE_PASSWORD`: Password to authenticate with.
    *

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -132,7 +132,7 @@ export class EnvironmentCredential implements TokenCredential {
       );
 
       logger.warning(
-        "Environment is configured to use username and password authentication. This authentication method is deprecated, as it doesn't support multifactor authentication (MFA). Use a more secure credential. For more details, see https://aka.ms/azsdk/identity/mfa."
+        "Environment is configured to use username and password authentication. This authentication method is deprecated, as it doesn't support multifactor authentication (MFA). Use a more secure credential. For more details, see https://aka.ms/azsdk/identity/mfa.",
       );
       this._credential = new UsernamePasswordCredential(
         tenantId,

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -51,7 +51,7 @@ export function getSendCertificateChain(): boolean {
 }
 
 /**
- * Enables authentication to Microsoft Entra ID using a client secret or certificate.
+ * Enables authentication to Microsoft Entra ID using a client secret or certificate. The username and password authentication is deprecated. See https://aka.ms/azsdk/identity/mfa for more details.
  */
 export class EnvironmentCredential implements TokenCredential {
   private _credential?:

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -51,7 +51,7 @@ export function getSendCertificateChain(): boolean {
 }
 
 /**
- * Enables authentication to Microsoft Entra ID using a client secret or certificate. The username and password authentication is deprecated. See https://aka.ms/azsdk/identity/mfa for more details.
+ * Enables authentication to Microsoft Entra ID using a client secret or certificate.
  */
 export class EnvironmentCredential implements TokenCredential {
   private _credential?:

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -51,8 +51,7 @@ export function getSendCertificateChain(): boolean {
 }
 
 /**
- * Enables authentication to Microsoft Entra ID using a client secret or certificate, or as a user
- * with a username and password.
+ * Enables authentication to Microsoft Entra ID using a client secret or certificate.
  */
 export class EnvironmentCredential implements TokenCredential {
   private _credential?:
@@ -130,6 +129,10 @@ export class EnvironmentCredential implements TokenCredential {
     if (tenantId && clientId && username && password) {
       logger.info(
         `Invoking UsernamePasswordCredential with tenant ID: ${tenantId}, clientId: ${clientId} and username: ${username}`,
+      );
+
+      logger.warning(
+        "Environment is configured to use username and password authentication. This authentication method is deprecated, as it doesn't support multifactor authentication (MFA). Use a more secure credential. For more details, see https://aka.ms/azsdk/identity/mfa."
       );
       this._credential = new UsernamePasswordCredential(
         tenantId,

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -74,7 +74,7 @@ export class EnvironmentCredential implements TokenCredential {
    * - `AZURE_CLIENT_CERTIFICATE_PASSWORD`: (optional) password for the certificate file.
    * - `AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`: (optional) indicates that the certificate chain should be set in x5c header to support subject name / issuer based authentication.
    *
-   * Alternatively, users can provide environment variables for username and password authentication:
+   * The username and password authentication is deprecated, since it doesn't support multifactor authentication (MFA). See https://aka.ms/azsdk/identity/mfa for more details. Though users can still provide environment variables for this authentication:
    * - `AZURE_USERNAME`: Username to authenticate with.
    * - `AZURE_PASSWORD`: Password to authenticate with.
    *


### PR DESCRIPTION
If UsernamePasswordCredential environment variables are detected in EnvironmentCredential and DefaultAzureCredential, we now ensure that a warning noting its deprecation is logged.

Without this, by default, the user won't see the warning emitted in the UsernamePasswordCredential class constructor if UsernamePasswordCredential wasn't directly instantiated by the user.