### PR TITLE
refactor(loadtesting): install @azure/identity and create config with DefaultAzureCredentials

### DIFF
--- a/sdk/loadtesting/create-playwright/src/initialize.ts
+++ b/sdk/loadtesting/create-playwright/src/initialize.ts
@@ -82,7 +82,7 @@ export class PlaywrightServiceInitialize {
   };
 
   private installServicePackage = async (): Promise<void> => {
-    const command = this._packageManager.installDevDependencyCommand("@azure/playwright");
+    const command = this._packageManager.installDevDependencyCommand("@azure/playwright @azure/identity");
     console.log(`Installing Service package (${command})`);
     await executeCommand(command);
   };
@@ -101,11 +101,13 @@ export class PlaywrightServiceInitialize {
 
     const importCommandTypeScript = `import { defineConfig } from '@playwright/test';
 import { getServiceConfig, ServiceOS } from '@azure/playwright';
+import { DefaultAzureCredential } from '@azure/identity';
 import config from '${customerConfigFileName}';
 `;
 
     const importCommandJavaScript = `const { defineConfig } = require('@playwright/test');
 const { getServiceConfig, ServiceOS } = require('@azure/playwright');
+const { DefaultAzureCredential } = require('@azure/identity');
 const config = require('${customerConfigFileName}');
 `;
 
@@ -122,9 +124,9 @@ export default defineConfig(
   config,
   getServiceConfig(config, {
     exposeNetwork: '<loopback>',
-    timeout: 30000,
+    timeout: 3 * 60 * 1000, // 3 minutes
     os: ServiceOS.LINUX,
-    useCloudHostedBrowsers: true
+    credential: new DefaultAzureCredential(),
   })
 );
 `;

--- a/sdk/loadtesting/create-playwright/src/initialize.ts
+++ b/sdk/loadtesting/create-playwright/src/initialize.ts
@@ -82,7 +82,9 @@ export class PlaywrightServiceInitialize {
   };
 
   private installServicePackage = async (): Promise<void> => {
-    const command = this._packageManager.installDevDependencyCommand("@azure/playwright @azure/identity");
+    const command = this._packageManager.installDevDependencyCommand(
+      "@azure/playwright @azure/identity",
+    );
     console.log(`Installing Service package (${command})`);
     await executeCommand(command);
   };

--- a/sdk/loadtesting/create-playwright/test/initialize.spec.ts
+++ b/sdk/loadtesting/create-playwright/test/initialize.spec.ts
@@ -37,7 +37,7 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("npm install --save-dev @azure/playwright");
+    expect(executeCommandStub).toHaveBeenCalledWith("npm install --save-dev @azure/playwright @azure/identity");
   });
 
   it("should install service package (yarn)", async () => {
@@ -49,7 +49,7 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("yarn add --dev @azure/playwright");
+    expect(executeCommandStub).toHaveBeenCalledWith("yarn add --dev @azure/playwright @azure/identity");
   });
 
   it("should install service package (pnpm - no workspace)", async () => {
@@ -61,7 +61,7 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("pnpm add --save-dev @azure/playwright");
+    expect(executeCommandStub).toHaveBeenCalledWith("pnpm add --save-dev @azure/playwright @azure/identity");
   });
 
   it("should install service package (pnpm - workspace)", async () => {
@@ -74,7 +74,7 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("pnpm add --save-dev @azure/playwright");
+    expect(executeCommandStub).toHaveBeenCalledWith("pnpm add --save-dev @azure/playwright @azure/identity");
   });
 
   it("should throw error if install service package fails", async () => {

--- a/sdk/loadtesting/create-playwright/test/initialize.spec.ts
+++ b/sdk/loadtesting/create-playwright/test/initialize.spec.ts
@@ -37,7 +37,9 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("npm install --save-dev @azure/playwright @azure/identity");
+    expect(executeCommandStub).toHaveBeenCalledWith(
+      "npm install --save-dev @azure/playwright @azure/identity",
+    );
   });
 
   it("should install service package (yarn)", async () => {
@@ -49,7 +51,9 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("yarn add --dev @azure/playwright @azure/identity");
+    expect(executeCommandStub).toHaveBeenCalledWith(
+      "yarn add --dev @azure/playwright @azure/identity",
+    );
   });
 
   it("should install service package (pnpm - no workspace)", async () => {
@@ -61,7 +65,9 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("pnpm add --save-dev @azure/playwright @azure/identity");
+    expect(executeCommandStub).toHaveBeenCalledWith(
+      "pnpm add --save-dev @azure/playwright @azure/identity",
+    );
   });
 
   it("should install service package (pnpm - workspace)", async () => {
@@ -74,7 +80,9 @@ describe("PlaywrightServiceInitialize", () => {
     const executeCommandStub = vi.spyOn(utils, "executeCommand");
     await playwrightServiceInitialize["installServicePackage"]();
     expect(executeCommandStub).toHaveBeenCalled();
-    expect(executeCommandStub).toHaveBeenCalledWith("pnpm add --save-dev @azure/playwright @azure/identity");
+    expect(executeCommandStub).toHaveBeenCalledWith(
+      "pnpm add --save-dev @azure/playwright @azure/identity",
+    );
   });
 
   it("should throw error if install service package fails", async () => {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/create-playwright

New config
```ts
import { defineConfig } from '@playwright/test';
import { getServiceConfig, ServiceOS } from '@azure/playwright';
import { DefaultAzureCredential } from '@azure/identity';
import config from './playwright.config';

/* Learn more about service configuration at https://aka.ms/mpt/config */
export default defineConfig(
  config,
  getServiceConfig(config, {
    exposeNetwork: '<loopback>',
    timeout: 3 * 60 * 1000, // 3 minutes
    os: ServiceOS.LINUX,
    credential: new DefaultAzureCredential(),
  })
);
```