### PR TITLE
[EngSys] use NodeJS v18 in copilot dev environment

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,10 +3,6 @@ name: "Copilot Setup Steps"
 # Allow testing of the setup steps from your repository's "Actions" tab.
 on: workflow_dispatch
 
-env:
-  # rush build cache, playwright for browser testing
-  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: azuresdkartifacts.blob.core.windows.net,cdn.playwright.dev,playwright.download.prss.microsoft.com
-
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
@@ -25,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "18"
 
       - name: Install Rush
         run: npm install -g @microsoft/rush


### PR DESCRIPTION
to prevent copilot from thinking that we no longer support v18

also remove COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS environment variable as
it only applies to current job.