### PR TITLE
Force js test resource md files into parity with tools repo

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -8,13 +8,11 @@ schema: 2.0.0
 # New-TestResources.ps1
 
 ## SYNOPSIS
-
 Deploys live test resources defined for a service directory to Azure.
 
 ## SYNTAX
 
 ### Default (Default)
-
 ```
 New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
  [-TestResourcesDirectory <String>] [-TestApplicationId <String>] [-TestApplicationSecret <String>]
@@ -26,7 +24,6 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
 ```
 
 ### Provisioner
-
 ```
 New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
  [-TestResourcesDirectory <String>] [-TestApplicationId <String>] [-TestApplicationSecret <String>]
@@ -40,7 +37,6 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
 ```
 
 ## DESCRIPTION
-
 Deploys live test resouces specified in test-resources.json or test-resources.bicep
 files to a new resource group.
 
@@ -63,7 +59,6 @@ or those specified in $ProvisionerApplicationId and $ProvisionerApplicationSecre
 ## EXAMPLES
 
 ### EXAMPLE 1
-
 ```
 Connect-AzAccount -Subscription 'REPLACE_WITH_SUBSCRIPTION_ID'
 New-TestResources.ps1 keyvault
@@ -79,7 +74,6 @@ Requires PowerShell 7 to use ConvertFrom-SecureString -AsPlainText or convert
 the SecureString to plaintext by another means.
 
 ### EXAMPLE 2
-
 ```
 Connect-AzAccount -Subscription 'REPLACE_WITH_SUBSCRIPTION_ID'
 New-TestResources.ps1 `
@@ -102,7 +96,6 @@ Requires PowerShell 7 to use ConvertFrom-SecureString -AsPlainText or convert
 the SecureString to plaintext by another means.
 
 ### EXAMPLE 3
-
 ```
 Connect-AzAccount -Subscription 'REPLACE_WITH_SUBSCRIPTION_ID'
 New-TestResources.ps1 `
@@ -122,7 +115,6 @@ to the 'TestApplicationId' for the resource group and the resources that it cont
 without altering its existing permissions.
 
 ### EXAMPLE 4
-
 ```
 New-TestResources.ps1 `
     -BaseName 'azsdk' `
@@ -153,7 +145,6 @@ Requires PowerShell 7 to use ConvertFrom-SecureString -AsPlainText or convert
 the SecureString to plaintext by another means.
 
 ### EXAMPLE 5
-
 ```
 New-TestResources.ps1 `
     -ServiceDirectory '$(ServiceDirectory)' `
@@ -176,11 +167,10 @@ log redaction).
 ## PARAMETERS
 
 ### -BaseName
-
 A name to use in the resource group and passed to the ARM template as 'baseName'.
 Limit $BaseName to enough characters to be under limit plus prefixes specified in
 the ARM template.
-See also https://learn.microsoft.com/azure/architecture/best-practices/resource-naming
+See also https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
 
 Note: The value specified for this parameter will be overriden and generated
 by New-TestResources.ps1 if $CI is specified.
@@ -198,7 +188,6 @@ Accept wildcard characters: False
 ```
 
 ### -ResourceGroupName
-
 Set this value to deploy directly to a Resource Group that has already been
 created or to create a new resource group with this name.
 
@@ -218,7 +207,6 @@ Accept wildcard characters: False
 ```
 
 ### -ServiceDirectory
-
 A directory under 'sdk' in the repository root - optionally with subdirectories
 specified - in which to discover ARM templates named 'test-resources.json' and
 Bicep templates named 'test-resources.bicep'.
@@ -240,7 +228,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestResourcesDirectory
-
 An override directory in which to discover ARM templates named 'test-resources.json' and
 Bicep templates named 'test-resources.bicep'.
 This can be an absolute path
@@ -259,7 +246,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationId
-
 Optional Azure Active Directory Application ID to authenticate the test runner
 against deployed resources.
 Passed to the ARM template as 'testApplicationId'.
@@ -289,7 +275,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationSecret
-
 Optional service principal secret (password) to authenticate the test runner
 against deployed resources.
 Passed to the ARM template as
@@ -311,7 +296,6 @@ Accept wildcard characters: False
 ```
 
 ### -TestApplicationOid
-
 Service Principal Object ID of the AAD Test Application.
 This is used to assign
 permissions to the AAD application so it can access tested features on the live
@@ -327,7 +311,7 @@ it will need the permission 'Application.Read.All' for the Microsoft Graph API
 in order to query AAD.
 
 For more information on the relationship between AAD Applications and Service
-Principals see: https://learn.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals
+Principals see: https://docs.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals
 
 ```yaml
 Type: String
@@ -342,7 +326,6 @@ Accept wildcard characters: False
 ```
 
 ### -TenantId
-
 The tenant ID of a service principal when a provisioner is specified.
 The same
 Tenant ID is used for Test Application and Provisioner Application.
