### PR TITLE
[communication][test] revert recording changes for chat and rooms

### DIFF
--- a/sdk/communication/communication-chat/assets.json
+++ b/sdk/communication/communication-chat/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-chat",
-  "Tag": "js/communication/communication-chat_37cbf617da"
+  "Tag": "js/communication/communication-chat_5593dd2de6"
 }

--- a/sdk/communication/communication-rooms/assets.json
+++ b/sdk/communication/communication-rooms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-rooms",
-  "Tag": "js/communication/communication-rooms_9038f02e82"
+  "Tag": "js/communication/communication-rooms_9e36c793b7"
 }


### PR DESCRIPTION
They were updated to work with newer version of communication-identity. However,
the package version of communication-identity has been fixed from 1.3.2 to
1.4.0-beta.1. Now communication-identity  v1.3.1 is used instead and caused
mismatch between requests and recordings.

This PR reverts the recordings change back to earlier version.