### PR TITLE
[Identity] update the DAC chain based on env var AZURE_TOKEN_CREDENTIALS

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Release History
 
-## 4.9.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 4.9.2 (2025-05-14)
 
 ### Other Changes
 
+- Added support for the `AZURE_TOKEN_CREDENTIALS` environment variable to `DefaultAzureCredential`, which allows for choosing between 'deployed service' and 'developer tools' credentials. Valid values are 'dev' for developer tools and 'prod' for deployed service.
 - Added deprecation warnings for username password usage in `EnvironmentCredential` constructor to warn the users. `UsernamePassword` authentication doesn't support Multi-Factor Authentication (MFA), and MFA will enabled soon on all tenants.  For more details, see [Planning for mandatory MFA](https://aka.ms/mfaforazure).
 
 ## 4.9.1 (2025-04-17)

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -34,7 +34,7 @@ export function createDefaultManagedIdentityCredential(
   options:
     | DefaultAzureCredentialOptions
     | DefaultAzureCredentialResourceIdOptions
-    | DefaultAzureCredentialClientIdOptions = {}
+    | DefaultAzureCredentialClientIdOptions = {},
 ): TokenCredential {
   options.retryOptions ??= {
     maxRetries: 5,
@@ -66,7 +66,7 @@ export function createDefaultManagedIdentityCredential(
 
     return new ManagedIdentityCredential(
       workloadIdentityClientId,
-      workloadIdentityCredentialOptions
+      workloadIdentityCredentialOptions,
     );
   }
 
@@ -90,7 +90,7 @@ export function createDefaultManagedIdentityCredential(
  * @internal
  */
 function createDefaultWorkloadIdentityCredential(
-  options?: DefaultAzureCredentialOptions | DefaultAzureCredentialClientIdOptions
+  options?: DefaultAzureCredentialOptions | DefaultAzureCredentialClientIdOptions,
 ): TokenCredential {
   const managedIdentityClientId =
     (options as DefaultAzureCredentialClientIdOptions)?.managedIdentityClientId ??
@@ -128,7 +128,7 @@ function createDefaultWorkloadIdentityCredential(
  * @internal
  */
 function createDefaultAzureDeveloperCliCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzureDeveloperCliCredential({ processTimeoutInMs, ...options });
@@ -141,7 +141,7 @@ function createDefaultAzureDeveloperCliCredential(
  * @internal
  */
 function createDefaultAzureCliCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzureCliCredential({ processTimeoutInMs, ...options });
@@ -154,7 +154,7 @@ function createDefaultAzureCliCredential(
  * @internal
  */
 function createDefaultAzurePowershellCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   const processTimeoutInMs = options.processTimeoutInMs;
   return new AzurePowerShellCredential({ processTimeoutInMs, ...options });
@@ -167,7 +167,7 @@ function createDefaultAzurePowershellCredential(
  * @internal
  */
 export function createEnvironmentCredential(
-  options: DefaultAzureCredentialOptions = {}
+  options: DefaultAzureCredentialOptions = {},
 ): TokenCredential {
   return new EnvironmentCredential(options);
 }
@@ -187,7 +187,7 @@ export class UnavailableDefaultCredential implements TokenCredential {
 
   getToken(): Promise<null> {
     logger.getToken.info(
-      `Skipping ${this.credentialName}, reason: ${this.credentialUnavailableErrorMessage}`
+      `Skipping ${this.credentialName}, reason: ${this.credentialUnavailableErrorMessage}`,
     );
     return Promise.resolve(null);
   }
@@ -234,7 +234,9 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
   constructor(options?: DefaultAzureCredentialOptions) {
     // If AZURE_TOKEN_CREDENTIALS is not set, use the default credential chain.
-    const azureTokenCredentials = (process.env.AZURE_TOKEN_CREDENTIALS) ? (process.env.AZURE_TOKEN_CREDENTIALS.trim()).toLowerCase() : undefined;
+    const azureTokenCredentials = process.env.AZURE_TOKEN_CREDENTIALS
+      ? process.env.AZURE_TOKEN_CREDENTIALS.trim().toLowerCase()
+      : undefined;
     const devCredentialFunctions = [
       createDefaultAzureCliCredential,
       createDefaultAzurePowershellCredential,
@@ -258,22 +260,17 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
           // If AZURE_TOKEN_CREDENTIALS is set to "prod", use the production credential chain.
           credentialFunctions = prodCredentialFunctions;
           break;
-        default:
-          {
-            // If AZURE_TOKEN_CREDENTIALS is set to an unsupported value, throw an error.
-            // We will throw an error here to prevent the creation of the DefaultAzureCredential.
-            const errorMessage = `Invalid value for AZURE_TOKEN_CREDENTIALS = ${process.env.AZURE_TOKEN_CREDENTIALS}. Valid values are 'prod' or 'dev'.`;
-            logger.warning(errorMessage);
-            throw new Error(errorMessage);
-          }
+        default: {
+          // If AZURE_TOKEN_CREDENTIALS is set to an unsupported value, throw an error.
+          // We will throw an error here to prevent the creation of the DefaultAzureCredential.
+          const errorMessage = `Invalid value for AZURE_TOKEN_CREDENTIALS = ${process.env.AZURE_TOKEN_CREDENTIALS}. Valid values are 'prod' or 'dev'.`;
+          logger.warning(errorMessage);
+          throw new Error(errorMessage);
+        }
       }
-    }
-    else {
+    } else {
       // If AZURE_TOKEN_CREDENTIALS is not set, use the default credential chain.
-      credentialFunctions = [
-        ...prodCredentialFunctions,
-        ...devCredentialFunctions
-      ];
+      credentialFunctions = [...prodCredentialFunctions, ...devCredentialFunctions];
     }
 
     // Errors from individual credentials should not be thrown in the DefaultAzureCredential constructor, instead throwing on getToken() which is handled by ChainedTokenCredential.
@@ -286,7 +283,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
         return createCredentialFn(options);
       } catch (err: any) {
         logger.warning(
-          `Skipped ${createCredentialFn.name} because of an error creating the credential: ${err}`
+          `Skipped ${createCredentialFn.name} because of an error creating the credential: ${err}`,
         );
         return new UnavailableDefaultCredential(createCredentialFn.name, err.message);
       }

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -234,13 +234,13 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
   constructor(options?: DefaultAzureCredentialOptions) {
     // If AZURE_TOKEN_CREDENTIALS is not set, use the default credential chain.
-    const azureTokenCredentials = (process.env.AZURE_TOKEN_CREDENTIALS)?.toLowerCase();
-    let devCredentialFunctions = [
+    const azureTokenCredentials = process.env.AZURE_TOKEN_CREDENTIALS?.toLowerCase();
+    const devCredentialFunctions = [
       createDefaultAzureCliCredential,
       createDefaultAzurePowershellCredential,
       createDefaultAzureDeveloperCliCredential,
     ];
-    let prodCredentialFunctions = [
+    const prodCredentialFunctions = [
       createEnvironmentCredential,
       createDefaultWorkloadIdentityCredential,
       createDefaultManagedIdentityCredential,
@@ -259,12 +259,14 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
           credentialFunctions = prodCredentialFunctions;
           break;
         default:
-          // If AZURE_TOKEN_CREDENTIALS is set to an unsupported value, throw an error.
-          // We will throw an error here to prevent the creation of the DefaultAzureCredential.
-          // We will throw an error here to prevent the creation of the DefaultAzureCredential.
-          const errorMessage = `Invalid value for AZURE_TOKEN_CREDENTIALS = ${process.env.AZURE_TOKEN_CREDENTIALS}. Valid values are 'prod' or 'dev'.`;
-        logger.warning(errorMessage);
-        throw new Error(errorMessage);
+          {
+            // If AZURE_TOKEN_CREDENTIALS is set to an unsupported value, throw an error.
+            // We will throw an error here to prevent the creation of the DefaultAzureCredential.
+            // We will throw an error here to prevent the creation of the DefaultAzureCredential.
+            const errorMessage = `Invalid value for AZURE_TOKEN_CREDENTIALS = ${process.env.AZURE_TOKEN_CREDENTIALS}. Valid values are 'prod' or 'dev'.`;
+            logger.warning(errorMessage);
+            throw new Error(errorMessage);
+          }
       }
     }
     else {

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -234,7 +234,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
   constructor(options?: DefaultAzureCredentialOptions) {
     // If AZURE_TOKEN_CREDENTIALS is not set, use the default credential chain.
-    const azureTokenCredentials = process.env.AZURE_TOKEN_CREDENTIALS?.toLowerCase();
+    const azureTokenCredentials = (process.env.AZURE_TOKEN_CREDENTIALS)? (process.env.AZURE_TOKEN_CREDENTIALS.trim()).toLowerCase() : undefined;
     const devCredentialFunctions = [
       createDefaultAzureCliCredential,
       createDefaultAzurePowershellCredential,
@@ -261,7 +261,6 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
         default:
           {
             // If AZURE_TOKEN_CREDENTIALS is set to an unsupported value, throw an error.
-            // We will throw an error here to prevent the creation of the DefaultAzureCredential.
             // We will throw an error here to prevent the creation of the DefaultAzureCredential.
             const errorMessage = `Invalid value for AZURE_TOKEN_CREDENTIALS = ${process.env.AZURE_TOKEN_CREDENTIALS}. Valid values are 'prod' or 'dev'.`;
             logger.warning(errorMessage);

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -246,7 +246,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     // If AZURE_TOKEN_CREDENTIALS is set, use it to determine which credentials to use.
     // The value of AZURE_TOKEN_CREDENTIALS should be either "development" or "production".
     if (process.env.AZURE_TOKEN_CREDENTIALS) {
-      if (process.env.AZURE_TOKEN_CREDENTIALS.toLowerCase() === "production") {
+      if (process.env.AZURE_TOKEN_CREDENTIALS.toLowerCase() === "prod") {
         // If AZURE_TOKEN_CREDENTIALS is set to "production", use the production credential chain.
         credentialFunctions = [
           createEnvironmentCredential,

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -256,7 +256,6 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
       } else if (process.env.AZURE_TOKEN_CREDENTIALS.toLowerCase() === "dev") {
         // If AZURE_TOKEN_CREDENTIALS is set to "development", use the development credential chain.
         credentialFunctions = [
-          createEnvironmentCredential,
           createDefaultAzureCliCredential,
           createDefaultAzurePowershellCredential,
           createDefaultAzureDeveloperCliCredential,

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -263,13 +263,14 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
         ];
       } else {
         // If AZURE_TOKEN_CREDENTIALS is set to an unsupported value, throw an error.
+        // We will throw an error here to prevent the creation of the DefaultAzureCredential.
         const errorMessage = `Unsupported value set for the environment AZURE_TOKEN_CREDENTIALS = ${process.env.AZURE_TOKEN_CREDENTIALS}. Only supported values are "development" and "production". Cannot create DefaultAzureCredential.`;
         logger.warning(errorMessage);
         throw new Error(errorMessage);
       }
     }
 
-    // DefaultCredential constructors should not throw, instead throwing on getToken() which is handled by ChainedTokenCredential.
+    // Errors from individual credentials should not be thrown in the DefaultAzureCredential constructor, instead throwing on getToken() which is handled by ChainedTokenCredential.
     // When adding new credentials to the default chain, consider:
     // 1. Making the constructor parameters required and explicit
     // 2. Validating any required parameters in the factory function

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -234,7 +234,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
 
   constructor(options?: DefaultAzureCredentialOptions) {
     // If AZURE_TOKEN_CREDENTIALS is not set, use the default credential chain.
-    const azureTokenCredentials = (process.env.AZURE_TOKEN_CREDENTIALS)? (process.env.AZURE_TOKEN_CREDENTIALS.trim()).toLowerCase() : undefined;
+    const azureTokenCredentials = (process.env.AZURE_TOKEN_CREDENTIALS) ? (process.env.AZURE_TOKEN_CREDENTIALS.trim()).toLowerCase() : undefined;
     const devCredentialFunctions = [
       createDefaultAzureCliCredential,
       createDefaultAzurePowershellCredential,

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -253,7 +253,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
           createDefaultWorkloadIdentityCredential,
           createDefaultManagedIdentityCredential,
         ];
-      } else if (process.env.AZURE_TOKEN_CREDENTIALS.toLowerCase() === "development") {
+      } else if (process.env.AZURE_TOKEN_CREDENTIALS.toLowerCase() === "dev") {
         // If AZURE_TOKEN_CREDENTIALS is set to "development", use the development credential chain.
         credentialFunctions = [
           createEnvironmentCredential,

--- a/sdk/identity/identity/test/internal/node/defaultAzureCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/defaultAzureCredential.spec.ts
@@ -15,13 +15,13 @@ describe("DefaultAzureCredential", () => {
   it("should throw an error if AZURE_TOKEN_CREDENTIALS is set to an unsupported value", () => {
     process.env.AZURE_TOKEN_CREDENTIALS = "randomValue";
     expect(() => new DefaultAzureCredential()).toThrowError(
-      "Invalid value for AZURE_TOKEN_CREDENTIALS = randomValue. Valid values are 'prod' or 'dev'."
+      "Invalid value for AZURE_TOKEN_CREDENTIALS = randomValue. Valid values are 'prod' or 'dev'.",
     );
   });
-    it("should not throw an error if AZURE_TOKEN_CREDENTIALS is set to a supported value", () => {
-        process.env.AZURE_TOKEN_CREDENTIALS = "prod";
-        expect(() => new DefaultAzureCredential()).not.toThrowError();
-        process.env.AZURE_TOKEN_CREDENTIALS = "dev";
-        expect(() => new DefaultAzureCredential()).not.toThrowError();
-    });
-}); 
+  it("should not throw an error if AZURE_TOKEN_CREDENTIALS is set to a supported value", () => {
+    process.env.AZURE_TOKEN_CREDENTIALS = "prod";
+    expect(() => new DefaultAzureCredential()).not.toThrowError();
+    process.env.AZURE_TOKEN_CREDENTIALS = "dev";
+    expect(() => new DefaultAzureCredential()).not.toThrowError();
+  });
+});

--- a/sdk/identity/identity/test/internal/node/defaultAzureCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/defaultAzureCredential.spec.ts
@@ -3,7 +3,7 @@
 import { DefaultAzureCredential } from "../../../src/index.js";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
-describe.only("DefaultAzureCredential", () => {
+describe("DefaultAzureCredential", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -24,4 +24,4 @@ describe.only("DefaultAzureCredential", () => {
         process.env.AZURE_TOKEN_CREDENTIALS = "dev";
         expect(() => new DefaultAzureCredential()).not.toThrowError();
     });
-});
+}); 

--- a/sdk/identity/identity/test/internal/node/defaultAzureCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/defaultAzureCredential.spec.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { DefaultAzureCredential } from "../../../src/index.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+describe.only("DefaultAzureCredential", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create a DefaultAzureCredential instance", () => {
+    const credential = new DefaultAzureCredential();
+    expect(credential).toBeInstanceOf(DefaultAzureCredential);
+  });
+  it("should throw an error if AZURE_TOKEN_CREDENTIALS is set to an unsupported value", () => {
+    process.env.AZURE_TOKEN_CREDENTIALS = "randomValue";
+    expect(() => new DefaultAzureCredential()).toThrowError(
+      "Invalid value for AZURE_TOKEN_CREDENTIALS = randomValue. Valid values are 'prod' or 'dev'."
+    );
+  });
+    it("should not throw an error if AZURE_TOKEN_CREDENTIALS is set to a supported value", () => {
+        process.env.AZURE_TOKEN_CREDENTIALS = "prod";
+        expect(() => new DefaultAzureCredential()).not.toThrowError();
+        process.env.AZURE_TOKEN_CREDENTIALS = "dev";
+        expect(() => new DefaultAzureCredential()).not.toThrowError();
+    });
+});


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- Opt-in env var for DAC


### Are there test cases added in this PR? _(If not, why?)_



### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
