### PR TITLE
Fix the autorest version to `v6.0.41`

### DIFF
--- a/.scripts/automation_generate.sh
+++ b/.scripts/automation_generate.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-code-gen-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@6.0.40 --typespecEmitter=@azure-tools/typespec-ts
+code-gen-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@6.0.41 --typespecEmitter=@azure-tools/typespec-ts

--- a/.scripts/automation_generate.sh
+++ b/.scripts/automation_generate.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-code-gen-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@^6.0.12 --typespecEmitter=@azure-tools/typespec-ts
+code-gen-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@6.0.40 --typespecEmitter=@azure-tools/typespec-ts


### PR DESCRIPTION
Currently the autorest.typescript version is floating in automation script and this would cause issues if autorest.typescript has upraged to pnpm dependency style in package.json.

Therefore before the migration is merged https://github.com/Azure/azure-sdk-for-js/pull/33993, we need to lock the codegen version for autorest. 