### PR TITLE
[Monitor OpenTelemetry] Add Support for Multi-iKey Feature Statsbeat Tracking

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Other Changes
 
 - Add customer statsbeat feature to feature statsbeat.
+- Add multi-ikey feature to feature statsbeat.
 
 ## 1.11.1 (2025-06-09)
 

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -12,7 +12,6 @@ import { LogHandler } from "./logs/index.js";
 import type { StatsbeatFeatures, StatsbeatInstrumentations } from "./types.js";
 import {
   AZURE_MONITOR_OPENTELEMETRY_VERSION,
-  MULTI_IKEY_USED,
   AzureMonitorOpenTelemetryOptions,
   APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
   InstrumentationOptions,
@@ -55,7 +54,6 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
     diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
     customerStatsbeat: process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] === "True",
-    multiIkey: !!process.env[MULTI_IKEY_USED],
   };
   getInstance().setStatsbeatFeatures(statsbeatInstrumentations, statsbeatFeatures);
 

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -12,6 +12,7 @@ import { LogHandler } from "./logs/index.js";
 import type { StatsbeatFeatures, StatsbeatInstrumentations } from "./types.js";
 import {
   AZURE_MONITOR_OPENTELEMETRY_VERSION,
+  MULTI_IKEY_USED,
   AzureMonitorOpenTelemetryOptions,
   InstrumentationOptions,
   BrowserSdkLoaderOptions,
@@ -52,6 +53,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     browserSdkLoader: config.browserSdkLoaderOptions.enabled,
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
     diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
+    multiIkey: !!process.env[MULTI_IKEY_USED],
   };
   getInstance().setStatsbeatFeatures(statsbeatInstrumentations, statsbeatFeatures);
 

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -69,6 +69,7 @@ export interface StatsbeatFeatures {
   distro?: boolean;
   liveMetrics?: boolean;
   shim?: boolean;
+  multiIkey?: boolean;
 }
 
 /**
@@ -82,6 +83,7 @@ export const StatsbeatFeaturesMap = new Map<string, number>([
   ["distro", 8],
   ["liveMetrics", 16],
   ["shim", 32],
+  ["multiIkey", 128],
 ]);
 
 /**
@@ -181,6 +183,12 @@ export const DEFAULT_LIVEMETRICS_ENDPOINT = "https://global.livediagnostics.moni
  */
 export const AzureMonitorSampleRate = "microsoft.sample_rate";
 
