### PR TITLE
Update docindex pool and add CODEOWNERS for notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1655,3 +1655,4 @@ sdk/ai/ai-projects @ganeshyb @glharper @dargilco @jhakulin @ZachhK
 # Add owners for notifications for specific pipelines
 /eng/pipelines/aggregate-reports.yml         @jeremymeng @xirzec
 /eng/common/pipelines/codeowners-linter.yml  @xirzec @jeremymeng
+/eng/pipelines/docindex.yml                  @danieljurek @mikeharder @weshaggard @benbp

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -57,8 +57,8 @@ jobs:
   - job: UpdateDocsMsBuildConfig
     timeoutInMinutes: 90
     pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals ubuntu-22.04
+      name: $(LINUXPOOL)
+      demands: $(LinuxImageDemand)
 
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -21,14 +21,15 @@ parameters:
 
 variables:
   - template: /eng/pipelines/templates/variables/globals.yml
+  - template: /eng/pipelines/templates/variables/image.yml
 jobs:
   - template: /eng/common/pipelines/templates/jobs/docindex.yml
 
   - job: UpgradeRexTool
     timeoutInMinutes: 10
     pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals ubuntu-22.04
+      name: $(LINUXPOOL)
+      demands: ImageOverride -equals $(LINUXVMIMAGE)
 
     steps:
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -29,7 +29,7 @@ jobs:
     timeoutInMinutes: 10
     pool:
       name: $(LINUXPOOL)
-      demands: ImageOverride -equals $(LINUXVMIMAGE)
+      demands: $(LinuxImageDemand)
 
     steps:
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -27,7 +27,8 @@ jobs:
   - job: UpgradeRexTool
     timeoutInMinutes: 10
     pool:
-      vmImage: ubuntu-22.04
+      name: azsdk-pool
+      demands: ImageOverride -equals ubuntu-22.04
 
     steps:
       - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -55,7 +56,9 @@ jobs:
   - job: UpdateDocsMsBuildConfig
     timeoutInMinutes: 90
     pool:
-      vmImage: ubuntu-20.04
+      name: azsdk-pool
+      demands: ImageOverride -equals ubuntu-22.04
+
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
       DocRepoOwner: MicrosoftDocs

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -24,3 +24,6 @@ variables:
     value: windows
   - name: MACOS
     value: macOS
+
+  - name: LinuxImageDemand
+    value: ImageOverride -equals $(LINUXVMIMAGE)


### PR DESCRIPTION
Example successful docindex run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4900330&view=results

This uses variables in image.yml. When the images are updated in those variables the docindex pipeline will follow from those changes.