### PR TITLE
[dev-tool] log tshy build errors

### DIFF
--- a/common/tools/dev-tool/src/commands/run/build-package.ts
+++ b/common/tools/dev-tool/src/commands/run/build-package.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { concurrently } from "concurrently";
 import { leafCommand, makeCommandInfo } from "../../framework/command";
 import { createPrinter } from "../../util/printer";
 import path from "node:path";
+import { spawnSync, StdioOptions } from "node:child_process";
+import { isWindows } from "../../util/platform";
 
 const log = createPrinter("build-package");
 
@@ -13,16 +14,22 @@ export const commandInfo = makeCommandInfo("build-package", "build a package for
 const TSHY_BIN_PATH = path.resolve(__dirname, "..", "..", "..", "node_modules", ".bin", "tshy");
 
 export default leafCommand(commandInfo, async () => {
-  log.info(`Building package with tshy from ${TSHY_BIN_PATH}`);
+  const commandPath = isWindows() ? `${TSHY_BIN_PATH}.CMD` : TSHY_BIN_PATH;
+  log.info(`Building package with tshy from ${commandPath}`);
 
-  await concurrently(
-    [
-      {
-        command: TSHY_BIN_PATH,
-      },
-    ],
-    { raw: true },
-  ).result;
+  const proc = spawnSync(commandPath, { stdio: "pipe" as StdioOptions, shell: isWindows() });
+
+  if (proc.error) {
+    log.error(proc.error.message);
+    return false;
+  }
+
+  if (proc.status !== 0) {
+    log.error(`Package failed to build:
+
+${proc.stdout.toString()}`);
+    return false;
+  }
 
   log.info("Package built successfully.");
 

--- a/sdk/appcontainers/arm-appcontainers/src/index.ts
+++ b/sdk/appcontainers/arm-appcontainers/src/index.ts
@@ -11,3 +11,5 @@ export { getContinuationToken } from "./pagingHelper.js";
 export * from "./models/index.js";
 export { ContainerAppsAPIClient } from "./containerAppsAPIClient.js";
 export * from "./operationsInterfaces/index.js";
+
+const a = b;

--- a/sdk/appcontainers/arm-appcontainers/src/index.ts
+++ b/sdk/appcontainers/arm-appcontainers/src/index.ts
@@ -11,5 +11,3 @@ export { getContinuationToken } from "./pagingHelper.js";
 export * from "./models/index.js";
 export { ContainerAppsAPIClient } from "./containerAppsAPIClient.js";
 export * from "./operationsInterfaces/index.js";
-
-const a = b;


### PR DESCRIPTION
We use rush to build packages. By default rush doesn't log output from each
package. It only shows summary, and errors if there are any. Rush also truncates
output. Combining with the fact that the error stdout output from tshy is quite
long, when a package fails to build, the final output by rush doesn't contain
useful information about actual build errors. So far we rely on `--verbose`
option to `rush`. However, This option leads to overwhelming logs for packages
that don't have errors.

This PR changes the `build-package` command to report tshy output via
`logger.error` when the spawned tshy process exits with non-zero code.


### Issues associated with this PR

https://github.com/Azure/azure-sdk-tools/issues/10739