### PR TITLE
[Identity] MI post script fix

### DIFF
--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -100,7 +100,7 @@ $AKS_OIDC_ISSUER = az aks show -n $DeploymentOutputs['IDENTITY_AKS_CLUSTER_NAME'
 
 # Create the federated identity
 Write-Host "Creating federated identity"
-az identity federated-credential create --name $MIName --identity-name $MIName --resource-group $DeploymentOutputs['IDENTITY_RESOURCE_GROUP'] --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:default:workload-identity-sa
+az identity federated-credential create --name $MIName --identity-name $MIName --resource-group $DeploymentOutputs['IDENTITY_RESOURCE_GROUP'] --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:default:workload-identity-sa --audiences api://AzureADTokenExchange
 
 # Build the kubernetes deployment yaml
 $kubeConfig = @"


### PR DESCRIPTION
Link to [Go PR](https://github.com/Azure/azure-sdk-for-go/pull/24755) for more context: "azidentity's live managed identity test pipeline is failing because az made a breaking change to require an explicit audience when creating a federated identity. This PR addresses that by specifying the default audience used by the previous az." Successful pipeline run [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4959735&view=results)