### PR TITLE
[core] bump dependency @azure/core-rest-pipeline version to ^1.20.0

### DIFF
--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-auth": "^1.4.0",
-    "@azure/core-rest-pipeline": "^1.9.1",
+    "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.6.1",
     "@azure/logger": "^1.0.0",

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
     "@azure/core-client": "^1.3.0",
-    "@azure/core-rest-pipeline": "^1.19.0"
+    "@azure/core-rest-pipeline": "^1.20.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "^1.0.0",


### PR DESCRIPTION
for core-client and core-http-compat.