### PR TITLE
convert to uint8array to add support for browser

### DIFF
--- a/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/string.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/encoding/string.ts
@@ -2,14 +2,18 @@
 // Licensed under the MIT License.
 
 import { BytePrefix } from "./prefix.js";
+import { hexStringToUint8Array, concatUint8Arrays } from "../../uint8.js";
 
-export function writeStringForBinaryEncoding(payload: string): Buffer {
-  let outputStream = Buffer.from(BytePrefix.String, "hex");
+export function writeStringForBinaryEncoding(payload: string): Uint8Array {
+  // Convert the BytePrefix.String hex into a Uint8Array.
+  const outputStream = hexStringToUint8Array(BytePrefix.String);
   const MAX_STRING_BYTES_TO_APPEND = 100;
-  const byteArray = [...Buffer.from(payload)];
+  // Use TextEncoder to get a UTF-8 byte array from the payload.
+  const byteArray = new TextEncoder().encode(payload);
 
   const isShortString = payload.length <= MAX_STRING_BYTES_TO_APPEND;
 
+  let finalStream = outputStream;
   for (
     let index = 0;
     index < (isShortString ? byteArray.length : MAX_STRING_BYTES_TO_APPEND + 1);
@@ -19,11 +23,13 @@ export function writeStringForBinaryEncoding(payload: string): Buffer {
     if (charByte < 0xff) {
       charByte++;
     }
-    outputStream = Buffer.concat([outputStream, Buffer.from(charByte.toString(16), "hex")]);
+    // Convert the byte value to a 2-digit hex string.
+    const hexRep = charByte.toString(16).padStart(2, "0");
+    finalStream = concatUint8Arrays([finalStream, hexStringToUint8Array(hexRep)]);
   }
 
   if (isShortString) {
-    outputStream = Buffer.concat([outputStream, Buffer.from(BytePrefix.Undefined, "hex")]);
+    finalStream = concatUint8Arrays([finalStream, hexStringToUint8Array(BytePrefix.Undefined)]);
   }
-  return outputStream;
+  return finalStream;
 }

--- a/sdk/cosmosdb/cosmos/src/utils/hashing/murmurHash.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hashing/murmurHash.ts
@@ -9,7 +9,7 @@
 
 // PRIVATE FUNCTIONS
 // -----------------
-
+import { hexStringToUint8Array, uint8ArrayToHex } from "../uint8.js";
 function _x86Multiply(m: number, n: number) {
   //
   // Given two 32bit ints, returns the two multiplied together as a
@@ -175,7 +175,7 @@ function _x64Fmix(h: number[]) {
 // PUBLIC FUNCTIONS
 // ----------------
 
-function x86Hash32(bytes: Buffer, seed?: number) {
+function x86Hash32(bytes: Uint8Array, seed?: number) {
   //
   // Given a string and an optional seed as an int, returns a 32 bit hash
   // using the x86 flavor of MurmurHash3, as an unsigned int.
@@ -229,7 +229,7 @@ function x86Hash32(bytes: Buffer, seed?: number) {
   return h1 >>> 0;
 }
 
-function x86Hash128(bytes: Buffer, seed?: number) {
+function x86Hash128(bytes: Uint8Array, seed?: number) {
   //
   // Given a string and an optional seed as an int, returns a 128 bit
   // hash using the x86 flavor of MurmurHash3, as an unsigned hex.
@@ -399,7 +399,7 @@ function x86Hash128(bytes: Buffer, seed?: number) {
   );
 }
 
-function x64Hash128(bytes: Buffer, seed?: number) {
+function x64Hash128(bytes: Uint8Array, seed?: number) {
   //
   // Given a string and an optional seed as an int, returns a 128 bit
   // hash using the x64 flavor of MurmurHash3, as an unsigned hex.
@@ -521,29 +521,29 @@ function x64Hash128(bytes: Buffer, seed?: number) {
 
   // Here we reverse h1 and h2 in Cosmos
   // This is an implementation detail and not part of the public spec
-  const h1Buff = Buffer.from(
+  // Convert h1 to hex string and then to Uint8Array.
+  const h1Hex =
     ("00000000" + (h1[0] >>> 0).toString(16)).slice(-8) +
-      ("00000000" + (h1[1] >>> 0).toString(16)).slice(-8),
-    "hex",
-  );
-  const h1Reversed = reverse(h1Buff).toString("hex");
-  const h2Buff = Buffer.from(
+    ("00000000" + (h1[1] >>> 0).toString(16)).slice(-8);
+  const h1Buff = hexStringToUint8Array(h1Hex);
+  const h1Reversed = uint8ArrayToHex(reverse(h1Buff));
+
+  const h2Hex =
     ("00000000" + (h2[0] >>> 0).toString(16)).slice(-8) +
-      ("00000000" + (h2[1] >>> 0).toString(16)).slice(-8),
-    "hex",
-  );
-  const h2Reversed = reverse(h2Buff).toString("hex");
+    ("00000000" + (h2[1] >>> 0).toString(16)).slice(-8);
+  const h2Buff = hexStringToUint8Array(h2Hex);
+  const h2Reversed = uint8ArrayToHex(reverse(h2Buff));
   return h1Reversed + h2Reversed;
 }
 
-export function reverse(buff: Buffer) {
-  const buffer = Buffer.allocUnsafe(buff.length);
+export function reverse(buff: Uint8Array) {
+  const uint8array = new Uint8Array(buff.length);
 
   for (let i = 0, j = buff.length - 1; i <= j; ++i, --j) {
-    buffer[i] = buff[j];
-    buffer[j] = buff[i];
+    uint8array[i] = buff[j];
+    uint8array[j] = buff[i];
   }
-  return buffer;
+  return uint8array;
 }
 
 export default {

--- a/sdk/cosmosdb/cosmos/src/utils/uint8.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/uint8.ts
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 export function hexStringToUint8Array(hex: string): Uint8Array {
-  if (hex.length % 2 !== 0) {
-    throw new Error("Invalid hex string");
-  }
   const arr = new Uint8Array(hex.length / 2);
   for (let i = 0; i < hex.length; i += 2) {
     arr[i / 2] = parseInt(hex.substr(i, 2), 16);

--- a/sdk/cosmosdb/cosmos/src/utils/uint8.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/uint8.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function hexStringToUint8Array(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error("Invalid hex string");
+  }
+  const arr = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    arr[i / 2] = parseInt(hex.substr(i, 2), 16);
+  }
+  return arr;
+}
+
+export function uint8ArrayToHex(arr: Uint8Array): string {
+  return Array.from(arr)
+    .map((byte) => ("00" + byte.toString(16)).slice(-2))
+    .join("");
+}
+
+export function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}

--- a/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v1.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v1.spec.ts
@@ -62,6 +62,10 @@ describe("effectivePartitionKey", () => {
         key: [123456789],
         output: "05C1D9E1A5311C05C19DB7CD8B40",
       },
+      {
+        key: ["redmond", 50, 5.5, true, false, null, "", 12313.1221],
+        output: "05C1EFE313830C087366656E706F6500",
+      },
     ];
     toMatch.forEach(({ key, output }) => {
       it("matches expected hash output", () => {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v2.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/hashing/v2.spec.ts
@@ -57,6 +57,10 @@ describe("effectivePartitionKey", () => {
         key: [123456789],
         output: "1F56D2538088EBA82CCF988F36E16760",
       },
+      {
+        key: ["redmond", 50, 5.5, true, false, null, "", 12313.1221],
+        output: "1A5E512F591E980E07A6D8AD5BD5AB2F",
+      },
     ];
     toMatch.forEach(({ key, output }) => {
       it("matches expected hash output", () => {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/utils/uint8.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/utils/uint8.spec.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import {
+  hexStringToUint8Array,
+  uint8ArrayToHex,
+  concatUint8Arrays,
+} from "../../../../src/utils/uint8.js";
+import { Buffer } from "buffer";
+
+describe("Uint8 utils", () => {
+  it("hexStringToUint8Array should produce same output as Buffer.from(hex, 'hex')", () => {
+    const hex = "deadbeef";
+    const actualArray = hexStringToUint8Array(hex);
+    const expectedArray = Uint8Array.from(Buffer.from(hex, "hex"));
+    assert.deepEqual(actualArray, expectedArray);
+  });
+
+  it("uint8ArrayToHex should produce same hex string as Buffer", () => {
+    const arr = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const actualHex = uint8ArrayToHex(arr);
+    const expectedHex = Buffer.from(arr).toString("hex");
+    assert.equal(actualHex, expectedHex);
+  });
+
+  it("concatUint8Arrays should produce same output as Buffer.concat", () => {
+    const part1 = hexStringToUint8Array("dead");
+    const part2 = hexStringToUint8Array("beef");
+    const concatenationFromUInt8Array = concatUint8Arrays([part1, part2]);
+    const concatenationFromBuffer = Buffer.concat([
+      Buffer.from("dead", "hex"),
+      Buffer.from("beef", "hex"),
+    ]);
+    assert.deepEqual(concatenationFromUInt8Array, concatenationFromBuffer);
+  });
+
+  it("concatUint8Arrays handles empty array correctly", () => {
+    const actual = concatUint8Arrays([]);
+    const expected = new Uint8Array(0);
+    assert.deepEqual(actual, expected);
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR
This PR uses Uint8Array instead of Buffer for partition-key hashing to support bulk operations in browsers env.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
