### PR TITLE
[core] log the non-http request before throwing error

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Log non-Https request before throwing error when Https url is expected in `bearerTokenAuthenticationPolicy`
+
 ## 1.20.0 (2025-05-01)
 
 ### Features Added

--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -9,6 +9,7 @@ import { createTokenCycler } from "../util/tokenCycler.js";
 import { logger as coreLogger } from "../log.js";
 import type { RestError } from "../restError.js";
 import { isRestError } from "../restError.js";
+import { Sanitizer } from "@typespec/ts-http-runtime/internal/util";
 
 /**
  * The programmatic identifier of the bearerTokenAuthenticationPolicy.
@@ -220,6 +221,8 @@ export function bearerTokenAuthenticationPolicy(
      */
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       if (!request.url.toLowerCase().startsWith("https://")) {
+        const sanitizer = new Sanitizer();
+        logger.info(`Bearer token authentication is not permitted for non-TLS protected (non-https) URLs. Request: ${sanitizer.sanitize(request)}`);
         throw new Error(
           "Bearer token authentication is not permitted for non-TLS protected (non-https) URLs.",
         );


### PR DESCRIPTION
This helps investigate issues in certain environments (AKS clusters for example.) Normally our LogPolicy would
log requests and responses. but in this case because LogPolicy is added after "Sign" phase, it is not executed.