### PR TITLE
[Monitor OpenTelemetry Exporter] Do Not Export Zero Value Statsbeat

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.32 ()
+
+### Other Changes
+
+- No longer send statsbeat counters when values are zero.
+
 ## 1.0.0-beta.31 (2025-04-16)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -147,7 +147,8 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
   private getEnvironmentStatus(observableResult: BatchObservableResult): void {
     this.setFeatures();
     let attributes;
-    if (this.instrumentation) {
+    // Only send instrumentation statsbeat if value is greater than zero
+    if (this.instrumentation > 0) {
       attributes = {
         ...this.commonProperties,
         feature: this.instrumentation,
@@ -156,7 +157,8 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
       observableResult.observe(this.featureStatsbeatGauge, 1, { ...attributes });
     }
 
-    if (this.feature) {
+    // Only send feature statsbeat if value is greater than zero
+    if (this.feature > 0) {
       attributes = {
         ...this.commonProperties,
         feature: this.feature,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -170,9 +170,12 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
   // Observable gauge callbacks
   private successCallback(observableResult: ObservableResult): void {
     const counter: NetworkStatsbeat = this.getNetworkStatsbeatCounter(this.endpointUrl, this.host);
-    const attributes = { ...this.commonProperties, ...this.networkProperties };
-    observableResult.observe(counter.totalSuccessfulRequestCount, attributes);
-    counter.totalSuccessfulRequestCount = 0;
+    // Only send metrics if count is greater than zero
+    if (counter.totalSuccessfulRequestCount > 0) {
+      const attributes = { ...this.commonProperties, ...this.networkProperties };
+      observableResult.observe(counter.totalSuccessfulRequestCount, attributes);
+      counter.totalSuccessfulRequestCount = 0;
+    }
   }
 
   private failureCallback(observableResult: BatchObservableResult): void {
@@ -186,11 +189,14 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
 
     // For each { statusCode -> count } mapping, call observe, passing the count and attributes that include the statusCode
     for (let i = 0; i < counter.totalFailedRequestCount.length; i++) {
-      attributes.statusCode = counter.totalFailedRequestCount[i].statusCode;
-      observableResult.observe(this.failureCountGauge, counter.totalFailedRequestCount[i].count, {
-        ...attributes,
-      });
-      counter.totalFailedRequestCount[i].count = 0;
+      // Only send metrics if count is greater than zero
+      if (counter.totalFailedRequestCount[i].count > 0) {
+        attributes.statusCode = counter.totalFailedRequestCount[i].statusCode;
+        observableResult.observe(this.failureCountGauge, counter.totalFailedRequestCount[i].count, {
+          ...attributes,
+        });
+        counter.totalFailedRequestCount[i].count = 0;
+      }
     }
   }
 
@@ -199,11 +205,14 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     const attributes = { ...this.networkProperties, ...this.commonProperties, statusCode: 0 };
 
     for (let i = 0; i < counter.retryCount.length; i++) {
-      attributes.statusCode = counter.retryCount[i].statusCode;
-      observableResult.observe(this.retryCountGauge, counter.retryCount[i].count, {
-        ...attributes,
-      });
-      counter.retryCount[i].count = 0;
+      // Only send metrics if count is greater than zero
+      if (counter.retryCount[i].count > 0) {
+        attributes.statusCode = counter.retryCount[i].statusCode;
+        observableResult.observe(this.retryCountGauge, counter.retryCount[i].count, {
+          ...attributes,
+        });
+        counter.retryCount[i].count = 0;
+      }
     }
   }
 
@@ -212,11 +221,14 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     const attributes = { ...this.networkProperties, ...this.commonProperties, statusCode: 0 };
 
     for (let i = 0; i < counter.throttleCount.length; i++) {
-      attributes.statusCode = counter.throttleCount[i].statusCode;
-      observableResult.observe(this.throttleCountGauge, counter.throttleCount[i].count, {
-        ...attributes,
-      });
-      counter.throttleCount[i].count = 0;
+      // Only send metrics if count is greater than zero
+      if (counter.throttleCount[i].count > 0) {
+        attributes.statusCode = counter.throttleCount[i].statusCode;
+        observableResult.observe(this.throttleCountGauge, counter.throttleCount[i].count, {
+          ...attributes,
+        });
+        counter.throttleCount[i].count = 0;
+      }
     }
   }
 
@@ -225,11 +237,14 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     const attributes = { ...this.networkProperties, ...this.commonProperties, exceptionType: "" };
 
     for (let i = 0; i < counter.exceptionCount.length; i++) {
-      attributes.exceptionType = counter.exceptionCount[i].exceptionType;
-      observableResult.observe(this.exceptionCountGauge, counter.exceptionCount[i].count, {
-        ...attributes,
-      });
-      counter.exceptionCount[i].count = 0;
+      // Only send metrics if count is greater than zero
+      if (counter.exceptionCount[i].count > 0) {
+        attributes.exceptionType = counter.exceptionCount[i].exceptionType;
+        observableResult.observe(this.exceptionCountGauge, counter.exceptionCount[i].count, {
+          ...attributes,
+        });
+        counter.exceptionCount[i].count = 0;
+      }
     }
   }
 
@@ -241,32 +256,47 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
       currentCounter.time = Number(new Date());
       const intervalRequests =
         currentCounter.totalRequestCount - currentCounter.lastRequestCount || 0;
-      currentCounter.averageRequestExecutionTime =
-        (currentCounter.intervalRequestExecutionTime -
-          currentCounter.lastIntervalRequestExecutionTime) /
-          intervalRequests || 0;
-      currentCounter.lastIntervalRequestExecutionTime = currentCounter.intervalRequestExecutionTime; // reset
 
+      // Only calculate average if there were actual requests
+      if (intervalRequests > 0) {
+        currentCounter.averageRequestExecutionTime =
+          (currentCounter.intervalRequestExecutionTime -
+            currentCounter.lastIntervalRequestExecutionTime) /
+            intervalRequests || 0;
+      } else {
+        currentCounter.averageRequestExecutionTime = 0;
+      }
+
+      currentCounter.lastIntervalRequestExecutionTime = currentCounter.intervalRequestExecutionTime; // reset
       currentCounter.lastRequestCount = currentCounter.totalRequestCount;
       currentCounter.lastTime = currentCounter.time;
     }
-    observableResult.observe(counter.averageRequestExecutionTime, attributes);
 
-    counter.averageRequestExecutionTime = 0;
+    // Only report if there's a non-zero average duration
+    if (counter.averageRequestExecutionTime > 0) {
+      observableResult.observe(counter.averageRequestExecutionTime, attributes);
+      counter.averageRequestExecutionTime = 0;
+    }
   }
 
   private readFailureCallback(observableResult: ObservableResult): void {
     const counter: NetworkStatsbeat = this.getNetworkStatsbeatCounter(this.endpointUrl, this.host);
-    const attributes = { ...this.commonProperties, ...this.networkProperties };
-    observableResult.observe(counter.totalReadFailureCount, attributes);
-    counter.totalReadFailureCount = 0;
+    // Only send metrics if count is greater than zero
+    if (counter.totalReadFailureCount > 0) {
+      const attributes = { ...this.commonProperties, ...this.networkProperties };
+      observableResult.observe(counter.totalReadFailureCount, attributes);
+      counter.totalReadFailureCount = 0;
+    }
   }
 
   private writeFailureCallback(observableResult: ObservableResult): void {
     const counter: NetworkStatsbeat = this.getNetworkStatsbeatCounter(this.endpointUrl, this.host);
-    const attributes = { ...this.commonProperties, ...this.networkProperties };
-    observableResult.observe(counter.totalWriteFailureCount, attributes);
-    counter.totalWriteFailureCount = 0;
+    // Only send metrics if count is greater than zero
+    if (counter.totalWriteFailureCount > 0) {
+      const attributes = { ...this.commonProperties, ...this.networkProperties };
+      observableResult.observe(counter.totalWriteFailureCount, attributes);
+      counter.totalWriteFailureCount = 0;
+    }
   }
 
   // Public methods to increase counters

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -312,7 +312,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const scopeMetrics = resourceMetrics.scopeMetrics;
         assert.strictEqual(scopeMetrics.length, 1, "Scope Metrics count");
         const metrics = scopeMetrics[0].metrics;
-        assert.strictEqual(metrics.length, 8, "Metrics count");
+        assert.strictEqual(metrics.length, 6, "Metrics count");
         assert.strictEqual(metrics[0].descriptor.name, StatsbeatCounter.SUCCESS_COUNT);
         assert.strictEqual(metrics[1].descriptor.name, StatsbeatCounter.FAILURE_COUNT);
         assert.strictEqual(metrics[2].descriptor.name, StatsbeatCounter.RETRY_COUNT);
@@ -420,6 +420,49 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         delete process.env.STATSBEAT_INSTRUMENTATIONS;
         delete process.env.STATSBEAT_FEATURES;
         delete process.env.LONG_INTERVAL_EXPORT_MILLIS;
+      });
+
+      it("should not export zero value statsbeats", async () => {
+        // Create a new statsbeat instance to avoid interference from other tests
+        const zeroStatsbeat = new NetworkStatsbeatMetrics({
+          ...options,
+          networkCollectionInterval: 100,
+        });
+        
+        try {
+          // Spy on the exporter's export method
+          const mockExport = vi.spyOn(zeroStatsbeat["networkAzureExporter"], "export");
+
+          zeroStatsbeat.countSuccess(0);
+          
+          // Wait for the export interval to trigger without adding any counts
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          
+          // Check that export was called
+          expect(mockExport).toHaveBeenCalled();
+          
+          // Get the metrics that were exported
+          const resourceMetrics = mockExport.mock.calls[0][0];
+          const scopeMetrics = resourceMetrics.scopeMetrics;
+          assert.strictEqual(scopeMetrics.length, 1, "Scope Metrics count");
+          
+          // Check the metrics - there should be 0 data points for most metrics
+          // since we're now filtering zero values
+          const metrics = scopeMetrics[0].metrics;
+          
+          // Check each metric to ensure zero values are filtered out
+          for (const metric of metrics) {
+            // We expect all metrics to have no data points as they all have zero values
+            assert.strictEqual(
+              metric.dataPoints.length, 
+              1, 
+              `${metric.descriptor.name} should have no data points apart from success since all other values are zero`
+            );
+          }
+        } finally {
+          // Clean up
+          await zeroStatsbeat.shutdown();
+        }
       });
     });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -428,35 +428,35 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           ...options,
           networkCollectionInterval: 100,
         });