@@ -362,7 +345,6 @@ Accept wildcard characters: False
 ```
 
 ### -SubscriptionId
-
 Optional subscription ID to use for new resources when logging in as a
 provisioner.
 You can also use Set-AzContext if not provisioning.
@@ -386,7 +368,6 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationId
-
 Optional Application ID of the Azure Active Directory service principal to use for
 provisioning the test resources.
 If not, specified New-TestResources.ps1 uses the
@@ -395,11 +376,11 @@ context of the caller to provision.
 If specified, the Provisioner Application principal would benefit from the following
 permissions to the Microsoft Graph API:
 
-- 'Application.Read.All' in order to query AAD to obtain the 'TestApplicaitonOid'
+  - 'Application.Read.All' in order to query AAD to obtain the 'TestApplicaitonOid'
 
-- 'Application.ReadWrite.OwnedBy' in order to create the Test Application principal
-  or grant an existing principal ownership of the resource group associated with
-  the test resources.
+  - 'Application.ReadWrite.OwnedBy' in order to create the Test Application principal
+     or grant an existing principal ownership of the resource group associated with
+     the test resources.
 
 If the provisioner does not have these permissions, it can still be used with
 New-TestResources.ps1 by specifying an existing Test Application principal, including
@@ -420,7 +401,6 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationOid
-
 {{ Fill ProvisionerApplicationOid Description }}
 
 ```yaml
@@ -436,7 +416,6 @@ Accept wildcard characters: False
 ```
 
 ### -ProvisionerApplicationSecret
-
 A service principal secret (password) used to provision test resources when a
 provisioner is specified.
 
@@ -455,7 +434,6 @@ Accept wildcard characters: False
 ```
 
 ### -DeleteAfterHours
-
 Positive integer number of hours from the current time to set the
 'DeleteAfter' tag on the created resource group.
 The computed value is a
@@ -479,15 +457,14 @@ Accept wildcard characters: False
 ```
 
 ### -Location
-
 Optional location where resources should be created.
 If left empty, the default
 is based on the cloud to which the template is being deployed:
 
-- AzureCloud -\> 'westus'
-- AzureUSGovernment -\> 'usgovvirginia'
-- AzureChinaCloud -\> 'chinaeast2'
-- Dogfood -\> 'westus'
+* AzureCloud -\> 'westus'
+* AzureUSGovernment -\> 'usgovvirginia'
+* AzureChinaCloud -\> 'chinaeast2'
+* Dogfood -\> 'westus'
 
 ```yaml
 Type: String
@@ -502,7 +479,6 @@ Accept wildcard characters: False
 ```
 
 ### -Environment
-
 Optional name of the cloud environment.
 The default is the Azure Public Cloud
 ('AzureCloud')
@@ -520,7 +496,6 @@ Accept wildcard characters: False
 ```
 
 ### -ResourceType
-
 {{ Fill ResourceType Description }}
 
 ```yaml
@@ -536,7 +511,6 @@ Accept wildcard characters: False
 ```
 
 ### -ArmTemplateParameters
-
 Optional key-value pairs of parameters to pass to the ARM template(s).
 
 ```yaml
@@ -552,7 +526,6 @@ Accept wildcard characters: False
 ```
 
 ### -AdditionalParameters
-
 Optional key-value pairs of parameters to pass to the ARM template(s) and pre-post scripts.
 
 ```yaml
@@ -568,7 +541,6 @@ Accept wildcard characters: False
 ```
 
 ### -EnvironmentVariables
-
 Optional key-value pairs of parameters to set as environment variables to the shell.
 
 ```yaml
@@ -584,7 +556,6 @@ Accept wildcard characters: False
 ```
 
 ### -CI
-
 Indicates the script is run as part of a Continuous Integration / Continuous
 Deployment (CI/CD) build (only Azure Pipelines is currently supported).
 
@@ -601,7 +572,6 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-
 Force creation of resources instead of being prompted.
 
 ```yaml
@@ -617,7 +587,6 @@ Accept wildcard characters: False
 ```
 
 ### -OutFile
-
 Save test environment settings into a .env file next to test resources template.
 The contents of the file are protected via the .NET Data Protection API (DPAPI).
 This is supported only on Windows.
@@ -643,7 +612,6 @@ Accept wildcard characters: False
 ```
 
 ### -SuppressVsoCommands
-
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted.
 For CI environments that don't support this (like
@@ -662,7 +630,6 @@ Accept wildcard characters: False
 ```
 
 ### -ServicePrincipalAuth
-
 Use the provisioner SP credentials to deploy, and pass the test SP credentials
 to tests.
 If provisioner and test SP are not set, provision an SP with user
@@ -681,7 +648,6 @@ Accept wildcard characters: False
 ```
 
 ### -NewTestResourcesRemainingArguments
-
 Captures any arguments not declared here (no parameter errors)
 This enables backwards compatibility with old script versions in
 hotfix branches if and when the dynamic subscription configuration
@@ -700,7 +666,6 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -717,7 +682,6 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -733,7 +697,6 @@ Accept wildcard characters: False
 ```
 
 ### -ProgressAction
