### PR TITLE
feat: extend MongoClusterManagementClient from ServiceClient and update dependencies

### DIFF
--- a/sdk/mongocluster/arm-mongocluster/package.json
+++ b/sdk/mongocluster/arm-mongocluster/package.json
@@ -60,6 +60,7 @@
     "@azure-rest/core-client": "^2.1.0",
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-auth": "^1.9.0",
+    "@azure/core-client": "^1.9.3",
     "@azure/core-lro": "^3.0.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",

--- a/sdk/mongocluster/arm-mongocluster/src/mongoClusterManagementClient.ts
+++ b/sdk/mongocluster/arm-mongocluster/src/mongoClusterManagementClient.ts
@@ -38,7 +38,7 @@ export class MongoClusterManagementClient extends ServiceClient {
     subscriptionId: string,
     options: MongoClusterManagementClientOptionalParams = {},
   ) {
-    super();
+    super(options);
 
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/sdk/mongocluster/arm-mongocluster/src/mongoClusterManagementClient.ts
+++ b/sdk/mongocluster/arm-mongocluster/src/mongoClusterManagementClient.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { TokenCredential } from "@azure/core-auth";
+import { ServiceClient } from "@azure/core-client";
 import { Pipeline } from "@azure/core-rest-pipeline";
 import { getOperationsOperations, OperationsOperations } from "./classic/operations/index.js";
 import {
@@ -26,7 +27,7 @@ import {
 
 export { MongoClusterManagementClientOptionalParams } from "./api/mongoClusterManagementContext.js";
 
-export class MongoClusterManagementClient {
+export class MongoClusterManagementClient extends ServiceClient {
   private _client: DocumentDBContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
@@ -37,6 +38,8 @@ export class MongoClusterManagementClient {
     subscriptionId: string,
     options: MongoClusterManagementClientOptionalParams = {},
   ) {
+    super();
+
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`


### PR DESCRIPTION
This allows vscode-azuretools works with this client (https://github.com/microsoft/vscode-azuretools/blob/c0467caa804cf5c5fc9ce009fa2d9f3044e69878/azure/index.d.ts#L461)


### Packages impacted by this PR
`@azure/arm-mongocluster`

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The package `vscode-azuretools` implements some wrappers of ServiceClients, like removing/adding policies headers and UA and etc. However, the MongoClusterManagementClient does not extend from ServiceClient, so it is not compatible with vscode-azuretools.

The MongoClusterManagementClient class already implements this interface, but does not extend

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
