### PR TITLE
Downgrade dependency to unblock release

### DIFF
--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
-    "@azure/core-paging": "^1.6.3",
+    "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",


### PR DESCRIPTION
@azure/core-paging 1.6.3 is not released yet. Downgrade the dependency to unblock the release.

## Packages impacted by this PR
@azure/web-pubsub

