### PR TITLE
[engSys] follow-up to Node 20 changes

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -13,7 +13,7 @@ import { S_IRWXO } from "constants";
 import { resolveProject } from "../../util/resolveProject";
 import { findSamplesRelativeDir } from "../../util/findSamplesDir";
 
-const defaultVersions = [18, 20, 21];
+const defaultVersions = [20, 22, 24];
 
 const log = createPrinter("check-node-versions-samples");
 

--- a/documentation/Generate-code-from-TypeSpec.md
+++ b/documentation/Generate-code-from-TypeSpec.md
@@ -8,7 +8,7 @@ Getting Started: Generate JS SDK with TypeSpec
 
 ## Prerequisites
 
-- [Node.js 18.x LTS](https://nodejs.org/en/download) or later
+- [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule)
 - [Git](https://git-scm.com/downloads)
 - Local Clone of Rest API Spec Repo Fork
   - If you don't already have a fork, [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository) the [Rest API Spec Repo](https://github.com/Azure/azure-rest-api-specs).

--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-ARG NODE_VERSION=18
+ARG NODE_VERSION=20
 
 # docker can't tell when the repo has changed and will therefore cache this layer
 # internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'

--- a/sdk/planetarycomputer/arm-planetarycomputer/package.json
+++ b/sdk/planetarycomputer/arm-planetarycomputer/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta.1",
   "description": "A generated SDK for SpatioClient.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "sideEffects": false,
   "autoPublish": false,

--- a/sdk/planetarycomputer/arm-planetarycomputer/samples/v1-beta/javascript/package.json
+++ b/sdk/planetarycomputer/arm-planetarycomputer/samples/v1-beta/javascript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "@azure/arm-planetarycomputer client library samples for JavaScript (Beta)",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/sdk/planetarycomputer/arm-planetarycomputer/samples/v1-beta/typescript/package.json
+++ b/sdk/planetarycomputer/arm-planetarycomputer/samples/v1-beta/typescript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "@azure/arm-planetarycomputer client library samples for TypeScript (Beta)",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
PR #34773 migrated the repo to Node 20. Because of the large size we chose to
spin off any follow-up fixes to a second PR.
