### PR TITLE
[notificationhubs][test] update recorded client sanitizers

### DIFF
--- a/sdk/notificationhubs/notification-hubs/assets.json
+++ b/sdk/notificationhubs/notification-hubs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/notificationhubs/notification-hubs",
-  "Tag": "js/notificationhubs/notification-hubs_0718648c50"
+  "Tag": "js/notificationhubs/notification-hubs_ff7034d91d"
 }

--- a/sdk/notificationhubs/notification-hubs/assets.json
+++ b/sdk/notificationhubs/notification-hubs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/notificationhubs/notification-hubs",
-  "Tag": "js/notificationhubs/notification-hubs_ff7034d91d"
+  "Tag": "js/notificationhubs/notification-hubs_9b371a54ae"
 }

--- a/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
@@ -41,9 +41,6 @@ export async function createRecordedClientContext(
           value: "class=REDACTED",
         },
       ],
-      removeHeaderSanitizer: {
-        headersForRemoval: ["ServiceBusNotification-Tags"],
-      },
     },
     ["record", "playback"],
   );

--- a/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
@@ -33,6 +33,20 @@ export async function createRecordedClientContext(
   recorder: Recorder,
 ): Promise<NotificationHubsClientContext> {
   await recorder.start(recorderOptions);
+  await recorder.addSanitizers(
+    {
+      headerSanitizers: [
+        {
+          key: "x-ms-azsdk-telemetry",
+          value: "class=REDACTED",
+        },
+      ],
+      removeHeaderSanitizer: {
+        headersForRemoval: ["ServiceBusNotification-Tags"],
+      }
+    },
+    ["record", "playback"],
+  );
   if (isBrowser) {
     // there are timestamps in the body, so do not match body
     await recorder.setMatcher("BodilessMatcher");

--- a/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
@@ -43,7 +43,7 @@ export async function createRecordedClientContext(
       ],
       removeHeaderSanitizer: {
         headersForRemoval: ["ServiceBusNotification-Tags"],
-      }
+      },
     },
     ["record", "playback"],
   );


### PR DESCRIPTION
After test entry name change, some broken playback test under test\public previously not included in `unit-test:node` are now running in `test:node` and failing.  This PR updates the recorded client to use header sanitizer for the `x-ms-azsdk-telemetry` header and update recordings for missing `ServiceBusNotification-Tags` header.
