### PR TITLE
REST<->SDK Model Translation for IncomingCall Event

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -691,15 +691,13 @@ export interface IncomingCall {
     callConnectionId: string;
     callerDisplayName?: string;
     correlationId: string;
-    customContext?: CustomCallingContextInternal;
-    from?: CommunicationIdentifierModel;
-    from?: CommunicationIdentifierModel;
+    customContext?: CustomCallingContext;
+    from?: CommunicationIdentifier;
     incomingCallContext?: string;
     kind: "IncomingCall";
     onBehalfOfCallee?: CommunicationIdentifier;
-    to?: CommunicationIdentifierModel;
-    // Warning: (ae-forgotten-export) The symbol "CommunicationIdentifierModel" needs to be exported by the entry point index.d.ts
-    to?: CommunicationIdentifierModel;
+    resultInformation?: ResultInformation;
+    to?: CommunicationIdentifier;
 }
 
 // @public

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -693,10 +693,12 @@ export interface IncomingCall {
     correlationId: string;
     customContext?: CustomCallingContextInternal;
     from?: CommunicationIdentifierModel;
+    from?: CommunicationIdentifierModel;
     incomingCallContext?: string;
     kind: "IncomingCall";
-    onBehalfOfCallee?: CommunicationIdentifierModel;
-    resultInformation?: ResultInformation;
+    onBehalfOfCallee?: CommunicationIdentifier;
+    to?: CommunicationIdentifierModel;
+    // Warning: (ae-forgotten-export) The symbol "CommunicationIdentifierModel" needs to be exported by the entry point index.d.ts
     to?: CommunicationIdentifierModel;
 }
 

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -5,8 +5,6 @@ import type { CommunicationIdentifier } from "@azure/communication-common";
 
 import type {
   Tone,
-  CustomCallingContextInternal,
-  CommunicationIdentifierModel,
   ChoiceResult,
   DtmfResult,
   RecognitionType,
@@ -14,13 +12,9 @@ import type {
   MediaStreamingUpdate,
   TranscriptionUpdate,
   RecordingKind,
-  RestIncomingCall,
-  CommunicationIdentifierModel,
-  RestIncomingCall,
-  CommunicationIdentifierModel,
 } from "../generated/src/models/index.js";
 
-import type { CallParticipant, RecordingState } from "./models.js";
+import type { CallParticipant, RecordingState, CustomCallingContext } from "./models.js";
 
 /** Callback events for Call Automation */
 export type CallAutomationEvent =

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -14,6 +14,10 @@ import type {
   MediaStreamingUpdate,
   TranscriptionUpdate,
   RecordingKind,
+  RestIncomingCall,
+  CommunicationIdentifierModel,
+  RestIncomingCall,
+  CommunicationIdentifierModel,
 } from "../generated/src/models/index.js";
 
 import type { CallParticipant, RecordingState } from "./models.js";
@@ -166,17 +170,17 @@ export interface IncomingCall {
   /** Call connection ID. */
   callConnectionId: string;
   /** The communication identifier of the target user.*/
-  to?: CommunicationIdentifierModel;
+  to?: CommunicationIdentifier;
   /** The communication identifier of the user who initiated the call.*/
-  from?: CommunicationIdentifierModel;
+  from?: CommunicationIdentifier;
   /** Display name of caller.*/
   callerDisplayName?: string;
   /** Custom Context of Incoming Call */
-  customContext?: CustomCallingContextInternal;
+  customContext?: CustomCallingContext;
   /** Incoming call context.*/
   incomingCallContext?: string;
   /** The communication identifier of the user on behalf of whom the call is made.*/
-  onBehalfOfCallee?: CommunicationIdentifierModel;
+  onBehalfOfCallee?: CommunicationIdentifier;
   /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
   correlationId: string;
   /** Contains the resulting SIP code/sub-code and message. */


### PR DESCRIPTION
Converted the REST identifier model to the SDK identifier model for IncomingCall event, specifically CustomCallingContextInternal & CommunicationIdentifierModel are no longer exposed.
IncomingCall event now uses CustomCallingContext & CommunicationIdentifier respectively.