### PR TITLE
[snippets.spec.ts] Add dedicated tsconfig.snippets.json

### DIFF
--- a/sdk/advisor/arm-advisor/tsconfig.json
+++ b/sdk/advisor/arm-advisor/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/advisor/arm-advisor/tsconfig.snippets.json
+++ b/sdk/advisor/arm-advisor/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/agricultureplatform/arm-agricultureplatform/tsconfig.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/agricultureplatform/arm-agricultureplatform/tsconfig.snippets.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/agrifood/agrifood-farming-rest/tsconfig.json
+++ b/sdk/agrifood/agrifood-farming-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/agrifood/agrifood-farming-rest/tsconfig.snippets.json
+++ b/sdk/agrifood/agrifood-farming-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/agrifood/arm-agrifood/tsconfig.json
+++ b/sdk/agrifood/arm-agrifood/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/agrifood/arm-agrifood/tsconfig.snippets.json
+++ b/sdk/agrifood/arm-agrifood/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/ai/ai-agents/tsconfig.json
+++ b/sdk/ai/ai-agents/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/ai/ai-agents/tsconfig.snippets.json
+++ b/sdk/ai/ai-agents/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/ai/ai-inference-rest/tsconfig.json
+++ b/sdk/ai/ai-inference-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/ai/ai-inference-rest/tsconfig.snippets.json
+++ b/sdk/ai/ai-inference-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/ai/ai-projects/tsconfig.json
+++ b/sdk/ai/ai-projects/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/ai/ai-projects/tsconfig.snippets.json
+++ b/sdk/ai/ai-projects/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/analysisservices/arm-analysisservices/tsconfig.json
+++ b/sdk/analysisservices/arm-analysisservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/analysisservices/arm-analysisservices/tsconfig.snippets.json
+++ b/sdk/analysisservices/arm-analysisservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/tsconfig.json
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/tsconfig.snippets.json
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/apicenter/arm-apicenter/tsconfig.json
+++ b/sdk/apicenter/arm-apicenter/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/apicenter/arm-apicenter/tsconfig.snippets.json
+++ b/sdk/apicenter/arm-apicenter/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.json
@@ -1,8 +1,17 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ],
   "compilerOptions": {
     "esModuleInterop": true

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.snippets.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/apimanagement/api-management-custom-widgets-tools/tsconfig.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/tsconfig.json
@@ -1,8 +1,17 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ],
   "compilerOptions": {
     "esModuleInterop": true

--- a/sdk/apimanagement/api-management-custom-widgets-tools/tsconfig.snippets.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/apimanagement/arm-apimanagement/tsconfig.json
+++ b/sdk/apimanagement/arm-apimanagement/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/apimanagement/arm-apimanagement/tsconfig.snippets.json
+++ b/sdk/apimanagement/arm-apimanagement/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/tsconfig.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/tsconfig.snippets.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appconfiguration/app-configuration/tsconfig.json
+++ b/sdk/appconfiguration/app-configuration/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/appconfiguration/app-configuration/tsconfig.snippets.json
+++ b/sdk/appconfiguration/app-configuration/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appconfiguration/arm-appconfiguration/tsconfig.json
+++ b/sdk/appconfiguration/arm-appconfiguration/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/appconfiguration/arm-appconfiguration/tsconfig.snippets.json
+++ b/sdk/appconfiguration/arm-appconfiguration/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appcontainers/arm-appcontainers/tsconfig.json
+++ b/sdk/appcontainers/arm-appcontainers/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/appcontainers/arm-appcontainers/tsconfig.snippets.json
+++ b/sdk/appcontainers/arm-appcontainers/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/applicationinsights/arm-appinsights/tsconfig.json
+++ b/sdk/applicationinsights/arm-appinsights/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/applicationinsights/arm-appinsights/tsconfig.snippets.json
+++ b/sdk/applicationinsights/arm-appinsights/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appservice/arm-appservice-rest/tsconfig.json
+++ b/sdk/appservice/arm-appservice-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/appservice/arm-appservice-rest/tsconfig.snippets.json
+++ b/sdk/appservice/arm-appservice-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/appservice/arm-appservice/tsconfig.json
+++ b/sdk/appservice/arm-appservice/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/appservice/arm-appservice/tsconfig.snippets.json
+++ b/sdk/appservice/arm-appservice/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/astro/arm-astro/tsconfig.json
+++ b/sdk/astro/arm-astro/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/astro/arm-astro/tsconfig.snippets.json
+++ b/sdk/astro/arm-astro/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/attestation/arm-attestation/tsconfig.json
+++ b/sdk/attestation/arm-attestation/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/attestation/arm-attestation/tsconfig.snippets.json
+++ b/sdk/attestation/arm-attestation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/attestation/attestation/tsconfig.json
+++ b/sdk/attestation/attestation/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/attestation/attestation/tsconfig.snippets.json
+++ b/sdk/attestation/attestation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/authorization/arm-authorization/tsconfig.json
+++ b/sdk/authorization/arm-authorization/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/authorization/arm-authorization/tsconfig.snippets.json
+++ b/sdk/authorization/arm-authorization/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/automanage/arm-automanage/tsconfig.json
+++ b/sdk/automanage/arm-automanage/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/automanage/arm-automanage/tsconfig.snippets.json
+++ b/sdk/automanage/arm-automanage/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/automation/arm-automation/tsconfig.json
+++ b/sdk/automation/arm-automation/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/automation/arm-automation/tsconfig.snippets.json
+++ b/sdk/automation/arm-automation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/avs/arm-avs/tsconfig.json
+++ b/sdk/avs/arm-avs/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/avs/arm-avs/tsconfig.snippets.json
+++ b/sdk/avs/arm-avs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/tsconfig.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/tsconfig.snippets.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/azurestack/arm-azurestack/tsconfig.json
+++ b/sdk/azurestack/arm-azurestack/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/azurestack/arm-azurestack/tsconfig.snippets.json
+++ b/sdk/azurestack/arm-azurestack/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/azurestackhci/arm-azurestackhci/tsconfig.json
+++ b/sdk/azurestackhci/arm-azurestackhci/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/azurestackhci/arm-azurestackhci/tsconfig.snippets.json
+++ b/sdk/azurestackhci/arm-azurestackhci/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/tsconfig.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/tsconfig.snippets.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/batch/arm-batch/tsconfig.json
+++ b/sdk/batch/arm-batch/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/batch/arm-batch/tsconfig.snippets.json
+++ b/sdk/batch/arm-batch/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/batch/batch-rest/tsconfig.json
+++ b/sdk/batch/batch-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/batch/batch-rest/tsconfig.snippets.json
+++ b/sdk/batch/batch-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/billing/arm-billing/tsconfig.json
+++ b/sdk/billing/arm-billing/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/billing/arm-billing/tsconfig.snippets.json
+++ b/sdk/billing/arm-billing/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/billingbenefits/arm-billingbenefits/tsconfig.json
+++ b/sdk/billingbenefits/arm-billingbenefits/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/billingbenefits/arm-billingbenefits/tsconfig.snippets.json
+++ b/sdk/billingbenefits/arm-billingbenefits/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/botservice/arm-botservice/tsconfig.json
+++ b/sdk/botservice/arm-botservice/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/botservice/arm-botservice/tsconfig.snippets.json
+++ b/sdk/botservice/arm-botservice/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/carbonoptimization/arm-carbonoptimization/tsconfig.json
+++ b/sdk/carbonoptimization/arm-carbonoptimization/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/carbonoptimization/arm-carbonoptimization/tsconfig.snippets.json
+++ b/sdk/carbonoptimization/arm-carbonoptimization/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cdn/arm-cdn/tsconfig.json
+++ b/sdk/cdn/arm-cdn/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/cdn/arm-cdn/tsconfig.snippets.json
+++ b/sdk/cdn/arm-cdn/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/changeanalysis/arm-changeanalysis/tsconfig.json
+++ b/sdk/changeanalysis/arm-changeanalysis/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/changeanalysis/arm-changeanalysis/tsconfig.snippets.json
+++ b/sdk/changeanalysis/arm-changeanalysis/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/changes/arm-changes/tsconfig.json
+++ b/sdk/changes/arm-changes/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/changes/arm-changes/tsconfig.snippets.json
+++ b/sdk/changes/arm-changes/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/chaos/arm-chaos/tsconfig.json
+++ b/sdk/chaos/arm-chaos/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/chaos/arm-chaos/tsconfig.snippets.json
+++ b/sdk/chaos/arm-chaos/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cognitivelanguage/ai-language-conversations/tsconfig.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/cognitivelanguage/ai-language-conversations/tsconfig.snippets.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cognitiveservices/arm-cognitiveservices/tsconfig.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/cognitiveservices/arm-cognitiveservices/tsconfig.snippets.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/commerce/arm-commerce/tsconfig.json
+++ b/sdk/commerce/arm-commerce/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/commerce/arm-commerce/tsconfig.snippets.json
+++ b/sdk/commerce/arm-commerce/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/arm-communication/tsconfig.json
+++ b/sdk/communication/arm-communication/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/communication/arm-communication/tsconfig.snippets.json
+++ b/sdk/communication/arm-communication/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-alpha-ids/tsconfig.json
+++ b/sdk/communication/communication-alpha-ids/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-alpha-ids/tsconfig.snippets.json
+++ b/sdk/communication/communication-alpha-ids/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-call-automation/tsconfig.json
+++ b/sdk/communication/communication-call-automation/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-call-automation/tsconfig.snippets.json
+++ b/sdk/communication/communication-call-automation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-chat/tsconfig.json
+++ b/sdk/communication/communication-chat/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-chat/tsconfig.snippets.json
+++ b/sdk/communication/communication-chat/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-common/tsconfig.json
+++ b/sdk/communication/communication-common/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-common/tsconfig.snippets.json
+++ b/sdk/communication/communication-common/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-email/tsconfig.json
+++ b/sdk/communication/communication-email/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-email/tsconfig.snippets.json
+++ b/sdk/communication/communication-email/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-identity/tsconfig.json
+++ b/sdk/communication/communication-identity/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-identity/tsconfig.snippets.json
+++ b/sdk/communication/communication-identity/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-job-router-rest/tsconfig.json
+++ b/sdk/communication/communication-job-router-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-job-router-rest/tsconfig.snippets.json
+++ b/sdk/communication/communication-job-router-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-messages-rest/tsconfig.json
+++ b/sdk/communication/communication-messages-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-messages-rest/tsconfig.snippets.json
+++ b/sdk/communication/communication-messages-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-phone-numbers/tsconfig.json
+++ b/sdk/communication/communication-phone-numbers/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-phone-numbers/tsconfig.snippets.json
+++ b/sdk/communication/communication-phone-numbers/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-recipient-verification/tsconfig.json
+++ b/sdk/communication/communication-recipient-verification/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-recipient-verification/tsconfig.snippets.json
+++ b/sdk/communication/communication-recipient-verification/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-rooms/tsconfig.json
+++ b/sdk/communication/communication-rooms/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-rooms/tsconfig.snippets.json
+++ b/sdk/communication/communication-rooms/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-short-codes/tsconfig.json
+++ b/sdk/communication/communication-short-codes/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-short-codes/tsconfig.snippets.json
+++ b/sdk/communication/communication-short-codes/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-sms/tsconfig.json
+++ b/sdk/communication/communication-sms/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-sms/tsconfig.snippets.json
+++ b/sdk/communication/communication-sms/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-tiering/tsconfig.json
+++ b/sdk/communication/communication-tiering/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-tiering/tsconfig.snippets.json
+++ b/sdk/communication/communication-tiering/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/communication/communication-toll-free-verification/tsconfig.json
+++ b/sdk/communication/communication-toll-free-verification/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/communication/communication-toll-free-verification/tsconfig.snippets.json
+++ b/sdk/communication/communication-toll-free-verification/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/compute/arm-compute-rest/tsconfig.json
+++ b/sdk/compute/arm-compute-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/compute/arm-compute-rest/tsconfig.snippets.json
+++ b/sdk/compute/arm-compute-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/compute/arm-compute/tsconfig.json
+++ b/sdk/compute/arm-compute/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/compute/arm-compute/tsconfig.snippets.json
+++ b/sdk/compute/arm-compute/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/computefleet/arm-computefleet/tsconfig.json
+++ b/sdk/computefleet/arm-computefleet/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/computefleet/arm-computefleet/tsconfig.snippets.json
+++ b/sdk/computefleet/arm-computefleet/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/computeschedule/arm-computeschedule/tsconfig.json
+++ b/sdk/computeschedule/arm-computeschedule/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/computeschedule/arm-computeschedule/tsconfig.snippets.json
+++ b/sdk/computeschedule/arm-computeschedule/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/confidentialledger/arm-confidentialledger/tsconfig.json
+++ b/sdk/confidentialledger/arm-confidentialledger/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/confidentialledger/arm-confidentialledger/tsconfig.snippets.json
+++ b/sdk/confidentialledger/arm-confidentialledger/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/confidentialledger/confidential-ledger-rest/tsconfig.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/confidentialledger/confidential-ledger-rest/tsconfig.snippets.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/confluent/arm-confluent/tsconfig.json
+++ b/sdk/confluent/arm-confluent/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/confluent/arm-confluent/tsconfig.snippets.json
+++ b/sdk/confluent/arm-confluent/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/connectedcache/arm-connectedcache/tsconfig.json
+++ b/sdk/connectedcache/arm-connectedcache/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/connectedcache/arm-connectedcache/tsconfig.snippets.json
+++ b/sdk/connectedcache/arm-connectedcache/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/connectedvmware/arm-connectedvmware/tsconfig.json
+++ b/sdk/connectedvmware/arm-connectedvmware/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/connectedvmware/arm-connectedvmware/tsconfig.snippets.json
+++ b/sdk/connectedvmware/arm-connectedvmware/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/consumption/arm-consumption/tsconfig.json
+++ b/sdk/consumption/arm-consumption/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/consumption/arm-consumption/tsconfig.snippets.json
+++ b/sdk/consumption/arm-consumption/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/containerinstance/arm-containerinstance/tsconfig.json
+++ b/sdk/containerinstance/arm-containerinstance/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/containerinstance/arm-containerinstance/tsconfig.snippets.json
+++ b/sdk/containerinstance/arm-containerinstance/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/containerregistry/arm-containerregistry/tsconfig.json
+++ b/sdk/containerregistry/arm-containerregistry/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/containerregistry/arm-containerregistry/tsconfig.snippets.json
+++ b/sdk/containerregistry/arm-containerregistry/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/containerregistry/container-registry/tsconfig.json
+++ b/sdk/containerregistry/container-registry/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/containerregistry/container-registry/tsconfig.snippets.json
+++ b/sdk/containerregistry/container-registry/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/containerservice/arm-containerservice-rest/tsconfig.json
+++ b/sdk/containerservice/arm-containerservice-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/containerservice/arm-containerservice-rest/tsconfig.snippets.json
+++ b/sdk/containerservice/arm-containerservice-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/containerservice/arm-containerservice/tsconfig.json
+++ b/sdk/containerservice/arm-containerservice/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/containerservice/arm-containerservice/tsconfig.snippets.json
+++ b/sdk/containerservice/arm-containerservice/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/containerservice/arm-containerservicefleet/tsconfig.json
+++ b/sdk/containerservice/arm-containerservicefleet/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/containerservice/arm-containerservicefleet/tsconfig.snippets.json
+++ b/sdk/containerservice/arm-containerservicefleet/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/contentsafety/ai-content-safety-rest/tsconfig.json
+++ b/sdk/contentsafety/ai-content-safety-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/contentsafety/ai-content-safety-rest/tsconfig.snippets.json
+++ b/sdk/contentsafety/ai-content-safety-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/abort-controller/tsconfig.json
+++ b/sdk/core/abort-controller/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/abort-controller/tsconfig.snippets.json
+++ b/sdk/core/abort-controller/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-amqp/tsconfig.json
+++ b/sdk/core/core-amqp/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-amqp/tsconfig.snippets.json
+++ b/sdk/core/core-amqp/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-auth/tsconfig.json
+++ b/sdk/core/core-auth/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-auth/tsconfig.snippets.json
+++ b/sdk/core/core-auth/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-client-rest/tsconfig.json
+++ b/sdk/core/core-client-rest/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-client-rest/tsconfig.snippets.json
+++ b/sdk/core/core-client-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-client/tsconfig.json
+++ b/sdk/core/core-client/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-client/tsconfig.snippets.json
+++ b/sdk/core/core-client/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-http-compat/tsconfig.json
+++ b/sdk/core/core-http-compat/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-http-compat/tsconfig.snippets.json
+++ b/sdk/core/core-http-compat/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-lro/tsconfig.json
+++ b/sdk/core/core-lro/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-lro/tsconfig.snippets.json
+++ b/sdk/core/core-lro/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-paging/tsconfig.json
+++ b/sdk/core/core-paging/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-paging/tsconfig.snippets.json
+++ b/sdk/core/core-paging/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-rest-pipeline/tsconfig.json
+++ b/sdk/core/core-rest-pipeline/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-rest-pipeline/tsconfig.snippets.json
+++ b/sdk/core/core-rest-pipeline/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-sse/tsconfig.json
+++ b/sdk/core/core-sse/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-sse/tsconfig.snippets.json
+++ b/sdk/core/core-sse/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-tracing/tsconfig.json
+++ b/sdk/core/core-tracing/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-tracing/tsconfig.snippets.json
+++ b/sdk/core/core-tracing/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-util/tsconfig.json
+++ b/sdk/core/core-util/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-util/tsconfig.snippets.json
+++ b/sdk/core/core-util/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/core-xml/tsconfig.json
+++ b/sdk/core/core-xml/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/core-xml/tsconfig.snippets.json
+++ b/sdk/core/core-xml/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/logger/tsconfig.json
+++ b/sdk/core/logger/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/logger/tsconfig.snippets.json
+++ b/sdk/core/logger/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/core/ts-http-runtime/tsconfig.json
+++ b/sdk/core/ts-http-runtime/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/core/ts-http-runtime/tsconfig.snippets.json
+++ b/sdk/core/ts-http-runtime/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cosmosdb/arm-cosmosdb/tsconfig.json
+++ b/sdk/cosmosdb/arm-cosmosdb/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/cosmosdb/arm-cosmosdb/tsconfig.snippets.json
+++ b/sdk/cosmosdb/arm-cosmosdb/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cosmosdb/cosmos/tsconfig.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/cosmosdb/cosmos/tsconfig.snippets.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/tsconfig.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/tsconfig.snippets.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/cost-management/arm-costmanagement/tsconfig.json
+++ b/sdk/cost-management/arm-costmanagement/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/cost-management/arm-costmanagement/tsconfig.snippets.json
+++ b/sdk/cost-management/arm-costmanagement/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/customer-insights/arm-customerinsights/tsconfig.json
+++ b/sdk/customer-insights/arm-customerinsights/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/customer-insights/arm-customerinsights/tsconfig.snippets.json
+++ b/sdk/customer-insights/arm-customerinsights/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dashboard/arm-dashboard/tsconfig.json
+++ b/sdk/dashboard/arm-dashboard/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dashboard/arm-dashboard/tsconfig.snippets.json
+++ b/sdk/dashboard/arm-dashboard/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/databasewatcher/arm-databasewatcher/tsconfig.json
+++ b/sdk/databasewatcher/arm-databasewatcher/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/databasewatcher/arm-databasewatcher/tsconfig.snippets.json
+++ b/sdk/databasewatcher/arm-databasewatcher/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/databoundaries/arm-databoundaries/tsconfig.json
+++ b/sdk/databoundaries/arm-databoundaries/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/databoundaries/arm-databoundaries/tsconfig.snippets.json
+++ b/sdk/databoundaries/arm-databoundaries/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/databox/arm-databox/tsconfig.json
+++ b/sdk/databox/arm-databox/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/databox/arm-databox/tsconfig.snippets.json
+++ b/sdk/databox/arm-databox/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/databoxedge/arm-databoxedge/tsconfig.json
+++ b/sdk/databoxedge/arm-databoxedge/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/databoxedge/arm-databoxedge/tsconfig.snippets.json
+++ b/sdk/databoxedge/arm-databoxedge/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/databricks/arm-databricks/tsconfig.json
+++ b/sdk/databricks/arm-databricks/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/databricks/arm-databricks/tsconfig.snippets.json
+++ b/sdk/databricks/arm-databricks/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/datacatalog/arm-datacatalog/tsconfig.json
+++ b/sdk/datacatalog/arm-datacatalog/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/datacatalog/arm-datacatalog/tsconfig.snippets.json
+++ b/sdk/datacatalog/arm-datacatalog/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/datadog/arm-datadog/tsconfig.json
+++ b/sdk/datadog/arm-datadog/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/datadog/arm-datadog/tsconfig.snippets.json
+++ b/sdk/datadog/arm-datadog/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/datafactory/arm-datafactory/tsconfig.json
+++ b/sdk/datafactory/arm-datafactory/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/datafactory/arm-datafactory/tsconfig.snippets.json
+++ b/sdk/datafactory/arm-datafactory/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/datalake-analytics/arm-datalake-analytics/tsconfig.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/datalake-analytics/arm-datalake-analytics/tsconfig.snippets.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/datamigration/arm-datamigration/tsconfig.json
+++ b/sdk/datamigration/arm-datamigration/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/datamigration/arm-datamigration/tsconfig.snippets.json
+++ b/sdk/datamigration/arm-datamigration/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dataprotection/arm-dataprotection/tsconfig.json
+++ b/sdk/dataprotection/arm-dataprotection/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dataprotection/arm-dataprotection/tsconfig.snippets.json
+++ b/sdk/dataprotection/arm-dataprotection/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/defendereasm/arm-defendereasm/tsconfig.json
+++ b/sdk/defendereasm/arm-defendereasm/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/defendereasm/arm-defendereasm/tsconfig.snippets.json
+++ b/sdk/defendereasm/arm-defendereasm/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dependencymap/arm-dependencymap/tsconfig.json
+++ b/sdk/dependencymap/arm-dependencymap/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dependencymap/arm-dependencymap/tsconfig.snippets.json
+++ b/sdk/dependencymap/arm-dependencymap/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/deploymentmanager/arm-deploymentmanager/tsconfig.json
+++ b/sdk/deploymentmanager/arm-deploymentmanager/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/deploymentmanager/arm-deploymentmanager/tsconfig.snippets.json
+++ b/sdk/deploymentmanager/arm-deploymentmanager/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/tsconfig.json
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/tsconfig.snippets.json
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/devcenter/arm-devcenter/tsconfig.json
+++ b/sdk/devcenter/arm-devcenter/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/devcenter/arm-devcenter/tsconfig.snippets.json
+++ b/sdk/devcenter/arm-devcenter/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/devcenter/developer-devcenter-rest/tsconfig.json
+++ b/sdk/devcenter/developer-devcenter-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/devcenter/developer-devcenter-rest/tsconfig.snippets.json
+++ b/sdk/devcenter/developer-devcenter-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/devhub/arm-devhub/tsconfig.json
+++ b/sdk/devhub/arm-devhub/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/devhub/arm-devhub/tsconfig.snippets.json
+++ b/sdk/devhub/arm-devhub/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/tsconfig.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/tsconfig.snippets.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/deviceregistry/arm-deviceregistry/tsconfig.json
+++ b/sdk/deviceregistry/arm-deviceregistry/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/deviceregistry/arm-deviceregistry/tsconfig.snippets.json
+++ b/sdk/deviceregistry/arm-deviceregistry/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/deviceupdate/arm-deviceupdate/tsconfig.json
+++ b/sdk/deviceupdate/arm-deviceupdate/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/deviceupdate/arm-deviceupdate/tsconfig.snippets.json
+++ b/sdk/deviceupdate/arm-deviceupdate/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/deviceupdate/iot-device-update-rest/tsconfig.json
+++ b/sdk/deviceupdate/iot-device-update-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/deviceupdate/iot-device-update-rest/tsconfig.snippets.json
+++ b/sdk/deviceupdate/iot-device-update-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/tsconfig.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/tsconfig.snippets.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/devspaces/arm-devspaces/tsconfig.json
+++ b/sdk/devspaces/arm-devspaces/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/devspaces/arm-devspaces/tsconfig.snippets.json
+++ b/sdk/devspaces/arm-devspaces/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/devtestlabs/arm-devtestlabs/tsconfig.json
+++ b/sdk/devtestlabs/arm-devtestlabs/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/devtestlabs/arm-devtestlabs/tsconfig.snippets.json
+++ b/sdk/devtestlabs/arm-devtestlabs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/digitaltwins/arm-digitaltwins/tsconfig.json
+++ b/sdk/digitaltwins/arm-digitaltwins/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/digitaltwins/arm-digitaltwins/tsconfig.snippets.json
+++ b/sdk/digitaltwins/arm-digitaltwins/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/digitaltwins/digital-twins-core/tsconfig.json
+++ b/sdk/digitaltwins/digital-twins-core/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/digitaltwins/digital-twins-core/tsconfig.snippets.json
+++ b/sdk/digitaltwins/digital-twins-core/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dns/arm-dns/tsconfig.json
+++ b/sdk/dns/arm-dns/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dns/arm-dns/tsconfig.snippets.json
+++ b/sdk/dns/arm-dns/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dnsresolver/arm-dnsresolver/tsconfig.json
+++ b/sdk/dnsresolver/arm-dnsresolver/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dnsresolver/arm-dnsresolver/tsconfig.snippets.json
+++ b/sdk/dnsresolver/arm-dnsresolver/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/documentintelligence/ai-document-intelligence-rest/tsconfig.json
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/documentintelligence/ai-document-intelligence-rest/tsconfig.snippets.json
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/documenttranslator/ai-document-translator-rest/tsconfig.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/documenttranslator/ai-document-translator-rest/tsconfig.snippets.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/domainservices/arm-domainservices/tsconfig.json
+++ b/sdk/domainservices/arm-domainservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/domainservices/arm-domainservices/tsconfig.snippets.json
+++ b/sdk/domainservices/arm-domainservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/durabletask/arm-durabletask/tsconfig.json
+++ b/sdk/durabletask/arm-durabletask/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/durabletask/arm-durabletask/tsconfig.snippets.json
+++ b/sdk/durabletask/arm-durabletask/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/dynatrace/arm-dynatrace/tsconfig.json
+++ b/sdk/dynatrace/arm-dynatrace/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/dynatrace/arm-dynatrace/tsconfig.snippets.json
+++ b/sdk/dynatrace/arm-dynatrace/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/easm/defender-easm-rest/tsconfig.json
+++ b/sdk/easm/defender-easm-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/easm/defender-easm-rest/tsconfig.snippets.json
+++ b/sdk/easm/defender-easm-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/edgezones/arm-edgezones/tsconfig.json
+++ b/sdk/edgezones/arm-edgezones/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/edgezones/arm-edgezones/tsconfig.snippets.json
+++ b/sdk/edgezones/arm-edgezones/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/education/arm-education/tsconfig.json
+++ b/sdk/education/arm-education/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/education/arm-education/tsconfig.snippets.json
+++ b/sdk/education/arm-education/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/elastic/arm-elastic/tsconfig.json
+++ b/sdk/elastic/arm-elastic/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/elastic/arm-elastic/tsconfig.snippets.json
+++ b/sdk/elastic/arm-elastic/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/elasticsans/arm-elasticsan/tsconfig.json
+++ b/sdk/elasticsans/arm-elasticsan/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/elasticsans/arm-elasticsan/tsconfig.snippets.json
+++ b/sdk/elasticsans/arm-elasticsan/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/entra/functions-authentication-events/tsconfig.json
+++ b/sdk/entra/functions-authentication-events/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/entra/functions-authentication-events/tsconfig.snippets.json
+++ b/sdk/entra/functions-authentication-events/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventgrid/arm-eventgrid/tsconfig.json
+++ b/sdk/eventgrid/arm-eventgrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/eventgrid/arm-eventgrid/tsconfig.snippets.json
+++ b/sdk/eventgrid/arm-eventgrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventgrid/eventgrid-namespaces/tsconfig.json
+++ b/sdk/eventgrid/eventgrid-namespaces/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/eventgrid/eventgrid-namespaces/tsconfig.snippets.json
+++ b/sdk/eventgrid/eventgrid-namespaces/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventgrid/eventgrid-systemevents/tsconfig.json
+++ b/sdk/eventgrid/eventgrid-systemevents/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/eventgrid/eventgrid-systemevents/tsconfig.snippets.json
+++ b/sdk/eventgrid/eventgrid-systemevents/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventgrid/eventgrid/tsconfig.json
+++ b/sdk/eventgrid/eventgrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/eventgrid/eventgrid/tsconfig.snippets.json
+++ b/sdk/eventgrid/eventgrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventhub/arm-eventhub/tsconfig.json
+++ b/sdk/eventhub/arm-eventhub/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/eventhub/arm-eventhub/tsconfig.snippets.json
+++ b/sdk/eventhub/arm-eventhub/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventhub/event-hubs/tsconfig.json
+++ b/sdk/eventhub/event-hubs/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/eventhub/event-hubs/tsconfig.snippets.json
+++ b/sdk/eventhub/event-hubs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.snippets.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.snippets.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/extendedlocation/arm-extendedlocation/tsconfig.json
+++ b/sdk/extendedlocation/arm-extendedlocation/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/extendedlocation/arm-extendedlocation/tsconfig.snippets.json
+++ b/sdk/extendedlocation/arm-extendedlocation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/fabric/arm-fabric/tsconfig.json
+++ b/sdk/fabric/arm-fabric/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/fabric/arm-fabric/tsconfig.snippets.json
+++ b/sdk/fabric/arm-fabric/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/face/ai-vision-face-rest/tsconfig.json
+++ b/sdk/face/ai-vision-face-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/face/ai-vision-face-rest/tsconfig.snippets.json
+++ b/sdk/face/ai-vision-face-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/features/arm-features/tsconfig.json
+++ b/sdk/features/arm-features/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/features/arm-features/tsconfig.snippets.json
+++ b/sdk/features/arm-features/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/fluidrelay/arm-fluidrelay/tsconfig.json
+++ b/sdk/fluidrelay/arm-fluidrelay/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/fluidrelay/arm-fluidrelay/tsconfig.snippets.json
+++ b/sdk/fluidrelay/arm-fluidrelay/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/formrecognizer/ai-form-recognizer/tsconfig.json
+++ b/sdk/formrecognizer/ai-form-recognizer/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/formrecognizer/ai-form-recognizer/tsconfig.snippets.json
+++ b/sdk/formrecognizer/ai-form-recognizer/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/frontdoor/arm-frontdoor/tsconfig.json
+++ b/sdk/frontdoor/arm-frontdoor/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/frontdoor/arm-frontdoor/tsconfig.snippets.json
+++ b/sdk/frontdoor/arm-frontdoor/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/graphservices/arm-graphservices/tsconfig.json
+++ b/sdk/graphservices/arm-graphservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/graphservices/arm-graphservices/tsconfig.snippets.json
+++ b/sdk/graphservices/arm-graphservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/guestconfiguration/arm-guestconfiguration/tsconfig.json
+++ b/sdk/guestconfiguration/arm-guestconfiguration/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/guestconfiguration/arm-guestconfiguration/tsconfig.snippets.json
+++ b/sdk/guestconfiguration/arm-guestconfiguration/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hanaonazure/arm-hanaonazure/tsconfig.json
+++ b/sdk/hanaonazure/arm-hanaonazure/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hanaonazure/arm-hanaonazure/tsconfig.snippets.json
+++ b/sdk/hanaonazure/arm-hanaonazure/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/tsconfig.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/tsconfig.snippets.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hdinsight/arm-hdinsight/tsconfig.json
+++ b/sdk/hdinsight/arm-hdinsight/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hdinsight/arm-hdinsight/tsconfig.snippets.json
+++ b/sdk/hdinsight/arm-hdinsight/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hdinsight/arm-hdinsightcontainers/tsconfig.json
+++ b/sdk/hdinsight/arm-hdinsightcontainers/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hdinsight/arm-hdinsightcontainers/tsconfig.snippets.json
+++ b/sdk/hdinsight/arm-hdinsightcontainers/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthbot/arm-healthbot/tsconfig.json
+++ b/sdk/healthbot/arm-healthbot/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthbot/arm-healthbot/tsconfig.snippets.json
+++ b/sdk/healthbot/arm-healthbot/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthcareapis/arm-healthcareapis/tsconfig.json
+++ b/sdk/healthcareapis/arm-healthcareapis/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthcareapis/arm-healthcareapis/tsconfig.snippets.json
+++ b/sdk/healthcareapis/arm-healthcareapis/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/tsconfig.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/tsconfig.snippets.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthdataaiservices/azure-health-deidentification/tsconfig.json
+++ b/sdk/healthdataaiservices/azure-health-deidentification/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthdataaiservices/azure-health-deidentification/tsconfig.snippets.json
+++ b/sdk/healthdataaiservices/azure-health-deidentification/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthinsights/health-insights-cancerprofiling-rest/tsconfig.json
+++ b/sdk/healthinsights/health-insights-cancerprofiling-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthinsights/health-insights-cancerprofiling-rest/tsconfig.snippets.json
+++ b/sdk/healthinsights/health-insights-cancerprofiling-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthinsights/health-insights-clinicalmatching-rest/tsconfig.json
+++ b/sdk/healthinsights/health-insights-clinicalmatching-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthinsights/health-insights-clinicalmatching-rest/tsconfig.snippets.json
+++ b/sdk/healthinsights/health-insights-clinicalmatching-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/healthinsights/health-insights-radiologyinsights-rest/tsconfig.json
+++ b/sdk/healthinsights/health-insights-radiologyinsights-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/healthinsights/health-insights-radiologyinsights-rest/tsconfig.snippets.json
+++ b/sdk/healthinsights/health-insights-radiologyinsights-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hybridcompute/arm-hybridcompute/tsconfig.json
+++ b/sdk/hybridcompute/arm-hybridcompute/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hybridcompute/arm-hybridcompute/tsconfig.snippets.json
+++ b/sdk/hybridcompute/arm-hybridcompute/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/tsconfig.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/tsconfig.snippets.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/tsconfig.json
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/tsconfig.snippets.json
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/tsconfig.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/tsconfig.snippets.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/hybridnetwork/arm-hybridnetwork/tsconfig.json
+++ b/sdk/hybridnetwork/arm-hybridnetwork/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/hybridnetwork/arm-hybridnetwork/tsconfig.snippets.json
+++ b/sdk/hybridnetwork/arm-hybridnetwork/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/identity/identity-broker/tsconfig.json
+++ b/sdk/identity/identity-broker/tsconfig.json
@@ -1,8 +1,17 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ],
   "compilerOptions": {
     "esModuleInterop": true

--- a/sdk/identity/identity-broker/tsconfig.snippets.json
+++ b/sdk/identity/identity-broker/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/identity/identity-cache-persistence/tsconfig.json
+++ b/sdk/identity/identity-cache-persistence/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/identity/identity-cache-persistence/tsconfig.snippets.json
+++ b/sdk/identity/identity-cache-persistence/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/identity/identity-vscode/tsconfig.json
+++ b/sdk/identity/identity-vscode/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/identity/identity-vscode/tsconfig.snippets.json
+++ b/sdk/identity/identity-vscode/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -1,8 +1,17 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ],
   "compilerOptions": {
     "esModuleInterop": true

--- a/sdk/identity/identity/tsconfig.snippets.json
+++ b/sdk/identity/identity/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/imagebuilder/arm-imagebuilder/tsconfig.json
+++ b/sdk/imagebuilder/arm-imagebuilder/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/imagebuilder/arm-imagebuilder/tsconfig.snippets.json
+++ b/sdk/imagebuilder/arm-imagebuilder/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/impactreporting/arm-impactreporting/tsconfig.json
+++ b/sdk/impactreporting/arm-impactreporting/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/impactreporting/arm-impactreporting/tsconfig.snippets.json
+++ b/sdk/impactreporting/arm-impactreporting/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/informatica/arm-informaticadatamanagement/tsconfig.json
+++ b/sdk/informatica/arm-informaticadatamanagement/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/informatica/arm-informaticadatamanagement/tsconfig.snippets.json
+++ b/sdk/informatica/arm-informaticadatamanagement/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/tsconfig.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/tsconfig.snippets.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/iot/iot-modelsrepository/tsconfig.json
+++ b/sdk/iot/iot-modelsrepository/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/iot/iot-modelsrepository/tsconfig.snippets.json
+++ b/sdk/iot/iot-modelsrepository/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/iotcentral/arm-iotcentral/tsconfig.json
+++ b/sdk/iotcentral/arm-iotcentral/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/iotcentral/arm-iotcentral/tsconfig.snippets.json
+++ b/sdk/iotcentral/arm-iotcentral/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/tsconfig.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/tsconfig.snippets.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/iothub/arm-iothub/tsconfig.json
+++ b/sdk/iothub/arm-iothub/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/iothub/arm-iothub/tsconfig.snippets.json
+++ b/sdk/iothub/arm-iothub/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/iotoperations/arm-iotoperations/tsconfig.json
+++ b/sdk/iotoperations/arm-iotoperations/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/iotoperations/arm-iotoperations/tsconfig.snippets.json
+++ b/sdk/iotoperations/arm-iotoperations/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/arm-keyvault/tsconfig.json
+++ b/sdk/keyvault/arm-keyvault/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/keyvault/arm-keyvault/tsconfig.snippets.json
+++ b/sdk/keyvault/arm-keyvault/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/keyvault-admin/tsconfig.json
+++ b/sdk/keyvault/keyvault-admin/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/keyvault/keyvault-admin/tsconfig.snippets.json
+++ b/sdk/keyvault/keyvault-admin/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/keyvault/keyvault-certificates/tsconfig.snippets.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/keyvault-common/tsconfig.json
+++ b/sdk/keyvault/keyvault-common/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/keyvault/keyvault-common/tsconfig.snippets.json
+++ b/sdk/keyvault/keyvault-common/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/keyvault-keys/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/keyvault/keyvault-keys/tsconfig.snippets.json
+++ b/sdk/keyvault/keyvault-keys/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/keyvault/keyvault-secrets/tsconfig.snippets.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/tsconfig.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/tsconfig.snippets.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/tsconfig.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/tsconfig.snippets.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/tsconfig.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/tsconfig.snippets.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/tsconfig.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/tsconfig.snippets.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/tsconfig.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/tsconfig.snippets.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/kusto/arm-kusto/tsconfig.json
+++ b/sdk/kusto/arm-kusto/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/kusto/arm-kusto/tsconfig.snippets.json
+++ b/sdk/kusto/arm-kusto/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/labservices/arm-labservices/tsconfig.json
+++ b/sdk/labservices/arm-labservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/labservices/arm-labservices/tsconfig.snippets.json
+++ b/sdk/labservices/arm-labservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/tsconfig.json
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/tsconfig.snippets.json
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/largeinstance/arm-largeinstance/tsconfig.json
+++ b/sdk/largeinstance/arm-largeinstance/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/largeinstance/arm-largeinstance/tsconfig.snippets.json
+++ b/sdk/largeinstance/arm-largeinstance/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/tsconfig.json
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/tsconfig.snippets.json
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/liftrqumulo/arm-qumulo/tsconfig.json
+++ b/sdk/liftrqumulo/arm-qumulo/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/liftrqumulo/arm-qumulo/tsconfig.snippets.json
+++ b/sdk/liftrqumulo/arm-qumulo/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/tsconfig.json
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/tsconfig.snippets.json
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/links/arm-links/tsconfig.json
+++ b/sdk/links/arm-links/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/links/arm-links/tsconfig.snippets.json
+++ b/sdk/links/arm-links/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/loadtesting/arm-loadtesting/tsconfig.json
+++ b/sdk/loadtesting/arm-loadtesting/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/loadtesting/arm-loadtesting/tsconfig.snippets.json
+++ b/sdk/loadtesting/arm-loadtesting/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/loadtesting/create-playwright/tsconfig.json
+++ b/sdk/loadtesting/create-playwright/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/loadtesting/create-playwright/tsconfig.snippets.json
+++ b/sdk/loadtesting/create-playwright/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/loadtesting/load-testing-rest/tsconfig.json
+++ b/sdk/loadtesting/load-testing-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/loadtesting/load-testing-rest/tsconfig.snippets.json
+++ b/sdk/loadtesting/load-testing-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/loadtesting/playwright/tsconfig.json
+++ b/sdk/loadtesting/playwright/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/loadtesting/playwright/tsconfig.snippets.json
+++ b/sdk/loadtesting/playwright/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/locks/arm-locks/tsconfig.json
+++ b/sdk/locks/arm-locks/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/locks/arm-locks/tsconfig.snippets.json
+++ b/sdk/locks/arm-locks/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/logic/arm-logic/tsconfig.json
+++ b/sdk/logic/arm-logic/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/logic/arm-logic/tsconfig.snippets.json
+++ b/sdk/logic/arm-logic/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/machinelearning/arm-commitmentplans/tsconfig.json
+++ b/sdk/machinelearning/arm-commitmentplans/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/machinelearning/arm-commitmentplans/tsconfig.snippets.json
+++ b/sdk/machinelearning/arm-commitmentplans/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/machinelearning/arm-machinelearning/tsconfig.json
+++ b/sdk/machinelearning/arm-machinelearning/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/machinelearning/arm-machinelearning/tsconfig.snippets.json
+++ b/sdk/machinelearning/arm-machinelearning/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/machinelearning/arm-webservices/tsconfig.json
+++ b/sdk/machinelearning/arm-webservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/machinelearning/arm-webservices/tsconfig.snippets.json
+++ b/sdk/machinelearning/arm-webservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/machinelearning/arm-workspaces/tsconfig.json
+++ b/sdk/machinelearning/arm-workspaces/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/machinelearning/arm-workspaces/tsconfig.snippets.json
+++ b/sdk/machinelearning/arm-workspaces/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/tsconfig.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/tsconfig.snippets.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/tsconfig.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/tsconfig.snippets.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maintenance/arm-maintenance/tsconfig.json
+++ b/sdk/maintenance/arm-maintenance/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maintenance/arm-maintenance/tsconfig.snippets.json
+++ b/sdk/maintenance/arm-maintenance/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/managedapplications/arm-managedapplications/tsconfig.json
+++ b/sdk/managedapplications/arm-managedapplications/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/managedapplications/arm-managedapplications/tsconfig.snippets.json
+++ b/sdk/managedapplications/arm-managedapplications/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/tsconfig.json
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/tsconfig.snippets.json
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/managementgroups/arm-managementgroups/tsconfig.json
+++ b/sdk/managementgroups/arm-managementgroups/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/managementgroups/arm-managementgroups/tsconfig.snippets.json
+++ b/sdk/managementgroups/arm-managementgroups/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/managementpartner/arm-managementpartner/tsconfig.json
+++ b/sdk/managementpartner/arm-managementpartner/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/managementpartner/arm-managementpartner/tsconfig.snippets.json
+++ b/sdk/managementpartner/arm-managementpartner/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/arm-maps/tsconfig.json
+++ b/sdk/maps/arm-maps/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/arm-maps/tsconfig.snippets.json
+++ b/sdk/maps/arm-maps/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/maps-common/tsconfig.json
+++ b/sdk/maps/maps-common/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/maps-common/tsconfig.snippets.json
+++ b/sdk/maps/maps-common/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/maps-geolocation-rest/tsconfig.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/maps-geolocation-rest/tsconfig.snippets.json
+++ b/sdk/maps/maps-geolocation-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/maps-render-rest/tsconfig.json
+++ b/sdk/maps/maps-render-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/maps-render-rest/tsconfig.snippets.json
+++ b/sdk/maps/maps-render-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/maps-route-rest/tsconfig.json
+++ b/sdk/maps/maps-route-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/maps-route-rest/tsconfig.snippets.json
+++ b/sdk/maps/maps-route-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/maps-search-rest/tsconfig.json
+++ b/sdk/maps/maps-search-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/maps-search-rest/tsconfig.snippets.json
+++ b/sdk/maps/maps-search-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/maps/maps-timezone-rest/tsconfig.json
+++ b/sdk/maps/maps-timezone-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/maps/maps-timezone-rest/tsconfig.snippets.json
+++ b/sdk/maps/maps-timezone-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/mariadb/arm-mariadb/tsconfig.json
+++ b/sdk/mariadb/arm-mariadb/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/mariadb/arm-mariadb/tsconfig.snippets.json
+++ b/sdk/mariadb/arm-mariadb/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/marketplaceordering/arm-marketplaceordering/tsconfig.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/marketplaceordering/arm-marketplaceordering/tsconfig.snippets.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/metricsadvisor/ai-metrics-advisor/tsconfig.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/metricsadvisor/ai-metrics-advisor/tsconfig.snippets.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/migrate/arm-migrate/tsconfig.json
+++ b/sdk/migrate/arm-migrate/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/migrate/arm-migrate/tsconfig.snippets.json
+++ b/sdk/migrate/arm-migrate/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/migrate/arm-migrationassessment/tsconfig.json
+++ b/sdk/migrate/arm-migrationassessment/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/migrate/arm-migrationassessment/tsconfig.snippets.json
+++ b/sdk/migrate/arm-migrationassessment/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/tsconfig.json
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/tsconfig.snippets.json
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/mobilenetwork/arm-mobilenetwork/tsconfig.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/mobilenetwork/arm-mobilenetwork/tsconfig.snippets.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/mongocluster/arm-mongocluster/tsconfig.json
+++ b/sdk/mongocluster/arm-mongocluster/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/mongocluster/arm-mongocluster/tsconfig.snippets.json
+++ b/sdk/mongocluster/arm-mongocluster/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/mongodbatlas/arm-mongodbatlas/tsconfig.json
+++ b/sdk/mongodbatlas/arm-mongodbatlas/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/mongodbatlas/arm-mongodbatlas/tsconfig.snippets.json
+++ b/sdk/mongodbatlas/arm-mongodbatlas/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/monitor/arm-monitor/tsconfig.json
+++ b/sdk/monitor/arm-monitor/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/monitor/arm-monitor/tsconfig.snippets.json
+++ b/sdk/monitor/arm-monitor/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/monitor/monitor-ingestion/tsconfig.json
+++ b/sdk/monitor/monitor-ingestion/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/monitor/monitor-ingestion/tsconfig.snippets.json
+++ b/sdk/monitor/monitor-ingestion/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/monitor/monitor-opentelemetry-exporter/tsconfig.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/tsconfig.snippets.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/monitor/monitor-opentelemetry/tsconfig.json
+++ b/sdk/monitor/monitor-opentelemetry/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/monitor/monitor-opentelemetry/tsconfig.snippets.json
+++ b/sdk/monitor/monitor-opentelemetry/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/monitor/monitor-query/tsconfig.json
+++ b/sdk/monitor/monitor-query/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/monitor/monitor-query/tsconfig.snippets.json
+++ b/sdk/monitor/monitor-query/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/msi/arm-msi/tsconfig.json
+++ b/sdk/msi/arm-msi/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/msi/arm-msi/tsconfig.snippets.json
+++ b/sdk/msi/arm-msi/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/mysql/arm-mysql-flexible/tsconfig.json
+++ b/sdk/mysql/arm-mysql-flexible/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/mysql/arm-mysql-flexible/tsconfig.snippets.json
+++ b/sdk/mysql/arm-mysql-flexible/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/mysql/arm-mysql/tsconfig.json
+++ b/sdk/mysql/arm-mysql/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/mysql/arm-mysql/tsconfig.snippets.json
+++ b/sdk/mysql/arm-mysql/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/neonpostgres/arm-neonpostgres/tsconfig.json
+++ b/sdk/neonpostgres/arm-neonpostgres/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/neonpostgres/arm-neonpostgres/tsconfig.snippets.json
+++ b/sdk/neonpostgres/arm-neonpostgres/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/netapp/arm-netapp/tsconfig.json
+++ b/sdk/netapp/arm-netapp/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/netapp/arm-netapp/tsconfig.snippets.json
+++ b/sdk/netapp/arm-netapp/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/network/arm-network-rest/tsconfig.json
+++ b/sdk/network/arm-network-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/network/arm-network-rest/tsconfig.snippets.json
+++ b/sdk/network/arm-network-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/network/arm-network/tsconfig.json
+++ b/sdk/network/arm-network/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/network/arm-network/tsconfig.snippets.json
+++ b/sdk/network/arm-network/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/networkcloud/arm-networkcloud/tsconfig.json
+++ b/sdk/networkcloud/arm-networkcloud/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/networkcloud/arm-networkcloud/tsconfig.snippets.json
+++ b/sdk/networkcloud/arm-networkcloud/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/networkfunction/arm-networkfunction/tsconfig.json
+++ b/sdk/networkfunction/arm-networkfunction/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/networkfunction/arm-networkfunction/tsconfig.snippets.json
+++ b/sdk/networkfunction/arm-networkfunction/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/newrelicobservability/arm-newrelicobservability/tsconfig.json
+++ b/sdk/newrelicobservability/arm-newrelicobservability/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/newrelicobservability/arm-newrelicobservability/tsconfig.snippets.json
+++ b/sdk/newrelicobservability/arm-newrelicobservability/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/nginx/arm-nginx/tsconfig.json
+++ b/sdk/nginx/arm-nginx/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/nginx/arm-nginx/tsconfig.snippets.json
+++ b/sdk/nginx/arm-nginx/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/notificationhubs/arm-notificationhubs/tsconfig.json
+++ b/sdk/notificationhubs/arm-notificationhubs/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/notificationhubs/arm-notificationhubs/tsconfig.snippets.json
+++ b/sdk/notificationhubs/arm-notificationhubs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/notificationhubs/notification-hubs/tsconfig.json
+++ b/sdk/notificationhubs/notification-hubs/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/notificationhubs/notification-hubs/tsconfig.snippets.json
+++ b/sdk/notificationhubs/notification-hubs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/oep/arm-oep/tsconfig.json
+++ b/sdk/oep/arm-oep/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/oep/arm-oep/tsconfig.snippets.json
+++ b/sdk/oep/arm-oep/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/tsconfig.json
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/tsconfig.snippets.json
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/openai/openai/tsconfig.json
+++ b/sdk/openai/openai/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ],
   "compilerOptions": {

--- a/sdk/openai/openai/tsconfig.snippets.json
+++ b/sdk/openai/openai/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/operationalinsights/arm-operationalinsights/tsconfig.json
+++ b/sdk/operationalinsights/arm-operationalinsights/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/operationalinsights/arm-operationalinsights/tsconfig.snippets.json
+++ b/sdk/operationalinsights/arm-operationalinsights/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/operationsmanagement/arm-operations/tsconfig.json
+++ b/sdk/operationsmanagement/arm-operations/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/operationsmanagement/arm-operations/tsconfig.snippets.json
+++ b/sdk/operationsmanagement/arm-operations/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/oracledatabase/arm-oracledatabase/tsconfig.json
+++ b/sdk/oracledatabase/arm-oracledatabase/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/oracledatabase/arm-oracledatabase/tsconfig.snippets.json
+++ b/sdk/oracledatabase/arm-oracledatabase/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/orbital/arm-orbital/tsconfig.json
+++ b/sdk/orbital/arm-orbital/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/orbital/arm-orbital/tsconfig.snippets.json
+++ b/sdk/orbital/arm-orbital/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/tsconfig.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/tsconfig.snippets.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/peering/arm-peering/tsconfig.json
+++ b/sdk/peering/arm-peering/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/peering/arm-peering/tsconfig.snippets.json
+++ b/sdk/peering/arm-peering/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/pineconevectordb/arm-pineconevectordb/tsconfig.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/pineconevectordb/arm-pineconevectordb/tsconfig.snippets.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/playwrighttesting/arm-playwrighttesting/tsconfig.json
+++ b/sdk/playwrighttesting/arm-playwrighttesting/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/playwrighttesting/arm-playwrighttesting/tsconfig.snippets.json
+++ b/sdk/playwrighttesting/arm-playwrighttesting/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/playwrighttesting/create-microsoft-playwright-testing/tsconfig.json
+++ b/sdk/playwrighttesting/create-microsoft-playwright-testing/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/playwrighttesting/create-microsoft-playwright-testing/tsconfig.snippets.json
+++ b/sdk/playwrighttesting/create-microsoft-playwright-testing/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/playwrighttesting/microsoft-playwright-testing/tsconfig.json
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/playwrighttesting/microsoft-playwright-testing/tsconfig.snippets.json
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/policy/arm-policy/tsconfig.json
+++ b/sdk/policy/arm-policy/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/policy/arm-policy/tsconfig.snippets.json
+++ b/sdk/policy/arm-policy/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/policyinsights/arm-policyinsights/tsconfig.json
+++ b/sdk/policyinsights/arm-policyinsights/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/policyinsights/arm-policyinsights/tsconfig.snippets.json
+++ b/sdk/policyinsights/arm-policyinsights/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/portal/arm-portal/tsconfig.json
+++ b/sdk/portal/arm-portal/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/portal/arm-portal/tsconfig.snippets.json
+++ b/sdk/portal/arm-portal/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/portalservices/arm-portalservicescopilot/tsconfig.json
+++ b/sdk/portalservices/arm-portalservicescopilot/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/portalservices/arm-portalservicescopilot/tsconfig.snippets.json
+++ b/sdk/portalservices/arm-portalservicescopilot/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/postgresql/arm-postgresql-flexible/tsconfig.json
+++ b/sdk/postgresql/arm-postgresql-flexible/tsconfig.json
@@ -8,7 +8,12 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ],
-  "include": ["./src/**/*.ts"]
+  "include": [
+    "./src/**/*.ts"
+  ]
 }

