### PR TITLE
[EngSys] fix CI runner testing for non-restricted packages

### DIFF
--- a/eng/tools/rush-runner/src/actions.js
+++ b/eng/tools/rush-runner/src/actions.js
@@ -41,7 +41,7 @@ export function executeActions(action, serviceDirs, rushParams, artifactNames, c
           action,
           getDirectionMappedPackages(packageNames, action, serviceDirs),
           rushParams,
-          ciFlag
+          ciFlag,
         );
         break;
 

--- a/eng/tools/rush-runner/src/helpers.js
+++ b/eng/tools/rush-runner/src/helpers.js
@@ -109,9 +109,7 @@ export const getDirectionMappedPackages = (packageNames, action, serviceDirs) =>
     // we are in a test task of some kind
     mappedPackages.push(
       ...fullPackageNames.map((p) => {
-        if (restrictedToPackages.includes(p)) {
-          return ["--only", p];
-        } else if (packageNames.includes(p)) {
+        if (!restrictedToPackages.includes(p) && packageNames.includes(p)) {
           return ["--impacted-by", p];
         } else {
           return ["--only", p];

--- a/eng/tools/rush-runner/src/helpers.js
+++ b/eng/tools/rush-runner/src/helpers.js
@@ -107,15 +107,17 @@ export const getDirectionMappedPackages = (packageNames, action, serviceDirs) =>
     }
   } else {
     // we are in a test task of some kind
-    mappedPackages.push(...fullPackageNames.map((p) => {
-      if (restrictedToPackages.includes(p)) {
-        return ["--only", p];
-      } else if (packageNames.includes(p)) {
-        return ["--impacted-by", p];
-      } else {
-        return ["--only", p];
-      }
-    }));
+    mappedPackages.push(
+      ...fullPackageNames.map((p) => {
+        if (restrictedToPackages.includes(p)) {
+          return ["--only", p];
+        } else if (packageNames.includes(p)) {
+          return ["--impacted-by", p];
+        } else {
+          return ["--only", p];
+        }
+      }),
+    );
   }
 
   return mappedPackages;

--- a/eng/tools/rush-runner/src/helpers.js
+++ b/eng/tools/rush-runner/src/helpers.js
@@ -107,9 +107,15 @@ export const getDirectionMappedPackages = (packageNames, action, serviceDirs) =>
     }
   } else {
     // we are in a test task of some kind
-    const rushCommandFlag = isReducedTestScopeEnabled ? "--only" : "--impacted-by";
-
-    mappedPackages.push(...fullPackageNames.map((p) => [rushCommandFlag, p]));
+    mappedPackages.push(...fullPackageNames.map((p) => {
+      if (restrictedToPackages.includes(p)) {
+        return ["--only", p];
+      } else if (packageNames.includes(p)) {
+        return ["--impacted-by", p];
+      } else {
+        return ["--only", p];
+      }
+    }));
   }
 
   return mappedPackages;

--- a/eng/tools/rush-runner/src/rush.js
+++ b/eng/tools/rush-runner/src/rush.js
@@ -57,11 +57,11 @@ export function rushRunAllWithDirection(action, packagesWithDirection, rushParam
   if (
     // 1. eng/tools/rush-runner/index.js is running in CI: "--ci" flag is set
     // Example: node eng/tools/rush-runner/index.js test:node servicebus template -packages "azure-service-bus,azure-template" --ci --verbose -p max
-    ciFlag
+    ciFlag &&
     // 2. Ensure not in "live" or "record" mode (run only in playback mode)
-    && (!["live", "record"].includes(process.env.TEST_MODE))
+    !["live", "record"].includes(process.env.TEST_MODE) &&
     // 3. Ensure the action is either 'test:node' or 'test:browser' (tests)
-    && (['test:node', 'test:browser'].includes(action))
+    ["test:node", "test:browser"].includes(action)
   ) {
     console.log(`Running rush list with ${invocation.join(" ")}`);
 
@@ -124,11 +124,12 @@ export function runRushInPackageDirs(action, packageDirs, onError) {
  */
 function parsePackageNames(rushListOutput) {
   const packageNames = [];
-  const lines = rushListOutput.split('\n'); // Split the output into lines
+  const lines = rushListOutput.split("\n"); // Split the output into lines
 
   for (const line of lines) {
     const trimmedLine = line.trim(); // Trim whitespace
-    if (trimmedLine.startsWith('@azure')) { // Assuming package names start with '@azure'
+    if (trimmedLine.startsWith("@azure")) {
+      // Assuming package names start with '@azure'
       packageNames.push(trimmedLine);
     }
   }

--- a/eng/tools/rush-runner/src/testProxyRestore.js
+++ b/eng/tools/rush-runner/src/testProxyRestore.js
@@ -17,40 +17,42 @@ export function runTestProxyRestore(packages) {
   // Get the path to the proxy executable from the environment variable
   const proxyExe = process.env.PROXY_EXE; // Set in the pipeline before this script is run
   if (!proxyExe) {
-    console.error('PROXY_EXE environment variable is not set');
+    console.error("PROXY_EXE environment variable is not set");
     return;
   }
 
-  console.log('Starting test-proxy restore for packages:', packages);
+  console.log("Starting test-proxy restore for packages:", packages);
   const completedPackages = [];
   for (const packageName of packages) {
     const rushSpec = readFileJson(pathJoin(getBaseDir(), "rush.json"));
 
     // Find the target package
     const targetPackage = rushSpec.projects.find(
-      packageSpec => packageSpec.packageName == packageName
+      (packageSpec) => packageSpec.packageName == packageName,
     );
 
     // Get the directory of the target package
     const targetPackageDir = pathJoin(getBaseDir(), targetPackage.projectFolder);
 
     // Path to the assets.json file in the target package directory
-    const assetsJsonPath = pathJoin(targetPackageDir, 'assets.json');
+    const assetsJsonPath = pathJoin(targetPackageDir, "assets.json");
 
     // Check if the assets.json file exists
     if (existsSync(assetsJsonPath)) {
       try {
         console.log(`Executing test-proxy restore for ${packageName}`);
-        execSync(`${proxyExe} restore -a "assets.json"`, { cwd: targetPackageDir, stdio: 'inherit' });
+        execSync(`${proxyExe} restore -a "assets.json"`, {
+          cwd: targetPackageDir,
+          stdio: "inherit",
+        });
         completedPackages.push(packageName);
       } catch (error) {
         console.error(`Error executing test-proxy restore: ${error.message}`);
       }
     }
   }
-  console.log('Completed test-proxy restore for the packages:', completedPackages);
+  console.log("Completed test-proxy restore for the packages:", completedPackages);
 }
-
 
 function readFileJson(filename) {
   try {

--- a/eng/tools/rush-runner/test/actions.spec.js
+++ b/eng/tools/rush-runner/test/actions.spec.js
@@ -8,6 +8,7 @@ import { executeActions } from "../src/actions.js";
 import { spawnNode } from "../src/spawn.js";
 import { getBaseDir } from "../src/env.js";
 import { join as pathJoin } from "node:path";
+import { existsSync } from "node:fs";
 
 const baseDir = getBaseDir();
 
@@ -47,6 +48,31 @@ describe("executeActions", () => {
     const packageDir = pathJoin(baseDir, "sdk/appconfiguration/app-configuration");
     const executeScript = pathJoin(baseDir, "common/scripts/install-run-rushx.js");
     assert.deepEqual(vi.mocked(spawnNode).mock.calls, [[packageDir, executeScript, "lint"]]);
+  });
+
+  it("should run test for those impacted by non-restricted package", () => {
+    executeActions("test:node", ["core", "communication"], [], "azure-communication-identity");
+    const packageDir = pathJoin(baseDir, "sdk/appconfiguration/app-configuration");
+    const executeScript = pathJoin(baseDir, "common/scripts/install-run-rush.js");
+    assert.deepEqual(vi.mocked(spawnNode).mock.calls, [
+      [
+        baseDir,
+        "common/scripts/install-run-rush.js",
+        "test:node",
+        "--impacted-by",
+        "@azure/communication-identity",
+        "--only",
+        "@azure-rest/synapse-access-control",
+        "--only",
+        "@azure/arm-resources",
+        "--only",
+        "@azure/identity",
+        "--only",
+        "@azure/service-bus",
+        "--only",
+        "@azure/template",
+      ],
+    ]);
   });
 
   it("should handle arbitrary rush commands", () => {

--- a/eng/tools/rush-runner/test/helpers.spec.js
+++ b/eng/tools/rush-runner/test/helpers.spec.js
@@ -70,14 +70,11 @@ describe("getDirectionMappedPackages", () => {
 
     it("should use --only when testing two or more service dirs", () => {
       const changed = ["@azure/app-configuration", "@azure/storage-blob"];
-      const mapped = getDirectionMappedPackages(changed, "test", [
-        "appconfiguration",
-        "storage",
-      ]);
+      const mapped = getDirectionMappedPackages(changed, "test", ["appconfiguration", "storage"]);
 
       assert.deepStrictEqual(mapped, [
-        ["--only", "@azure/app-configuration"],
-        ["--only", "@azure/storage-blob"],
+        ["--impacted-by", "@azure/app-configuration"],
+        ["--impacted-by", "@azure/storage-blob"],
       ]);
     });
   });


### PR DESCRIPTION
Currently if reduced test matrix is enabled, we use `--only` for all packages.
We actually only want to do that for restricted packages because the list of
packages impacted by them is too large.  We still want to build and test
packages impacted by non-restricted packages.