### PR TITLE
[keyvault] Add missing key wrap algos

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -365,7 +365,7 @@ export interface KeyVaultKeyIdentifier {
 }
 
 // @public
-export type KeyWrapAlgorithm = "A128KW" | "A192KW" | "A256KW" | "RSA-OAEP" | "RSA-OAEP-256" | "RSA1_5";
+export type KeyWrapAlgorithm = "A128KW" | "A192KW" | "A256KW" | "RSA-OAEP" | "RSA-OAEP-256" | "RSA1_5" | "CKM_AES_KEY_WRAP" | "CKM_AES_KEY_WRAP_PAD";
 
 // @public
 export enum KnownDeletionRecoveryLevel {

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClientModels.ts
@@ -35,7 +35,9 @@ export type KeyWrapAlgorithm =
   | "A256KW"
   | "RSA-OAEP"
   | "RSA-OAEP-256"
-  | "RSA1_5";
+  | "RSA1_5"
+  | "CKM_AES_KEY_WRAP"
+  | "CKM_AES_KEY_WRAP_PAD";
 
 /**
  * Result of the {@link encrypt} operation.


### PR DESCRIPTION
Looks like I never added the new `CKM_AES_KEY_WRAP{_PAD}` algorithms to the
union type. This PR adds them to the public API.