+/**
+ * Environment variable to track multi-ikey usage.
+ * @internal
+ */
+export const MULTI_IKEY_USED = "MULTI_IKEY_USED";
+
 export enum StatsbeatFeature {
   NONE = 0,
   DISK_RETRY = 1,
@@ -189,6 +197,7 @@ export enum StatsbeatFeature {
   DISTRO = 8,
   LIVE_METRICS = 16,
   SHIM = 32,
+  MULTI_IKEY = 128,
 }
 
 export enum StatsbeatInstrumentation {

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -186,12 +186,6 @@ export const DEFAULT_LIVEMETRICS_ENDPOINT = "https://global.livediagnostics.moni
 export const AzureMonitorSampleRate = "microsoft.sample_rate";
 
 /**
- * Environment variable to track multi-ikey usage.
- * @internal
- */
-export const MULTI_IKEY_USED = "MULTI_IKEY_USED";
-
-/**
  * Enables the preview version of customer-facing Statsbeat.
  * @internal
  */

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -9,8 +9,8 @@ import { useAzureMonitor, shutdownAzureMonitor } from "../../../src/index.js";
 import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import type { StatsbeatEnvironmentConfig } from "../../../src/types.js";
 import {
-  APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
   AZURE_MONITOR_STATSBEAT_FEATURES,
+  APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
   StatsbeatFeature,
   StatsbeatInstrumentation,
   StatsbeatInstrumentationMap,

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -425,33 +425,29 @@ describe("Main functions", () => {
     const features = Number(output["feature"]);
     assert.ok(!(features & StatsbeatFeature.MULTI_IKEY), "MULTI_IKEY is set when it should not be");
     void shutdownAzureMonitor();
-
-  describe("Customer Statsbeat Environment Variable", () => {
-    it("should set customerStatsbeat to true only when env var is exactly 'True'", () => {
-      const config: AzureMonitorOpenTelemetryOptions = {
-        azureMonitorExporterOptions: {
-          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
-        },
-      };
-      process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "True";
-      useAzureMonitor(config);
-      assert.ok(true, "useAzureMonitor executed successfully with 'True'");
-      void shutdownAzureMonitor();
-    });
-
-    it("should set customerStatsbeat to false when env var is not set", () => {
-      const config: AzureMonitorOpenTelemetryOptions = {
-        azureMonitorExporterOptions: {
-          connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
-        },
-      };
-      delete process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
-      useAzureMonitor(config);
-
-      assert.ok(true, "useAzureMonitor executed successfully with undefined env var");
-
-      void shutdownAzureMonitor();
-    });
   });
-});
+
+  it("should set customerStatsbeat to true only when env var is exactly 'True'", () => {
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+    };
+    process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "True";
+    useAzureMonitor(config);
+    assert.ok(true, "useAzureMonitor executed successfully with 'True'");
+    void shutdownAzureMonitor();
+  });
+
+  it("should set customerStatsbeat to false when env var is not set", () => {
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+    };
+    delete process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
+    useAzureMonitor(config);
+    assert.ok(true, "useAzureMonitor executed successfully with undefined env var");
+    void shutdownAzureMonitor();
+  });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -397,11 +397,7 @@ describe("Main functions", () => {
 
   it("should detect MULTI_IKEY feature when AZURE_MONITOR_STATSBEAT_FEATURES has MULTI_IKEY enabled", () => {
     const env = <{ [id: string]: string }>{};
-    // Pre-set the AZURE_MONITOR_STATSBEAT_FEATURES with MULTI_IKEY feature enabled
-    env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
-      feature: StatsbeatFeature.MULTI_IKEY,
-      instrumentation: 0,
-    });
+    env[AZURE_MONITOR_STATSBEAT_FEATURES] = String(StatsbeatFeature.MULTI_IKEY);
     process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
@@ -417,11 +413,7 @@ describe("Main functions", () => {
 
   it("should not detect MULTI_IKEY feature when AZURE_MONITOR_STATSBEAT_FEATURES has MULTI_IKEY disabled", () => {
     const env = <{ [id: string]: string }>{};
-    // Pre-set the AZURE_MONITOR_STATSBEAT_FEATURES with MULTI_IKEY feature disabled
-    env[AZURE_MONITOR_STATSBEAT_FEATURES] = JSON.stringify({
-      feature: StatsbeatFeature.DISTRO, // Different feature, not MULTI_IKEY
-      instrumentation: 0,
-    });
+    env[AZURE_MONITOR_STATSBEAT_FEATURES] = String(StatsbeatFeature.DISTRO);
     process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
@@ -429,35 +421,60 @@ describe("Main functions", () => {
       },
     };
     useAzureMonitor(config);
-    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
-    const features = Number(output["feature"]);
-    // Should have DISTRO and potentially other features, but the MULTI_IKEY detection should not add it
-    // since it wasn't in the environment variable
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const features = Number(output["feature"] || 0);
     assert.ok(!(features & StatsbeatFeature.MULTI_IKEY), "MULTI_IKEY detected when it should not be");
     void shutdownAzureMonitor();
   });
 
-  it("should set customerStatsbeat to true only when env var is exactly 'True'", () => {
+  it("should detect CUSTOMER_STATSBEAT feature when APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW is 'True'", () => {
+    const env = <{ [id: string]: string }>{};
+    env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "True";
+    process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
         connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
       },
     };
-    process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "True";
     useAzureMonitor(config);
-    assert.ok(true, "useAzureMonitor executed successfully with 'True'");
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const features = Number(output["feature"] || 0);
+    assert.ok(features & StatsbeatFeature.CUSTOMER_STATSBEAT, "CUSTOMER_STATSBEAT feature should be detected when env var is 'True'");
+    assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should also be set");
     void shutdownAzureMonitor();
   });
 
-  it("should set customerStatsbeat to false when env var is not set", () => {
+  it("should not detect CUSTOMER_STATSBEAT feature when APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW is not 'True'", () => {
+    const env = <{ [id: string]: string }>{};
+    env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "false";
+    process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
         connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
       },
     };
-    delete process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
     useAzureMonitor(config);
-    assert.ok(true, "useAzureMonitor executed successfully with undefined env var");
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const features = Number(output["feature"] || 0);
+    assert.ok(!(features & StatsbeatFeature.CUSTOMER_STATSBEAT), "CUSTOMER_STATSBEAT feature should not be detected when env var is not 'True'");
+    assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
+    void shutdownAzureMonitor();
+  });
+
+  it("should not detect CUSTOMER_STATSBEAT feature when APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW is not set", () => {
+    const env = <{ [id: string]: string }>{};
+    delete env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
+    process.env = env;
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+    };
+    useAzureMonitor(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const features = Number(output["feature"] || 0);
+    assert.ok(!(features & StatsbeatFeature.CUSTOMER_STATSBEAT), "CUSTOMER_STATSBEAT feature should not be detected when env var is undefined");
+    assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
     void shutdownAzureMonitor();
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -405,7 +405,9 @@ describe("Main functions", () => {
       },
     };
     useAzureMonitor(config);
-    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
+      feature?: number;
+    };
     const features = Number(output["feature"] || 0);
     assert.ok(features & StatsbeatFeature.MULTI_IKEY, "MULTI_IKEY not detected");
     void shutdownAzureMonitor();
@@ -421,9 +423,14 @@ describe("Main functions", () => {
       },
     };
     useAzureMonitor(config);
-    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
+      feature?: number;
+    };
     const features = Number(output["feature"] || 0);
-    assert.ok(!(features & StatsbeatFeature.MULTI_IKEY), "MULTI_IKEY detected when it should not be");
+    assert.ok(
+      !(features & StatsbeatFeature.MULTI_IKEY),
+      "MULTI_IKEY detected when it should not be",
+    );
     void shutdownAzureMonitor();
   });
 
@@ -437,9 +444,14 @@ describe("Main functions", () => {
       },
     };
     useAzureMonitor(config);
-    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
+      feature?: number;
+    };
     const features = Number(output["feature"] || 0);
-    assert.ok(features & StatsbeatFeature.CUSTOMER_STATSBEAT, "CUSTOMER_STATSBEAT feature should be detected when env var is 'True'");
+    assert.ok(
+      features & StatsbeatFeature.CUSTOMER_STATSBEAT,
+      "CUSTOMER_STATSBEAT feature should be detected when env var is 'True'",
+    );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should also be set");
     void shutdownAzureMonitor();
   });
