### PR TITLE
[EventHubs] fix typecheck tests

### DIFF
--- a/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventHubConsumerClient.spec.ts
@@ -451,7 +451,7 @@ describe("EventHubConsumerClient", () => {
       clients.push(createConsumer().consumer);
 
       const startPosition = await getStartingPositionsForTests(clients[0]);
-      for (const partitionId of await partitionIds) {
+      for (const partitionId of partitionIds) {
         const subscription = clients[0].subscribe(partitionId, tester, { startPosition });
         subscriptions.push(subscription);
       }

--- a/sdk/eventhub/event-hubs/test/public/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/receiver.spec.ts
@@ -11,6 +11,7 @@ import type {
 import { earliestEventPosition, latestEventPosition } from "../../src/index.js";
 import debugModule from "debug";
 import { should } from "../utils/chai.js";
+import "../utils/chai.js";
 import { describe, it, afterEach, beforeEach } from "vitest";
 import { createConsumer, createProducer } from "../utils/clients.js";
 

--- a/sdk/eventhub/event-hubs/test/utils/chai.ts
+++ b/sdk/eventhub/event-hubs/test/utils/chai.ts
@@ -11,3 +11,9 @@ chai.use(chaiExclude);
 chai.use(chaiAzure);
 const should = shouldFn();
 export { should, expect, assert };
+
+declare global {
+  interface Object {
+    should: Chai.Assertion;
+  }
+}

--- a/sdk/eventhub/eventhubs-checkpointstore-table/test/public/tables-checkpointstore.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/test/public/tables-checkpointstore.spec.ts
@@ -8,6 +8,8 @@ import { TableCheckpointStore } from "../../src/index.js";
 import debugModule from "debug";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { should } from "../util/chai.js";
+import "../util/chai.js";
+
 import { createClients } from "../util/clients.js";
 import { addToOffset } from "../util/testUtils.js";
 

--- a/sdk/eventhub/eventhubs-checkpointstore-table/test/util/chai.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/test/util/chai.ts
@@ -7,3 +7,9 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const should = shouldFn();
 export { should, expect, assert };
+
+declare global {
+  interface Object {
+    should: Chai.Assertion;
+  }
+}


### PR DESCRIPTION
in latest version of vitest, the augmenting type declaration of `Object.should`
was commented out, which broke our type checking for `.should` usage in the
test.

This PR adds the declaration in Event Hubs' chai test util and import it once so
that the augmentation is available in global scope.