### PR TITLE
Initialize containers publish pipeline

### DIFF
--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -1,0 +1,62 @@
+pr: none
+
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - eng/containers/
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+    - stage:
+      displayName: Docker Build and Publish
+      variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+      - template: /eng/pipelines/templates/variables/image.yml
+      - name: configPath
+        value: ./common/tools/turborepo-remote-cache
+      - name: containerRegistry
+        value: 'azsdkengsys'
+      - name: imageRepository
+        value: 'js/turborepo-remote-cache'
+      - name: imageTag
+        value: $(build.buildid)
+
+      jobs:
+      - job:
+        displayName: Docker Build and Publish
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+
+        templateContext:
+          outputs:
+          - output: containerImage
+            image: image:tag
+            remoteImage:
+            - $(containerRegistry).azurecr.io/$(imageRepository):$(imageTag)
+
+        steps:
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+
+        - task: AzureCLI@2
+          displayName: Login to $(containerRegistry)
+          inputs:
+            azureSubscription: "Azure SDK Engineering System"
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              az acr login --name $(containerRegistry)
+
+        - task: 1ES.BuildContainerImage@1
+          displayName: Build Docker Image
+          inputs:
+            path: $(configPath)
+            image: image:tag
+            enableNetwork: true
+            useBuildKit: true


### PR DESCRIPTION
Copying over the container pipeline from net/java so that we can publish the new turborepo remote cache image (https://github.com/Azure/azure-sdk-for-js/tree/feat/pnpm-prep/common/tools/turborepo-remote-cache)