### PR TITLE
[Monitor OpenTelemetry Exporter] Stop Sending Client OS

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/context/context.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/context/context.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as os from "node:os";
 import { SDK_INFO } from "@opentelemetry/core";
 import { ATTR_TELEMETRY_SDK_VERSION } from "@opentelemetry/semantic-conventions";
 import { KnownContextTagKeys } from "../../../generated/index.js";
@@ -30,12 +29,7 @@ export class Context {
 
   constructor() {
     this.tags = {};
-    this._loadDeviceContext();
     this._loadInternalContext();
-  }
-
-  private _loadDeviceContext(): void {
-    this.tags[KnownContextTagKeys.AiDeviceOsVersion] = os && `${os.type()} ${os.release()}`;
   }
 
   private _loadInternalContext(): void {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/context.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/context.spec.ts
@@ -10,7 +10,6 @@ describe("context.ts", () => {
     assert.ok(Context.nodeVersion, "Missing nodeVersion");
     assert.ok(Context.opentelemetryVersion, "Missing opentelemetryVersion");
     assert.ok(Context.sdkVersion, "Missing sdkVersion");
-    assert.ok(context.tags["ai.device.osVersion"], "Missing ai.device.osVersion");
     assert.ok(context.tags["ai.internal.sdkVersion"], "Missing ai.internal.sdkVersion");
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/metricUtil.spec.ts
@@ -4,7 +4,6 @@
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import fs from "node:fs";
 import path from "node:path";
-import * as os from "node:os";
 import type {
   ResourceMetrics,
   PeriodicExportingMetricReaderOptions,
@@ -102,7 +101,7 @@ function assertStatsbeatEnvelope(
 
   assert.strictEqual(envelope.instrumentationKey, "ikey");
 
-  assert.deepStrictEqual(Object.keys(envelope.tags || {}).length, 2);
+  assert.deepStrictEqual(Object.keys(envelope.tags || {}).length, 1);
 }
 
 describe("metricUtil.ts", () => {
@@ -146,7 +145,6 @@ describe("metricUtil.ts", () => {
   describe("#resourceMetricsToEnvelope", () => {
     it("should create a metric envelope", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData: Partial<RequestData> = {
@@ -195,7 +193,6 @@ describe("metricUtil.ts", () => {
       process.env = newEnv;
 
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData: Partial<RequestData> = {
@@ -243,7 +240,6 @@ describe("metricUtil.ts", () => {
   describe("#performanceMetricsToEnvelope", () => {
     it("should create private bytes envelopes with the correct name", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {
@@ -284,7 +280,6 @@ describe("metricUtil.ts", () => {
     });
     it("should create available bytes envelopes with the correct name", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {
@@ -325,7 +320,6 @@ describe("metricUtil.ts", () => {
     });
     it("should create processor time envelopes with the correct name", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {
@@ -366,7 +360,6 @@ describe("metricUtil.ts", () => {
     });
     it("should create process time envelopes with the correct name", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {
@@ -407,7 +400,6 @@ describe("metricUtil.ts", () => {
     });
     it("should create request rate envelopes with the correct name", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {
@@ -448,7 +440,6 @@ describe("metricUtil.ts", () => {
     });
     it("should create request duration envelopes with the correct name", async () => {
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {
@@ -497,7 +488,6 @@ describe("metricUtil.ts", () => {
       process.env = newEnv;
 
       const expectedTags: Tags = {
-        "ai.device.osVersion": os && `${os.type()} ${os.release()}`,
         "ai.internal.sdkVersion": `${prefix}node${Context.nodeVersion}:otel${Context.opentelemetryVersion}:${version}`,
       };
       const expectedBaseData = {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
Client OS should not be sent in the telemetry data.

### Are there test cases added in this PR? _(If not, why?)_
Test cases are modified.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
