### PR TITLE
[dev-tool] ignore CHANGELOG.md from update-snippets

### DIFF
--- a/common/tools/dev-tool/src/commands/run/update-snippets.ts
+++ b/common/tools/dev-tool/src/commands/run/update-snippets.ts
@@ -51,7 +51,11 @@ interface SnippetLocationInfo {
 async function* getAllSnippetFiles(dir: string): AsyncIterable<string> {
   // Only consider markdown files up to a depth of 1 (i.e. _in_ the project folder). This is to prevent grabbing things
   // like samples/*/README.md and other similar files that are not really part of the "source" of the package.
-  yield* findMatchingFiles(dir, (name) => name.endsWith(".md"), { maxDepth: 1 });
+  yield* findMatchingFiles(
+    dir,
+    (name) => name.endsWith(".md") && name.toLowerCase() !== "changelog.md",
+    { maxDepth: 1 },
+  );
 
   if (existsSync(path.join(dir, "src"))) {
     yield* findMatchingFiles(path.join(dir, "src"), (name) => name.endsWith(".ts"));

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 1.9.1 (Unreleased)

--- a/sdk/core/abort-controller/CHANGELOG.md
+++ b/sdk/core/abort-controller/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 2.1.3 (Unreleased)

--- a/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->"
-
 # Release History
 
 ## 2.0.1 (2025-05-13)

--- a/sdk/documentintelligence/ai-document-intelligence-rest/CHANGELOG.md
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 1.1.0 (2025-05-08)

--- a/sdk/documentintelligence/ai-document-intelligence-rest/README.md
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/README.md
@@ -92,8 +92,10 @@ const client = DocumentIntelligence(process.env["DOCUMENT_INTELLIGENCE_ENDPOINT"
 
 Connect to alternative Azure cloud environments (such as Azure China or Azure Government) by specifying the `scopes` field in the `credentials` option and use the appropriate value from `KnownDocumentIntelligenceAudience`.
 
-```ts
-import DocumentIntelligence, { KnownDocumentIntelligenceAudience } from "@azure-rest/ai-document-intelligence";
+```ts snippet:ReadmeSampleCreateClient_SovereignClouds
+import DocumentIntelligence, {
+  KnownDocumentIntelligenceAudience,
+} from "@azure-rest/ai-document-intelligence";
 import { DefaultAzureCredential } from "@azure/identity";
 
 const client = DocumentIntelligence(
@@ -102,9 +104,9 @@ const client = DocumentIntelligence(
   {
     credentials: {
       // Use the correct audience for your cloud environment
-      scopes: [KnownDocumentIntelligenceAudience.AzureGovernment]
-    }
-  }
+      scopes: [KnownDocumentIntelligenceAudience.AzureGovernment],
+    },
+  },
 );
 ```
 

--- a/sdk/documentintelligence/ai-document-intelligence-rest/test/snippets.spec.ts
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/test/snippets.spec.ts
@@ -4,6 +4,7 @@
 import DocumentIntelligence, {
   AnalyzeOperationOutput,
   DocumentClassifierBuildOperationDetailsOutput,
+  KnownDocumentIntelligenceAudience,
   getLongRunningPoller,
   isUnexpected,
   paginate,
@@ -337,6 +338,19 @@ describe("snippets", () => {
     for await (const model of paginate(client, response)) {
       console.log(model.modelId);
     }
+  });
+
+  it("ReadmeSampleCreateClient_SovereignClouds", () => {
+    const client = DocumentIntelligence(
+      process.env["DOCUMENT_INTELLIGENCE_ENDPOINT"],
+      new DefaultAzureCredential(),
+      {
+        credentials: {
+          // Use the correct audience for your cloud environment
+          scopes: [KnownDocumentIntelligenceAudience.AzureGovernment],
+        },
+      },
+    );
   });
 
   it("SetLogLevel", async () => {

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 6.0.1 (Unreleased)

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -79,8 +79,6 @@
 
 - Allow certain response headers to be logged in `AzurePipelinesCredential` for diagnostics and include them in the error message [#31209](https://github.com/Azure/azure-sdk-for-js/pull/31209)
 
-<!-- dev-tool snippets ignore -->
-
 ## 4.5.0-beta.3 (2024-09-18)
 
 ### Features Added

--- a/sdk/keyvault/keyvault-admin/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-admin/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 4.7.0-beta.2 (Unreleased)

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 4.10.0-beta.2 (Unreleased)

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 4.10.0-beta.2 (Unreleased)

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 4.10.0-beta.2 (Unreleased)

--- a/sdk/openai/openai/CHANGELOG.md
+++ b/sdk/openai/openai/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 2.1.0-beta.1 (2025-04-02)

--- a/sdk/quantum/quantum-jobs/CHANGELOG.md
+++ b/sdk/quantum/quantum-jobs/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 1.0.0-beta.2 (Unreleased)

--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 1.4.0-beta.1 (Unreleased)

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 7.10.0 (Unreleased)

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 12.28.0-beta.2 (2025-05-20)

--- a/sdk/storage/storage-common/CHANGELOG.md
+++ b/sdk/storage/storage-common/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 12.0.0-beta.2 (2025-05-20)

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 12.28.0-beta.1 (2025-05-20)

--- a/sdk/storage/storage-queue/CHANGELOG.md
+++ b/sdk/storage/storage-queue/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 12.27.0-beta.1 (2025-05-20)

--- a/sdk/tables/data-tables/CHANGELOG.md
+++ b/sdk/tables/data-tables/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 13.3.1 (2025-05-06)

--- a/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
+++ b/sdk/web-pubsub/web-pubsub-express/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- dev-tool snippets ignore -->
-
 # Release History
 
 ## 1.0.6 (2025-02-26)


### PR DESCRIPTION
It's not a scenario where we would need to keep code blocks in sync with
snippets in snippets.spec.ts. This PR changes to ignore change log files so that
we don't have to add the ignore directive to every CHANGELOG.md.