### PR TITLE
[Monitor OpenTelemetry Exporter] Fix LongIntervalStatsbeat Reader Register

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Other Changes
 
+- Ensure that the longIntervalStatsbeat reader is properly bound to a MetricProducer.
 - Removed error logging upon failure to initialize long interval statsbeat.
 - No longer send statsbeat counters when values are zero.
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -81,7 +81,7 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
       longIntervalMetricReaderOptions,
     );
     this.longIntervalStatsbeatMeterProvider = new MeterProvider({
-      readers: [new PeriodicExportingMetricReader(longIntervalMetricReaderOptions)],
+      readers: [this.longIntervalMetricReader],
     });
     this.longIntervalStatsbeatMeter = this.longIntervalStatsbeatMeterProvider.getMeter(
       "Azure Monitor Long Interval Statsbeat",
@@ -130,14 +130,25 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
 
       // Export Feature/Attach Statsbeat once upon app initialization after 15 second delay
       setTimeout(async () => {
-        this.longIntervalAzureExporter.export(
-          (await this.longIntervalMetricReader.collect()).resourceMetrics,
-          (result: ExportResult) => {
-            if (result.code !== ExportResultCode.SUCCESS) {
-              diag.debug(`LongIntervalStatsbeat: metrics export failed (error ${result.error})`);
-            }
-          },
-        );
+        try {
+          const collectionResult = await this.longIntervalMetricReader.collect();
+          if (collectionResult) {
+            this.longIntervalAzureExporter.export(
+              collectionResult.resourceMetrics,
+              (result: ExportResult) => {
+                if (result.code !== ExportResultCode.SUCCESS) {
+                  diag.debug(
+                    `LongIntervalStatsbeat: metrics export failed (error ${result.error})`,
+                  );
+                }
+              },
+            );
+          } else {
+            diag.debug("LongIntervalStatsbeat: No metrics collected");
+          }
+        } catch (error) {
+          diag.debug(`LongIntervalStatsbeat: Error collecting metrics: ${error}`);
+        }
       }, 15000); // 15 seconds
     } catch (error) {
       diag.debug("Call to get the resource provider failed.");

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -484,5 +484,34 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         delete process.env[LEGACY_ENV_DISABLE_STATSBEAT];
       });
     });
+
+    describe("Long Interval Statsbeat Metrics", () => {
+      it("should properly bind the metric reader to a metric producer", async () => {
+        // Get an instance of LongIntervalStatsbeatMetrics
+        const longIntervalStatsbeat = getInstance(options);
+
+        // Create a spy on the collect method to ensure it doesn't throw an error
+        const collectSpy = vi.spyOn(longIntervalStatsbeat["longIntervalMetricReader"], "collect");
+
+        // Attempt to collect metrics - this would throw an error if the MetricReader is not bound
+        // to a MetricProducer properly
+        try {
+          await longIntervalStatsbeat["longIntervalMetricReader"].collect();
+          // If we get here without an error, the test passes
+          assert.ok(true, "Metric reader collect method executed without errors");
+        } catch (error) {
+          // If an error occurs, the test should fail
+          assert.fail(
+            `Metric reader collect method threw an error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+
+        // Verify the collect method was called
+        expect(collectSpy).toHaveBeenCalled();
+
+        // Restore the spy
+        collectSpy.mockRestore();
+      });
+    });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Fixed an issue where the first call to collect long interval statsbeat would throw since the reader was not registered. This issue was introduced as a part of #34146.

### Are there test cases added in this PR? _(If not, why?)_
Yes, one added to ensure we don't regress on this issue.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
