### PR TITLE
[EngSys] save and restore git state when checking snippets

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -78,6 +78,10 @@ steps:
       node eng/tools/rush-runner/index.js check-format $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose
     displayName: "Check Format in Libraries"
 
+  - script: |
+      git stash
+    displayName: "Git Stash before checking snippets"
+
   - pwsh: |
       node eng/tools/rush-runner/index.js update-snippets $(ChangedServices) -packages "$(ArtifactPackageNames)" --verbose
     displayName: "Update snippets"
@@ -85,6 +89,10 @@ steps:
   - pwsh: |
       eng/tools/check-snippet-changes.ps1
     displayName: "Check snippet changes"
+
+  - script: |
+      git stash pop
+    displayName: "Pop Git Stash after checking snippets"
 
   - template: /eng/common/pipelines/templates/steps/verify-changelogs.yml
     parameters:


### PR DESCRIPTION
so that unrelated changes are not showing up when check-snippets-changes script does `git diff`