### PR TITLE
[docs] update bundling instruction for Parcel bundler

### DIFF
--- a/documentation/Bundling.md
+++ b/documentation/Bundling.md
@@ -404,6 +404,14 @@ Parcel uses [browserslist](https://github.com/browserslist/browserslist) to conf
   ],
 ```
 
+Also add the following to your package.json to enable exports map
+
+```json
+  "@parcel/resolver-default": {
+    "packageExports": true
+  }
+```
+
 In order to use Azure SDK libraries inside JS, you need to import code from the package you installed earlier.
 
 To accomplish this, let's create two files, `index.js` and `index.html`:

--- a/samples/Bundling/parcel/js/package.json
+++ b/samples/Bundling/parcel/js/package.json
@@ -16,5 +16,8 @@
     "@azure/storage-blob": "^12.26.0",
     "buffer": "^6.0.3",
     "process": "^0.11.10"
+  },
+  "@parcel/resolver-default": {
+    "packageExports": true
   }
 }

--- a/samples/Bundling/parcel/ts/package.json
+++ b/samples/Bundling/parcel/ts/package.json
@@ -16,5 +16,8 @@
     "@azure/storage-blob": "^12.26.0",
     "buffer": "^6.0.3",
     "process": "^0.11.10"
+  },
+  "@parcel/resolver-default": {
+    "packageExports": true
   }
 }


### PR DESCRIPTION
to opt in package exports support. Otherwise Parcel won't be able to resolve imports from subpaths.
