### PR TITLE
[ServiceBus] reduce max count of messages to delete

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -60,7 +60,7 @@ export const defaultMaxTimeAfterFirstMessageForBatchingMs = 1000;
  * The maximum number of messages to delete in a single batch.  This cap is established and enforced by the service.
  * @internal
  */
-export const MaxDeleteMessageCount = 4000;
+export const MaxDeleteMessageCount = 500;
 
 /**
  * A receiver that does not handle sessions.


### PR DESCRIPTION
as the service reduced the valid range to 1-500.

Resolves #34274