### PR TITLE
Remove hardcoded osvmimage variable

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,5 @@
 variables:
   DocWardenVersion: '0.5.0'
-  OSVmImage: "ubuntu-20.04"
   skipComponentGovernanceDetection: true
   coalesceResultFilter: $[ coalesce(variables['packageGlobFilter'], '**') ]
   ServiceVersion: ""


### PR DESCRIPTION
I assume this is a leftover and should not be defined here + could conflict with our other settings.