### PR TITLE
Fix recordings

### DIFF
--- a/sdk/communication/communication-call-automation/assets.json
+++ b/sdk/communication/communication-call-automation/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-call-automation",
-  "Tag": "js/communication/communication-call-automation_dc0f002cba"
+  "Tag": "js/communication/communication-call-automation_e825a01487"
 }

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -79,7 +79,7 @@
     "@azure-tools/test-recorder": "^4.1.0",
     "@azure-tools/test-utils-vitest": "^1.0.0",
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
-    "@azure/communication-identity": "^1.2.0",
+    "@azure/communication-identity": "^1.3.0",
     "@azure/communication-phone-numbers": "^1.2.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -79,7 +79,7 @@
     "@azure-tools/test-recorder": "^4.1.0",
     "@azure-tools/test-utils-vitest": "^1.0.0",
     "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
-    "@azure/communication-identity": "^1.3.0",
+    "@azure/communication-identity": "^1.3.1",
     "@azure/communication-phone-numbers": "^1.2.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",

--- a/sdk/communication/communication-chat/assets.json
+++ b/sdk/communication/communication-chat/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-chat",
-  "Tag": "js/communication/communication-chat_37cbf617da"
+  "Tag": "js/communication/communication-chat_5593dd2de6"
 }

--- a/sdk/communication/communication-rooms/assets.json
+++ b/sdk/communication/communication-rooms/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/communication/communication-rooms",
-  "Tag": "js/communication/communication-rooms_9038f02e82"
+  "Tag": "js/communication/communication-rooms_9e36c793b7"
 }


### PR DESCRIPTION
### Packages impacted by this PR
This pr is fixing tests for communication packages:
- call-automation
- rooms
- chat

### Issues associated with this PR


### Describe the problem that is addressed by this PR
This PR fixes [Failing build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4963547&view=ms.vss-test-web.build-test-results-tab&runId=55078128&resultId=100009&paneView=debug). 

After this [PR](https://github.com/Azure/azure-sdk-for-js/pull/33209), recordings were pointing to wrong API version. Recordings have been reverted or updated to point to proper API version in call-automation case.


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_
pipeline started failing after: https://github.com/Azure/azure-sdk-for-js/pull/33209

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
