### PR TITLE
fix: pass apiKeyHeaderName

### DIFF
--- a/sdk/ai/ai-agents/src/api/agentsContext.ts
+++ b/sdk/ai/ai-agents/src/api/agentsContext.ts
@@ -35,6 +35,7 @@ export function createAgents(
     loggingOptions: { logger: options.loggingOptions?.logger ?? logger.info },
     credentials: {
       scopes: options.credentials?.scopes ?? ["https://ai.azure.com/.default"],
+      apiKeyHeaderName: options.credentials?.apiKeyHeaderName ?? "x-api-key",
     },
   };
   const clientContext = getClient(endpointParam, credential, updatedOptions);


### PR DESCRIPTION
### Packages impacted by this PR

Fixes lost `apiKeyHeaderName` when creating `AgentsClient` with `AzureKeyCredential`

### Issues associated with this PR


### Describe the problem that is addressed by this PR

Error `Error: Missing API Key Header Name` when using `AgentsClient` with `AzureKeyCredential`

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
