### PR TITLE
Enforce the presence of artifacts for non-pr builds

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -12,6 +12,7 @@ steps:
     parameters:
       PackageInfo: $(Build.ArtifactStagingDirectory)/PackageInfo
       Artifacts: ${{ parameters.Artifacts }}
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -46,6 +46,7 @@ steps:
     parameters:
       PackageInfo: $(Build.ArtifactStagingDirectory)/PackageInfo
       Artifacts: ${{ parameters.Artifacts }}
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
     - task: AzureCLI@2

--- a/eng/pipelines/templates/steps/set-artifact-packages.yml
+++ b/eng/pipelines/templates/steps/set-artifact-packages.yml
@@ -1,7 +1,19 @@
 parameters:
   PackageInfo: ''
   Artifacts: []
+  ServiceDirectory: ''
 steps:
+  - ${{ if ne(parameters.ServiceDirectory, 'auto') }}:
+    - pwsh: |
+        $artifacts = '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+
+        if (!$artifacts) {
+          Write-Host "No artifacts provided on a non-PR build where at least one package must be provided."
+          Write-Host "Check the ci.yml for the service directory `"${{ parameters.ServiceDirectory }}`" for an `"Artifacts`" parameter and ensure it is properly populated."
+          exit 1
+        }
+      displayName: 'Check for valid artifacts'
+
   # Package-Properties folder contains the package properties for all discovered packages that were either A) affected by the PR or
   # B) explicitly present in the service directory. This repo splits the builds into two categories: "mgmt" and "dataplane". While
   # a given directory may contain both, there will be a separate build definition to release the management packages. Due to this
@@ -13,6 +25,7 @@ steps:
   # individual ci.yml and ci.mgmt.yml files.
   - pwsh: |
       $artifacts = '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+
       $knownArtifacts = @()
       if ($artifacts) {
         $knownArtifacts = $artifacts | ForEach-Object { $_.name }

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -21,6 +21,7 @@ steps:
     parameters:
       PackageInfo: $(Build.ArtifactStagingDirectory)/PackageInfo
       Artifacts: ${{ parameters.Artifacts }}
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
   # The default on Windows is "cores - 1" (microsoft/rushstack#436).


### PR DESCRIPTION
I'm walking the rest of the `set-artifact-packages` across the repos to ensure that we handle this similarly across all of these. There will likely be further follow-up PRs .