### PR TITLE
[Identity] Add Thumbprint Property Back

### DIFF
--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -177,6 +177,7 @@ export class ClientCertificateCredential implements TokenCredential {
     }
 
     return {
+      thumbprint: parts.thumbprint,
       thumbprintSha256: parts.thumbprintSha256,
       privateKey,
       x5c: parts.x5c,
@@ -218,6 +219,11 @@ export async function parseCertificate(
     throw new Error("The file at the specified path does not contain a PEM-encoded certificate.");
   }
 
+  const thumbprint = createHash("sha1")
+    .update(Buffer.from(publicKeys[0], "base64"))
+    .digest("hex")
+    .toUpperCase();
+
   const thumbprintSha256 = createHash("sha256")
     .update(Buffer.from(publicKeys[0], "base64"))
     .digest("hex")
@@ -226,6 +232,7 @@ export async function parseCertificate(
   return {
     certificateContents,
     thumbprintSha256,
+    thumbprint,
     x5c,
   };
 }

--- a/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
+++ b/sdk/identity/identity/src/credentials/onBehalfOfCredential.ts
@@ -238,6 +238,7 @@ export class OnBehalfOfCredential implements TokenCredential {
     try {
       const parts = await this.parseCertificate({ certificatePath }, this.sendCertificateChain);
       return {
+        thumbprint: parts.thumbprint,
         thumbprintSha256: parts.thumbprintSha256,
         privateKey: parts.certificateContents,
         x5c: parts.x5c,
@@ -272,8 +273,12 @@ export class OnBehalfOfCredential implements TokenCredential {
     if (publicKeys.length === 0) {
       throw new Error("The file at the specified path does not contain a PEM-encoded certificate.");
     }
+    const thumbprint = createHash("sha1")
+      .update(Buffer.from(publicKeys[0], "base64"))
+      .digest("hex")
+      .toUpperCase();
 
-    const thumbprintSha256 = createHash("sha1")
+    const thumbprintSha256 = createHash("sha256")
       .update(Buffer.from(publicKeys[0], "base64"))
       .digest("hex")
       .toUpperCase();
@@ -281,6 +286,7 @@ export class OnBehalfOfCredential implements TokenCredential {
     return {
       certificateContents,
       thumbprintSha256,
+      thumbprint,
       x5c,
     };
   }

--- a/sdk/identity/identity/src/msal/types.ts
+++ b/sdk/identity/identity/src/msal/types.ts
@@ -83,7 +83,12 @@ export interface CertificateParts {
    * Hex encoded X.509 SHA-256 thumbprint of the certificate.
    */
   thumbprintSha256: string;
-
+  /**
+   * Hex encoded X.509 SHA-1 thumbprint of the certificate.
+   * @deprecated Use thumbprintSha256 property instead. Thumbprint needs to be computed with SHA-256 algorithm.
+   * SHA-1 is only needed for backwards compatibility with older versions of ADFS.
+   */
+  thumbprint: string;
   /**
    * The PEM encoded private key.
    */


### PR DESCRIPTION
- Keep property `thumbprint` to ensure backwards compatibility with older version of ADFS. Mark the property as deprecated since it's not recommended and `thumbprintSha256` is preferred