-        
+
         try {
           // Spy on the exporter's export method
           const mockExport = vi.spyOn(zeroStatsbeat["networkAzureExporter"], "export");
 
           zeroStatsbeat.countSuccess(0);
-          
+
           // Wait for the export interval to trigger without adding any counts
           await new Promise((resolve) => setTimeout(resolve, 500));
-          
+
           // Check that export was called
           expect(mockExport).toHaveBeenCalled();
-          
+
           // Get the metrics that were exported
           const resourceMetrics = mockExport.mock.calls[0][0];
           const scopeMetrics = resourceMetrics.scopeMetrics;
           assert.strictEqual(scopeMetrics.length, 1, "Scope Metrics count");
-          
+
           // Check the metrics - there should be 0 data points for most metrics
           // since we're now filtering zero values
           const metrics = scopeMetrics[0].metrics;
-          
+
           // Check each metric to ensure zero values are filtered out
           for (const metric of metrics) {
             // We expect all metrics to have no data points as they all have zero values
             assert.strictEqual(
-              metric.dataPoints.length, 
-              1, 
-              `${metric.descriptor.name} should have no data points apart from success since all other values are zero`
+              metric.dataPoints.length,
+              1,
+              `${metric.descriptor.name} should have no data points apart from success since all other values are zero`,
             );
           }
         } finally {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
We should not send network/instrumentation/feature statsbeat when counts are zero.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
