### PR TITLE
Fix turbo.json depends

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,6 @@
       "cache": false
     },
     "build:test": {
-      "dependsOn": ["^build:test"],
       "cache": false
     },
     "check-format": {
@@ -41,13 +40,15 @@
     "test": {
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^build"]
     },
     "unit-test": {
     },
     "unit-test:browser": {
+      "dependsOn": ["build"]
     },
     "unit-test:node": {
+      "dependsOn": ["build"]
     },
     "update-snippets": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -7,9 +7,6 @@
       "outputs": ["dist/**", "dist-esm/**", "dist-test/**", "types/**"]
     },
     "build:samples": {
-      "dependsOn": [
-        "^build:samples"
-      ],
       "cache": false
     },
     "build:test": {
@@ -17,55 +14,42 @@
       "cache": false
     },
     "check-format": {
-      "dependsOn": ["^check-format"],
       "cache": false
     },
     "clean": {
-      "dependsOn": ["^clean"],
       "cache": false
     },
     "format": {
-      "dependsOn": ["^format"],
       "cache": false
     },
     "integration-test": {
-      "dependsOn": ["^integration-test"]
     },
     "integration-test:browser": {
-      "dependsOn": ["^integration-test:browser"]
     },
     "integration-test:node": {
-      "dependsOn": ["^integration-test:node"]
     },
     "lint": {
-      "dependsOn": ["^lint"],
       "cache": false
     },
     "lint:fix": {
-      "dependsOn": ["^lint:fix"],
       "cache": false
     },
     "pack": {
-      "dependsOn": ["^pack", "build"],
+      "dependsOn": ["build"],
       "cache": false
     },
     "test": {
-      "dependsOn": ["^test"]
     },
     "typecheck": {
       "dependsOn": ["^typecheck"]
     },
     "unit-test": {
-      "dependsOn": ["^unit-test"]
     },
     "unit-test:browser": {
-      "dependsOn": ["^unit-test:browser"]
     },
     "unit-test:node": {
-      "dependsOn": ["^unit-test:node"]
     },
     "update-snippets": {
-      "dependsOn": ["^update-snippets"],
       "cache": false
     },
     "dev": {


### PR DESCRIPTION
using "^format" means running "format" for all dependencies first, which is not what we want for tasks that can be run independently.  This PR removes `dependsOn` for tasks that doesn't need their dependencies to run that task first.

