### PR TITLE
Manual Queues of `Integration` build are not publishing

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -237,48 +237,49 @@ stages:
       - template: /eng/pipelines/templates/variables/globals.yml
     jobs:
       - ${{ each artifact in parameters.Artifacts }}:
-          - ${{if and(ne(artifact.skipPublishDevFeed, 'true'), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))}}:
-            - job: DetectPackageArchive_${{ replace(artifact.name, '-', '_') }}
-              variables:
-                - template: /eng/pipelines/templates/variables/image.yml
-              pool:
-                name: $(LINUXPOOL)
-                image: $(LINUXVMIMAGE)
-                os: linux
-              displayName: 'Detecting package archive_${{artifact.name}}'
-              steps:
-              - checkout: self
-              - download: current
-              - pwsh: |
-                  $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz
-                  Write-Host "Detected package name: $($detectedPackageName)"
-                  if ($detectedPackageName -notmatch "-alpha")
-                  {
-                    Write-Error "Found non alpha version artifact to publish as dev version. Failing publish step. VersionPolicy should be client or core in rush.json to get alpha version build."
-                    exit 1
-                  }
-                  echo "##vso[task.setvariable variable=Package.Archive]$detectedPackageName"
-                  if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-js') {
-                    $npmToken="$(azure-sdk-npm-token)"
-                    $registry="${{parameters.Registry}}"
-                  }
-                  else {
-                    $npmToken="$(azure-sdk-devops-npm-token)"
-                    $registry="${{parameters.PrivateRegistry}}"
-                  }
-                  echo "##vso[task.setvariable variable=NpmToken]$npmToken"
-                  echo "##vso[task.setvariable variable=Registry]$registry"
-                displayName: Detecting package archive_${{artifact.name}}
-            - template: /eng/pipelines/templates/jobs/npm-release-task.yml
-              parameters:
-                Artifact: ${{artifact}}
-                Registry: ${{parameters.Registry}}
-                PathToArtifacts: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
-                VarDependencies:
-                  Tag: "dev"
-                Environment: 'none'
-                DependsOn:
-                  - DetectPackageArchive_${{ replace(artifact.name, '-', '_') }}
+        - ${{ if ne(artifact.skipPublishDevFeed, 'true') }}:
+          - job: DetectPackageArchive_${{ replace(artifact.name, '-', '_') }}
+            condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),  ne(variables['Skip.PublishDocs'], 'true'))))
+            variables:
+              - template: /eng/pipelines/templates/variables/image.yml
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+            displayName: 'Detecting package archive_${{artifact.name}}'
+            steps:
+            - checkout: self
+            - download: current
+            - pwsh: |
+                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz
+                Write-Host "Detected package name: $($detectedPackageName)"
+                if ($detectedPackageName -notmatch "-alpha")
+                {
+                  Write-Error "Found non alpha version artifact to publish as dev version. Failing publish step. VersionPolicy should be client or core in rush.json to get alpha version build."
+                  exit 1
+                }
+                echo "##vso[task.setvariable variable=Package.Archive]$detectedPackageName"
+                if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-js') {
+                  $npmToken="$(azure-sdk-npm-token)"
+                  $registry="${{parameters.Registry}}"
+                }
+                else {
+                  $npmToken="$(azure-sdk-devops-npm-token)"
+                  $registry="${{parameters.PrivateRegistry}}"
+                }
+                echo "##vso[task.setvariable variable=NpmToken]$npmToken"
+                echo "##vso[task.setvariable variable=Registry]$registry"
+              displayName: Detecting package archive_${{artifact.name}}
+          - template: /eng/pipelines/templates/jobs/npm-release-task.yml
+            parameters:
+              Artifact: ${{artifact}}
+              Registry: ${{parameters.Registry}}
+              PathToArtifacts: $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}
+              VarDependencies:
+                Tag: "dev"
+              Environment: 'none'
+              DependsOn:
+                - DetectPackageArchive_${{ replace(artifact.name, '-', '_') }}
 
       - job: PublishDocsToNightlyBranch
         variables:

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -239,7 +239,7 @@ stages:
       - ${{ each artifact in parameters.Artifacts }}:
         - ${{ if ne(artifact.skipPublishDevFeed, 'true') }}:
           - job: DetectPackageArchive_${{ replace(artifact.name, '-', '_') }}
-            condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'),  ne(variables['Skip.PublishDocs'], 'true'))))
+            condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))
             variables:
               - template: /eng/pipelines/templates/variables/image.yml
             pool:


### PR DESCRIPTION
See evidence:

Manually queued `js - ai`: 
![image](https://github.com/user-attachments/assets/ae006bb7-2471-4a50-888e-98cd9cc1595b)

Nightly queued `js - ai`:
![image](https://github.com/user-attachments/assets/0100e4f8-5699-4d80-801a-c1d65e61eade)

I believe the issue is that the condition based on a build time variable is no longer working -- somehow? I honestly don't understand it but AFAICT nothing has changed except for the variable is no longer honored in a compile time fashion.

By moving this compile-time condition to `runtime`, I believe that we can get around this problem. Here [is evidence](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4824878&view=logs&j=43330500-c246-546c-96b0-add58568f780)