-
 {{ Fill ProgressAction Description }}
 
 ```yaml
@@ -749,7 +712,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -1,15 +1,15 @@
 # Live Test Resource Management
 
 Running and recording live tests often requires first creating some resources
-in Azure. Service directories that include a `test-resources.json` or `test-resources.bicep`
+in Azure. Service directories that include a `test-resources.json` or `test-resources.bicep` 
 file require running [New-TestResources.ps1][] to create these resources and output
 environment variables you must set.
 
 The following scripts can be used both in on your desktop for developer
 scenarios as well as on hosted agents for continuous integration testing.
 
-- [New-TestResources.ps1][] - Creates new test resources for a given service.
-- [Remove-TestResources.ps1][] - Deletes previously created resources.
+* [New-TestResources.ps1][] - Creates new test resources for a given service.
+* [Remove-TestResources.ps1][] - Deletes previously created resources.
 
 ## Prerequisites
 
@@ -19,8 +19,8 @@ scenarios as well as on hosted agents for continuous integration testing.
 ## On the Desktop
 
 To set up your Azure account to run live tests, you'll need to log into Azure,
-and create the resources defined in your `test-resources.json` or `test-resources.bicep`
-template as shown in the following example using Azure Key Vault. The script will create
+and create the resources defined in your `test-resources.json` or `test-resources.bicep` 
+template as shown in the following example using Azure Key Vault. The script will create 
 a service principal automatically, or you may create a service principal that can be reused
 subsequently.
 
@@ -34,8 +34,8 @@ Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
 eng\common\TestResources\New-TestResources.ps1 keyvault
 ```
 
-The `OutFile` switch will be set by default if you are running this for a .NET project on Windows.
-This will save test environment settings into a `test-resources.json.env` file next to `test-resources.json`
+The `OutFile` switch will be set by default if you are running this for a .NET project on Windows. 
+This will save test environment settings into a `test-resources.json.env` file next to `test-resources.json` 
 or a `test-resources.bicep.env` file next to `test-resources.bicep`. The file is protected via DPAPI.
 The environment file would be scoped to the current repository directory and avoids the need to
 set environment variables or restart your IDE to recognize them.
@@ -88,7 +88,6 @@ Typically the created artifact will need to be passed to `test-resources.json` t
 Below is an example of how `$templateFileParameters` can be used to pass data from the `pre-` script to `test-resources.json`.
 
 **Snippet from `test-resources-pre.ps1`**
-
 ```powershell
 Import-Module -Name ./eng/common/scripts/X509Certificate2
 $cert = New-X509Certificate2 -SubjectName 'E=opensource@microsoft.com, CN=Azure SDK, OU=Azure SDK, O=Microsoft, L=Frisco, S=TX, C=US' -ValidDays 3652
@@ -100,7 +99,6 @@ $templateFileParameters['ConfidentialLedgerPrincipalPEMPK'] = Format-X509Certifi
 **Snippet from the corresponding `test-resources.json`.**
 
 Note that the values present in `$templateFileParameters` will map to parameters of the same name.
-
 ```json
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -119,7 +117,7 @@ Note that the values present in `$templateFileParameters` will map to parameters
         "description": "The certificate to configure as a certBasedSecurityPrincipal."
       }
     }
-  }
+  },
 }
 ```
 
@@ -162,7 +160,7 @@ remove-test-resources.yml like in the following examples:
 ```yml
 - template: /eng/common/TestResources/deploy-test-resources.yml
   parameters:
-    ServiceDirectory: "${{ parameters.ServiceDirectory }}"
+    ServiceDirectory: '${{ parameters.ServiceDirectory }}'
 
 # Run tests
 
@@ -186,9 +184,9 @@ After the markdown files are generated, please make sure all "http" URIs use "ht
 
 PowerShell markdown documentation created with [platyPS][].
 
-[New-TestResources.ps1]: https://aka.ms/azsdk/tools/New-TestResources
-[Update-TestResources.ps1]: https://aka.ms/azsdk/tools/Update-TestResources
-[Remove-TestResources.ps1]: https://aka.ms/azsdk/tools/Remove-TestResources
-[PowerShell]: https://github.com/PowerShell/PowerShell
-[PowerShellAz]: https://learn.microsoft.com/powershell/azure/install-az-ps
-[platyPS]: https://github.com/PowerShell/platyPS
+  [New-TestResources.ps1]: https://aka.ms/azsdk/tools/New-TestResources
+  [Update-TestResources.ps1]: https://aka.ms/azsdk/tools/Update-TestResources
+  [Remove-TestResources.ps1]: https://aka.ms/azsdk/tools/Remove-TestResources
+  [PowerShell]: https://github.com/PowerShell/PowerShell
+  [PowerShellAz]: https://docs.microsoft.com/powershell/azure/install-az-ps
+  [platyPS]: https://github.com/PowerShell/platyPS


### PR DESCRIPTION
This got out of sync due to https://github.com/Azure/azure-sdk-for-js/commit/57056dcef4d646fdca6f4af7bd5b2539c3cb57a2, for which we bypassed checks to prevent a build storm. As a result the eng/common change prevention didn't run.