### PR TITLE
deprecate old bulk API

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1417,6 +1417,7 @@ export class ItemResponse<T extends ItemDefinition> extends ResourceResponse<T &
 export class Items {
     constructor(container: Container, clientContext: ClientContext);
     batch(operations: OperationInput[], partitionKey?: PartitionKey, options?: RequestOptions): Promise<Response_2<OperationResponse[]>>;
+    // @deprecated
     bulk(operations: OperationInput[], bulkOptions?: BulkOptions, options?: RequestOptions): Promise<BulkOperationResponse>;
     // @deprecated
     changeFeed(partitionKey: PartitionKey, changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -779,6 +779,7 @@ export class Items {
 
   /**
    * Execute bulk operations on items.
+   * @deprecated Use `executeBulkOperations` instead.
    *
    * Bulk takes an array of Operations which are typed based on what the operation does.
    * The choices are: Create, Upsert, Read, Replace, and Delete


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR
This PR deprecates the old bulk API. The old bulk API should be replaced with a new method `executeBulkOperations`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
