### PR TITLE
[Test][core-util] disable file Paralleism

### DIFF
--- a/sdk/core/core-util/vitest.config.ts
+++ b/sdk/core/core-util/vitest.config.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      fileParallelism: false,
+    },
+  }),
+);


### PR DESCRIPTION
to avoid the possibility of mocked timers in one file affecting tests in another file.  There are only a handful of tests in core-util so the running time shouldn't be affected too much.

Related issue: https://github.com/Azure/azure-sdk-for-js/issues/34965