### PR TITLE
Fix: default value for useMultipleWriteLocations & enableBackgroundEndpointRefreshing flag should be false

### DIFF
--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
@@ -45,7 +45,7 @@ export const defaultConnectionPolicy: ConnectionPolicy = Object.freeze({
     fixedRetryIntervalInMilliseconds: Constants.ThrottledRequestFixedRetryIntervalInMs,
     maxWaitTimeInSeconds: Constants.ThrottledRequestMaxWaitTimeInSeconds,
   },
-  useMultipleWriteLocations: true,
+  useMultipleWriteLocations: false,
   endpointRefreshRateInMs: 300000,
-  enableBackgroundEndpointRefreshing: true,
+  enableBackgroundEndpointRefreshing: false,
 });

--- a/sdk/cosmosdb/cosmos/test/public/integration/client.retry.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/client.retry.spec.ts
@@ -8,6 +8,7 @@ import { PluginOn } from "../../../src/index.js";
 import { TimeoutErrorCode } from "../../../src/request/TimeoutError.js";
 import { getEmptyCosmosDiagnostics } from "../../../src/utils/diagnostics.js";
 import { describe, it, assert } from "vitest";
+import { connect } from "http2";
 
 const endpoint = "https://failovertest.documents.azure.com/";
 
@@ -123,6 +124,9 @@ describe("RetryPolicy", () => {
       const options = {
         endpoint,
         key: masterKey,
+        connectionPolicy: {
+          useMultipleWriteLocations: true,
+        },
       };
       const plugins = getPlugins(responses, lastEndpointCalled);
       const client = new CosmosClient(Object.assign(Object.assign({}, options), { plugins }));


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR
In the connection policy, the default value of these two flags needs to be false. 

1. useMultipleWriteLocations: The flag that enables writes on any locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service.
2. enableBackgroundEndpointRefreshing : Flag to enable/disable background refreshing of endpoints.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
