### PR TITLE
feat: add isRestError typeguard from core-rest-pipeline

### DIFF
--- a/sdk/cosmosdb/cosmos/src/index.ts
+++ b/sdk/cosmosdb/cosmos/src/index.ts
@@ -138,7 +138,7 @@ export { CosmosDbDiagnosticLevel } from "./diagnostics/CosmosDbDiagnosticLevel.j
 export { GlobalEndpointManager } from "./globalEndpointManager.js";
 export { SasTokenPermissionKind } from "./common/constants.js";
 export { createAuthorizationSasToken } from "./utils/SasToken.js";
-export { RestError } from "@azure/core-rest-pipeline";
+export { RestError, isRestError } from "@azure/core-rest-pipeline";
 export { AbortError } from "@azure/abort-controller";
 export * from "./encryption/enums/index.js";
 export * from "./encryption/ClientEncryptionKey/index.js";

--- a/sdk/storage/storage-blob/src/index-browser.mts
+++ b/sdk/storage/storage-blob/src/index-browser.mts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, isRestError } from "@azure/core-rest-pipeline";
 
 export * from "./BlobServiceClient.js";
 export * from "./Clients.js";
@@ -58,7 +58,7 @@ export * from "./policies/StorageSharedKeyCredentialPolicyV2.js";
 export * from "./StorageRetryPolicyFactory.js";
 export { CommonOptions } from "./StorageClient.js";
 export * from "./generatedModels.js";
-export { RestError };
+export { RestError, isRestError };
 export {
   PageBlobGetPageRangesDiffResponse,
   PageBlobGetPageRangesResponse,

--- a/sdk/storage/storage-blob/src/index.ts
+++ b/sdk/storage/storage-blob/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, isRestError } from "@azure/core-rest-pipeline";
 
 export { PollOperationState, PollerLike } from "@azure/core-lro";
 export * from "./BlobServiceClient.js";
@@ -91,7 +91,7 @@ export {
   MatchConditions,
   ModifiedAccessConditions,
 } from "./models.js";
-export { RestError };
+export { RestError, isRestError };
 export {
   PageBlobGetPageRangesDiffResponse,
   PageBlobGetPageRangesResponse,

--- a/sdk/storage/storage-file-datalake/src/index-browser.mts
+++ b/sdk/storage/storage-file-datalake/src/index-browser.mts
@@ -41,5 +41,5 @@ export {
 } from "@azure/storage-blob";
 export { CommonOptions } from "./StorageClient.js";
 export { ToBlobEndpointHostMappings, ToDfsEndpointHostMappings } from "./utils/constants.js";
-export { RestError } from "@azure/core-rest-pipeline";
+export { RestError, isRestError } from "@azure/core-rest-pipeline";
 export { logger } from "./log.js";

--- a/sdk/storage/storage-file-datalake/src/index.ts
+++ b/sdk/storage/storage-file-datalake/src/index.ts
@@ -59,6 +59,6 @@ export {
 export { CommonOptions } from "./StorageClient.js";
 export { SasIPRange } from "./sas/SasIPRange.js";
 export { ToBlobEndpointHostMappings, ToDfsEndpointHostMappings } from "./utils/constants.js";
-export { RestError } from "@azure/core-rest-pipeline";
+export { RestError, isRestError } from "@azure/core-rest-pipeline";
 export { logger } from "./log.js";
 export * from "./sas/DirectorySASPermissions.js";

--- a/sdk/storage/storage-file-share/src/index-browser.mts
+++ b/sdk/storage/storage-file-share/src/index-browser.mts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, isRestError } from "@azure/core-rest-pipeline";
 
 export * from "./Clients.js";
 export { AnonymousCredential } from "@azure/storage-blob";
@@ -48,5 +48,5 @@ export {
   ResponseWithHeaders,
   HttpResponse,
 } from "./utils/utils.common.js";
-export { RestError };
+export { RestError, isRestError };
 export { logger } from "./log.js";

--- a/sdk/storage/storage-file-share/src/index.ts
+++ b/sdk/storage/storage-file-share/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, isRestError } from "@azure/core-rest-pipeline";
 
 export * from "./AccountSASPermissions.js";
 export * from "./AccountSASResourceTypes.js";
@@ -83,5 +83,5 @@ export {
   ResponseWithHeaders,
   HttpResponse,
 } from "./utils/utils.common.js";
-export { RestError };
+export { RestError, isRestError };
 export { logger } from "./log.js";

--- a/sdk/storage/storage-queue/src/index-browser.mts
+++ b/sdk/storage/storage-queue/src/index-browser.mts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, isRestError } from "@azure/core-rest-pipeline";
 export { AnonymousCredential } from "@azure/storage-blob";
 export { Credential } from "@azure/storage-blob";
 export { SasIPRange } from "./SasIPRange.js";
@@ -32,5 +32,5 @@ export {
   ResponseWithHeaders,
   HttpResponse,
 } from "./utils/utils.common.js";
-export { RestError };
+export { RestError, isRestError };
 export { logger } from "./log.js";

--- a/sdk/storage/storage-queue/src/index.ts
+++ b/sdk/storage/storage-queue/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, isRestError } from "@azure/core-rest-pipeline";
 
 export * from "./AccountSASPermissions.js";
 export * from "./AccountSASResourceTypes.js";
@@ -56,5 +56,5 @@ export {
   ResponseWithHeaders,
   HttpResponse,
 } from "./utils/utils.common.js";
-export { RestError };
+export { RestError, isRestError };
 export { logger } from "./log.js";

--- a/sdk/tables/data-tables/src/index.ts
+++ b/sdk/tables/data-tables/src/index.ts
@@ -10,4 +10,4 @@ export { TableTransaction } from "./TableTransaction.js";
 export { TableClient } from "./TableClient.js";
 export { odata } from "./odata.js";
 export { AzureNamedKeyCredential, AzureSASCredential, NamedKeyCredential } from "@azure/core-auth";
-export { RestError } from "@azure/core-rest-pipeline";
+export { RestError, isRestError } from "@azure/core-rest-pipeline";


### PR DESCRIPTION
A refactor in the core-rest-pipeline has meant that the RestError class isn't always consistently returned as the same instance across all libraries, however a typeguard is now provided by the library instead.

The change implemented here: https://github.com/Azure/azure-sdk-for-js/pull/33948 and released in a recent version of `@azure/core-rest-pipeline` ends up making it difficult to capture `RestError` objects based on their class definition. Instead the typeguard needs to be used. This PR adds the type guard as an export to packages that also export the underlying class.


### Packages impacted by this PR

- comosdb
- storage-blob
- storage-file-datalake
- storage-file-share
- storage-queue
- data-tables

### Issues associated with this PR

n/a

### Describe the problem that is addressed by this PR

`RestError` objects that are thrown can no longer be consitently caught using `err instanceof RestError` due to some refactoring working the underlying library. This change gives library consumers access to the underlying typeguard as a better way of capturing the `RestError` objects.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_

- https://github.com/Azure/azure-sdk-for-js/pull/33948 

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
