### PR TITLE
[storage-blob-changefeed] fix test typecheck failure (#34732)

### DIFF
--- a/sdk/storage/storage-blob-changefeed/test/chunk.spec.ts
+++ b/sdk/storage/storage-blob-changefeed/test/chunk.spec.ts
@@ -4,7 +4,7 @@
 import { Chunk } from "../src/Chunk.js";
 import { AvroReader } from "@azure/storage-internal-avro";
 import type { BlobChangeFeedEvent } from "../src/index.js";
-import { describe, it, assert, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, assert, beforeEach, afterEach, vi } from "vitest";
 
 class FakeAvroReader {
   constructor(
@@ -48,7 +48,11 @@ describe("Chunk", () => {
   });
 
   it("hasNext()", async () => {
-    const avroReaderStub = new AvroReader(expect.anything());
+    const readable = {
+      position: 0,
+      read: () => Promise.resolve(new Uint8Array()),
+    };
+    const avroReaderStub = new AvroReader(readable);
     vi.mocked(avroReaderStub.hasNext).mockReturnValue(true);
 
     const chunk = new Chunk(avroReaderStub as any, 0, 0, "log/00/2020/07/30/2300/");
@@ -62,7 +66,11 @@ describe("Chunk", () => {
     // set up
     const record = { a: 1 };
     const fakeAvroReader = new FakeAvroReader(0, 0, true, record);
-    const avroReaderStub = new AvroReader(expect.anything());
+    const readable = {
+      position: 0,
+      read: () => Promise.resolve(new Uint8Array()),
+    };
+    const avroReaderStub = new AvroReader(readable);
     vi.mocked(avroReaderStub.hasNext).mockImplementation(() => fakeAvroReader.hasNext);
     vi.mocked(avroReaderStub.parseObjects).mockReturnValue(fakeAvroReader.parseObjects());
     vi.spyOn(avroReaderStub, "blockOffset", "get").mockReturnValue(fakeAvroReader.blockOffset);


### PR DESCRIPTION
After upgrading to vitest 3.2.0, new typecheck errors started appearing because of the typing improvement to the return type of `expect.anything()`. 

>Argument of type 'AsymmetricMatcher<unknown, MatcherState>' is not
assignable to parameter of type 'AvroReadable'. Type 'AsymmetricMatcher<unknown, MatcherState>' is missing the following properties from type 'AvroReadable' position, read

Looking at the test, we actually don't need anything from the constructor argument. This PR updates the tests by replacing `expect.anything()` usage with a simple object literal.


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
