### PR TITLE
[Monitor OpenTelemetry] Add Tracking for Customer Statsbeat to Feature Statsbeat

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.11.2 (Unreleased)
+
+### Other Changes
+
+- Add customer statsbeat feature to feature statsbeat.
+
 ## 1.11.1 (2025-06-09)
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.11.2 (Unreleased)
+## 1.11.2 ()
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -13,6 +13,7 @@ import type { StatsbeatFeatures, StatsbeatInstrumentations } from "./types.js";
 import {
   AZURE_MONITOR_OPENTELEMETRY_VERSION,
   AzureMonitorOpenTelemetryOptions,
+  APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
   InstrumentationOptions,
   BrowserSdkLoaderOptions,
 } from "./types.js";
@@ -52,6 +53,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     browserSdkLoader: config.browserSdkLoaderOptions.enabled,
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
     diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
+    customerStatsbeat: process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] === "True",
   };
   getInstance().setStatsbeatFeatures(statsbeatInstrumentations, statsbeatFeatures);
 

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -187,7 +187,8 @@ export const AzureMonitorSampleRate = "microsoft.sample_rate";
  * Enables the preview version of customer-facing Statsbeat.
  * @internal
  */
-export declare const APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW = "APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW";
+export declare const APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW =
+  "APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW";
 
 export enum StatsbeatFeature {
   NONE = 0,

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -69,6 +69,7 @@ export interface StatsbeatFeatures {
   distro?: boolean;
   liveMetrics?: boolean;
   shim?: boolean;
+  customerStatsbeat?: boolean;
 }
 
 /**
@@ -82,6 +83,7 @@ export const StatsbeatFeaturesMap = new Map<string, number>([
   ["distro", 8],
   ["liveMetrics", 16],
   ["shim", 32],
+  ["customerStatsbeat", 64],
 ]);
 
 /**
@@ -181,6 +183,12 @@ export const DEFAULT_LIVEMETRICS_ENDPOINT = "https://global.livediagnostics.moni
  */
 export const AzureMonitorSampleRate = "microsoft.sample_rate";
 
+/**
+ * Enables the preview version of customer-facing Statsbeat.
+ * @internal
+ */
+export declare const APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW = "APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW";
+
 export enum StatsbeatFeature {
   NONE = 0,
   DISK_RETRY = 1,
@@ -189,6 +197,7 @@ export enum StatsbeatFeature {
   DISTRO = 8,
   LIVE_METRICS = 16,
   SHIM = 32,
+  CUSTOMER_STATSBEAT = 64,
 }
 
 export enum StatsbeatInstrumentation {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -10,6 +10,7 @@ import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import type { StatsbeatEnvironmentConfig } from "../../../src/types.js";
 import {
   AZURE_MONITOR_STATSBEAT_FEATURES,
+  APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
   StatsbeatFeature,
   StatsbeatInstrumentation,
   StatsbeatInstrumentationMap,
@@ -392,5 +393,33 @@ describe("Main functions", () => {
       };
     }
     assert.strictEqual(updatedStatsbeat.instrumentation, StatsbeatInstrumentation.FS);
+  });
+
+  describe("Customer Statsbeat Environment Variable", () => {
+    it("should set customerStatsbeat to true only when env var is exactly 'True'", () => {
+      const config: AzureMonitorOpenTelemetryOptions = {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      };
+      process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "True";
+      useAzureMonitor(config);
+      assert.ok(true, "useAzureMonitor executed successfully with 'True'");
+      void shutdownAzureMonitor();
+    });
+
+    it("should set customerStatsbeat to false when env var is not set", () => {
+      const config: AzureMonitorOpenTelemetryOptions = {
+        azureMonitorExporterOptions: {
+          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        },
+      };
+      delete process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
+      useAzureMonitor(config);
+      
+      assert.ok(true, "useAzureMonitor executed successfully with undefined env var");
+      
+      void shutdownAzureMonitor();
+    });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -416,9 +416,9 @@ describe("Main functions", () => {
       };
       delete process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
       useAzureMonitor(config);
-      
+
       assert.ok(true, "useAzureMonitor executed successfully with undefined env var");
-      
+
       void shutdownAzureMonitor();
     });
   });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Feature Addition: Customer Statsbeat
* Updated the `StatsbeatFeatures` interface and `StatsbeatFeaturesMap` to include the `customerStatsbeat` property. (`sdk/monitor/monitor-opentelemetry/src/types.ts`, [[1]](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028R72) [[2]](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028R86)
* Added a new enum value, `CUSTOMER_STATSBEAT`, to `StatsbeatFeature` for tracking this feature. (`sdk/monitor/monitor-opentelemetry/src/types.ts`, [sdk/monitor/monitor-opentelemetry/src/types.tsR200](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028R200))

### Code Integration
* Updated the `useAzureMonitor` function to check the new environment variable and set the `customerStatsbeat` property accordingly. (`sdk/monitor/monitor-opentelemetry/src/index.ts`, [sdk/monitor/monitor-opentelemetry/src/index.tsR56](diffhunk://#diff-e7e1dcf8f0ac5c3aea3811994ab032c757ad020b9ca8855dec69d18bb5343ef3R56))
* Imported the new environment variable constant in the necessary files. (`sdk/monitor/monitor-opentelemetry/src/index.ts`, [[1]](diffhunk://#diff-e7e1dcf8f0ac5c3aea3811994ab032c757ad020b9ca8855dec69d18bb5343ef3R16); `sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts`, [[2]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7R13)

### Testing
* Added unit tests to verify the behavior of the `customerStatsbeat` feature when the environment variable is set to "True" or not set at all. (`sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts`, [sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.tsR397-R424](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7R397-R424))

### Documentation
* Updated the changelog to include the addition of the customer statsbeat feature. (`sdk/monitor/monitor-opentelemetry/CHANGELOG.md`, [sdk/monitor/monitor-opentelemetry/CHANGELOG.mdR3-R8](diffhunk://#diff-ac8e2149ba18d601cb7e70506ec0eae272490d5068ff91dd731651ac432633a0R3-R8))

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
