### PR TITLE
Add moveParticipants functionality

### DIFF
--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -167,7 +167,7 @@ export class CallConnection {
     getParticipant(targetParticipant: CommunicationIdentifier, options?: GetParticipantOptions): Promise<CallParticipant>;
     hangUp(isForEveryone: boolean, options?: HangUpOptions): Promise<void>;
     listParticipants(options?: GetParticipantOptions): Promise<ListParticipantsResult>;
-    moveParticipants(targetParticipants: CommunicationIdentifier[], options: MoveParticipantsOptions): Promise<MoveParticipantsResult>;
+    moveParticipants(targetParticipants: CommunicationIdentifier[], fromCall: string, options?: MoveParticipantsOptions): Promise<MoveParticipantsResult>;
     muteParticipant(participant: CommunicationIdentifier, options?: MuteParticipantOption): Promise<MuteParticipantResult>;
     removeParticipant(participant: CommunicationIdentifier, options?: RemoveParticipantsOption): Promise<RemoveParticipantResult>;
     transferCallToParticipant(targetParticipant: CommunicationIdentifier, options?: TransferCallToParticipantOptions): Promise<TransferCallResult>;
@@ -969,7 +969,6 @@ export interface MoveParticipantFailed {
 
 // @public
 export interface MoveParticipantsOptions extends OperationOptions {
-    fromCall: string;
     operationCallbackUrl?: string;
     operationContext?: string;
 }

--- a/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
+++ b/sdk/communication/communication-call-automation/review/communication-call-automation.api.md
@@ -136,7 +136,7 @@ export interface CallAutomationClientOptions extends CommonClientOptions {
 }
 
 // @public
-export type CallAutomationEvent = AddParticipantSucceeded | AddParticipantFailed | RemoveParticipantSucceeded | RemoveParticipantFailed | CallConnected | CallDisconnected | CallTransferAccepted | CallTransferFailed | ParticipantsUpdated | RecordingStateChanged | PlayCompleted | PlayFailed | PlayCanceled | RecognizeCompleted | RecognizeCanceled | RecognizeFailed | ContinuousDtmfRecognitionToneReceived | ContinuousDtmfRecognitionToneFailed | ContinuousDtmfRecognitionStopped | SendDtmfTonesCompleted | SendDtmfTonesFailed | CancelAddParticipantSucceeded | CancelAddParticipantFailed | TranscriptionStarted | TranscriptionStopped | TranscriptionUpdated | TranscriptionFailed | CreateCallFailed | AnswerFailed | HoldFailed | ConnectFailed | MediaStreamingStarted | MediaStreamingStopped | MediaStreamingFailed | StartRecordingFailed | PlayStarted | PlayPaused | PlayResumed | HoldAudioStarted | HoldAudioPaused | HoldAudioResumed | HoldAudioCompleted | IncomingCall;
+export type CallAutomationEvent = AddParticipantSucceeded | AddParticipantFailed | RemoveParticipantSucceeded | RemoveParticipantFailed | MoveParticipantSucceeded | MoveParticipantFailed | CallConnected | CallDisconnected | CallTransferAccepted | CallTransferFailed | ParticipantsUpdated | RecordingStateChanged | PlayCompleted | PlayFailed | PlayCanceled | RecognizeCompleted | RecognizeCanceled | RecognizeFailed | ContinuousDtmfRecognitionToneReceived | ContinuousDtmfRecognitionToneFailed | ContinuousDtmfRecognitionStopped | SendDtmfTonesCompleted | SendDtmfTonesFailed | CancelAddParticipantSucceeded | CancelAddParticipantFailed | TranscriptionStarted | TranscriptionStopped | TranscriptionUpdated | TranscriptionFailed | CreateCallFailed | AnswerFailed | HoldFailed | ConnectFailed | MediaStreamingStarted | MediaStreamingStopped | MediaStreamingFailed | StartRecordingFailed | PlayStarted | PlayPaused | PlayResumed | HoldAudioStarted | HoldAudioPaused | HoldAudioResumed | HoldAudioCompleted | IncomingCall;
 
 // @public
 export class CallAutomationEventProcessor {
@@ -167,6 +167,7 @@ export class CallConnection {
     getParticipant(targetParticipant: CommunicationIdentifier, options?: GetParticipantOptions): Promise<CallParticipant>;
     hangUp(isForEveryone: boolean, options?: HangUpOptions): Promise<void>;
     listParticipants(options?: GetParticipantOptions): Promise<ListParticipantsResult>;
+    moveParticipants(targetParticipants: CommunicationIdentifier[], options: MoveParticipantsOptions): Promise<MoveParticipantsResult>;
     muteParticipant(participant: CommunicationIdentifier, options?: MuteParticipantOption): Promise<MuteParticipantResult>;
     removeParticipant(participant: CommunicationIdentifier, options?: RemoveParticipantsOption): Promise<RemoveParticipantResult>;
     transferCallToParticipant(targetParticipant: CommunicationIdentifier, options?: TransferCallToParticipantOptions): Promise<TransferCallResult>;
@@ -945,6 +946,52 @@ export interface MediaStreamingUpdate {
     mediaStreamingStatus?: MediaStreamingStatus;
     // (undocumented)
     mediaStreamingStatusDetails?: MediaStreamingStatusDetails;
+}
+
+// @public
+export interface MoveParticipantEventResult {
+    failureResult?: MoveParticipantFailed;
+    isSuccess: boolean;
+    successResult?: MoveParticipantSucceeded;
+}
+
+// @public
+export interface MoveParticipantFailed {
+    callConnectionId: string;
+    correlationId: string;
+    fromCall?: string;
+    kind: "MoveParticipantFailed";
+    operationContext?: string;
+    participant?: CommunicationIdentifier;
+    resultInformation?: ResultInformation;
+    serverCallId: string;
+}
+
+// @public
+export interface MoveParticipantsOptions extends OperationOptions {
+    fromCall: string;
+    operationCallbackUrl?: string;
+    operationContext?: string;
+}
+
+// @public
+export interface MoveParticipantsResult {
+    fromCall?: string;
+    operationContext?: string;
+    participants?: CallParticipant[];
+    waitForEventProcessor(abortSignal?: AbortSignalLike, timeoutInMs?: number): Promise<MoveParticipantEventResult>;
+}
+
+// @public
+export interface MoveParticipantSucceeded {
+    callConnectionId: string;
+    correlationId: string;
+    fromCall?: string;
+    kind: "MoveParticipantSucceeded";
+    operationContext?: string;
+    participant?: CommunicationIdentifier;
+    resultInformation?: ResultInformation;
+    serverCallId: string;
 }
 
 // @public

--- a/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
@@ -97,10 +97,12 @@ export function parseCallAutomationEvent(
     case "Microsoft.Communication.MoveParticipantSucceeded":
       callbackEvent = { kind: "MoveParticipantSucceeded" } as MoveParticipantSucceeded;
       parsed.participant = communicationIdentifierConverter(data.participant);
+      parsed.fromCall = data.fromCall;
       break;
     case "Microsoft.Communication.MoveParticipantFailed":
       callbackEvent = { kind: "MoveParticipantFailed" } as MoveParticipantFailed;
       parsed.participant = communicationIdentifierConverter(data.participant);
+      parsed.fromCall = data.fromCall;
       break;
     case "Microsoft.Communication.CallConnected":
       callbackEvent = { kind: "CallConnected" } as CallConnected;

--- a/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
+++ b/sdk/communication/communication-call-automation/src/callAutomationEventParser.ts
@@ -25,6 +25,8 @@ import type {
   RecognizeFailed,
   RemoveParticipantSucceeded,
   RemoveParticipantFailed,
+  MoveParticipantSucceeded,
+  MoveParticipantFailed,
   ContinuousDtmfRecognitionToneReceived,
   ContinuousDtmfRecognitionToneFailed,
   ContinuousDtmfRecognitionStopped,
@@ -90,6 +92,14 @@ export function parseCallAutomationEvent(
       break;
     case "Microsoft.Communication.RemoveParticipantFailed":
       callbackEvent = { kind: "RemoveParticipantFailed" } as RemoveParticipantFailed;
+      parsed.participant = communicationIdentifierConverter(data.participant);
+      break;
+    case "Microsoft.Communication.MoveParticipantSucceeded":
+      callbackEvent = { kind: "MoveParticipantSucceeded" } as MoveParticipantSucceeded;
+      parsed.participant = communicationIdentifierConverter(data.participant);
+      break;
+    case "Microsoft.Communication.MoveParticipantFailed":
+      callbackEvent = { kind: "MoveParticipantFailed" } as MoveParticipantFailed;
       parsed.participant = communicationIdentifierConverter(data.participant);
       break;
     case "Microsoft.Communication.CallConnected":

--- a/sdk/communication/communication-call-automation/src/callConnection.ts
+++ b/sdk/communication/communication-call-automation/src/callConnection.ts
@@ -426,17 +426,19 @@ export class CallConnection {
    * Move participants to the call
    *
    * @param targetParticipants - The participants to be moved to the call.
-   * @param options - Additional attributes for move participants including fromCall.
+   * @param fromCall - The CallConnectionId for the call you want to move the participant from.
+   * @param options - Additional attributes for move participants.
    */
   public async moveParticipants(
     targetParticipants: CommunicationIdentifier[],
-    options: MoveParticipantsOptions,
+    fromCall: string,
+    options: MoveParticipantsOptions = {},
   ): Promise<MoveParticipantsResult> {
     const moveParticipantsRequest: MoveParticipantsRequest = {
       targetParticipants: targetParticipants.map((participant) =>
         communicationIdentifierModelConverter(participant),
       ),
-      fromCall: options.fromCall,
+      fromCall: fromCall,
       operationContext: options.operationContext ? options.operationContext : randomUUID(),
       operationCallbackUri: options.operationCallbackUrl,
     };
@@ -455,6 +457,7 @@ export class CallConnection {
       participants: result.participants?.map((participant) =>
         callParticipantConverter(participant),
       ),
+      fromCall: fromCall,
       waitForEventProcessor: async (abortSignal, timeoutInMs) => {
         const moveParticipantEventResult: MoveParticipantEventResult = {
           isSuccess: false,

--- a/sdk/communication/communication-call-automation/src/callConnection.ts
+++ b/sdk/communication/communication-call-automation/src/callConnection.ts
@@ -8,6 +8,7 @@ import type {
   CallAutomationApiClient,
   CallAutomationApiClientOptionalParams,
   CustomCallingContextInternal,
+  MoveParticipantsRequest,
   MuteParticipantsRequest,
   RemoveParticipantRequest,
   TransferToParticipantRequest,
@@ -25,6 +26,7 @@ import type {
   GetCallConnectionPropertiesOptions,
   GetParticipantOptions,
   HangUpOptions,
+  MoveParticipantsOptions,
   MuteParticipantOption,
   RemoveParticipantsOption,
   TransferCallToParticipantOptions,
@@ -34,6 +36,7 @@ import type {
   TransferCallResult,
   AddParticipantResult,
   RemoveParticipantResult,
+  MoveParticipantsResult,
   MuteParticipantResult,
   CancelAddParticipantOperationResult,
 } from "./models/responses.js";
@@ -53,6 +56,7 @@ import type {
   AddParticipantEventResult,
   CancelAddParticipantEventResult,
   RemoveParticipantEventResult,
+  MoveParticipantEventResult,
   TransferCallToParticipantEventResult,
 } from "./eventprocessor/eventResponses.js";
 import { createCustomCallAutomationApiClient } from "./credential/callAutomationAuthPolicy.js";
@@ -416,6 +420,74 @@ export class CallConnection {
       },
     };
     return removeParticipantsResult;
+  }
+
+  /**
+   * Move participants to the call
+   *
+   * @param targetParticipants - The participants to be moved to the call.
+   * @param options - Additional attributes for move participants including fromCall.
+   */
+  public async moveParticipants(
+    targetParticipants: CommunicationIdentifier[],
+    options: MoveParticipantsOptions,
+  ): Promise<MoveParticipantsResult> {
+    const moveParticipantsRequest: MoveParticipantsRequest = {
+      targetParticipants: targetParticipants.map((participant) =>
+        communicationIdentifierModelConverter(participant),
+      ),
+      fromCall: options.fromCall,
+      operationContext: options.operationContext ? options.operationContext : randomUUID(),
+      operationCallbackUri: options.operationCallbackUrl,
+    };
+    const optionsInternal = {
+      ...options,
+      repeatabilityFirstSent: new Date(),
+      repeatabilityRequestID: randomUUID(),
+    };
+    const result = await this.callConnection.moveParticipants(
+      this.callConnectionId,
+      moveParticipantsRequest,
+      optionsInternal,
+    );
+    const moveParticipantsResult: MoveParticipantsResult = {
+      ...result,
+      participants: result.participants?.map((participant) =>
+        callParticipantConverter(participant),
+      ),
+      waitForEventProcessor: async (abortSignal, timeoutInMs) => {
+        const moveParticipantEventResult: MoveParticipantEventResult = {
+          isSuccess: false,
+        };
+        await this.callAutomationEventProcessor.waitForEventProcessor(
+          (event) => {
+            if (
+              event.callConnectionId === this.callConnectionId &&
+              event.kind === "MoveParticipantSucceeded" &&
+              event.operationContext === moveParticipantsRequest.operationContext
+            ) {
+              moveParticipantEventResult.isSuccess = true;
+              moveParticipantEventResult.successResult = event;
+              return true;
+            } else if (
+              event.callConnectionId === this.callConnectionId &&
+              event.kind === "MoveParticipantFailed" &&
+              event.operationContext === moveParticipantsRequest.operationContext
+            ) {
+              moveParticipantEventResult.isSuccess = false;
+              moveParticipantEventResult.failureResult = event;
+              return true;
+            } else {
+              return false;
+            }
+          },
+          abortSignal,
+          timeoutInMs,
+        );
+        return moveParticipantEventResult;
+      },
+    };
+    return moveParticipantsResult;
   }
 
   /**

--- a/sdk/communication/communication-call-automation/src/eventprocessor/eventResponses.ts
+++ b/sdk/communication/communication-call-automation/src/eventprocessor/eventResponses.ts
@@ -11,6 +11,8 @@ import type {
   PlayFailed,
   RemoveParticipantSucceeded,
   RemoveParticipantFailed,
+  MoveParticipantSucceeded,
+  MoveParticipantFailed,
   SendDtmfTonesCompleted,
   SendDtmfTonesFailed,
   RecognizeCompleted,
@@ -108,6 +110,18 @@ export interface RemoveParticipantEventResult {
   successResult?: RemoveParticipantSucceeded;
   /** contains failure event if the result was failure */
   failureResult?: RemoveParticipantFailed;
+}
+
+/**
+ * MoveParticipant event result
+ */
+export interface MoveParticipantEventResult {
+  /** returns true if move participant was successful */
+  isSuccess: boolean;
+  /** contains success event if the result was successful */
+  successResult?: MoveParticipantSucceeded;
+  /** contains failure event if the result was failure */
+  failureResult?: MoveParticipantFailed;
 }
 
 /**

--- a/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/index.ts
@@ -989,51 +989,6 @@ export interface ErrorModel {
   innerError?: ErrorModel;
 }
 
-/** Moving the participant successfully event. */
-export interface MoveParticipantSucceeded {
-  /** The CallConnectionId for the call you want to move the participant from */
-  fromCall?: string;
-  /** Call connection ID. */
-  callConnectionId?: string;
-  /** Server call ID. */
-  serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
-  correlationId?: string;
-  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
-  operationContext?: string;
-  /** Contains the resulting SIP code, sub-code and message. */
-  resultInformation?: RestResultInformation;
-  /** Participant */
-  participant?: CommunicationIdentifierModel;
-}
-
-export interface RestResultInformation {
-  /** Code of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
-  code?: number;
-  /** Subcode of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
-  subCode?: number;
-  /** Detail message that describes the current result. */
-  message?: string;
-}
-
-/** Moving the participant failed event. */
-export interface MoveParticipantFailed {
-  /** The CallConnectionId for the call you want to move the participant from */
-  fromCall?: string;
-  /** Call connection ID. */
-  callConnectionId?: string;
-  /** Server call ID. */
-  serverCallId?: string;
-  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
-  correlationId?: string;
-  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
-  operationContext?: string;
-  /** Contains the resulting SIP code, sub-code and message. */
-  resultInformation?: RestResultInformation;
-  /** Participant */
-  participant?: CommunicationIdentifierModel;
-}
-
 export interface DtmfResult {
   /** NOTE: This property will not be serialized. It can only be populated by the server. */
   readonly tones?: Tone[];
@@ -1075,6 +1030,15 @@ export interface DialogCompleted {
   operationContext?: string;
   /** Contains the resulting SIP code, sub-code and message. */
   resultInformation?: RestResultInformation;
+}
+
+export interface RestResultInformation {
+  /** Code of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
+  code?: number;
+  /** Subcode of the current result. This can be helpful to Call Automation team to troubleshoot the issue if this result was unexpected. */
+  subCode?: number;
+  /** Detail message that describes the current result. */
+  message?: string;
 }
 
 export interface DialogFailed {
@@ -1315,6 +1279,42 @@ export interface RestAddParticipantSucceeded {
 
 /** The failed to add participants event. */
 export interface RestAddParticipantFailed {
+  /** Call connection ID. */
+  callConnectionId?: string;
+  /** Server call ID. */
+  serverCallId?: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId?: string;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** Participant */
+  participant?: CommunicationIdentifierModel;
+}
+
+/** Moving the participant successfully event. */
+export interface RestMoveParticipantSucceeded {
+  /** The CallConnectionId for the call you want to move the participant from */
+  fromCall?: string;
+  /** Call connection ID. */
+  callConnectionId?: string;
+  /** Server call ID. */
+  serverCallId?: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId?: string;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
+  /** Contains the resulting SIP code, sub-code and message. */
+  resultInformation?: RestResultInformation;
+  /** Participant */
+  participant?: CommunicationIdentifierModel;
+}
+
+/** Moving the participant failed event. */
+export interface RestMoveParticipantFailed {
+  /** The CallConnectionId for the call you want to move the participant from */
+  fromCall?: string;
   /** Call connection ID. */
   callConnectionId?: string;
   /** Server call ID. */

--- a/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/models/mappers.ts
@@ -2749,139 +2749,6 @@ export const ErrorModel: coreClient.CompositeMapper = {
   },
 };
 
-export const MoveParticipantSucceeded: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "MoveParticipantSucceeded",
-    modelProperties: {
-      fromCall: {
-        serializedName: "fromCall",
-        type: {
-          name: "String",
-        },
-      },
-      callConnectionId: {
-        serializedName: "callConnectionId",
-        type: {
-          name: "String",
-        },
-      },
-      serverCallId: {
-        serializedName: "serverCallId",
-        type: {
-          name: "String",
-        },
-      },
-      correlationId: {
-        serializedName: "correlationId",
-        type: {
-          name: "String",
-        },
-      },
-      operationContext: {
-        serializedName: "operationContext",
-        type: {
-          name: "String",
-        },
-      },
-      resultInformation: {
-        serializedName: "resultInformation",
-        type: {
-          name: "Composite",
-          className: "RestResultInformation",
-        },
-      },
-      participant: {
-        serializedName: "participant",
-        type: {
-          name: "Composite",
-          className: "CommunicationIdentifierModel",
-        },
-      },
-    },
-  },
-};
-
-export const RestResultInformation: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "RestResultInformation",
-    modelProperties: {
-      code: {
-        serializedName: "code",
-        type: {
-          name: "Number",
-        },
-      },
-      subCode: {
-        serializedName: "subCode",
-        type: {
-          name: "Number",
-        },
-      },
-      message: {
-        serializedName: "message",
-        type: {
-          name: "String",
-        },
-      },
-    },
-  },
-};
-
-export const MoveParticipantFailed: coreClient.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "MoveParticipantFailed",
-    modelProperties: {
-      fromCall: {
-        serializedName: "fromCall",
-        type: {
-          name: "String",
-        },
-      },
-      callConnectionId: {
-        serializedName: "callConnectionId",
-        type: {
-          name: "String",
-        },
-      },
-      serverCallId: {
-        serializedName: "serverCallId",
-        type: {
-          name: "String",
-        },
-      },
-      correlationId: {
-        serializedName: "correlationId",
-        type: {
-          name: "String",
-        },
-      },
-      operationContext: {
-        serializedName: "operationContext",
-        type: {
-          name: "String",
-        },
-      },
-      resultInformation: {
-        serializedName: "resultInformation",
-        type: {
-          name: "Composite",
-          className: "RestResultInformation",
-        },
-      },
-      participant: {
-        serializedName: "participant",
-        type: {
-          name: "Composite",
-          className: "CommunicationIdentifierModel",
-        },
-      },
-    },
-  },
-};
-
 export const DtmfResult: coreClient.CompositeMapper = {
   type: {
     name: "Composite",
@@ -2992,6 +2859,33 @@ export const DialogCompleted: coreClient.CompositeMapper = {
         type: {
           name: "Composite",
           className: "RestResultInformation",
+        },
+      },
+    },
+  },
+};
+
+export const RestResultInformation: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestResultInformation",
+    modelProperties: {
+      code: {
+        serializedName: "code",
+        type: {
+          name: "Number",
+        },
+      },
+      subCode: {
+        serializedName: "subCode",
+        type: {
+          name: "Number",
+        },
+      },
+      message: {
+        serializedName: "message",
+        type: {
+          name: "String",
         },
       },
     },
@@ -3604,6 +3498,112 @@ export const RestAddParticipantFailed: coreClient.CompositeMapper = {
     name: "Composite",
     className: "RestAddParticipantFailed",
     modelProperties: {
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        type: {
+          name: "String",
+        },
+      },
+      operationContext: {
+        serializedName: "operationContext",
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      participant: {
+        serializedName: "participant",
+        type: {
+          name: "Composite",
+          className: "CommunicationIdentifierModel",
+        },
+      },
+    },
+  },
+};
+
+export const RestMoveParticipantSucceeded: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestMoveParticipantSucceeded",
+    modelProperties: {
+      fromCall: {
+        serializedName: "fromCall",
+        type: {
+          name: "String",
+        },
+      },
+      callConnectionId: {
+        serializedName: "callConnectionId",
+        type: {
+          name: "String",
+        },
+      },
+      serverCallId: {
+        serializedName: "serverCallId",
+        type: {
+          name: "String",
+        },
+      },
+      correlationId: {
+        serializedName: "correlationId",
+        type: {
+          name: "String",
+        },
+      },
+      operationContext: {
+        serializedName: "operationContext",
+        type: {
+          name: "String",
+        },
+      },
+      resultInformation: {
+        serializedName: "resultInformation",
+        type: {
+          name: "Composite",
+          className: "RestResultInformation",
+        },
+      },
+      participant: {
+        serializedName: "participant",
+        type: {
+          name: "Composite",
+          className: "CommunicationIdentifierModel",
+        },
+      },
+    },
+  },
+};
+
+export const RestMoveParticipantFailed: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "RestMoveParticipantFailed",
+    modelProperties: {
+      fromCall: {
+        serializedName: "fromCall",
+        type: {
+          name: "String",
+        },
+      },
       callConnectionId: {
         serializedName: "callConnectionId",
         type: {

--- a/sdk/communication/communication-call-automation/src/models/events.ts
+++ b/sdk/communication/communication-call-automation/src/models/events.ts
@@ -22,6 +22,8 @@ export type CallAutomationEvent =
   | AddParticipantFailed
   | RemoveParticipantSucceeded
   | RemoveParticipantFailed
+  | MoveParticipantSucceeded
+  | MoveParticipantFailed
   | CallConnected
   | CallDisconnected
   | CallTransferAccepted
@@ -141,6 +143,46 @@ export interface RemoveParticipantFailed {
   participant?: CommunicationIdentifier;
   /** kind of this event. */
   kind: "RemoveParticipantFailed";
+}
+
+/** The participant successfully moved event. */
+export interface MoveParticipantSucceeded {
+  /** The CallConnectionId for the call you want to move the participant from */
+  fromCall?: string;
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Used this to correlate the request to the response event. */
+  operationContext?: string;
+  /** Contains the resulting SIP code/sub-code and message. */
+  resultInformation?: ResultInformation;
+  /** The participant in the call. */
+  participant?: CommunicationIdentifier;
+  /** kind of this event. */
+  kind: "MoveParticipantSucceeded";
+}
+
+/** The failed to move participant event. */
+export interface MoveParticipantFailed {
+  /** The CallConnectionId for the call you want to move the participant from */
+  fromCall?: string;
+  /** Call connection ID. */
+  callConnectionId: string;
+  /** Server call ID. */
+  serverCallId: string;
+  /** Correlation ID for event to call correlation. Also called ChainId for skype chain ID. */
+  correlationId: string;
+  /** Used this to correlate the request to the response event. */
+  operationContext?: string;
+  /** Contains the resulting SIP code/sub-code and message. */
+  resultInformation?: ResultInformation;
+  /** The participant in the call. */
+  participant?: CommunicationIdentifier;
+  /** kind of this event. */
+  kind: "MoveParticipantFailed";
 }
 
 /** Event when call was established. */

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -199,8 +199,6 @@ export interface AddParticipantOptions extends OperationOptions {
 
 /** Options to move participants. */
 export interface MoveParticipantsOptions extends OperationOptions {
-  /** The CallConnectionId for the call you want to move the participant from */
-  fromCall: string;
   /** Used by customers when calling mid-call actions to correlate the request to the response event. */
   operationContext?: string;
   /**

--- a/sdk/communication/communication-call-automation/src/models/options.ts
+++ b/sdk/communication/communication-call-automation/src/models/options.ts
@@ -197,6 +197,19 @@ export interface AddParticipantOptions extends OperationOptions {
   operationCallbackUrl?: string;
 }
 
+/** Options to move participants. */
+export interface MoveParticipantsOptions extends OperationOptions {
+  /** The CallConnectionId for the call you want to move the participant from */
+  fromCall: string;
+  /** Used by customers when calling mid-call actions to correlate the request to the response event. */
+  operationContext?: string;
+  /**
+   * Set a callback URL that overrides the default callback URL set by CreateCall/AnswerCall for this operation.
+   * This setup is per-action. If this is not set, the default callback URI set by CreateCall/AnswerCall will be used.
+   */
+  operationCallbackUrl?: string;
+}
+
 /**
  * Options to remove participants.
  */

--- a/sdk/communication/communication-call-automation/src/models/responses.ts
+++ b/sdk/communication/communication-call-automation/src/models/responses.ts
@@ -16,6 +16,7 @@ import type {
   TransferCallToParticipantEventResult,
   CancelAddParticipantEventResult,
   ConnectCallEventResult,
+  MoveParticipantEventResult,
 } from "../eventprocessor/eventResponses.js";
 import type { AbortSignalLike } from "@azure/abort-controller";
 
@@ -113,6 +114,21 @@ export interface RemoveParticipantResult {
     abortSignal?: AbortSignalLike,
     timeoutInMs?: number,
   ): Promise<RemoveParticipantEventResult>;
+}
+
+/** The response payload for moving participants to the call. */
+export interface MoveParticipantsResult {
+  /** List of current participants in the call. */
+  participants?: CallParticipant[];
+  /** The operation context provided by client. */
+  operationContext?: string;
+  /** The CallConnectionId for the call you want to move the participant from */
+  fromCall?: string;
+  /** Waiting for event processor to process the event */
+  waitForEventProcessor(
+    abortSignal?: AbortSignalLike,
+    timeoutInMs?: number,
+  ): Promise<MoveParticipantEventResult>;
 }
 
 /** The response payload for muting participant from the call. */

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -64,6 +64,12 @@ directive:
       from: AddParticipantFailed
       to: RestAddParticipantFailed
   - rename-model:
+      from: MoveParticipantSucceeded
+      to: RestMoveParticipantSucceeded
+  - rename-model:
+      from: MoveParticipantFailed
+      to: RestMoveParticipantFailed
+  - rename-model:
       from: RemoveParticipantSucceeded
       to: RestRemoveParticipantSucceeded
   - rename-model:

--- a/sdk/communication/communication-call-automation/test/node/callConnection.spec.ts
+++ b/sdk/communication/communication-call-automation/test/node/callConnection.spec.ts
@@ -523,15 +523,13 @@ describe("CallConnection Unit Tests", () => {
     );
 
     const targetParticipants = [target.targetParticipant];
-    const options: MoveParticipantsOptions = {
-      fromCall: "source-call-connection-id",
-    };
-    const promiseResult = callConnection.moveParticipants(targetParticipants, options);
+    const fromCall = "source-call-connection-id";
+    const promiseResult = callConnection.moveParticipants(targetParticipants, fromCall);
 
     // asserts
     const result = await promiseResult;
     assert.isNotNull(result);
-    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, options);
+    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, fromCall);
     assert.equal(result, moveParticipantsResultMock);
     assert.equal(result.fromCall, "source-call-connection-id");
     assert.isDefined(result.participants);
@@ -561,17 +559,21 @@ describe("CallConnection Unit Tests", () => {
       target.targetParticipant,
       { communicationUserId: CALL_TARGET_ID_2 },
     ];
+    const fromCall = "source-call-connection-id";
     const options: MoveParticipantsOptions = {
-      fromCall: "source-call-connection-id",
       operationContext: "move-operation-context",
       operationCallbackUrl: "https://callback.example.com",
     };
-    const promiseResult = callConnection.moveParticipants(targetParticipants, options);
+    const promiseResult = callConnection.moveParticipants(targetParticipants, fromCall, options);
 
     // asserts
     const result = await promiseResult;
     assert.isNotNull(result);
-    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, options);
+    expect(callConnection.moveParticipants).toHaveBeenCalledWith(
+      targetParticipants,
+      fromCall,
+      options,
+    );
     assert.equal(result, moveParticipantsResultMock);
     assert.equal(result.fromCall, "source-call-connection-id");
     assert.equal(result.operationContext, "move-operation-context");
@@ -603,15 +605,13 @@ describe("CallConnection Unit Tests", () => {
     );
 
     const targetParticipants = [target.targetParticipant];
-    const options: MoveParticipantsOptions = {
-      fromCall: "source-call-connection-id",
-    };
-    const promiseResult = callConnection.moveParticipants(targetParticipants, options);
+    const fromCall = "source-call-connection-id";
+    const promiseResult = callConnection.moveParticipants(targetParticipants, fromCall);
 
     // asserts
     const result = await promiseResult;
     assert.isNotNull(result);
-    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, options);
+    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, fromCall);
     assert.equal(result, moveParticipantsResultMock);
 
     // Test event processor

--- a/sdk/communication/communication-call-automation/test/node/callConnection.spec.ts
+++ b/sdk/communication/communication-call-automation/test/node/callConnection.spec.ts
@@ -12,17 +12,20 @@ import type {
   AddParticipantResult,
   TransferCallResult,
   RemoveParticipantResult,
+  MoveParticipantsResult,
   MuteParticipantResult,
   CancelAddParticipantOperationResult,
   AddParticipantEventResult,
   TransferCallToParticipantEventResult,
   RemoveParticipantEventResult,
+  MoveParticipantEventResult,
   CancelAddParticipantEventResult,
   CancelAddParticipantSucceeded,
   CreateCallOptions,
   AnswerCallOptions,
   AddParticipantOptions,
   RemoveParticipantsOption,
+  MoveParticipantsOptions,
   CancelAddParticipantOperationOptions,
   TransferCallToParticipantOptions,
 } from "../../src/index.js";
@@ -60,6 +63,7 @@ vi.mock(import("../../src/index.js"), async (importOriginal) => {
   CallConnection.prototype.addParticipant = vi.fn();
   CallConnection.prototype.transferCallToParticipant = vi.fn();
   CallConnection.prototype.removeParticipant = vi.fn();
+  CallConnection.prototype.moveParticipants = vi.fn();
   CallConnection.prototype.muteParticipant = vi.fn();
   CallConnection.prototype.cancelAddParticipantOperation = vi.fn();
 
@@ -501,6 +505,121 @@ describe("CallConnection Unit Tests", () => {
     assert.isNotNull(result);
     expect(callConnection.removeParticipant).toHaveBeenCalledWith(target.targetParticipant);
     assert.equal(result, removeParticipantResultMock);
+  });
+
+  it("MoveParticipants", async () => {
+    // mocks
+    const moveParticipantsResultMock: MoveParticipantsResult = {
+      participants: [{ identifier: target.targetParticipant }],
+      fromCall: "source-call-connection-id",
+      waitForEventProcessor: async () => {
+        return {} as MoveParticipantEventResult;
+      },
+    };
+    callConnection.moveParticipants.mockReturnValue(
+      new Promise((resolve) => {
+        resolve(moveParticipantsResultMock);
+      }),
+    );
+
+    const targetParticipants = [target.targetParticipant];
+    const options: MoveParticipantsOptions = {
+      fromCall: "source-call-connection-id",
+    };
+    const promiseResult = callConnection.moveParticipants(targetParticipants, options);
+
+    // asserts
+    const result = await promiseResult;
+    assert.isNotNull(result);
+    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, options);
+    assert.equal(result, moveParticipantsResultMock);
+    assert.equal(result.fromCall, "source-call-connection-id");
+    assert.isDefined(result.participants);
+    assert.equal(result.participants.length, 1);
+  });
+
+  it("MoveParticipantsWithOptions", async () => {
+    // mocks
+    const moveParticipantsResultMock: MoveParticipantsResult = {
+      participants: [
+        { identifier: target.targetParticipant },
+        { identifier: { communicationUserId: CALL_TARGET_ID_2 } },
+      ],
+      fromCall: "source-call-connection-id",
+      operationContext: "move-operation-context",
+      waitForEventProcessor: async () => {
+        return {} as MoveParticipantEventResult;
+      },
+    };
+    callConnection.moveParticipants.mockReturnValue(
+      new Promise((resolve) => {
+        resolve(moveParticipantsResultMock);
+      }),
+    );
+
+    const targetParticipants = [
+      target.targetParticipant,
+      { communicationUserId: CALL_TARGET_ID_2 },
+    ];
+    const options: MoveParticipantsOptions = {
+      fromCall: "source-call-connection-id",
+      operationContext: "move-operation-context",
+      operationCallbackUrl: "https://callback.example.com",
+    };
+    const promiseResult = callConnection.moveParticipants(targetParticipants, options);
+
+    // asserts
+    const result = await promiseResult;
+    assert.isNotNull(result);
+    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, options);
+    assert.equal(result, moveParticipantsResultMock);
+    assert.equal(result.fromCall, "source-call-connection-id");
+    assert.equal(result.operationContext, "move-operation-context");
+    assert.isDefined(result.participants);
+    assert.equal(result.participants.length, 2);
+  });
+
+  it("MoveParticipantsWithSingleParticipant", async () => {
+    // mocks
+    const moveParticipantsResultMock: MoveParticipantsResult = {
+      participants: [{ identifier: target.targetParticipant }],
+      fromCall: "source-call-connection-id",
+      waitForEventProcessor: async () => {
+        return {
+          isSuccess: true,
+          successResult: {
+            kind: "MoveParticipantSucceeded",
+            callConnectionId: "target-call-connection-id",
+            fromCall: "source-call-connection-id",
+            participant: target.targetParticipant,
+          },
+        } as MoveParticipantEventResult;
+      },
+    };
+    callConnection.moveParticipants.mockReturnValue(
+      new Promise((resolve) => {
+        resolve(moveParticipantsResultMock);
+      }),
+    );
+
+    const targetParticipants = [target.targetParticipant];
+    const options: MoveParticipantsOptions = {
+      fromCall: "source-call-connection-id",
+    };
+    const promiseResult = callConnection.moveParticipants(targetParticipants, options);
+
+    // asserts
+    const result = await promiseResult;
+    assert.isNotNull(result);
+    expect(callConnection.moveParticipants).toHaveBeenCalledWith(targetParticipants, options);
+    assert.equal(result, moveParticipantsResultMock);
+
+    // Test event processor
+    const eventResult = await result.waitForEventProcessor();
+    assert.isTrue(eventResult.isSuccess);
+    assert.isDefined(eventResult.successResult);
+    assert.equal(eventResult.successResult?.kind, "MoveParticipantSucceeded");
+    assert.equal(eventResult.successResult?.fromCall, "source-call-connection-id");
   });
 
   it("MuteParticipant", async () => {


### PR DESCRIPTION
### Packages impacted by this PR
Communication-Call-Automation

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Implements moveParticipants method for Azure Communication Services Call Automation SDK, enabling movement of participants between different calls. Follows existing SDK patterns with MoveParticipantSucceeded/MoveParticipantFailed events (singular per participant) and fromCall tracking for source call identification. Includes comprehensive interfaces (MoveParticipantsOptions, MoveParticipantsResult), event processing integration, and full test coverage with unit and live integration tests. API: moveParticipants(targetParticipants: CommunicationIdentifier[], options: MoveParticipantsOptions). Added unit tests for move participants.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-sdk-for-net/pull/50197
https://github.com/Azure/azure-sdk-for-python/pull/41448

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
