### PR TITLE
[containerregistry] use Microsoft images for test resource deployment

### DIFF
--- a/sdk/containerregistry/test-resources-post.ps1
+++ b/sdk/containerregistry/test-resources-post.ps1
@@ -8,20 +8,20 @@ param (
 Import-AzContainerRegistryImage `
     -ResourceGroupName $DeploymentOutputs['CONTAINERREGISTRY_RESOURCE_GROUP'] `
     -RegistryName $DeploymentOutputs['CONTAINER_REGISTRY_NAME'] `
-    -SourceImage 'library/busybox' -SourceRegistryUri 'registry.hub.docker.com' `
+    -SourceImage 'mcr/hello-world' -SourceRegistryUri 'mcr.microsoft.com' `
     -Mode 'Force' `
     -TargetTag 'library/busybox:latest'
 
 Import-AzContainerRegistryImage `
     -ResourceGroupName $DeploymentOutputs['CONTAINERREGISTRY_RESOURCE_GROUP'] `
     -RegistryName $DeploymentOutputs['CONTAINER_REGISTRY_NAME'] `
-    -SourceImage 'library/hello-world' -SourceRegistryUri 'registry.hub.docker.com' `
+    -SourceImage 'mcr/hello-world' -SourceRegistryUri 'mcr.microsoft.com' `
     -Mode 'Force' `
     -TargetTag 'library/hello-world:test1','library/hello-world:test-delete'
 
 Import-AzContainerRegistryImage `
     -ResourceGroupName $DeploymentOutputs['CONTAINERREGISTRY_RESOURCE_GROUP'] `
     -RegistryName $DeploymentOutputs['CONTAINER_REGISTRY_ANONYMOUS_NAME'] `
-    -SourceImage 'library/hello-world' -SourceRegistryUri 'registry.hub.docker.com' `
+    -SourceImage 'mcr/hello-world' -SourceRegistryUri 'mcr.microsoft.com' `
     -Mode 'Force' `
     -TargetTag 'library/hello-world:latest','library/hello-world:v1','library/hello-world:v2','library/hello-world:v3','library/hello-world:v4'


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/container-registry`

### Issues associated with this PR

- Fix #34390

### Describe the problem that is addressed by this PR

We were getting rate limited by Docker Hub so switching over to MCR. Just using the same image for everything since we don't actually care about the image content in our tests.