--- a/sdk/postgresql/arm-postgresql-flexible/tsconfig.snippets.json
+++ b/sdk/postgresql/arm-postgresql-flexible/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/postgresql/arm-postgresql/tsconfig.json
+++ b/sdk/postgresql/arm-postgresql/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/postgresql/arm-postgresql/tsconfig.snippets.json
+++ b/sdk/postgresql/arm-postgresql/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/powerbidedicated/arm-powerbidedicated/tsconfig.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/powerbidedicated/arm-powerbidedicated/tsconfig.snippets.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/powerbiembedded/arm-powerbiembedded/tsconfig.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/powerbiembedded/arm-powerbiembedded/tsconfig.snippets.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/privatedns/arm-privatedns/tsconfig.json
+++ b/sdk/privatedns/arm-privatedns/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/privatedns/arm-privatedns/tsconfig.snippets.json
+++ b/sdk/privatedns/arm-privatedns/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/tsconfig.json
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/tsconfig.snippets.json
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purestorageblock/arm-purestorageblock/tsconfig.json
+++ b/sdk/purestorageblock/arm-purestorageblock/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purestorageblock/arm-purestorageblock/tsconfig.snippets.json
+++ b/sdk/purestorageblock/arm-purestorageblock/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purview/arm-purview/tsconfig.json
+++ b/sdk/purview/arm-purview/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purview/arm-purview/tsconfig.snippets.json
+++ b/sdk/purview/arm-purview/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purview/purview-administration-rest/tsconfig.json
+++ b/sdk/purview/purview-administration-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purview/purview-administration-rest/tsconfig.snippets.json
+++ b/sdk/purview/purview-administration-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purview/purview-datamap-rest/tsconfig.json
+++ b/sdk/purview/purview-datamap-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purview/purview-datamap-rest/tsconfig.snippets.json
+++ b/sdk/purview/purview-datamap-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purview/purview-scanning-rest/tsconfig.json
+++ b/sdk/purview/purview-scanning-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purview/purview-scanning-rest/tsconfig.snippets.json
+++ b/sdk/purview/purview-scanning-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purview/purview-sharing-rest/tsconfig.json
+++ b/sdk/purview/purview-sharing-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purview/purview-sharing-rest/tsconfig.snippets.json
+++ b/sdk/purview/purview-sharing-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/purview/purview-workflow-rest/tsconfig.json
+++ b/sdk/purview/purview-workflow-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/purview/purview-workflow-rest/tsconfig.snippets.json
+++ b/sdk/purview/purview-workflow-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/quantum/arm-quantum/tsconfig.json
+++ b/sdk/quantum/arm-quantum/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/quantum/arm-quantum/tsconfig.snippets.json
+++ b/sdk/quantum/arm-quantum/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/quantum/quantum-jobs/tsconfig.json
+++ b/sdk/quantum/quantum-jobs/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/quantum/quantum-jobs/tsconfig.snippets.json
+++ b/sdk/quantum/quantum-jobs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/quota/arm-quota/tsconfig.json
+++ b/sdk/quota/arm-quota/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/quota/arm-quota/tsconfig.snippets.json
+++ b/sdk/quota/arm-quota/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/recoveryservices/arm-recoveryservices/tsconfig.json
+++ b/sdk/recoveryservices/arm-recoveryservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/recoveryservices/arm-recoveryservices/tsconfig.snippets.json
+++ b/sdk/recoveryservices/arm-recoveryservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/tsconfig.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/tsconfig.snippets.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/tsconfig.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/tsconfig.snippets.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/tsconfig.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/tsconfig.snippets.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/redhatopenshift/arm-redhatopenshift/tsconfig.json
+++ b/sdk/redhatopenshift/arm-redhatopenshift/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/redhatopenshift/arm-redhatopenshift/tsconfig.snippets.json
+++ b/sdk/redhatopenshift/arm-redhatopenshift/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/redis/arm-rediscache/tsconfig.json
+++ b/sdk/redis/arm-rediscache/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/redis/arm-rediscache/tsconfig.snippets.json
+++ b/sdk/redis/arm-rediscache/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/redisenterprise/arm-redisenterprisecache/tsconfig.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/redisenterprise/arm-redisenterprisecache/tsconfig.snippets.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/relay/arm-relay/tsconfig.json
+++ b/sdk/relay/arm-relay/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/relay/arm-relay/tsconfig.snippets.json
+++ b/sdk/relay/arm-relay/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/reservations/arm-reservations/tsconfig.json
+++ b/sdk/reservations/arm-reservations/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/reservations/arm-reservations/tsconfig.snippets.json
+++ b/sdk/reservations/arm-reservations/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resourceconnector/arm-resourceconnector/tsconfig.json
+++ b/sdk/resourceconnector/arm-resourceconnector/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resourceconnector/arm-resourceconnector/tsconfig.snippets.json
+++ b/sdk/resourceconnector/arm-resourceconnector/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resourcegraph/arm-resourcegraph/tsconfig.json
+++ b/sdk/resourcegraph/arm-resourcegraph/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resourcegraph/arm-resourcegraph/tsconfig.snippets.json
+++ b/sdk/resourcegraph/arm-resourcegraph/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resourcehealth/arm-resourcehealth/tsconfig.json
+++ b/sdk/resourcehealth/arm-resourcehealth/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resourcehealth/arm-resourcehealth/tsconfig.snippets.json
+++ b/sdk/resourcehealth/arm-resourcehealth/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resourcemover/arm-resourcemover/tsconfig.json
+++ b/sdk/resourcemover/arm-resourcemover/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resourcemover/arm-resourcemover/tsconfig.snippets.json
+++ b/sdk/resourcemover/arm-resourcemover/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/tsconfig.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/tsconfig.snippets.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resources/arm-resources/tsconfig.json
+++ b/sdk/resources/arm-resources/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resources/arm-resources/tsconfig.snippets.json
+++ b/sdk/resources/arm-resources/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/tsconfig.json
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/tsconfig.snippets.json
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/run.js
+++ b/sdk/run.js
@@ -1,0 +1,49 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const TEST_FILE        = path.join("test", "snippets.spec.ts");
+const OUTPUT_FILE      = "tsconfig.snippets.json";
+const OUTPUT_CONTENT   = `{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}
+`;
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const dirsWithTests = new Set();
+
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+
+    const full = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      const nested = await walk(full);
+      nested.forEach(dirsWithTests.add, dirsWithTests);
+    } else if (entry.isFile() && entry.name === path.basename(TEST_FILE)) {
+      if (full.endsWith(TEST_FILE)) {
+        dirsWithTests.add(path.dirname(path.dirname(full))); // directory that contains "test"
+      }
+    }
+  }
+  return [...dirsWithTests];
+}
+
+async function main() {
+  const root = process.cwd();
+  const dirs = await walk(root);
+
+  console.log(`Found ${dirs.length} folders with ${TEST_FILE}`);
+  await Promise.all(
+    dirs.map(async (dir) => {
+      const outPath = path.join(dir, OUTPUT_FILE);
+      await fs.writeFile(outPath, OUTPUT_CONTENT, "utf8");
+      console.log(`Wrote ${outPath}`);
+    })
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk/schemaregistry/schema-registry-avro/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry-avro/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ],
   "compilerOptions": {

--- a/sdk/schemaregistry/schema-registry-avro/tsconfig.snippets.json
+++ b/sdk/schemaregistry/schema-registry-avro/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/schemaregistry/schema-registry-json/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry-json/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ],
   "compilerOptions": {

--- a/sdk/schemaregistry/schema-registry-json/tsconfig.snippets.json
+++ b/sdk/schemaregistry/schema-registry-json/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/schemaregistry/schema-registry/tsconfig.json
+++ b/sdk/schemaregistry/schema-registry/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/schemaregistry/schema-registry/tsconfig.snippets.json
+++ b/sdk/schemaregistry/schema-registry/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/scvmm/arm-scvmm/tsconfig.json
+++ b/sdk/scvmm/arm-scvmm/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/scvmm/arm-scvmm/tsconfig.snippets.json
+++ b/sdk/scvmm/arm-scvmm/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/search/arm-search/tsconfig.json
+++ b/sdk/search/arm-search/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/search/arm-search/tsconfig.snippets.json
+++ b/sdk/search/arm-search/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/search/search-documents/tsconfig.json
+++ b/sdk/search/search-documents/tsconfig.json
@@ -1,7 +1,16 @@
 {
   "references": [
-    { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.samples.json" },
-    { "path": "./tsconfig.test.json" }
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.samples.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
+    }
   ]
 }

--- a/sdk/search/search-documents/tsconfig.snippets.json
+++ b/sdk/search/search-documents/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/security/arm-security/tsconfig.json
+++ b/sdk/security/arm-security/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/security/arm-security/tsconfig.snippets.json
+++ b/sdk/security/arm-security/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/securitydevops/arm-securitydevops/tsconfig.json
+++ b/sdk/securitydevops/arm-securitydevops/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/securitydevops/arm-securitydevops/tsconfig.snippets.json
+++ b/sdk/securitydevops/arm-securitydevops/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/securityinsight/arm-securityinsight/tsconfig.json
+++ b/sdk/securityinsight/arm-securityinsight/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/securityinsight/arm-securityinsight/tsconfig.snippets.json
+++ b/sdk/securityinsight/arm-securityinsight/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/selfhelp/arm-selfhelp/tsconfig.json
+++ b/sdk/selfhelp/arm-selfhelp/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/selfhelp/arm-selfhelp/tsconfig.snippets.json
+++ b/sdk/selfhelp/arm-selfhelp/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/serialconsole/arm-serialconsole/tsconfig.json
+++ b/sdk/serialconsole/arm-serialconsole/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/serialconsole/arm-serialconsole/tsconfig.snippets.json
+++ b/sdk/serialconsole/arm-serialconsole/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/service-map/arm-servicemap/tsconfig.json
+++ b/sdk/service-map/arm-servicemap/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/service-map/arm-servicemap/tsconfig.snippets.json
+++ b/sdk/service-map/arm-servicemap/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicebus/arm-servicebus/tsconfig.json
+++ b/sdk/servicebus/arm-servicebus/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicebus/arm-servicebus/tsconfig.snippets.json
+++ b/sdk/servicebus/arm-servicebus/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicebus/service-bus/tsconfig.json
+++ b/sdk/servicebus/service-bus/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ],
   "compilerOptions": {

--- a/sdk/servicebus/service-bus/tsconfig.snippets.json
+++ b/sdk/servicebus/service-bus/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicefabric/arm-servicefabric-rest/tsconfig.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicefabric/arm-servicefabric-rest/tsconfig.snippets.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicefabric/arm-servicefabric/tsconfig.json
+++ b/sdk/servicefabric/arm-servicefabric/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicefabric/arm-servicefabric/tsconfig.snippets.json
+++ b/sdk/servicefabric/arm-servicefabric/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/tsconfig.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/tsconfig.snippets.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/tsconfig.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/tsconfig.snippets.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicelinker/arm-servicelinker/tsconfig.json
+++ b/sdk/servicelinker/arm-servicelinker/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicelinker/arm-servicelinker/tsconfig.snippets.json
+++ b/sdk/servicelinker/arm-servicelinker/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/servicenetworking/arm-servicenetworking/tsconfig.json
+++ b/sdk/servicenetworking/arm-servicenetworking/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/servicenetworking/arm-servicenetworking/tsconfig.snippets.json
+++ b/sdk/servicenetworking/arm-servicenetworking/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/signalr/arm-signalr/tsconfig.json
+++ b/sdk/signalr/arm-signalr/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/signalr/arm-signalr/tsconfig.snippets.json
+++ b/sdk/signalr/arm-signalr/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/sitemanager/arm-sitemanager/tsconfig.json
+++ b/sdk/sitemanager/arm-sitemanager/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/sitemanager/arm-sitemanager/tsconfig.snippets.json
+++ b/sdk/sitemanager/arm-sitemanager/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/sphere/arm-sphere/tsconfig.json
+++ b/sdk/sphere/arm-sphere/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/sphere/arm-sphere/tsconfig.snippets.json
+++ b/sdk/sphere/arm-sphere/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/springappdiscovery/arm-springappdiscovery/tsconfig.json
+++ b/sdk/springappdiscovery/arm-springappdiscovery/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/springappdiscovery/arm-springappdiscovery/tsconfig.snippets.json
+++ b/sdk/springappdiscovery/arm-springappdiscovery/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/sql/arm-sql/tsconfig.json
+++ b/sdk/sql/arm-sql/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/sql/arm-sql/tsconfig.snippets.json
+++ b/sdk/sql/arm-sql/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/tsconfig.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/tsconfig.snippets.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/standbypool/arm-standbypool/tsconfig.json
+++ b/sdk/standbypool/arm-standbypool/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/standbypool/arm-standbypool/tsconfig.snippets.json
+++ b/sdk/standbypool/arm-standbypool/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/arm-storage/tsconfig.json
+++ b/sdk/storage/arm-storage/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/arm-storage/tsconfig.snippets.json
+++ b/sdk/storage/arm-storage/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-blob-changefeed/tsconfig.json
+++ b/sdk/storage/storage-blob-changefeed/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-blob-changefeed/tsconfig.snippets.json
+++ b/sdk/storage/storage-blob-changefeed/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-blob/tsconfig.json
+++ b/sdk/storage/storage-blob/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-blob/tsconfig.snippets.json
+++ b/sdk/storage/storage-blob/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-common/tsconfig.json
+++ b/sdk/storage/storage-common/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-common/tsconfig.snippets.json
+++ b/sdk/storage/storage-common/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-file-datalake/tsconfig.json
+++ b/sdk/storage/storage-file-datalake/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-file-datalake/tsconfig.snippets.json
+++ b/sdk/storage/storage-file-datalake/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-file-share/tsconfig.json
+++ b/sdk/storage/storage-file-share/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-file-share/tsconfig.snippets.json
+++ b/sdk/storage/storage-file-share/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-internal-avro/tsconfig.json
+++ b/sdk/storage/storage-internal-avro/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-internal-avro/tsconfig.snippets.json
+++ b/sdk/storage/storage-internal-avro/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storage/storage-queue/tsconfig.json
+++ b/sdk/storage/storage-queue/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storage/storage-queue/tsconfig.snippets.json
+++ b/sdk/storage/storage-queue/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storageactions/arm-storageactions/tsconfig.json
+++ b/sdk/storageactions/arm-storageactions/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storageactions/arm-storageactions/tsconfig.snippets.json
+++ b/sdk/storageactions/arm-storageactions/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storagecache/arm-storagecache/tsconfig.json
+++ b/sdk/storagecache/arm-storagecache/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storagecache/arm-storagecache/tsconfig.snippets.json
+++ b/sdk/storagecache/arm-storagecache/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storageimportexport/arm-storageimportexport/tsconfig.json
+++ b/sdk/storageimportexport/arm-storageimportexport/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storageimportexport/arm-storageimportexport/tsconfig.snippets.json
+++ b/sdk/storageimportexport/arm-storageimportexport/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storagemover/arm-storagemover/tsconfig.json
+++ b/sdk/storagemover/arm-storagemover/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storagemover/arm-storagemover/tsconfig.snippets.json
+++ b/sdk/storagemover/arm-storagemover/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storagesync/arm-storagesync/tsconfig.json
+++ b/sdk/storagesync/arm-storagesync/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storagesync/arm-storagesync/tsconfig.snippets.json
+++ b/sdk/storagesync/arm-storagesync/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storsimple1200series/arm-storsimple1200series/tsconfig.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storsimple1200series/arm-storsimple1200series/tsconfig.snippets.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/storsimple8000series/arm-storsimple8000series/tsconfig.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/storsimple8000series/arm-storsimple8000series/tsconfig.snippets.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/streamanalytics/arm-streamanalytics/tsconfig.json
+++ b/sdk/streamanalytics/arm-streamanalytics/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/streamanalytics/arm-streamanalytics/tsconfig.snippets.json
+++ b/sdk/streamanalytics/arm-streamanalytics/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/tsconfig.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/tsconfig.snippets.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/subscription/arm-subscriptions/tsconfig.json
+++ b/sdk/subscription/arm-subscriptions/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/subscription/arm-subscriptions/tsconfig.snippets.json
+++ b/sdk/subscription/arm-subscriptions/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/support/arm-support/tsconfig.json
+++ b/sdk/support/arm-support/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/support/arm-support/tsconfig.snippets.json
+++ b/sdk/support/arm-support/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/arm-synapse/tsconfig.json
+++ b/sdk/synapse/arm-synapse/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/arm-synapse/tsconfig.snippets.json
+++ b/sdk/synapse/arm-synapse/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/synapse-access-control-rest/tsconfig.json
+++ b/sdk/synapse/synapse-access-control-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/synapse-access-control-rest/tsconfig.snippets.json
+++ b/sdk/synapse/synapse-access-control-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/synapse-access-control/tsconfig.json
+++ b/sdk/synapse/synapse-access-control/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/synapse-access-control/tsconfig.snippets.json
+++ b/sdk/synapse/synapse-access-control/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/synapse-artifacts/tsconfig.json
+++ b/sdk/synapse/synapse-artifacts/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/synapse-artifacts/tsconfig.snippets.json
+++ b/sdk/synapse/synapse-artifacts/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/synapse-managed-private-endpoints/tsconfig.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/synapse-managed-private-endpoints/tsconfig.snippets.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/synapse-monitoring/tsconfig.json
+++ b/sdk/synapse/synapse-monitoring/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/synapse-monitoring/tsconfig.snippets.json
+++ b/sdk/synapse/synapse-monitoring/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/synapse/synapse-spark/tsconfig.json
+++ b/sdk/synapse/synapse-spark/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/synapse/synapse-spark/tsconfig.snippets.json
+++ b/sdk/synapse/synapse-spark/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/tables/data-tables/tsconfig.json
+++ b/sdk/tables/data-tables/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/tables/data-tables/tsconfig.snippets.json
+++ b/sdk/tables/data-tables/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/template/template-dpg/tsconfig.json
+++ b/sdk/template/template-dpg/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/template/template-dpg/tsconfig.snippets.json
+++ b/sdk/template/template-dpg/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/template/template/tsconfig.json
+++ b/sdk/template/template/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/template/template/tsconfig.snippets.json
+++ b/sdk/template/template/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/templatespecs/arm-templatespecs/tsconfig.json
+++ b/sdk/templatespecs/arm-templatespecs/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/templatespecs/arm-templatespecs/tsconfig.snippets.json
+++ b/sdk/templatespecs/arm-templatespecs/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/terraform/arm-terraform/tsconfig.json
+++ b/sdk/terraform/arm-terraform/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/terraform/arm-terraform/tsconfig.snippets.json
+++ b/sdk/terraform/arm-terraform/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/tsconfig.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/tsconfig.snippets.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/trafficmanager/arm-trafficmanager/tsconfig.json
+++ b/sdk/trafficmanager/arm-trafficmanager/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/trafficmanager/arm-trafficmanager/tsconfig.snippets.json
+++ b/sdk/trafficmanager/arm-trafficmanager/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/translation/ai-translation-document-rest/tsconfig.json
+++ b/sdk/translation/ai-translation-document-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/translation/ai-translation-document-rest/tsconfig.snippets.json
+++ b/sdk/translation/ai-translation-document-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/translation/ai-translation-text-rest/tsconfig.json
+++ b/sdk/translation/ai-translation-text-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/translation/ai-translation-text-rest/tsconfig.snippets.json
+++ b/sdk/translation/ai-translation-text-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/trustedsigning/arm-trustedsigning/tsconfig.json
+++ b/sdk/trustedsigning/arm-trustedsigning/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/trustedsigning/arm-trustedsigning/tsconfig.snippets.json
+++ b/sdk/trustedsigning/arm-trustedsigning/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/vision/ai-vision-image-analysis-rest/tsconfig.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/vision/ai-vision-image-analysis-rest/tsconfig.snippets.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/visualstudio/arm-visualstudio/tsconfig.json
+++ b/sdk/visualstudio/arm-visualstudio/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/visualstudio/arm-visualstudio/tsconfig.snippets.json
+++ b/sdk/visualstudio/arm-visualstudio/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/tsconfig.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/tsconfig.snippets.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/voiceservices/arm-voiceservices/tsconfig.json
+++ b/sdk/voiceservices/arm-voiceservices/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/voiceservices/arm-voiceservices/tsconfig.snippets.json
+++ b/sdk/voiceservices/arm-voiceservices/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/web-pubsub/arm-webpubsub/tsconfig.json
+++ b/sdk/web-pubsub/arm-webpubsub/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/web-pubsub/arm-webpubsub/tsconfig.snippets.json
+++ b/sdk/web-pubsub/arm-webpubsub/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.snippets.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/web-pubsub/web-pubsub-client/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-client/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/web-pubsub/web-pubsub-client/tsconfig.snippets.json
+++ b/sdk/web-pubsub/web-pubsub-client/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/web-pubsub/web-pubsub-express/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub-express/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ],
   "compilerOptions": {

--- a/sdk/web-pubsub/web-pubsub-express/tsconfig.snippets.json
+++ b/sdk/web-pubsub/web-pubsub-express/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/web-pubsub/web-pubsub/tsconfig.json
+++ b/sdk/web-pubsub/web-pubsub/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/web-pubsub/web-pubsub/tsconfig.snippets.json
+++ b/sdk/web-pubsub/web-pubsub/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/workloads/arm-workloads/tsconfig.json
+++ b/sdk/workloads/arm-workloads/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/workloads/arm-workloads/tsconfig.snippets.json
+++ b/sdk/workloads/arm-workloads/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}

--- a/sdk/workloads/arm-workloadssapvirtualinstance/tsconfig.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.test.json"
+    },
+    {
+      "path": "./tsconfig.snippets.json"
     }
   ]
 }

--- a/sdk/workloads/arm-workloadssapvirtualinstance/tsconfig.snippets.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.snippets.base.json"]
+}


### PR DESCRIPTION
The snippets.spec.ts file contains README samples that may have unused variables. This PR introduces a dedicated tsconfig.snippets.json file in each library that configures TS to not complain about such unused variables. See https://github.com/Azure/azure-sdk-for-js/blob/main/tsconfig.snippets.base.json