### PR TITLE
[credscan] move storage-file-datalake test acl id into fakeTestSecrets

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -34,6 +34,7 @@
         "sdk/batch/batch-rest/test/utils/fakeTestSecrets.ts",
         "sdk/cosmosdb/cosmos/test/public/common/_fakeTestSecrets.ts",
         "sdk/storage/storage-blob/test/utils/fakeTestSecrets.ts",
+        "sdk/storage/storage-file-datalake/test/utils/fakeTestSecrets.ts",
         "sdk/servicebus/service-bus/test/public/fakeTestSecrets.ts",
         "sdk/tables/data-tables/test/internal/fakeTestSecrets.ts",
         "sdk/test-utils/test-utils/src/fakeTestSecrets.ts",

--- a/sdk/storage/storage-file-datalake/test/node/filesystemclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/filesystemclient.spec.ts
@@ -22,6 +22,7 @@ import { getDataLakeServiceAccountAudience } from "../../src/models.js";
 import { assertClientUsesTokenCredential } from "../utils/assert.js";
 import { createTestCredential } from "@azure-tools/test-credential";
 import { describe, it, assert, beforeEach, afterEach } from "vitest";
+import { aclIdForTest } from "../utils/fakeTestSecrets.js";
 
 describe("DataLakeFileSystemClient Node.js only", () => {
   let fileSystemName: string;
@@ -114,7 +115,7 @@ describe("DataLakeFileSystemClient Node.js only", () => {
           permissions: FileSystemSASPermissions.parse("rwd").toString(),
           startsOn: new Date("2017-12-31T11:22:33.4567890Z"),
         },
-        id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+        id: aclIdForTest,
       },
     ];
 
@@ -138,7 +139,7 @@ describe("DataLakeFileSystemClient Node.js only", () => {
           permissions: FileSystemSASPermissions.parse("rwd").toString(),
           startsOn: new Date("2017-12-31T11:22:33.4567890Z"),
         },
-        id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+        id: aclIdForTest,
       },
     ];
 
@@ -155,7 +156,7 @@ describe("DataLakeFileSystemClient Node.js only", () => {
         accessPolicy: {
           permissions: FileSystemSASPermissions.parse("rwd").toString(),
         },
-        id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+        id: aclIdForTest,
       },
     ];
 

--- a/sdk/storage/storage-file-datalake/test/utils/fakeTestSecrets.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/fakeTestSecrets.ts
@@ -7,3 +7,5 @@ export const Test_CPK_INFO: CpkInfo = {
   encryptionKey: "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=", // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="This is a fake secret")]
   encryptionKeySha256: "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=", // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="This is a fake secret")]
 };
+
+export const aclIdForTest = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=";


### PR DESCRIPTION
It is not a secret and can be suppressed.