### PR TITLE
[core] fix AZURE_LOG_LEVEL environment variable not being properly respected

### DIFF
--- a/sdk/core/ts-http-runtime/src/logger/logger.ts
+++ b/sdk/core/ts-http-runtime/src/logger/logger.ts
@@ -140,6 +140,24 @@ export function createLoggerContext(options: CreateLoggerContextOptions): Logger
     debug.log(...args);
   };
 
+  function setLogLevel(level?: TypeSpecRuntimeLogLevel): void {
+    if (level && !isTypeSpecRuntimeLogLevel(level)) {
+      throw new Error(
+        `Unknown log level '${level}'. Acceptable values: ${TYPESPEC_RUNTIME_LOG_LEVELS.join(",")}`,
+      );
+    }
+    logLevel = level;
+
+    const enabledNamespaces = [];
+    for (const logger of registeredLoggers) {
+      if (shouldEnable(logger)) {
+        enabledNamespaces.push(logger.namespace);
+      }
+    }
+
+    debug.enable(enabledNamespaces.join(","));
+  }
+
   if (logLevelFromEnv) {
     // avoid calling setLogLevel because we don't want a mis-set environment variable to crash
     if (isTypeSpecRuntimeLogLevel(logLevelFromEnv)) {
@@ -177,37 +195,25 @@ export function createLoggerContext(options: CreateLoggerContextOptions): Logger
     return logger;
   }
 
+  function getLogLevel(): TypeSpecRuntimeLogLevel | undefined {
+    return logLevel;
+  }
+
+  function createClientLogger(namespace: string): TypeSpecRuntimeLogger {
+    const clientRootLogger: TypeSpecRuntimeClientLogger = clientLogger.extend(namespace);
+    patchLogMethod(clientLogger, clientRootLogger);
+    return {
+      error: createLogger(clientRootLogger, "error"),
+      warning: createLogger(clientRootLogger, "warning"),
+      info: createLogger(clientRootLogger, "info"),
+      verbose: createLogger(clientRootLogger, "verbose"),
+    };
+  }
+
   return {
-    setLogLevel(level?: TypeSpecRuntimeLogLevel): void {
-      if (level && !isTypeSpecRuntimeLogLevel(level)) {
-        throw new Error(
-          `Unknown log level '${level}'. Acceptable values: ${TYPESPEC_RUNTIME_LOG_LEVELS.join(",")}`,
-        );
-      }
-      logLevel = level;
-
-      const enabledNamespaces = [];
-      for (const logger of registeredLoggers) {
-        if (shouldEnable(logger)) {
-          enabledNamespaces.push(logger.namespace);
-        }
-      }
-
-      debug.enable(enabledNamespaces.join(","));
-    },
-    getLogLevel(): TypeSpecRuntimeLogLevel | undefined {
-      return logLevel;
-    },
-    createClientLogger(namespace: string): TypeSpecRuntimeLogger {
-      const clientRootLogger: TypeSpecRuntimeClientLogger = clientLogger.extend(namespace);
-      patchLogMethod(clientLogger, clientRootLogger);
-      return {
-        error: createLogger(clientRootLogger, "error"),
-        warning: createLogger(clientRootLogger, "warning"),
-        info: createLogger(clientRootLogger, "info"),
-        verbose: createLogger(clientRootLogger, "verbose"),
-      };
-    },
+    setLogLevel,
+    getLogLevel,
+    createClientLogger,
     logger: clientLogger,
   };
 }


### PR DESCRIPTION
### Packages impacted by this PR

- `@typespec/ts-http-runtime`

### Describe the problem that is addressed by this PR

I noticed that setting `AZURE_LOG_LEVEL` was not updating the log level properly. This was because when updating the log level to reflect the environment variable value in `createLoggerContext`, we were calling the top-level `setLogLevel` instead of the context's setLogLevel function (so effectively, we were updating the unbranded log level instead of the Azure one like we should have been). This PR fixes that behavior by defining `setLogLevel` in `createLoggerContext` instead of defining it inline at the return site, so that the correct version of `setLogLevel` is called when we read the environment variable.