### PR TITLE
Updating Communication Common SDK to version supporting Teams Phone Extensibility GA version

### DIFF
--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Release History
 
-## 2.3.2-beta.2 (Unreleased)
+## 2.4.0 (Unreleased)
 
 ### Features Added
+Introduced support for `TokenCredential` with `EntraCommunicationTokenCredentialOptions`, allowing an Entra user with a Teams license to use Teams Phone Extensibility features through the Azure Communication Services resource.
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added support for a new communication identifier `TeamsExtensionUserIdentifier`.
+    - Added a type `TeamsExtensionUserKind` with rawId in the format `8:acs:{resourceId}_{tenantId}_{userId}`.
+    - Added a method `isTeamsExtensionUserIdentifier` to check if the identifier is `TeamsExtensionUserIdentifier`.
+    - Mandatory fields of `TeamsExtensionUserIdentifier` are `userId`, `tenantId` and `resourceId`.
+    - With this version, rawId starting with `8:acs` may be either `CommunicationUserIdentifier` or new `TeamsExtensionUserIdentifier`.
+- Added optional fields `isAnonymous` and `assertedId` to the communication identifier `PhoneNumberIdentifier`.
+    - `isAnonymous` is used for anonymous numbers with rawId equals to `4:anonymous`.
+    - `assertedId` is used when the same number is used several times in the same call. It contains value after the last underscore (_)
+      character in the phone number. It is undefined otherwise.
 
 ## 2.3.2-beta.1 (2025-03-28)
 