@@ -454,9 +466,14 @@ describe("Main functions", () => {
       },
     };
     useAzureMonitor(config);
-    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
+      feature?: number;
+    };
     const features = Number(output["feature"] || 0);
-    assert.ok(!(features & StatsbeatFeature.CUSTOMER_STATSBEAT), "CUSTOMER_STATSBEAT feature should not be detected when env var is not 'True'");
+    assert.ok(
+      !(features & StatsbeatFeature.CUSTOMER_STATSBEAT),
+      "CUSTOMER_STATSBEAT feature should not be detected when env var is not 'True'",
+    );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
     void shutdownAzureMonitor();
   });
@@ -471,9 +488,14 @@ describe("Main functions", () => {
       },
     };
     useAzureMonitor(config);
-    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as { feature?: number };
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"])) as {
+      feature?: number;
+    };
     const features = Number(output["feature"] || 0);
-    assert.ok(!(features & StatsbeatFeature.CUSTOMER_STATSBEAT), "CUSTOMER_STATSBEAT feature should not be detected when env var is undefined");
+    assert.ok(
+      !(features & StatsbeatFeature.CUSTOMER_STATSBEAT),
+      "CUSTOMER_STATSBEAT feature should not be detected when env var is undefined",
+    );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
     void shutdownAzureMonitor();
   });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
We should track multi-ikey feature usage in Statsbeat.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
