### PR TITLE
[EngSys] move key vault vitest timeout to config files 

### DIFF
--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -48,7 +48,7 @@
     "pack": "npm pack 2>&1",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo Skipped",
-    "test:node": "dev-tool run test:vitest -- --test-timeout 100000 --hook-timeout 100000",
+    "test:node": "dev-tool run test:vitest",
     "test:node:esm": "echo skipped",
     "test:node:live": "dev-tool run vendored cross-env TEST_MODE=live dev-tool run test:vitest --no-test-proxy --esm",
     "update-snippets": "dev-tool run update-snippets"

--- a/sdk/keyvault/keyvault-admin/vitest.config.ts
+++ b/sdk/keyvault/keyvault-admin/vitest.config.ts
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      testTimeout: 100000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -45,8 +45,8 @@
     "pack": "npm pack 2>&1",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
-    "test:node": "dev-tool run test:vitest -- --test-timeout 100000 --hook-timeout 100000",
-    "test:node:esm": "dev-tool run test:vitest --no-test-proxy --esm -- --test-timeout 350000",
+    "test:node": "dev-tool run test:vitest",
+    "test:node:esm": "dev-tool run test:vitest --no-test-proxy --esm",
     "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,

--- a/sdk/keyvault/keyvault-certificates/vitest.config.ts
+++ b/sdk/keyvault/keyvault-certificates/vitest.config.ts
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      testTimeout: 100000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-certificates/vitest.esm.config.ts
+++ b/sdk/keyvault/keyvault-certificates/vitest.esm.config.ts
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { mergeConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
-export default mergeConfig(vitestConfig, vitestEsmConfig);
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig,
+  defineConfig({
+    test: {
+      testTimeout: 350000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-certificates/vitest.esm.config.ts
+++ b/sdk/keyvault/keyvault-certificates/vitest.esm.config.ts
@@ -6,8 +6,10 @@ import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
 export default mergeConfig(
-  vitestConfig,
-  vitestEsmConfig,
+  mergeConfig(
+    vitestConfig,
+    vitestEsmConfig,
+  ),
   defineConfig({
     test: {
       testTimeout: 350000,

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -45,8 +45,8 @@
     "pack": "npm pack 2>&1",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
-    "test:node": "dev-tool run test:vitest -- --test-timeout 100000 --hook-timeout 100000",
-    "test:node:esm": "dev-tool run test:vitest --no-test-proxy --esm -- --test-timeout 5000000 --hook-timeout 100000",
+    "test:node": "dev-tool run test:vitest",
+    "test:node:esm": "dev-tool run test:vitest --no-test-proxy --esm",
     "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,

--- a/sdk/keyvault/keyvault-keys/vitest.config.ts
+++ b/sdk/keyvault/keyvault-keys/vitest.config.ts
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      testTimeout: 100000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-keys/vitest.esm.config.ts
+++ b/sdk/keyvault/keyvault-keys/vitest.esm.config.ts
@@ -6,8 +6,10 @@ import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
 export default mergeConfig(
-  vitestConfig,
-  vitestEsmConfig,
+  mergeConfig(
+    vitestConfig,
+    vitestEsmConfig,
+  ),
   defineConfig({
     test: {
       testTimeout: 5000000,

--- a/sdk/keyvault/keyvault-keys/vitest.esm.config.ts
+++ b/sdk/keyvault/keyvault-keys/vitest.esm.config.ts
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { mergeConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
-export default mergeConfig(vitestConfig, vitestEsmConfig);
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig,
+  defineConfig({
+    test: {
+      testTimeout: 5000000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -45,8 +45,8 @@
     "pack": "npm pack 2>&1",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
-    "test:node": "dev-tool run test:vitest -- --test-timeout 250000",
-    "test:node:esm": "dev-tool run test:vitest --no-test-proxy --esm -- --test-timeout 350000",
+    "test:node": "dev-tool run test:vitest",
+    "test:node:esm": "dev-tool run test:vitest --no-test-proxy --esm",
     "update-snippets": "dev-tool run update-snippets"
   },
   "sideEffects": false,

--- a/sdk/keyvault/keyvault-secrets/vitest.config.ts
+++ b/sdk/keyvault/keyvault-secrets/vitest.config.ts
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      testTimeout: 250000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-secrets/vitest.esm.config.ts
+++ b/sdk/keyvault/keyvault-secrets/vitest.esm.config.ts
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { mergeConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
 import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
-export default mergeConfig(vitestConfig, vitestEsmConfig);
+export default mergeConfig(
+  vitestConfig,
+  vitestEsmConfig,
+  defineConfig({
+    test: {
+      testTimeout: 350000,
+      hookTimeout: 100000,
+    },
+  }),
+);

--- a/sdk/keyvault/keyvault-secrets/vitest.esm.config.ts
+++ b/sdk/keyvault/keyvault-secrets/vitest.esm.config.ts
@@ -6,8 +6,10 @@ import vitestConfig from "./vitest.config.ts";
 import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
 
 export default mergeConfig(
-  vitestConfig,
-  vitestEsmConfig,
+  mergeConfig(
+    vitestConfig,
+    vitestEsmConfig,
+  ),
   defineConfig({
     test: {
       testTimeout: 350000,


### PR DESCRIPTION
Like most of packages do so testing NPM scripts are cleaner.