### PR TITLE
[Eng Sys] Update Dependency Testing Config for Browser

### DIFF
--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -42,7 +42,7 @@ const finalViteConfig = mergeConfig(
       include: ["./**/*.spec.ts"],
       exclude: [
         "**/node_modules/**",
-        "./**/browser/*.spec.ts"
+        "**/browser/*.spec.ts"
       ],
     },
   }),

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -30,13 +30,18 @@ try {
 }
 
 // 2. Merge the shared base config with some standard test settings for min/max tests.
-// These settings apply to all packages unless specifically overridden,
+// These settings apply to all packages unless specifically overridden
+// By default, the config includes all test files ending with .spec.ts
+// and excludes any test files located in the node_modules directory or those that are browser-specific.
 const baseConfig = mergeConfig(
   viteConfig,
   defineConfig({
     test: {
       include: ["./**/*.spec.ts"],
-      exclude: ["**/node_modules/**"],
+      exclude: [
+        "**/node_modules/**",
+        "**/browser/*.spec.ts"
+      ],
     },
   }),
 );

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -13,8 +13,10 @@ import viteConfig from "../../../../../vitest.shared.config.ts";
 // This allows each package to have its own tailored test configuration,
 // but it's optional. 
 let packageConfig = {};
+let foundPackageConfig = false;
 try {
   packageConfig = (await import("../../vitest.config.ts")).default;
+  foundPackageConfig = true;
 } catch (e: any) {
   if (e.code === "ERR_MODULE_NOT_FOUND") {
     // If no specific config is found, we log this fact.
@@ -29,12 +31,12 @@ try {
   }
 }
 // If the package config isn't present, we proceed with the default shared setup.
-packageConfig = packageConfig || viteConfig;
+const baseConfig = foundPackageConfig ? packageConfig : viteConfig;
 
 // 2. Merge the shared base config/ package specific config with the standard test settings for min/max tests.
 // These settings apply to all packages.
 const finalViteConfig = mergeConfig(
-  packageConfig,
+  baseConfig,
   defineConfig({
     test: {
       include: ["./**/*.spec.ts"],

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -5,13 +5,13 @@ import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../../../vitest.shared.config.ts";
 
 // The goal of this file is to create a unified test configuration for Vitest
-// by combining a base configuration shared across packages with package-specific settings.
+// by combining a base configuration for dependency testing with package-specific settings.
 // This ensures that we maintain consistent test behavior when running min/max tests,
 // while allowing for individual package overrides where necessary.
 
 // 1. Try to load the package-specific vitest config, if available.
 // This allows each package to have its own tailored test configuration,
-// but it's optional. If the package config isn't present, we proceed with a default setup.
+// but it's optional. 
 let packageConfig = {};
 try {
   packageConfig = (await import("../../vitest.config.ts")).default;
@@ -28,28 +28,23 @@ try {
     throw e;
   }
 }
+// If the package config isn't present, we proceed with the default shared setup.
+packageConfig = packageConfig || viteConfig;
 
-// 2. Merge the shared base config with some standard test settings for min/max tests.
-// These settings apply to all packages unless specifically overridden
-// By default, the config includes all test files ending with .spec.ts
-// and excludes any test files located in the node_modules directory or those that are browser-specific.
-const baseConfig = mergeConfig(
-  viteConfig,
+// 2. Merge the shared base config/ package specific config with the standard test settings for min/max tests.
+// These settings apply to all packages.
+const finalViteConfig = mergeConfig(
+  packageConfig,
   defineConfig({
     test: {
       include: ["./**/*.spec.ts"],
       exclude: [
         "**/node_modules/**",
-        "**/browser/*.spec.ts"
+        "./**/browser/*.spec.ts"
       ],
     },
   }),
 );
-
-// 3. Merge the package-specific config with the base config to produce the final result.
-// This allows for package-level customizations while still adhering to the shared setup,
-// ensuring consistency across the entire codebase.
-const finalViteConfig = mergeConfig(baseConfig, packageConfig);
 
 console.log("Using the following Vitest configuration:");
 console.log(JSON.stringify(finalViteConfig, null, 2));

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -16,7 +16,6 @@ let packageConfig = undefined;
 
 try {
   packageConfig = (await import("../../vitest.config.ts")).default;
-  foundPackageConfig = true;
 } catch (e: any) {
   if (e.code === "ERR_MODULE_NOT_FOUND") {
     // If no specific config is found, we log this fact.

--- a/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
+++ b/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts
@@ -12,8 +12,8 @@ import viteConfig from "../../../../../vitest.shared.config.ts";
 // 1. Try to load the package-specific vitest config, if available.
 // This allows each package to have its own tailored test configuration,
 // but it's optional. 
-let packageConfig = {};
-let foundPackageConfig = false;
+let packageConfig = undefined;
+
 try {
   packageConfig = (await import("../../vitest.config.ts")).default;
   foundPackageConfig = true;
@@ -31,7 +31,7 @@ try {
   }
 }
 // If the package config isn't present, we proceed with the default shared setup.
-const baseConfig = foundPackageConfig ? packageConfig : viteConfig;
+const baseConfig = packageConfig ?? viteConfig;
 
 // 2. Merge the shared base config/ package specific config with the standard test settings for min/max tests.
 // These settings apply to all packages.


### PR DESCRIPTION
The current merged config for dependency testing tries to run all tests under `test/public` folder as shown [here](https://github.com/Azure/azure-sdk-for-js/blob/main/eng/tools/dependency-testing/templates/vitest.dependency-test.config.ts#L38). This is because dependency testing uses `test/public` test folder [here](https://github.com/Azure/azure-sdk-for-js/blame/main/eng/pipelines/templates/jobs/live.tests.yml#L131), so the default vitest config exclude properties for the browser `test/**/browser/*.spec.ts` will miss the browser folder.

The current logic for min/max config is redundant after our centralizing Vitest config effort. All package configs are extended from the shared config, so we no longer have to use the 3-way merging logic for dependency testing. The PR updates the logic to only merge the config once.

Live test runs picking up the right folder [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4821234&view=logs&j=8599d413-ac92-517d-1cdb-470be2ca69b4&t=af68e8c3-9690-58e5-a6a2-90be73a0bcc3)