### PR TITLE
[Monitor OpenTelemetry Exporter] Make Network Statsbeat Singleton

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -9,6 +9,7 @@
 - No longer send statsbeat counters when values are zero.
 - Fix statsbeat throttle recording logic.
 - SEMATTRS_ENDUSER_ID is properly added to tags but not to properties in telemetry envelopes.
+- Update network statsbeat to follow a singleton pattern.
 
 ## 1.0.0-beta.31 (2025-04-16)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/longIntervalStatsbeatMetrics.ts
@@ -24,13 +24,12 @@ import { StatsbeatCounter, STATSBEAT_LANGUAGE, StatsbeatFeatureType } from "./ty
 import { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
 import { getAttachType } from "../../utils/metricUtils.js";
 
-let instance: LongIntervalStatsbeatMetrics | null = null;
-
 /**
  * Long Interval Statsbeat Metrics
  * @internal
  */
-class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
+export class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
+  private static instance: LongIntervalStatsbeatMetrics | null = null;
   private statsCollectionLongInterval: number = 86400000; // 1 day
   // Custom dimensions
   private cikey: string;
@@ -201,15 +200,14 @@ class LongIntervalStatsbeatMetrics extends StatsbeatMetrics {
   public shutdown(): Promise<void> {
     return this.longIntervalStatsbeatMeterProvider.shutdown();
   }
-}
-
-/**
- * Singleton LongIntervalStatsbeatMetrics instance.
- * @internal
- */
-export function getInstance(options: StatsbeatOptions): LongIntervalStatsbeatMetrics {
-  if (!instance) {
-    instance = new LongIntervalStatsbeatMetrics(options);
+  /**
+   * Singleton LongIntervalStatsbeatMetrics instance.
+   * @internal
+   */
+  public static getInstance(options: StatsbeatOptions): LongIntervalStatsbeatMetrics {
+    if (!LongIntervalStatsbeatMetrics.instance) {
+      LongIntervalStatsbeatMetrics.instance = new LongIntervalStatsbeatMetrics(options);
+    }
+    return LongIntervalStatsbeatMetrics.instance;
   }
-  return instance;
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -23,13 +23,8 @@ import { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
 import { ENV_DISABLE_STATSBEAT } from "../../Declarations/Constants.js";
 import { getAttachType } from "../../utils/metricUtils.js";
 
-/**
- * Singleton instance for NetworkStatsbeatMetrics
- * @internal
- */
-let instance: NetworkStatsbeatMetrics | null = null;
-
 export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
+  private static instance: NetworkStatsbeatMetrics | null = null;
   private disableNonEssentialStatsbeat: boolean = !!process.env[ENV_DISABLE_STATSBEAT];
   private commonProperties: CommonStatsbeatProperties;
   private networkProperties: NetworkStatsbeatProperties;
@@ -427,49 +422,15 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     }
     return shortHost;
   }
+
   /**
-   * Get singleton instance of NetworkStatsbeatMetrics
-   * @param options - Statsbeat configuration options
-   * @returns NetworkStatsbeatMetrics singleton instance
+   * Singleton Network Statsbeat Metrics instance.
    * @internal
    */
   public static getInstance(options: StatsbeatOptions): NetworkStatsbeatMetrics {
-    if (!instance) {
-      instance = new NetworkStatsbeatMetrics(options);
+    if (!NetworkStatsbeatMetrics.instance) {
+      NetworkStatsbeatMetrics.instance = new NetworkStatsbeatMetrics(options);
     }
-    return instance;
+    return NetworkStatsbeatMetrics.instance;
   }
-
-  /**
-   * Shutdown the singleton instance
-   * Used for cleanup and complete shutdown
-   * @internal
-   */
-  public static shutdown(): Promise<void> {
-    if (instance) {
-      const shutdownPromise = instance.shutdown();
-      instance = null;
-      return shutdownPromise;
-    }
-    return Promise.resolve();
-  }
-}
-
-/**
- * Get singleton instance of NetworkStatsbeatMetrics
- * @param options - Statsbeat configuration options
- * @returns NetworkStatsbeatMetrics singleton instance
- * @internal
- */
-export function getInstance(options: StatsbeatOptions): NetworkStatsbeatMetrics {
-  return NetworkStatsbeatMetrics.getInstance(options);
-}
-
-/**
- * Shutdown the singleton instance
- * Used for cleanup and complete shutdown
- * @internal
- */
-export function shutdown(): Promise<void> {
-  return NetworkStatsbeatMetrics.shutdown();
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -456,13 +456,13 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     if (referenceCount > 0) {
       referenceCount--;
     }
-    
+
     if (referenceCount === 0 && instance) {
       const shutdownPromise = instance.shutdown();
       instance = null;
       return shutdownPromise;
     }
-    
+
     return Promise.resolve();
   }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/networkStatsbeatMetrics.ts
@@ -29,12 +29,6 @@ import { getAttachType } from "../../utils/metricUtils.js";
  */
 let instance: NetworkStatsbeatMetrics | null = null;
 
-/**
- * Reference count for the singleton instance
- * @internal
- */
-let referenceCount: number = 0;
-
 export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
   private disableNonEssentialStatsbeat: boolean = !!process.env[ENV_DISABLE_STATSBEAT];
   private commonProperties: CommonStatsbeatProperties;
@@ -443,38 +437,18 @@ export class NetworkStatsbeatMetrics extends StatsbeatMetrics {
     if (!instance) {
       instance = new NetworkStatsbeatMetrics(options);
     }
-    referenceCount++;
     return instance;
   }
 
   /**
-   * Release a reference to the singleton instance
-   * When reference count reaches zero, the instance is shut down
+   * Shutdown the singleton instance
+   * Used for cleanup and complete shutdown
    * @internal
    */
-  public static releaseInstance(): Promise<void> {
-    if (referenceCount > 0) {
-      referenceCount--;
-    }
-
-    if (referenceCount === 0 && instance) {
-      const shutdownPromise = instance.shutdown();
-      instance = null;
-      return shutdownPromise;
-    }
-
-    return Promise.resolve();
-  }
-
-  /**
-   * Shutdown and reset the singleton instance immediately (for testing)
-   * @internal
-   */
-  public static shutdownInstance(): Promise<void> {
+  public static shutdown(): Promise<void> {
     if (instance) {
       const shutdownPromise = instance.shutdown();
       instance = null;
-      referenceCount = 0;
       return shutdownPromise;
     }
     return Promise.resolve();
@@ -492,18 +466,10 @@ export function getInstance(options: StatsbeatOptions): NetworkStatsbeatMetrics 
 }
 
 /**
- * Release a reference to the singleton instance
- * When reference count reaches zero, the instance is shut down
+ * Shutdown the singleton instance
+ * Used for cleanup and complete shutdown
  * @internal
  */
-export function releaseInstance(): Promise<void> {
-  return NetworkStatsbeatMetrics.releaseInstance();
-}
-
-/**
- * Shutdown and reset the singleton instance immediately (for testing)
- * @internal
- */
-export function shutdownInstance(): Promise<void> {
-  return NetworkStatsbeatMetrics.shutdownInstance();
+export function shutdown(): Promise<void> {
+  return NetworkStatsbeatMetrics.shutdown();
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -9,7 +9,6 @@ import type { ExportResult } from "@opentelemetry/core";
 import { ExportResultCode } from "@opentelemetry/core";
 import {
   getInstance as getNetworkStatsbeatInstance,
-  releaseInstance as releaseNetworkStatsbeatInstance,
   type NetworkStatsbeatMetrics,
 } from "../../export/statsbeat/networkStatsbeatMetrics.js";
 import { getInstance } from "../../export/statsbeat/longIntervalStatsbeatMetrics.js";
@@ -254,9 +253,8 @@ export abstract class BaseSender {
    * Shutdown statsbeat metrics
    */
   private shutdownStatsbeat(): void {
-    // Release reference to network statsbeat singleton
+    // Clear reference to network statsbeat singleton
     if (this.networkStatsbeatMetrics) {
-      releaseNetworkStatsbeatInstance();
       this.networkStatsbeatMetrics = undefined;
     }
     this.longIntervalStatsbeatMetrics?.shutdown();

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -94,13 +94,17 @@ export abstract class BaseSender {
           }, this.batchSendRetryIntervalMs);
           this.retryTimer.unref();
         }
-        // If we are not exportings statsbeat and statsbeat is not disabled -- count success
-        this.networkStatsbeatMetrics?.countSuccess(duration);
+        // If we are not exporting statsbeat and statsbeat is not disabled -- count success
+        if (!this.isStatsbeatSender) {
+          this.networkStatsbeatMetrics?.countSuccess(duration);
+        }
         return { code: ExportResultCode.SUCCESS };
       } else if (statusCode && isRetriable(statusCode)) {
         // Failed -- persist failed data
         if (statusCode === 429 || statusCode === 439) {
-          this.networkStatsbeatMetrics?.countThrottle(statusCode);
+          if (!this.isStatsbeatSender) {
+            this.networkStatsbeatMetrics?.countThrottle(statusCode);
+          }
           return {
             code: ExportResultCode.SUCCESS,
           };
@@ -110,7 +114,7 @@ export abstract class BaseSender {
           const breezeResponse = JSON.parse(result) as BreezeResponse;
           const filteredEnvelopes: Envelope[] = [];
           // If we have a partial success, count the succeeded envelopes
-          if (breezeResponse.itemsAccepted > 0 && statusCode === 206) {
+          if (breezeResponse.itemsAccepted > 0 && statusCode === 206 && !this.isStatsbeatSender) {
             this.networkStatsbeatMetrics?.countSuccess(duration);
           }
           // Figure out if we need to either retry or count failures
@@ -122,23 +126,29 @@ export abstract class BaseSender {
             });
           }
           if (filteredEnvelopes.length > 0) {
-            this.networkStatsbeatMetrics?.countRetry(statusCode);
+            if (!this.isStatsbeatSender) {
+              this.networkStatsbeatMetrics?.countRetry(statusCode);
+            }
             // calls resultCallback(ExportResult) based on result of persister.push
             return await this.persist(filteredEnvelopes);
           }
           // Failed -- not retriable
-          this.networkStatsbeatMetrics?.countFailure(duration, statusCode);
+          if (!this.isStatsbeatSender) {
+            this.networkStatsbeatMetrics?.countFailure(duration, statusCode);
+          }
           return {
             code: ExportResultCode.FAILED,
           };
         } else {
           // calls resultCallback(ExportResult) based on result of persister.push
-          this.networkStatsbeatMetrics?.countRetry(statusCode);
+          if (!this.isStatsbeatSender) {
+            this.networkStatsbeatMetrics?.countRetry(statusCode);
+          }
           return await this.persist(envelopes);
         }
       } else {
         // Failed -- not retriable
-        if (this.networkStatsbeatMetrics) {
+        if (this.networkStatsbeatMetrics && !this.isStatsbeatSender) {
           if (statusCode) {
             this.networkStatsbeatMetrics.countFailure(duration, statusCode);
           }
@@ -172,7 +182,9 @@ export abstract class BaseSender {
           }
         } else {
           const redirectError = new Error("Circular redirect");
-          this.networkStatsbeatMetrics?.countException(redirectError);
+          if (!this.isStatsbeatSender) {
+            this.networkStatsbeatMetrics?.countException(redirectError);
+          }
           return { code: ExportResultCode.FAILED, error: redirectError };
         }
       } else if (
@@ -199,7 +211,7 @@ export abstract class BaseSender {
         return { code: ExportResultCode.SUCCESS };
       }
       if (this.isRetriableRestError(restError)) {
-        if (restError.statusCode) {
+        if (restError.statusCode && !this.isStatsbeatSender) {
           this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
         }
         if (!this.isStatsbeatSender) {
@@ -210,7 +222,9 @@ export abstract class BaseSender {
         }
         return this.persist(envelopes);
       }
-      this.networkStatsbeatMetrics?.countException(restError);
+      if (!this.isStatsbeatSender) {
+        this.networkStatsbeatMetrics?.countException(restError);
+      }
       if (!this.isStatsbeatSender) {
         diag.error(
           "Envelopes could not be exported and are not retriable. Error message:",
@@ -234,7 +248,9 @@ export abstract class BaseSender {
             error: new Error("Failed to persist envelope in disk."),
           };
     } catch (ex: any) {
-      this.networkStatsbeatMetrics?.countWriteFailure();
+      if (!this.isStatsbeatSender) {
+        this.networkStatsbeatMetrics?.countWriteFailure();
+      }
       return { code: ExportResultCode.FAILED, error: ex };
     }
   }
@@ -268,7 +284,9 @@ export abstract class BaseSender {
         await this.send(envelopes);
       }
     } catch (err: any) {
-      this.networkStatsbeatMetrics?.countReadFailure();
+      if (!this.isStatsbeatSender) {
+        this.networkStatsbeatMetrics?.countReadFailure();
+      }
       diag.warn(`Failed to fetch persisted file`, err);
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -48,7 +48,6 @@ export abstract class BaseSender {
     this.disableOfflineStorage = options.exporterOptions.disableOfflineStorage || false;
     this.persister = new FileSystemPersist(options.instrumentationKey, options.exporterOptions);
     if (options.trackStatsbeat) {
-      // Initialize statsbeatMetrics using singleton pattern
       this.networkStatsbeatMetrics = getNetworkStatsbeatInstance({
         instrumentationKey: options.instrumentationKey,
         endpointUrl: options.endpointUrl,
@@ -269,9 +268,8 @@ export abstract class BaseSender {
    * Shutdown statsbeat metrics
    */
   private shutdownStatsbeat(): void {
-    // Clear reference to network statsbeat singleton
     if (this.networkStatsbeatMetrics) {
-      this.networkStatsbeatMetrics = undefined;
+      this.networkStatsbeatMetrics.shutdown();
     }
     this.longIntervalStatsbeatMetrics?.shutdown();
     this.statsbeatFailureCount = 0;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -7,11 +7,8 @@ import type { AzureMonitorExporterOptions } from "../../config.js";
 import { FileSystemPersist } from "./persist/index.js";
 import type { ExportResult } from "@opentelemetry/core";
 import { ExportResultCode } from "@opentelemetry/core";
-import {
-  getInstance as getNetworkStatsbeatInstance,
-  type NetworkStatsbeatMetrics,
-} from "../../export/statsbeat/networkStatsbeatMetrics.js";
-import { getInstance } from "../../export/statsbeat/longIntervalStatsbeatMetrics.js";
+import { NetworkStatsbeatMetrics } from "../../export/statsbeat/networkStatsbeatMetrics.js";
+import { LongIntervalStatsbeatMetrics } from "../../export/statsbeat/longIntervalStatsbeatMetrics.js";
 import type { RestError } from "@azure/core-rest-pipeline";
 import { MAX_STATSBEAT_FAILURES, isStatsbeatShutdownStatus } from "../../export/statsbeat/types.js";
 import type { BreezeResponse } from "../../utils/breezeUtils.js";
@@ -48,12 +45,12 @@ export abstract class BaseSender {
     this.disableOfflineStorage = options.exporterOptions.disableOfflineStorage || false;
     this.persister = new FileSystemPersist(options.instrumentationKey, options.exporterOptions);
     if (options.trackStatsbeat) {
-      this.networkStatsbeatMetrics = getNetworkStatsbeatInstance({
+      this.networkStatsbeatMetrics = NetworkStatsbeatMetrics.getInstance({
         instrumentationKey: options.instrumentationKey,
         endpointUrl: options.endpointUrl,
         disableOfflineStorage: this.disableOfflineStorage,
       });
-      this.longIntervalStatsbeatMetrics = getInstance({
+      this.longIntervalStatsbeatMetrics = LongIntervalStatsbeatMetrics.getInstance({
         instrumentationKey: options.instrumentationKey,
         endpointUrl: options.endpointUrl,
         disableOfflineStorage: this.disableOfflineStorage,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -7,7 +7,11 @@ import type { AzureMonitorExporterOptions } from "../../config.js";
 import { FileSystemPersist } from "./persist/index.js";
 import type { ExportResult } from "@opentelemetry/core";
 import { ExportResultCode } from "@opentelemetry/core";
-import { getInstance as getNetworkStatsbeatInstance, releaseInstance as releaseNetworkStatsbeatInstance, type NetworkStatsbeatMetrics } from "../../export/statsbeat/networkStatsbeatMetrics.js";
+import {
+  getInstance as getNetworkStatsbeatInstance,
+  releaseInstance as releaseNetworkStatsbeatInstance,
+  type NetworkStatsbeatMetrics,
+} from "../../export/statsbeat/networkStatsbeatMetrics.js";
 import { getInstance } from "../../export/statsbeat/longIntervalStatsbeatMetrics.js";
 import type { RestError } from "@azure/core-rest-pipeline";
 import { MAX_STATSBEAT_FAILURES, isStatsbeatShutdownStatus } from "../../export/statsbeat/types.js";

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -66,6 +66,11 @@ vi.mock("../../src/export/statsbeat/networkStatsbeatMetrics.js", () => {
     NetworkStatsbeatMetrics: vi.fn().mockImplementation(() => {
       return mockNetworkStats;
     }),
+    getInstance: vi.fn().mockImplementation(() => {
+      return mockNetworkStats;
+    }),
+    releaseInstance: vi.fn().mockResolvedValue(undefined),
+    shutdownInstance: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -441,7 +446,8 @@ describe("BaseSender", () => {
       const result = await sender.exportEnvelopes([{ name: "test", time: new Date() }]);
 
       expect(result.code).toBe(ExportResultCode.SUCCESS);
-      expect(sender.getNetworkStats().shutdown).toHaveBeenCalled();
+      // Network stats now use singleton pattern, so no direct shutdown call
+      // Long interval stats still have shutdown method
       expect(sender.getLongIntervalStats().shutdown).toHaveBeenCalled();
     });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -67,7 +67,7 @@ vi.mock("../../src/export/statsbeat/networkStatsbeatMetrics.js", () => {
       static getInstance = vi.fn().mockImplementation(() => {
         return mockNetworkStats;
       });
-      
+
       constructor() {
         return mockNetworkStats;
       }
@@ -81,7 +81,7 @@ vi.mock("../../src/export/statsbeat/longIntervalStatsbeatMetrics.js", () => {
       static getInstance = vi.fn().mockImplementation(() => {
         return mockLongIntervalStats;
       });
-      
+
       constructor() {
         return mockLongIntervalStats;
       }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -63,22 +63,29 @@ vi.mock("../../src/platform/nodejs/persist/index.js", () => {
 
 vi.mock("../../src/export/statsbeat/networkStatsbeatMetrics.js", () => {
   return {
-    NetworkStatsbeatMetrics: vi.fn().mockImplementation(() => {
-      return mockNetworkStats;
-    }),
-    getInstance: vi.fn().mockImplementation(() => {
-      return mockNetworkStats;
-    }),
-    releaseInstance: vi.fn().mockResolvedValue(undefined),
-    shutdownInstance: vi.fn().mockResolvedValue(undefined),
+    NetworkStatsbeatMetrics: class MockNetworkStatsbeatMetrics {
+      static getInstance = vi.fn().mockImplementation(() => {
+        return mockNetworkStats;
+      });
+      
+      constructor() {
+        return mockNetworkStats;
+      }
+    },
   };
 });
 
 vi.mock("../../src/export/statsbeat/longIntervalStatsbeatMetrics.js", () => {
   return {
-    getInstance: vi.fn().mockImplementation(() => {
-      return mockLongIntervalStats;
-    }),
+    LongIntervalStatsbeatMetrics: class MockLongIntervalStatsbeatMetrics {
+      static getInstance = vi.fn().mockImplementation(() => {
+        return mockLongIntervalStats;
+      });
+      
+      constructor() {
+        return mockLongIntervalStats;
+      }
+    },
   };
 });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -12,7 +12,7 @@ import nock from "nock";
 import type { NetworkStatsbeatMetrics } from "../../src/export/statsbeat/networkStatsbeatMetrics.js";
 import {
   getInstance as getNetworkStatsbeatInstance,
-  shutdownInstance as shutdownNetworkStatsbeatInstance,
+  shutdown as shutdownNetworkStatsbeat,
 } from "../../src/export/statsbeat/networkStatsbeatMetrics.js";
 import { AZURE_MONITOR_AUTO_ATTACH, StatsbeatCounter } from "../../src/export/statsbeat/types.js";
 import { getInstance } from "../../src/export/statsbeat/longIntervalStatsbeatMetrics.js";
@@ -63,7 +63,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
     // Clean up singleton between tests
     afterEach(async () => {
-      await shutdownNetworkStatsbeatInstance();
+      await shutdownNetworkStatsbeat();
     });
 
     beforeAll(() => {
@@ -176,7 +176,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           assert.ok(getContext().tags["ai.internal.sdkVersion"]);
         } finally {
           process.env = originalEnv;
-          await shutdownNetworkStatsbeatInstance();
+          await shutdownNetworkStatsbeat();
         }
       });
 
@@ -190,7 +190,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           assert.strictEqual(statsbeat["commonProperties"]["rp"], "appsvc");
         } finally {
           process.env = originalEnv;
-          await shutdownNetworkStatsbeatInstance();
+          await shutdownNetworkStatsbeat();
         }
       });
 
@@ -243,7 +243,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       afterEach(async () => {
-        await shutdownNetworkStatsbeatInstance();
+        await shutdownNetworkStatsbeat();
       });
 
       it("it should determine if the rp is unknown", async () => {
@@ -329,7 +329,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
 
       afterEach(async () => {
-        await shutdownNetworkStatsbeatInstance();
+        await shutdownNetworkStatsbeat();
         process.env.WEBSITE_SITE_NAME = undefined;
       });
 
@@ -496,7 +496,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           }
         } finally {
           // Clean up
-          await shutdownNetworkStatsbeatInstance();
+          await shutdownNetworkStatsbeat();
         }
       });
     });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -10,13 +10,26 @@ import {
 } from "../../src/Declarations/Constants.js";
 import nock from "nock";
 import type { NetworkStatsbeatMetrics } from "../../src/export/statsbeat/networkStatsbeatMetrics.js";
-import { getInstance as getNetworkStatsbeatInstance, shutdownInstance as shutdownNetworkStatsbeatInstance } from "../../src/export/statsbeat/networkStatsbeatMetrics.js";
+import {
+  getInstance as getNetworkStatsbeatInstance,
+  shutdownInstance as shutdownNetworkStatsbeatInstance,
+} from "../../src/export/statsbeat/networkStatsbeatMetrics.js";
 import { AZURE_MONITOR_AUTO_ATTACH, StatsbeatCounter } from "../../src/export/statsbeat/types.js";
 import { getInstance } from "../../src/export/statsbeat/longIntervalStatsbeatMetrics.js";
 import { getInstance as getContext } from "../../src/platform/nodejs/context/context.js";
 import { AzureMonitorTraceExporter } from "../../src/export/trace.js";
 import { diag } from "@opentelemetry/api";
-import { describe, it, assert, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  assert,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
 
 describe("#AzureMonitorStatsbeatExporter", () => {
   process.env.LONG_INTERVAL_EXPORT_MILLIS = "100";

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -140,10 +140,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
         // Ensure network statsbeat attributes are populated
         assert.strictEqual(statsbeat["attach"], "Manual");
-        assert.strictEqual(
-          statsbeat["cikey"],
-          "1aa11111-bbbb-1ccc-8ddd-eeeeffff3333",
-        );
+        assert.strictEqual(statsbeat["cikey"], "1aa11111-bbbb-1ccc-8ddd-eeeeffff3333");
         assert.strictEqual(statsbeat["language"], "node");
         assert.strictEqual(statsbeat["resourceProvider"], "unknown");
         assert.strictEqual(
@@ -160,7 +157,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const newEnv = <{ [id: string]: string }>{};
         process.env = newEnv;
         newEnv[AZURE_MONITOR_AUTO_ATTACH] = "true";
-        
+
         // Reset singleton to pick up new environment variable
         (NetworkStatsbeatMetrics as any).instance = null;
         const statsbeat = NetworkStatsbeatMetrics.getInstance(options);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
The network statsbeat should be a singleton to avoid scenarios where multiple statsbeat exports are initialized.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
