### PR TITLE
[monitor-opentelemetry] fix type checking build error

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
@@ -12,14 +12,15 @@ import {
 import { diag } from "@opentelemetry/api";
 
 export function ignoreOutgoingRequestHook(request: http.RequestOptions): boolean {
-  if (request && request.headers) {
+  if (request && request.headers && !Array.isArray(request.headers)) {
+    const outgoingHeaders = request.headers as http.OutgoingHttpHeaders;
     if (
-      (request.headers["User-Agent"] &&
-        request.headers["User-Agent"]
+      (outgoingHeaders["User-Agent"] &&
+        outgoingHeaders["User-Agent"]
           .toString()
           .indexOf("azsdk-js-monitor-opentelemetry-exporter") > -1) ||
-      (request.headers["user-agent"] &&
-        request.headers["user-agent"]
+      (outgoingHeaders["user-agent"] &&
+        outgoingHeaders["user-agent"]
           .toString()
           .indexOf("azsdk-js-monitor-opentelemetry-exporter") > -1)
     ) {


### PR DESCRIPTION
The latest @types/node changes add `string[]` to the `RequestOptions.headers` type:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72617

https://github.com/nodejs/node/pull/58049

This PR adds a check and narrow the type to `http.OutgoingHttpHeaders` before accessing user-agent
property. We don't ever set the user agent header using the `string[]` form so this should be fine.