### PR TITLE
[core-client-rest] bump core-auth version

### DIFF
--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.3.0",
+    "@azure/core-auth": "^1.6.0",
     "@azure/core-rest-pipeline": "^1.5.0",
     "@azure/core-tracing": "^1.0.1",
     "@typespec/ts-http-runtime": "^0.2.2",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure-rest/core-client`

### Describe the problem that is addressed by this PR

`core-client-rest` is using `isKeyCredential` from `core-auth` which is only available in `1.6.0` or newer. This PR bumps the minimum version accordingly to prevent dependency issues.
