### PR TITLE
[identity] Fix return type for workload identity

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Fixed the bug in interactive authentication request to account for the correct user login prompt based on the login hint provided, in case there are multiple accounts present in the browser flow. [#34321](https://github.com/Azure/azure-sdk-for-js/pull/34321)
+- Fixed the typing for `WorkloadIdentityCredential.getToken` to better represent the runtime behavior. [#34786](https://github.com/Azure/azure-sdk-for-js/pull/34786)
 
 ## 4.10.0 (2025-05-14)
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -471,7 +471,7 @@ export interface VisualStudioCodeCredentialOptions extends MultiTenantTokenCrede
 // @public
 export class WorkloadIdentityCredential implements TokenCredential {
     constructor(options?: WorkloadIdentityCredentialOptions);
-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/workloadIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/workloadIdentityCredential.ts
@@ -105,7 +105,7 @@ export class WorkloadIdentityCredential implements TokenCredential {
   public async getToken(
     scopes: string | string[],
     options?: GetTokenOptions,
-  ): Promise<AccessToken | null> {
+  ): Promise<AccessToken> {
     if (!this.client) {
       const errorMessage = `${credentialName}: is unavailable. tenantId, clientId, and federatedTokenFilePath are required parameters. 
       In DefaultAzureCredential and ManagedIdentityCredential, these can be provided as environment variables - 


### PR DESCRIPTION
A customer pointed out that the return type of WorkloadIdentityCredential is
inconsistent and misleading. 

While core-auth exposes a getToken with a return type of `Promise<AccessToken |
null>`, Identity credentials generally throw if they're unsuccessful in getting a token and
their return types are the narrower `Promise<AccessToken>` 

Aligning WorkloadIdentityCredential with the rest of our credential return types
provides consistency and is not a breaking change (you can narrow return types
and widen input types)

Resolves #32612