### PR TITLE
[Cosmos] Enhance partition key extraction logic and update tests for system key

### DIFF
--- a/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
@@ -35,45 +35,46 @@ export function extractPartitionKeys(
   partitionKeyDefinition?: PartitionKeyDefinition,
 ): PartitionKeyInternal | undefined {
   if (
-    partitionKeyDefinition &&
-    partitionKeyDefinition.paths &&
-    partitionKeyDefinition.paths.length > 0
+    !partitionKeyDefinition ||
+    !partitionKeyDefinition.paths ||
+    partitionKeyDefinition.paths.length <= 0
   ) {
-    if (
-      partitionKeyDefinition.paths.length === 1 &&
-      partitionKeyDefinition.paths[0] === DEFAULT_PARTITION_KEY_PATH
-    ) {
-      const defaultKey = extractPartitionKey(DEFAULT_PARTITION_KEY_PATH, document);
-      if (defaultKey === undefined) {
-        if (partitionKeyDefinition.systemKey === true) {
-          return [];
-        }
-        logger.warning("Unsupported PartitionKey found.");
-        return undefined;
-      } else if (defaultKey === NullPartitionKeyLiteral || defaultKey === NonePartitionKeyLiteral) {
-        if (partitionKeyDefinition.systemKey === true) {
-          return [];
-        }
-      }
-      return [defaultKey];
-    }
-
-    if (partitionKeyDefinition.systemKey === true) {
-      return [];
-    }
-    const partitionKeys: PrimitivePartitionKeyValue[] = [];
-    partitionKeyDefinition.paths.forEach((path: string) => {
-      const obj = extractPartitionKey(path, document);
-      if (obj === undefined) {
-        logger.warning("Unsupported PartitionKey found.");
-        return undefined;
-      }
-      partitionKeys.push(obj);
-    });
-    return partitionKeys;
+    logger.error("Unexpected Partition Key Definition Found.");
+    return undefined;
   }
-  logger.error("Unexpected Partition Key Definition Found.");
-  return undefined;
+
+  if (
+    partitionKeyDefinition.paths.length === 1 &&
+    partitionKeyDefinition.paths[0] === DEFAULT_PARTITION_KEY_PATH
+  ) {
+    const defaultKey = extractPartitionKey(DEFAULT_PARTITION_KEY_PATH, document);
+    if (defaultKey === undefined) {
+      if (partitionKeyDefinition.systemKey === true) {
+        return [];
+      }
+      logger.warning("Unsupported PartitionKey found.");
+      return undefined;
+    } else if (defaultKey === NullPartitionKeyLiteral || defaultKey === NonePartitionKeyLiteral) {
+      if (partitionKeyDefinition.systemKey === true) {
+        return [];
+      }
+    }
+    return [defaultKey];
+  }
+
+  if (partitionKeyDefinition.systemKey === true) {
+    return [];
+  }
+  const partitionKeys: PrimitivePartitionKeyValue[] = [];
+  partitionKeyDefinition.paths.forEach((path: string) => {
+    const obj = extractPartitionKey(path, document);
+    if (obj === undefined) {
+      logger.warning("Unsupported PartitionKey found.");
+      return undefined;
+    }
+    partitionKeys.push(obj);
+  });
+  return partitionKeys;
 }
 
 function extractPartitionKey(path: string, obj: unknown): any {

--- a/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/extractPartitionKey.ts
@@ -39,17 +39,28 @@ export function extractPartitionKeys(
     partitionKeyDefinition.paths &&
     partitionKeyDefinition.paths.length > 0
   ) {
-    if (partitionKeyDefinition.systemKey === true) {
-      return [];
-    }
-
     if (
       partitionKeyDefinition.paths.length === 1 &&
       partitionKeyDefinition.paths[0] === DEFAULT_PARTITION_KEY_PATH
     ) {
-      return [extractPartitionKey(DEFAULT_PARTITION_KEY_PATH, document)];
+      const defaultKey = extractPartitionKey(DEFAULT_PARTITION_KEY_PATH, document);
+      if (defaultKey === undefined) {
+        if (partitionKeyDefinition.systemKey === true) {
+          return [];
+        }
+        logger.warning("Unsupported PartitionKey found.");
+        return undefined;
+      } else if (defaultKey === NullPartitionKeyLiteral || defaultKey === NonePartitionKeyLiteral) {
+        if (partitionKeyDefinition.systemKey === true) {
+          return [];
+        }
+      }
+      return [defaultKey];
     }
 
+    if (partitionKeyDefinition.systemKey === true) {
+      return [];
+    }
     const partitionKeys: PrimitivePartitionKeyValue[] = [];
     partitionKeyDefinition.paths.forEach((path: string) => {
       const obj = extractPartitionKey(path, document);

--- a/sdk/cosmosdb/cosmos/test/public/integration/extractPartitionKey.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/extractPartitionKey.spec.ts
@@ -15,7 +15,8 @@ describe("extractPartitionKey", () => {
 
   describe("With a defined partitionKeyDefinition", () => {
     const partitionKeyDefinition = { paths: ["/a/b"] };
-    const migratedPartitionKeyDefinition = { paths: ["/_partitionKey"], isSystemKey: true };
+    const migratedPartitionKeyDefinition = { paths: ["/_partitionKey"], systemKey: true };
+    const defaultPartitionKeyDefinition = { paths: ["/_partitionKey"] };
 
     it("should return [{}] when document has no partition key value", () => {
       const document = {};
@@ -26,7 +27,7 @@ describe("extractPartitionKey", () => {
     it("should return [] when container is migrated from non-partitioned and document has no partition key value", () => {
       const document = {};
       const result = extractPartitionKeys(document, migratedPartitionKeyDefinition);
-      assert.deepEqual(result, [{}]);
+      assert.deepEqual(result, []);
     });
 
     it("should return [null] when document has a null partition key value", () => {
@@ -45,6 +46,37 @@ describe("extractPartitionKey", () => {
       const document = { a: { b: "some value" } };
       const result = extractPartitionKeys(document, partitionKeyDefinition);
       assert.deepEqual(result, ["some value"]);
+    });
+
+    it("should handle default partition key path with valid value", () => {
+      const document = { _partitionKey: "test-value" };
+      const result = extractPartitionKeys(document, defaultPartitionKeyDefinition);
+      assert.deepEqual(result, ["test-value"]);
+    });
+
+    it("should handle default partition key path with undefined value and system key", () => {
+      const document = {};
+      const result = extractPartitionKeys(document, migratedPartitionKeyDefinition);
+      assert.deepEqual(result, []);
+    });
+
+    it("should handle default partition key path with undefined value and non-system key", () => {
+      const document = {};
+      const result = extractPartitionKeys(document, defaultPartitionKeyDefinition);
+      assert.deepEqual(result, [{}]);
+    });
+
+    it("should handle default partition key path with unsupported value type", () => {
+      const document = { _partitionKey: { nested: "value" } };
+      const result = extractPartitionKeys(document, defaultPartitionKeyDefinition);
+      assert.deepEqual(result, undefined);
+    });
+
+    it("should handle system key with non-default partition key path", () => {
+      const systemKeyDefinition = { paths: ["/customPath"], systemKey: true };
+      const document = {};
+      const result = extractPartitionKeys(document, systemKeyDefinition);
+      assert.deepEqual(result, []);
     });
   });
 });

--- a/sdk/cosmosdb/cosmos/test/public/integration/extractPartitionKey.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/extractPartitionKey.spec.ts
@@ -47,10 +47,23 @@ describe("extractPartitionKey", () => {
       const result = extractPartitionKeys(document, partitionKeyDefinition);
       assert.deepEqual(result, ["some value"]);
     });
+    // add a test case for Hierarchical partition key paths
+    it("should return [value] for hierarchical partition key paths", () => {
+      const hierarchicalPartitionKeyDefinition = { paths: ["/a", "/bc", "/d"] };
+      const document = { a: "a", bc: "bc", d: "d" };
+      const result = extractPartitionKeys(document, hierarchicalPartitionKeyDefinition);
+      assert.deepEqual(result, ["a", "bc", "d"]);
+    });
 
     it("should handle default partition key path with valid value", () => {
       const document = { _partitionKey: "test-value" };
       const result = extractPartitionKeys(document, defaultPartitionKeyDefinition);
+      assert.deepEqual(result, ["test-value"]);
+    });
+
+    it("should handle migrated partition key path with valid value", () => {
+      const document = { _partitionKey: "test-value" };
+      const result = extractPartitionKeys(document, migratedPartitionKeyDefinition);
       assert.deepEqual(result, ["test-value"]);
     });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR

### Describe the problem that is addressed by this PR
This PR fixes a bug where the partition key for a migrated container was incorrectly returned as an empty array ([]). It now returns the correct partition key value.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
