### PR TITLE
[storage] allow publishing @azure/storage-common

### DIFF
--- a/sdk/storage/storage-common/package.json
+++ b/sdk/storage/storage-common/package.json
@@ -2,7 +2,6 @@
   "name": "@azure/storage-common",
   "sdk-type": "client",
   "sideEffects": false,
-  "private": true,
   "author": "Microsoft Corporation",
   "version": "12.0.0-beta.1",
   "description": "Azure Storage Common Client Library for JavaScript",


### PR DESCRIPTION
- remove the `"private": true` field from its package.json
