### PR TITLE
[ai-agents,projects] fix paths mapping in tsconfig.samples.json

### DIFF
--- a/sdk/ai/ai-agents/test/snippets.spec.ts
+++ b/sdk/ai/ai-agents/test/snippets.spec.ts
@@ -19,7 +19,7 @@ import {
   MessageTextContent,
   RequiredToolCall,
   ThreadRun,
-} from "@azure/ai-agents";
+} from "../src/index.js";
 import { createProjectsClient } from "./public/utils/createClient.js";
 import { DefaultAzureCredential } from "@azure/identity";
 import { beforeEach, it, describe } from "vitest";

--- a/sdk/ai/ai-agents/tsconfig.samples.json
+++ b/sdk/ai/ai-agents/tsconfig.samples.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.samples.base.json",
   "compilerOptions": {
     "paths": {
-      "@azure-rest/ai-agents": ["./dist/esm"]
+      "@azure/ai-agents": ["./dist/esm"]
     }
   }
 }

--- a/sdk/ai/ai-projects/test/snippets.spec.ts
+++ b/sdk/ai/ai-projects/test/snippets.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import type { VitestTestContext } from "@azure-tools/test-recorder";
-import { AIProjectClient, DatasetVersion, EvaluatorIds } from "@azure/ai-projects";
+import { AIProjectClient, DatasetVersion, EvaluatorIds } from "../src/index.js";
 import type {
   AzureAISearchIndex,
   Connection,
@@ -10,7 +10,7 @@ import type {
   Evaluation,
   EvaluationWithOptionalName,
   ModelDeployment,
-} from "@azure/ai-projects";
+} from "../src/index.js";
 import { isRestError } from "@azure/core-rest-pipeline";
 import { createProjectsClient } from "./public/utils/createClient.js";
 import { DefaultAzureCredential } from "@azure/identity";

--- a/sdk/ai/ai-projects/tsconfig.samples.json
+++ b/sdk/ai/ai-projects/tsconfig.samples.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.samples.base.json",
   "compilerOptions": {
     "paths": {
-      "@azure-rest/ai-projects": ["./dist/esm"]
+      "@azure/ai-projects": ["./dist/esm"]
     }
   }
 }


### PR DESCRIPTION
The names should match the package names.

Also change `test/snippets.spec.ts` to import from `"../src/index.js"` so it stay in-sync with source changes. Previously `update-snippets` wasn't working properly on Windows when importing from `"../src/index.js"`. The issue has been fixed in dev-tool.

