### PR TITLE
[core] fix stack overflow when passing a Blob for multipart part body in Node

### DIFF
--- a/sdk/core/ts-http-runtime/src/util/concat.ts
+++ b/sdk/core/ts-http-runtime/src/util/concat.ts
@@ -50,7 +50,7 @@ function toStream(
   if (source instanceof Uint8Array) {
     return Readable.from(Buffer.from(source));
   } else if (isBlob(source)) {
-    return toStream(source);
+    return ensureNodeStream(source.stream());
   } else {
     return ensureNodeStream(source);
   }

--- a/sdk/core/ts-http-runtime/test/multipartPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/multipartPolicy.spec.ts
@@ -270,6 +270,26 @@ describe("multipartPolicy", function () {
     });
   });
 
+  it("Supports Blob body", async function () {
+    const blob = new Blob(["part1"]);
+
+    const request = await performRequest({
+      multipartBody: {
+        boundary: "blah",
+        parts: [
+          {
+            body: blob,
+            headers: createHttpHeaders(),
+          },
+        ],
+      },
+    });
+
+    const expectedBody = stringToUint8Array("--blah\r\n\r\npart1\r\n--blah--\r\n\r\n", "utf-8");
+    await assertBodyMatches(request.body, expectedBody);
+    assert.equal(request.headers.get("Content-Length"), expectedBody.byteLength.toString());
+  });
+
   describe("part headers", function () {
     it("are present when specified", async function () {
       const request = await performRequest({


### PR DESCRIPTION
### Packages impacted by this PR

- `@typespec/ts-http-runtime`

### Issues associated with this PR

- Fixes bug introduced in #33948 (unreleased)

### Describe the problem that is addressed by this PR

Came across this when investigating with @HarshaNalluru yesterday evening. I introduced this when taking the `createFile` shim and friends out of the Unbranded package. The logic I 'fixed' results in infinite recursion if a `Blob` is passed into `toStream` in Node. Apparently we didn't have a test for passing a `Blob` body into `multipartPolicy` so this wasn't caught. I added a test here to fix the gap in coverage.

Ultimately, it seems unlikely that someone would actually pass a Blob as input here in Node, so the impact of this would probably have been limited, but it's still a bug and it's an easy fix.