--- a/sdk/communication/communication-common/README.md
+++ b/sdk/communication/communication-common/README.md
@@ -115,25 +115,8 @@ const tokenCredential = new AzureCommunicationTokenCredential({
 
 For scenarios where an Entra user can be used with Communication Services, you need to initialize any implementation of [TokenCredential interface](https://learn.microsoft.com/es-mx/javascript/api/@azure/core-auth/tokencredential?view=azure-node-latest) and provide it to the ``EntraCommunicationTokenCredentialOptions``.
 Along with this, you must provide the URI of the Azure Communication Services resource and the scopes required for the Entra user token. These scopes determine the permissions granted to the token.
-If the scopes are not provided, by default, it sets the scopes to `https://communication.azure.com/clients/.default`.
 
-```ts snippet:ReadmeSampleCredentialEntraUser 
-import { AzureCommunicationTokenCredential } from "@azure/communication-common";
-
-function fetchTokenFromMyServerForUser(user: string): Promise<string> {
-  // Your custom implementation to fetch a token for the user
-  return Promise.resolve("some-unique-token-for-" + user);
-}
-
-const tokenCredential = new AzureCommunicationTokenCredential({
-  tokenRefresher: async () => fetchTokenFromMyServerForUser("bob@contoso.com"),
-  refreshProactively: true,
-  token:
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjM2MDB9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-});
-```
-
-The same approach can be used for authorizing an Entra user with a Teams license to use Teams Phone Extensibility features through your Azure Communication Services resource.
+This approach needs to be used for authorizing an Entra user with a Teams license to use Teams Phone Extensibility features through your Azure Communication Services resource.
 This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope.
 
 ```ts snippet:ReadmeSampleCredentialEntraUserTeamsPhoneExtensibility 
@@ -158,6 +141,33 @@ const entraTokenCredentialOptions: EntraCommunicationTokenCredentialOptions = {
 
 const credential = new AzureCommunicationTokenCredential(entraTokenCredentialOptions);
 ```
+
+Other scenarios for Entra users to utilize Azure Communication Services are currently in the **preview stage only and should not be used in production**.
+The scopes for these scenarios follow the format `https://communication.azure.com/clients/<ACS Scope>`. If specific scopes are not provided, the default scopes will be set to `https://communication.azure.com/clients/.default`.
+
+```ts snippet:ReadmeSampleCredentialEntraUser 
+import { InteractiveBrowserCredential } from "@azure/identity";
+import {
+  EntraCommunicationTokenCredentialOptions,
+  AzureCommunicationTokenCredential,
+} from "@azure/communication-common";
+
+const options = {
+  tenantId: "<your-tenant-id>",
+  clientId: "<your-client-id>",
+  redirectUri: "<your-redirect-uri>",
+};
+const entraTokenCredential = new InteractiveBrowserCredential(options);
+
+const entraTokenCredentialOptions: EntraCommunicationTokenCredentialOptions = {
+  resourceEndpoint: "https://<your-resource>.communication.azure.com",
+  tokenCredential: entraTokenCredential,
+  scopes: ["https://communication.azure.com/clients/VoIP"],
+};
+
+const credential = new AzureCommunicationTokenCredential(entraTokenCredentialOptions);
+```
+
 ## Troubleshooting
 
 - **Invalid token specified**: Make sure the token you are passing to the `AzureCommunicationTokenCredential` constructor or to the `tokenRefresher` callback is a bare JWT token string. E.g. if you're using the [Azure Communication Identity library][invalid_token_sdk] or [REST API][invalid_token_rest] to obtain the token, make sure you're passing just the `token` part of the response object.

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-common",
-  "version": "2.3.2-beta.2",
+  "version": "2.4.0",
   "description": "Common package for Azure Communication services.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-common/src/entraTokenCredential.ts
+++ b/sdk/communication/communication-common/src/entraTokenCredential.ts
@@ -18,7 +18,7 @@ import {
 const TeamsExtensionScopePrefix = "https://auth.msft.communication.azure.com/";
 const CommunicationClientsScopePrefix = "https://communication.azure.com/clients/";
 const TeamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
-const TeamsExtensionApiVersion = "2025-03-02-preview";
+const TeamsExtensionApiVersion = "2025-06-30";
 const CommunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
 const CommunicationClientsApiVersion = "2025-03-02-preview";
 

--- a/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
+++ b/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
@@ -18,8 +18,7 @@ const acsToken = "acsToken";
 const comunicationClientsEndpoint =
   "/access/entra/:exchangeAccessToken?api-version=2025-03-02-preview";
 const communicationClientsScope = "https://communication.azure.com/clients/VoIP";
-const teamsExtensionEndpoint =
-  "/access/teamsExtension/:exchangeAccessToken?api-version=2025-06-30";
+const teamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken?api-version=2025-06-30";
 const teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
 
 const tokenCredential: TokenCredential = {

--- a/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
+++ b/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
@@ -19,7 +19,7 @@ const comunicationClientsEndpoint =
   "/access/entra/:exchangeAccessToken?api-version=2025-03-02-preview";
 const communicationClientsScope = "https://communication.azure.com/clients/VoIP";
 const teamsExtensionEndpoint =
-  "/access/teamsExtension/:exchangeAccessToken?api-version=2025-03-02-preview";
+  "/access/teamsExtension/:exchangeAccessToken?api-version=2025-06-30";
 const teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
 
 const tokenCredential: TokenCredential = {

--- a/sdk/communication/communication-common/test/snippets.spec.ts
+++ b/sdk/communication/communication-common/test/snippets.spec.ts
@@ -54,17 +54,21 @@ describe("snippets", () => {
   });
 
   it("ReadmeSampleCredentialEntraUser", async () => {
-    function fetchTokenFromMyServerForUser(user: string): Promise<string> {
-      // Your custom implementation to fetch a token for the user
-      return Promise.resolve("some-unique-token-for-" + user);
-    }
+    const options = {
+      tenantId: "<your-tenant-id>",
+      clientId: "<your-client-id>",
+      redirectUri: "<your-redirect-uri>",
+    };
+    const entraTokenCredential = new InteractiveBrowserCredential(options);
     // @ts-preserve-whitespace
-    const tokenCredential = new AzureCommunicationTokenCredential({
-      tokenRefresher: async () => fetchTokenFromMyServerForUser("bob@contoso.com"),
-      refreshProactively: true,
-      token:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjM2MDB9.adM-ddBZZlQ1WlN3pdPBOF5G4Wh9iZpxNP_fSvpF4cWs",
-    });
+    const entraTokenCredentialOptions: EntraCommunicationTokenCredentialOptions = {
+      resourceEndpoint: "https://<your-resource>.communication.azure.com",
+      tokenCredential: entraTokenCredential,
+      scopes: ["https://communication.azure.com/clients/VoIP"],
+    };
+    // @ts-preserve-whitespace
+    const credential = new AzureCommunicationTokenCredential(entraTokenCredentialOptions);
+
   });
 
   it("ReadmeSampleCredentialEntraUserTeamsPhoneExtensibility", async () => {

--- a/sdk/communication/communication-common/test/snippets.spec.ts
+++ b/sdk/communication/communication-common/test/snippets.spec.ts
@@ -68,7 +68,6 @@ describe("snippets", () => {
     };
     // @ts-preserve-whitespace
     const credential = new AzureCommunicationTokenCredential(entraTokenCredentialOptions);
-
   });
 
   it("ReadmeSampleCredentialEntraUserTeamsPhoneExtensibility", async () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/communication-common

### Issues associated with this PR


### Describe the problem that is addressed by this PR
ACS Auth TeamsExtension REST API moved to GA.
This PR updates the Communication Common SDK to use the GA version of the TeamsExtension REST API for token exchange and prepares the SDK for major release.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
