### PR TITLE
Updates to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,101 +1,47 @@
-# Prompt for GitHub Copilot
+# Azure SDK for JavaScript - AI Agent Instructions
 
-You are a highly experienced engineer with expertise in
+## Core Requirements
 
-- Node.js (https://nodejs.org)
-- TypeScript (https://www.typescriptlang.org)
-- JavaScript (https://developer.mozilla.org/docs/Web/JavaScript)
-- Vitest (https://vitest.dev/)
-- rush (https://rushjs.io).
+**Technologies:** Node.js, TypeScript, JavaScript, Vitest, Rush
 
-## Behavior
+**Non-negotiable Rules:**
 
-- Always run `rush update` at least once before running other `rush` or `rushx` commands.
-- Always ensure your solutions prioritize clarity, maintainability, and testability.
-- Never suggest re-recording tests as a fix to an issue
-- NEVER turn off a rule in `eslint-plugin-azure-sdk` plugin to resolve linting issues.
-- Always review your own code for consistency, maintainability, and testability
-- Always ask how to verify that your changes are correct, including any relevant tests or documentation checks.
-- Always ask for clarifications if the request is ambiguous or lacks sufficient context.
-- Always provide detailed justifications for each recommended approach and clarify potential ambiguities before proceeding.
-- Always provide abundant context, erring on the side of more detail rather than less.
-- Never recommend writing an LRO by hand - instead you always use the LRO primitives from the core packages. When discussing LROs you will always review the implementation in `sdk/core/core-lro` and `sdk/core/core-client` to ensure that the recommendation is correct and follows the latest code.
-- All options types should be extending `OperationOptions`, or be `OperationOptions` type if no new options are needed.
+- Never disable `eslint-plugin-azure-sdk` rules
+- Always use LRO primitives from core packages (never write LROs manually)
+- All options types must extend `OperationOptions`
 
-Include detailed justifications for each recommended approach and clarify potential ambiguities before proceeding.
+**Code Quality Standards:**
 
-When suggesting code, always include tests and documentation updates. If the code is complex, provide a detailed explanation of how it works and why you chose that approach. If there are multiple ways to solve a problem, explain the trade-offs of each approach and why you chose one over the others.
+- Prioritize clarity, maintainability, and testability
+- Include tests and documentation with all code suggestions
+- Provide detailed justifications for complex solutions
+- Ask for clarification when requirements are ambiguous
 
-### Data sources
+## Key Reference Documentation
 
-Always attempt to browse the following resources and incorporate relevant information from the following sources:
+**Coding Guidelines:**
 
-- General Guidelines:
-  - https://azure.github.io/azure-sdk/general_introduction.html
-  - https://azure.github.io/azure-sdk/general_terminology.html
-  - https://azure.github.io/azure-sdk/general_design.html
-  - https://azure.github.io/azure-sdk/general_implementation.html
-  - https://azure.github.io/azure-sdk/general_documentation.html
-  - https://azure.github.io/azure-sdk/general_azurecore.html
-- TypeScript:
-  - https://azure.github.io/azure-sdk/typescript_introduction.html
-  - https://azure.github.io/azure-sdk/typescript_design.html
-  - https://azure.github.io/azure-sdk/typescript_implementation.html
-  - https://azure.github.io/azure-sdk/typescript_documentation.html
-- Implementation details:
-  - https://github.com/Azure/azure-sdk/blob/main/docs/policies/repostructure.md
-  - https://azure.github.io/azure-sdk/typescript_introduction.html
-  - https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md
-  - linting: https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/linting.md
+- [TypeScript Guidelines](../documentation/llms/guidelines/introduction.md)
+- [Implementation Guidelines](../documentation/llms/guidelines/implementation.md)
+- [Documentation Guidelines](../documentation/llms/guidelines/documentation.md)
+- [Design and Naming Guidelines](../documentation/llms/guidelines/design.md)
 
-When reviewing documentation URLs (especially Azure SDK documentation), extract key points, principles, and examples to inform your responses.
-Always cite the specific sections of documentation you've referenced in your responses.
+**Repository Resources:**
 
-## Repository structure
+- [Testing Guide](../documentation/Quickstart-on-how-to-write-tests.md)
+- [Linting Documentation](../documentation/linting.md)
 
-### Core Packages
+## Repository Structure
 
-In general, whenever a code refers to `@azure/core-*` packages, we will expect copilot to use the in-repository core package. The core packages are listed below along with the path to the package in the repository:
+**Core Packages:** Use in-repository packages, not external versions
 
-- `@azure/core-amqp`: `sdk/core/core-amqp`
 - `@azure/core-auth`: `sdk/core/core-auth`
-- `@azure/core-client`: `sdk/core/core-client`
 - `@azure/core-client`: `sdk/core/core-client`
 - `@azure/core-lro`: `sdk/core/core-lro`
 - `@azure/core-paging`: `sdk/core/core-paging`
 - `@azure/core-rest-pipeline`: `sdk/core/core-rest-pipeline`
 - `@azure/core-tracing`: `sdk/core/core-tracing`
 - `@azure/core-util`: `sdk/core/core-util`
-- `@azure/core-xml`: `sdk/core/core-xml`
 - `@azure-rest/core-client`: `sdk/core/core-client-rest`
 
-If a change requires updates to the core packages, you will remind the user to run `rush build -t .` commands.
-
-Refer to `rush.json` if you need to resolve a package directory from its package name.
-
-## Azure SDK Guidelines
-
-Generate TypeScript code that adheres strictly to these guidelines.
-
-Core Principles:
-
-- Be idiomatic, consistent, approachable, diagnosable, and dependable.
-- Use natural TypeScript patterns and follow modern JS practices (async/await, Promises, iterators).
-
-API Design:
-
-- Create service client classes (with “Client” suffix) with minimal, overloaded constructors.
-- Use options bags (<MethodName>Options) for additional parameters.
-- Support cancellation via AbortSignal.
-- Follow standard verbs (create, upsert, get, delete, etc.) and expose subclients via get<SubClient>Client().
-
-Implementation:
-
-- Follow semver guidelines. for example, increment package minor version when adding new features, and upgrade dependents if changes are introduced which depend on added features.
-- Leverage the HTTP pipeline with built-in policies (telemetry, retry, authentication, logging, distributed tracing).
-- Validate only client parameters; use built-in error types and robust logging.
-- Use core packages like @azure/core-rest-pipeline and @azure/core-auth.
-
-Prioritize TypeScript-specific practices over general rules when conflicts occur.
-
-When possible, refer to the Azure SDK for JS Design Guidelines for specific examples and best practices. Explicitly state when you are deviating from these guidelines and provide a justification for the deviation.
+**Important:** When modifying core packages, remind users to run `rush build -t .`

--- a/documentation/llms/README.md
+++ b/documentation/llms/README.md
@@ -1,0 +1,3 @@
+# LLM-friendly documentation
+
+This folder contains documentation intended for LLM agents such as GitHub Copilot, and is not meant for human consumption.

--- a/documentation/llms/guidelines/design.md
+++ b/documentation/llms/guidelines/design.md
@@ -1,0 +1,253 @@
+# Azure SDK TypeScript Guidelines - API Design
+
+## Platform Support
+
+**MUST:**
+
+- Support all LTS versions of Node.js and newer versions up to latest
+- Support latest 2 versions of: Safari, Chrome, Edge, Firefox
+- Compile without errors on TypeScript versions less than 2 years old
+
+**MUST NOT:**
+
+- Support IE11 (requires Architecture Board approval if needed)
+
+## Package Naming and Distribution
+
+**MUST:**
+
+- Publish to `@azure` npm scope
+- Use kebab-case package names that tie to the service
+- Tag beta packages with `next` distribution tag
+- Tag generally available packages with `latest`
+
+**Package Name Prefixes:**
+
+- `ai` - Artificial intelligence/machine learning
+- `analytics` - Metrics and usage data
+- `communication` - Communication services
+- `data` - Database and structured data
+- `identity` - Authentication and authorization
+- `iot` - Internet of things
+- `management` - Control Plane (ARM)
+- `messaging` - Pub-sub and messaging
+- `storage` - Unstructured data storage
+
+## Service Client Design
+
+### Client Structure
+
+```typescript
+export class ServiceClient {
+  // Overloaded constructors for different auth schemes
+  constructor(connectionString: string, options?: ServiceClientOptions);
+  constructor(url: string, credential: TokenCredential, options?: ServiceClientOptions);
+
+  // Service methods with options
+  async createItem(options?: CreateItemOptions): Promise<CreateItemResponse>;
+  async deleteItem(options?: DeleteItemOptions): Promise<DeleteItemResponse>;
+
+  // Pagination
+  listItems(): PagedAsyncIterableIterator<Item, ItemPage>;
+
+  // Sub-clients
+  getItemClient(itemName: string): ItemClient;
+}
+```
+
+### Constructor Rules
+
+**MUST:**
+
+- Allow minimal information needed to connect and authenticate
+- Support 100% of service features
+- Use overloads for different construction scenarios
+
+**SHOULD:**
+
+- Prefer overloads over unions for correlated parameters
+- Use static `fromX()` methods only when overloads would be ambiguous
+
+### Service Versions
+
+**MUST:**
+
+- Call highest supported service API version by default
+- Allow explicit service version selection via `serviceVersion` option
+- Use string literal union or enum for supported versions
+
+## Method Naming Conventions
+
+**MUST:**
+
+- Use "Client" suffix for service client types
+- Follow approved verbs:
+
+| Verb            | Use Case                            | Returns                    |
+| --------------- | ----------------------------------- | -------------------------- |
+| `create<Noun>`  | Create new item (fails if exists)   | Created item               |
+| `upsert<Noun>`  | Create or update item               | Updated/created item       |
+| `set<Noun>`     | Create or update (dictionary-like)  | Updated/created item       |
+| `update<Noun>`  | Update existing (fails if missing)  | Updated item               |
+| `replace<Noun>` | Replace existing (fails if missing) | Replaced item              |
+| `get<Noun>`     | Retrieve item                       | Item or null               |
+| `list<Noun>s`   | List items                          | PagedAsyncIterableIterator |
+| `<noun>Exists`  | Check existence                     | boolean                    |
+| `delete<Noun>`  | Delete item (succeeds if missing)   | void                       |
+
+**MUST NOT:**
+
+- Include noun when operating on the resource itself (e.g., `delete()` not `deleteItem()` on ItemClient)
+
+## Options and Parameters
+
+### Options Naming
+
+**MUST:**
+
+- Name options bags as `<ClassName>Options` or `<MethodName>Options`
+- Use `OperationOptions` from Azure Core if no custom options needed
+- Name abort signal options `abortSignal`
+- Suffix durations with `In<Unit>` (e.g., `timeoutInMs`, `delayInSeconds`)
+
+### Retry Options
+
+**MUST support:**
+
+- `retryMode`: 'fixed' | 'linear' | 'exponential'
+- `maxRetries`: number >= 0
+- `retryDelayInMs`: number > 0
+- `maxRetryDelayInMs`: number > 0
+- `tryTimeoutInMs`: number > 0
+
+## Async Patterns and Modern JavaScript
+
+**MUST:**
+
+- Use built-in Promises for async operations
+- Accept `AbortSignalLike` on all async calls
+- Use iterators and async iterators for sequences
+
+**SHOULD:**
+
+- Use `async` functions for implementing async APIs
+- Prefer interface types over class types for parameters
+
+**Example of good async patterns:**
+
+```typescript
+// Good async iterator
+async function* listItems() {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+// Good with AbortSignal
+async function getItem(id: string, options: { abortSignal?: AbortSignal } = {}) {
+  // Implementation
+}
+```
+
+## Response Formats
+
+**MUST:**
+
+- Optimize for returning the logical entity (99%+ case)
+- Make complete response (headers, status, body) accessible
+- Provide enough information for error remediation
+
+**MUST NOT:**
+
+- Use property names `object` or `value` in logical entities
+- Return headers/metadata unless it's clear which request they correspond to
+
+## Pagination
+
+**MUST:**
+
+- Provide `list` methods that return `PagedAsyncIterableIterator`
+- Support `continuationToken` in `byPage()` method
+- Use consistent page interface with `continuationToken` property
+
+```typescript
+interface PagedAsyncIterableIterator<TElement, TPage = TElement[]> {
+  next(): Promise<IteratorResult<TElement>>;
+  [Symbol.asyncIterator](): PagedAsyncIterableIterator<TElement, TPage>;
+  byPage: (settings?: {
+    continuationToken?: string;
+  }) => AsyncIterableIterator<ContinuablePage<TElement, TPage>>;
+}
+```
+
+## Long Running Operations (LROs)
+
+**MUST:**
+
+- Use objects that encapsulate polling and operation status
+- Support: querying state, async completion notification, cancellation, manual polling
+- Prefix LRO method names with `begin`
+- Support `pollInterval` configuration
+- Use `@azure/core-lro` package abstractions
+
+**MUST NOT:**
+
+- Cancel the service operation when cancellation token is triggered (only cancel polling)
+
+## Model Types
+
+**MUST:**
+
+- Follow naming conventions:
+  - `<Model>` - Full resource data
+  - `<Model>Details` - Less important details (attach as `details` property)
+  - `<Model>Item` - Partial data for enumeration
+  - `<Operation>Options` - Method parameters
+  - `<Operation>Result` - Operation-specific results
+
+## Conditional Requests
+
+When model has `etag` property:
+
+- `onlyIfChanged` - sets `if-match` header
+- `onlyIfUnchanged` - sets `if-none-match` header
+- `onlyIfMissing` - sets `if-none-match: *`
+- `onlyIfPresent` - sets `if-match: *`
+
+When model lacks `etag`:
+
+- Use `conditions.ifMatch`, `conditions.ifNoneMatch`, etc.
+
+## TypeScript-Specific Requirements
+
+**MUST:**
+
+- Implement library in TypeScript
+- Include type declarations
+- Set `tsconfig.json` properly:
+  - `strict: true`
+  - `esModuleInterop: true`
+  - `allowSyntheticDefaultImports: true`
+  - `forceConsistentCasingInFileNames: true`
+  - `declaration: true`
+  - `sourceMap: true` and `declarationMap: true`
+  - `importHelpers: true`
+
+**MUST NOT:**
+
+- Use TypeScript namespaces
+- Use `const enum`
+- Set `compilerOptions.lib` field
+- Set `experimentalDecorators: true`
+
+## Using Azure Core
+
+**MUST:**
+
+- Use Azure Core packages for consistent behavior:
+  - `@azure/core-rest-pipeline` - HTTP pipeline
+  - `@azure/core-auth` - Authentication
+  - `@azure/core-lro` - Long-running operations
+  - `@azure/core-paging` - Pagination
+  - `@azure/logger` - Logging
+  - `@azure/core-tracing` - Distributed tracing

--- a/documentation/llms/guidelines/documentation.md
+++ b/documentation/llms/guidelines/documentation.md
@@ -1,0 +1,263 @@
+# Azure SDK TypeScript Guidelines - Documentation
+
+## Required Documentation Deliverables
+
+1. **README.md** - In library root directory with installation and usage info
+2. **API Reference** - Generated from docstrings, published on docs.microsoft.com
+3. **Code Snippets** - Short examples for champion scenarios
+4. **Quickstart** - docs.microsoft.com article expanding on README
+5. **Conceptual Documentation** - Long-form tutorials, how-to guides, etc.
+
+## General Documentation Requirements
+
+**MUST:**
+
+- Include service content developer in architecture review
+- Follow Azure SDK Contributors Guide
+- Follow Microsoft style guides:
+  - Microsoft Writing Style Guide
+  - Microsoft Cloud Style Guide
+- Document required `tsconfig.json` settings in README under "Configure TypeScript" section (after "Install the Package")
+
+**SHOULD:**
+
+- Document library into silence - preempt usage questions
+- Include information on service limits, errors, and recovery strategies
+
+## Code Snippets
+
+**MUST:**
+
+- Include example code snippets alongside library code in repository
+- Build and test snippets using CI to ensure they remain functional
+- Include snippets in library docstrings for API reference
+- Include snippets for every common operation and complex scenarios
+- Cover all champion scenarios identified for the library
+
+**MUST NOT:**
+
+- Combine multiple operations in one snippet unless required for demonstration
+- Force developers to understand tangential code to extract what they need
+
+**Guidelines for Snippets:**
+
+- Show atomic operations clearly
+- Make code copy-pastable into projects
+- Focus on single operation per snippet
+- Provide separate snippets for each distinct operation
+
+### Example Structure
+
+```typescript
+// Good - Single operation focus
+async function createContainer() {
+  const containerClient = new ContainerClient(connectionString, containerName);
+  await containerClient.create();
+}
+
+// Good - Separate snippet for different operation
+async function listBlobs() {
+  const containerClient = new ContainerClient(connectionString, containerName);
+  for await (const blob of containerClient.listBlobs()) {
+    console.log(blob.name);
+  }
+}
+
+// Avoid - Multiple unrelated operations
+async function createAndList() {
+  // Creates cognitive load - user has to understand container creation
+  // even if they just want to list blobs
+  const containerClient = new ContainerClient(connectionString, containerName);
+  await containerClient.create(); // Not needed for listing scenario
+  for await (const blob of containerClient.listBlobs()) {
+    console.log(blob.name);
+  }
+}
+```
+
+## Samples
+
+**MUST:**
+
+- Have samples available for JavaScript
+
+**SHOULD:**
+
+- Have samples available in both JavaScript and TypeScript
+- Have browser samples tailored for browser scenarios (don't duplicate all samples)
+
+### Sample Organization
+
+- Organize by scenario, not by language feature
+- Include both basic and advanced usage patterns
+- Provide samples for different environments (Node.js, browser)
+- Include error handling examples
+- Show authentication patterns
+
+### Sample Quality
+
+- Samples should be production-ready code style
+- Include proper error handling
+- Use realistic variable names and scenarios
+- Include comments explaining key concepts
+- Be self-contained and runnable
+
+## README.md Structure
+
+**Required Sections:**
+
+1. **Installation** - How to install the package
+2. **Configure TypeScript** - Required tsconfig.json settings (if any)
+3. **Authentication** - How to authenticate with the service
+4. **Basic Usage** - Simple code examples for main scenarios
+5. **Advanced Usage** - Complex scenarios and configuration options
+6. **Troubleshooting** - Common issues and solutions
+7. **Next Steps** - Links to more documentation
+
+**Example README Flow:**
+
+````markdown
+# Azure Service Client Library for JavaScript
+
+## Install the Package
+
+```bash
+npm install @azure/service-name
+```
+````
+
+## Configure TypeScript
+
+This library requires the following TypeScript compiler options:
+
+```json
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  }
+}
+```
+
+## Authentication
+
+// Clear auth examples
+
+## Basic Usage
+
+// Champion scenario examples
+
+## Advanced Usage
+
+// Complex scenarios, configuration
+
+## Troubleshooting
+
+// Common issues, error handling
+
+## Next Steps
+
+// Links to more docs
+
+````
+
+## API Documentation (Docstrings)
+
+**MUST:**
+- Document all public APIs with clear descriptions
+- Include parameter descriptions and types
+- Document return values and types
+- Include example usage in docstrings
+- Document exceptions that can be thrown
+- Explain when network calls are made
+
+**SHOULD:**
+- Include performance considerations
+- Document service limitations
+- Provide links to service documentation
+- Include version information when features were added
+
+### Docstring Format
+```typescript
+/**
+ * Creates a new container in the storage account.
+ *
+ * @param containerName - The name of the container to create
+ * @param options - Optional parameters for container creation
+ * @returns Promise that resolves when container is created
+ *
+ * @throws {@link StorageError} When container already exists or name is invalid
+ *
+ * @example
+ * ```typescript
+ * const client = new BlobServiceClient(connectionString);
+ * await client.createContainer("my-container");
+ * ```
+ *
+ * @remarks
+ * Container names must be lowercase and between 3-63 characters.
+ * This operation makes a network call to the Azure Storage service.
+ */
+async createContainer(
+  containerName: string,
+  options: CreateContainerOptions = {}
+): Promise<CreateContainerResponse>
+````
+
+## Error Documentation
+
+**MUST:**
+
+- Document all error types that methods can throw
+- Provide error handling examples
+- Explain error recovery strategies
+- Include error codes and meanings
+
+**Example Error Documentation:**
+
+````typescript
+/**
+ * @throws {@link NotFoundError} When the specified resource doesn't exist
+ * @throws {@link AuthenticationError} When credentials are invalid
+ * @throws {@link ServiceError} When the service returns an error response
+ *
+ * @example Handle specific errors
+ * ```typescript
+ * try {
+ *   await client.getItem("nonexistent");
+ * } catch (error) {
+ *   if (error.name === "NotFoundError") {
+ *     // Handle missing resource
+ *   } else if (error.name === "AuthenticationError") {
+ *     // Handle auth failure
+ *   }
+ * }
+ * ```
+ */
+````
+
+## Documentation Testing
+
+**MUST:**
+
+- Test code snippets in documentation as part of CI
+- Ensure all examples are runnable and current
+- Validate links in documentation
+
+**SHOULD:**
+
+- Use automated tools to validate documentation quality
+- Include documentation review as part of PR process
+- Test documentation with real users when possible
+
+## Browser-Specific Documentation
+
+**MUST:**
+
+- Document any browser-specific requirements or limitations
+- Provide browser setup instructions if needed
+- Include CORS configuration guidance when applicable
+
+**SHOULD:**
+
+- Provide browser-specific code examples when patterns differ from Node.js
+- Document bundler configuration recommendations

--- a/documentation/llms/guidelines/implementation.md
+++ b/documentation/llms/guidelines/implementation.md
@@ -1,0 +1,241 @@
+# Azure SDK TypeScript Guidelines - Implementation
+
+### Environment Variables
+
+**MUST:**
+
+- Prefix Azure environment variables with `AZURE_`
+- Get Architecture Board approval for new environment variables
+- Use format: `AZURE_<ServiceName>_<ConfigurationKey>`
+
+**MUST NOT:**
+
+- Use non-alpha-numeric characters except underscore
+
+## Parameter Validation
+
+**MUST:**
+
+- Validate client parameters (used to construct URI, file uploads, etc.)
+- Validate developer experience with service parameters
+
+**MUST NOT:**
+
+- Validate service parameters (let service handle validation)
+
+## Network Requests
+
+**MUST:**
+
+- Use HTTP pipeline from `@azure/core-rest-pipeline`
+- Implement required policies: Telemetry, Unique Request ID, Retry, Authentication, Response downloader, Distributed tracing, Logging
+
+**SHOULD:**
+
+- Use Azure Core policy implementations when possible
+- Engage Architecture Board before writing custom policies
+
+## Authentication
+
+**MUST:**
+
+- Provide authentication policy for non-standard credentials
+- Support custom connection strings if needed
+
+**MUST NOT:**
+
+- Persist, cache, or reuse security credentials
+- Create security vulnerabilities (PII leakage, credential leakage)
+
+## Error Handling
+
+**MUST:**
+
+- Produce error when HTTP request fails with non-successful status
+- Include HTTP response and originating request in error
+- Include rich service error information in service-specific properties
+- Document errors that methods can produce
+
+**SHOULD:**
+
+- Prefer exceptions over error return values
+- Coerce incorrect types when possible (JavaScript fuzziness)
+- Check error `name` property instead of `instanceof` in catch clauses
+
+**MUST NOT:**
+
+- Create new error types unless developer can take alternate action
+- Create new error types when built-in types suffice
+
+**Built-in Error Types:**
+
+- `TypeError` - Wrong type passed
+- `RangeError` - Value outside allowable range
+- `Error` - Other validation failures
+
+## Distributed Tracing
+
+**MUST:**
+
+- Support OpenTelemetry for distributed tracing
+- Take `parentSpanId` option for all async operations
+- Pass context to backend via appropriate headers (`traceparent`, `tracestate`)
+- Create new span for each user-called method
+- Create child span for each REST call
+- Log polling status at Info level
+
+## Dependencies
+
+**MUST:**
+
+- Depend on Azure Core library for common functionality
+
+**MUST NOT:**
+
+- Depend on other packages (thoroughly vetted through architecture review)
+- Depend on concrete logging, DI, or configuration technologies (except Azure Core)
+
+**SHOULD:**
+
+- Consider copying/linking code to avoid dependencies
+- Get Architecture Board approval for large dependencies
+
+**SHOULD NOT:**
+
+- Take dependencies on tiny libraries
+- Depend on polyfills that modify global scope
+
+**Blessed Dependencies:**
+
+- `events` - Node EventEmitter polyfill
+- `stream-browserify` - Node Stream polyfill for browsers
+- `process` - Node Process polyfill
+- `rhea` - AMQP library
+- `rhea-promise` - Promisified rhea
+
+## Testing
+
+**SHOULD:**
+
+- Use Mocha and Karma for testing (supports CI and browsers)
+
+## Versioning
+
+**MUST:**
+
+- Change version when ANYTHING changes
+- Increment patch for bug fixes
+- Increment major/minor for new features or service API versions
+- Use semantic versioning (semver)
+- Support specific service API versions
+- Provide ability to call specific supported service versions
+
+**MUST NOT:**
+
+- Include new features in patch releases
+- Make breaking changes (requires Architecture Board approval)
+- Have pre-release version for stable packages
+- Have build metadata for stable packages
+
+**SHOULD:**
+
+- Increment major version for large feature changes
+
+**Beta Packages:**
+
+- Use format `1.0.0-beta.X` where X is integer
+
+## Packaging
+
+### Package Layout
+
+```
+azure-library/
+├─ README.md
+├─ LICENSE
+├─ dist/           # Build
+├─ types/          # TypeScript declarations
+└─ package.json
+```
+
+**MUST:**
+
+- Follow canonical file structure
+- Add files explicitly via `package.json` files key
+
+**MUST NOT:**
+
+- Include `tsconfig.json` in package
+- Use `.npmignore` files
+
+### package.json Requirements
+
+**MUST set:**
+
+- `name`: `@azure/<service-name>` (kebab-case)
+- `description`: Useful but terse description
+- `keywords`: Array including "Azure", "cloud", service name
+- `author`: "Microsoft Corporation"
+- `license`: "MIT"
+- `sideEffects`: false (unless explicitly approved)
+- `main`: CommonJS/UMD entry point
+- `module`: ES6 module entry point
+- `types`: TypeScript declarations file
+- `engine.node`: Supported Node versions
+- `repository`: "github:Azure/azure-sdk-for-js"
+- `homepage`: URL to library's readme in repo
+- `bugs.url`: "https://github.com/Azure/azure-sdk-for-js/issues"
+
+**Required scripts:**
+
+- `build` - Generate main export
+- `test` - Run functional tests
+
+**MUST NOT:**
+
+- Include ES6+ syntax in `main` entry point
+- Depend on shell scripts for build/test
+
+### Distribution Requirements
+
+**MUST:**
+
+- Include source code in source map files using `inlineSources`
+- Include CommonJS or UMD build for Node support
+- Flatten CommonJS/UMD build (use Rollup)
+- Include ESM build
+- Include original TypeScript sources
+
+**MUST NOT:**
+
+- Flatten ESM build
+- Include browser bundle in package
+
+### Module Requirements
+
+**MUST:**
+
+- Have named exports at top level
+
+**MUST NOT:**
+
+- Have default export at top level
+
+## Service-Specific Common Libraries
+
+**MUST:**
+
+- Get Architecture Board approval before implementing
+- Minimize code in common library
+- Store in same namespace as associated clients
+
+**Approval Criteria:**
+
+- Consumer directly consumes objects from common library, AND
+- Information shared between multiple client libraries
+
+## Native Code
+
+**SHOULD NOT:**
+
+- Write platform-specific/native code unless language compiles to machine-native format

--- a/documentation/llms/guidelines/introduction.md
+++ b/documentation/llms/guidelines/introduction.md
@@ -1,0 +1,56 @@
+# Azure SDK TypeScript Guidelines - Introduction
+
+These guidelines help create consistent, developer-friendly TypeScript client libraries for Azure services.
+
+## Core Design Principles
+
+### 1. Idiomatic
+
+- Follow TypeScript/JavaScript conventions and patterns
+- Feel natural to TypeScript and JavaScript developers
+- Use modern language features (async/await, promises, iterators)
+
+### 2. Consistent
+
+- Be consistent within TypeScript, with the service, and between languages
+- Priority order: TypeScript consistency > service consistency > cross-language consistency
+- Use consistent patterns for logging, HTTP communication, and error handling
+
+### 3. Approachable
+
+- Provide excellent documentation and examples
+- Use sensible defaults that follow best practices
+- Make common scenarios discoverable and easy to implement
+- Minimize the learning curve for new developers
+
+### 4. Diagnosable
+
+- Make it clear when network calls occur
+- Provide meaningful error messages with actionable guidance
+- Support debugging and troubleshooting
+- Implement comprehensive logging and tracing
+
+### 5. Dependable
+
+- Avoid breaking changes
+- Maintain backward compatibility
+- Be careful with dependencies that could force breaking changes
+
+## General Requirements
+
+**MUST:**
+
+- Follow the General Azure SDK Guidelines
+- Place all code in the azure/azure-sdk-for-js repository
+- Follow Azure SDK engineering systems guidelines
+- Use these guidelines for `@azure` scope packages
+
+**SHOULD:**
+
+- Follow these guidelines even for non-Azure packages
+
+## Key Terminology
+
+- **CommonJS (CJS)**: Node.js module format using `require` and `module.exports`
+- **ECMAScript Module (ESM)**: Standard import/export syntax from ES6
+- **AMD Module**: Browser module format (e.g., RequireJS)


### PR DESCRIPTION
Trying to clean up and simplify our Copilot instructions. Most of this is based on getting Copilot to help refine the instructions, but I did a few other things

- Removed instruction to run `rush update` (it was doing this too much). We may need to bring this instruction back in some form but disabling it for now.
- The guidelines now reference files in-repo instead of URLs since Copilot doesn't generally follow the URLs if they're not in the repository.
- Spun off our guidelines into a separate 'LLM documentation' area. These files are just Copilot summaries of the guidelines on the website.
  - The guidelines are quite outdated, and so are these summaries as a result! We should probably clean this up.