### PR TITLE
[openai] Add retry to Browser vitest config

### DIFF
--- a/sdk/openai/openai/vitest.browser.config.ts
+++ b/sdk/openai/openai/vitest.browser.config.ts
@@ -19,6 +19,7 @@ export default mergeConfig(
       globalSetup: [resolve(__dirname, "test/utils/setup.ts")],
       setupFiles: [resolve(__dirname, "test/utils/logging.ts")],
       include: ["dist-test/browser/test/**/*.spec.js"],
+      retry: 2,
     },
   }),
 );


### PR DESCRIPTION
Browser vitest config doesn't inherit from generic vitest config, so it needs to have its own retry setting.