### PR TITLE
Allow for publishing to DevOps feed instead of nmpjs.com

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -3,8 +3,8 @@ parameters:
   TestPipeline: false
   ArtifactName: packages
   DependsOn: Build
-  Registry: https://registry.npmjs.org/
-  PrivateRegistry: https://pkgs.dev.azure.com/azure-sdk/internal/_packaging/azure-sdk-for-js-pr/npm/registry/
+  PublicRegistry: https://registry.npmjs.org/
+  PublicPublishEnvironment: 'package-publish'
   TargetDocRepoOwner: ''
   TargetDocRepoName: ''
   ServiceDirectory: ''
@@ -66,7 +66,8 @@ stages:
                       DeploymentName: PublishPackage_${{ replace(artifact.name, '-', '_') }}
                       ArtifactName: ${{ parameters.ArtifactName }}
                       ArtifactSubPath: '${{ artifact.name }}'
-                      Registry: 'https://registry.npmjs.org/'
+                      Registry: ${{ parameters.PublicRegistry }}
+                      Environment: ${{ parameters.PublicPublishEnvironment }}
 
               - ${{ if ne(artifact.skipPublishDocMs, 'true') }}:
                   - job: PublishDocs

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -42,6 +42,12 @@ parameters:
   - name: oneESTemplateTag
     type: string
     default: release
+  - name: PublicRegistry
+    type: string
+    default: 'https://registry.npmjs.org/'
+  - name: PublicPublishEnvironment
+    type: string
+    default: 'package-publish'
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -85,3 +91,5 @@ extends:
                 TestPipeline: true
               TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
               TargetDocRepoName: ${{ parameters.TargetDocRepoName }}
+              PublicRegistry: ${{ parameters.PublicRegistry }}
+              PublicPublishEnvironment: ${{ parameters.PublicPublishEnvironment }}

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -31,9 +31,18 @@ pr:
       - sdk/storage/arm-storage/
       - sdk/storage/arm-storage-profile-2020-09-01-hybrid
       - sdk/storage/arm-storage
+
+parameters:
+  - name: ReleaseToDevOpsOnly
+    displayName: 'Release package to DevOps feed instead of npmjs.com'
+    type: boolean
+    default: false
+
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    ${{ if eq(parameters.ReleaseToDevOpsOnly, true) }}:
+      PublicRegistry: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/storage-staging/npm/registry/'
     ServiceDirectory: storage
     Artifacts:
       - name: azure-storage-common

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -34,10 +34,22 @@ parameters:
     values:
       - release
       - canary
+  - name: ReleaseToDevOpsOnly
+    displayName: 'Release package to DevOps feed instead of npmjs.com'
+    type: boolean
+    default: false
+  - name: AutoApproveRelease
+    displayName: 'Automatically approve the release stage'
+    type: boolean
+    default: false
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    ${{ if eq(parameters.ReleaseToDevOpsOnly, true) }}:
+      PublicRegistry: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/storage-staging/npm/registry/'
+    ${{ if eq(parameters.AutoApproveRelease, true) }}:
+      PublicPublishEnvironment: none
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
     ServiceDirectory: template
     Artifacts:


### PR DESCRIPTION
Add feature to enable the Storage team to release to a devops feed instead of public nuget.org for releases. This allows them to do a soft GA where consumers can use the latest GA from the Devops feed if they know their regions have the new storage features. The GA will get published to nuget.org once all the regions have the new features.
