### PR TITLE
[data-tables] add partitionKey and rowKey validation

### DIFF
--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 # Release History
 
-## 13.3.1 (2025-01-14)
+## 13.3.1 (2025-05-06)
 
 ### Bugs Fixed
 
 - Fix issue [#28624](https://github.com/Azure/azure-sdk-for-js/issues/28624) where request options were not available when submitting a transaction operation.
 - Fix issue [#32239](https://github.com/Azure/azure-sdk-for-js/issues/32239) where Azurite emulator endpoint with a non-default port was treated as Cosmos endpoint.
+- Add `partitionKey` and `rowKey` validation for `TableClient` methods.
 
 ## 13.3.0 (2024-11-18)
 

--- a/sdk/tables/data-tables/src/TableClient.ts
+++ b/sdk/tables/data-tables/src/TableClient.ts
@@ -360,6 +360,12 @@ export class TableClient {
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options: GetTableEntityOptions = {},
   ): Promise<GetTableEntityResponse<TableEntityResult<T>>> {
+    if (partitionKey === undefined || partitionKey === null) {
+      throw new Error("The entity's partitionKey cannot be undefined or null.");
+    }
+    if (rowKey === undefined || rowKey === null) {
+      throw new Error("The entity's rowKey cannot be undefined or null.");
+    }
     return tracingClient.withSpan("TableClient.getEntity", options, async (updatedOptions) => {
       let parsedBody: any;
       function onResponse(rawResponse: FullOperationResponse, flatResponse: unknown): void {
@@ -594,6 +600,12 @@ export class TableClient {
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options: DeleteTableEntityOptions = {},
   ): Promise<DeleteTableEntityResponse> {
+    if (partitionKey === undefined || partitionKey === null) {
+      throw new Error("The entity's partitionKey cannot be undefined or null.");
+    }
+    if (rowKey === undefined || rowKey === null) {
+      throw new Error("The entity's rowKey cannot be undefined or null.");
+    }
     return tracingClient.withSpan("TableClient.deleteEntity", options, (updatedOptions) => {
       const { etag = "*", ...rest } = updatedOptions;
       const deleteOptions: TableDeleteEntityOptionalParams = {
@@ -652,6 +664,12 @@ export class TableClient {
     // eslint-disable-next-line @azure/azure-sdk/ts-naming-options
     options: UpdateTableEntityOptions = {},
   ): Promise<UpdateEntityResponse> {
+    if (entity.partitionKey === undefined || entity.partitionKey === null) {
+      throw new Error("The entity's partitionKey cannot be undefined or null.");
+    }
+    if (entity.rowKey === undefined || entity.rowKey === null) {
+      throw new Error("The entity's rowKey cannot be undefined or null.");
+    }
     return tracingClient.withSpan(
       "TableClient.updateEntity",
       options,
@@ -727,6 +745,13 @@ export class TableClient {
       "TableClient.upsertEntity",
       options,
       async (updatedOptions) => {
+        if (entity.partitionKey === undefined || entity.partitionKey === null) {
+          throw new Error("The entity's partitionKey cannot be undefined or null.");
+        }
+        if (entity.rowKey === undefined || entity.rowKey === null) {
+          throw new Error("The entity's rowKey cannot be undefined or null.");
+        }
+
         const partitionKey = escapeQuotes(entity.partitionKey);
         const rowKey = escapeQuotes(entity.rowKey);
 

--- a/sdk/tables/data-tables/test/internal/errorHandling.spec.ts
+++ b/sdk/tables/data-tables/test/internal/errorHandling.spec.ts
@@ -38,6 +38,232 @@ describe("ErrorHandling", () => {
         assert.isTrue(threw, "Expected to throw on non-404");
       }
     });
+
+    describe("getEntity validation", () => {
+      const client = new TableClient("https://example.org", "fakeTable");
+
+      interface TestCase {
+        description: string;
+        partitionKey: any;
+        rowKey: any;
+        expectedErrorMessage: string;
+      }
+
+      const testCases: TestCase[] = [
+        {
+          description: "should throw error when partitionKey is undefined",
+          partitionKey: undefined,
+          rowKey: "testRowKey",
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when partitionKey is null",
+          partitionKey: null,
+          rowKey: "testRowKey",
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is undefined",
+          partitionKey: "testPartitionKey",
+          rowKey: undefined,
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is null",
+          partitionKey: "testPartitionKey",
+          rowKey: null,
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+      ];
+
+      testCases.forEach(({ description, partitionKey, rowKey, expectedErrorMessage }) => {
+        it(description, async () => {
+          try {
+            await client.getEntity(partitionKey, rowKey);
+            assert.fail(`Expected an error to be thrown: ${description}`);
+          } catch (error: any) {
+            assert.equal(error.message, expectedErrorMessage);
+          }
+        });
+      });
+    });
+    describe("updateEntity validation", () => {
+      const client = new TableClient("https://example.org", "fakeTable");
+
+      interface TestCase {
+        description: string;
+        entity: {
+          partitionKey: any;
+          rowKey: any;
+          data: string;
+        };
+        mode?: "Merge" | "Replace";
+        expectedErrorMessage: string;
+      }
+
+      const testCases: TestCase[] = [
+        {
+          description: "should throw error when partitionKey is undefined",
+          entity: {
+            partitionKey: undefined,
+            rowKey: "testRowKey",
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when partitionKey is null",
+          entity: {
+            partitionKey: null,
+            rowKey: "testRowKey",
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is undefined",
+          entity: {
+            partitionKey: "testPartitionKey",
+            rowKey: undefined,
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is null",
+          entity: {
+            partitionKey: "testPartitionKey",
+            rowKey: null,
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+      ];
+
+      testCases.forEach(({ description, entity, mode, expectedErrorMessage }) => {
+        it(description, async () => {
+          try {
+            await client.updateEntity(entity, mode);
+            assert.fail(`Expected an error to be thrown: ${description}`);
+          } catch (error: any) {
+            assert.equal(error.message, expectedErrorMessage);
+          }
+        });
+      });
+    });
+
+    describe("deleteEntity validation", () => {
+      const client = new TableClient("https://example.org", "fakeTable");
+
+      interface TestCase {
+        description: string;
+        partitionKey: any;
+        rowKey: any;
+        expectedErrorMessage: string;
+      }
+
+      const testCases: TestCase[] = [
+        {
+          description: "should throw error when partitionKey is undefined",
+          partitionKey: undefined,
+          rowKey: "testRowKey",
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when partitionKey is null",
+          partitionKey: null,
+          rowKey: "testRowKey",
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is undefined",
+          partitionKey: "testPartitionKey",
+          rowKey: undefined,
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is null",
+          partitionKey: "testPartitionKey",
+          rowKey: null,
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+      ];
+
+      testCases.forEach(({ description, partitionKey, rowKey, expectedErrorMessage }) => {
+        it(description, async () => {
+          try {
+            await client.deleteEntity(partitionKey, rowKey);
+            assert.fail(`Expected an error to be thrown: ${description}`);
+          } catch (error: any) {
+            assert.equal(error.message, expectedErrorMessage);
+          }
+        });
+      });
+    });
+
+    describe("upsertEntity validation", () => {
+      const client = new TableClient("https://example.org", "fakeTable");
+
+      interface TestCase {
+        description: string;
+        entity: {
+          partitionKey: any;
+          rowKey: any;
+          data: string;
+        };
+        expectedErrorMessage: string;
+      }
+
+      const testCases: TestCase[] = [
+        {
+          description: "should throw error when partitionKey is undefined",
+          entity: {
+            partitionKey: undefined,
+            rowKey: "testRowKey",
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when partitionKey is null",
+          entity: {
+            partitionKey: null,
+            rowKey: "testRowKey",
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's partitionKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is undefined",
+          entity: {
+            partitionKey: "testPartitionKey",
+            rowKey: undefined,
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+        {
+          description: "should throw error when rowKey is null",
+          entity: {
+            partitionKey: "testPartitionKey",
+            rowKey: null,
+            data: "test data",
+          },
+          expectedErrorMessage: "The entity's rowKey cannot be undefined or null.",
+        },
+      ];
+
+      testCases.forEach(({ description, entity, expectedErrorMessage }) => {
+        it(description, async () => {
+          try {
+            await client.upsertEntity(entity);
+            assert.fail(`Expected an error to be thrown: ${description}`);
+          } catch (error: any) {
+            assert.equal(error.message, expectedErrorMessage);
+          }
+        });
+      });
+    });
   });
 
   describe("TableServiceClient", () => {


### PR DESCRIPTION
Although tables allow empty strings as partition/row key values, null value is not permitted. Our typing is correct, and TypeScript compiler will report errors if `null` or `undefined` is passed to either one of them. However, developers who don't use type checking will get a non-helpful error at runtime in this case:

>TypeError: Cannot read properties of undefined (reading 'replace')
 at escapeQuotes (.../node_modules/@azure/data-tables/dist/index.js:4439:18)
 at TableClient.upsertEntity

This PR adds validation for entity `partitionKey` and `rowKey` so a better error is thrown when undefined or null is passed as value for them.

### Packages impacted by this PR
`@azure/data-tables`

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/34129
