### PR TITLE
Use bundler module resolution

### DIFF
--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "composite": true
   },
   "include": ["${configDir}/src"]

--- a/tsconfig.nonlib.json
+++ b/tsconfig.nonlib.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2023",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "composite": true
   }


### PR DESCRIPTION
Our code is meant to run in both NodeJS and the browser so it is more accurate to use the bundler module resolution to resolve paths in TypeScript code.