### PR TITLE
[Identity] Revert AKS to node 18 image

### DIFF
--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-ARG NODE_VERSION=20
+ARG NODE_VERSION=18
 
 # docker can't tell when the repo has changed and will therefore cache this layer
 # internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'

--- a/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
+++ b/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
@@ -14,11 +14,8 @@ describe("Azure Kubernetes Integration test", function () {
     const podName = requireEnvVar("IDENTITY_AKS_POD_NAME");
     const pods = runCommand("kubectl", `get pods -o jsonpath='{.items[0].metadata.name}'`);
     assert.include(pods, podName);
-    console.log(`Using pod:  ${podName.substring(0, 10)}`);
-    const loggingPod = runCommand("kubectl", `describe pod ${podName}`);
-    console.log(`Logs for pod ${podName}: ${loggingPod}`);
-    podOutput = runCommand("kubectl", `exec ${podName} -- node /app/index.js`);
 
+    podOutput = runCommand("kubectl", `exec ${podName} -- node /app/index.js`);
   });
 
   it("can authenticate using managed identity", async function (ctx) {

--- a/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
+++ b/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
@@ -14,11 +14,11 @@ describe("Azure Kubernetes Integration test", function () {
     const podName = requireEnvVar("IDENTITY_AKS_POD_NAME");
     const pods = runCommand("kubectl", `get pods -o jsonpath='{.items[0].metadata.name}'`);
     assert.include(pods, podName);
-    console.log(`Using pod: ${podName}`);
-    podOutput = runCommand("kubectl", `exec ${podName} -- node /app/index.js`);
-
+    console.log(`Using pod:  ${podName.substring(0, 10)}`);
     const loggingPod = runCommand("kubectl", `describe pod ${podName}`);
     console.log(`Logs for pod ${podName}: ${loggingPod}`);
+    podOutput = runCommand("kubectl", `exec ${podName} -- node /app/index.js`);
+
   });
 
   it("can authenticate using managed identity", async function (ctx) {

--- a/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
+++ b/sdk/identity/identity/test/integration/node/azureKubernetesTest.spec.ts
@@ -14,8 +14,11 @@ describe("Azure Kubernetes Integration test", function () {
     const podName = requireEnvVar("IDENTITY_AKS_POD_NAME");
     const pods = runCommand("kubectl", `get pods -o jsonpath='{.items[0].metadata.name}'`);
     assert.include(pods, podName);
-
+    console.log(`Using pod: ${podName}`);
     podOutput = runCommand("kubectl", `exec ${podName} -- node /app/index.js`);
+
+    const loggingPod = runCommand("kubectl", `describe pod ${podName}`);
+    console.log(`Logs for pod ${podName}: ${loggingPod}`);
   });
 
   it("can authenticate using managed identity", async function (ctx) {


### PR DESCRIPTION
Revert AKS test to node 18 for the MCR image. Pipelines passing [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5005857&view=results)
- Linked issue for tracking purpose: #34944