### PR TITLE
Write error log if we fail to retrieve he dev package

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -207,8 +207,8 @@ function HasPackageSourceCodeChanges($package, $workingDirectory) {
 
   $packageAfterName = npm pack $name@dev --pack --pack-destination $workingDirectory 2> $workingDirectory/error.txt
   if ($LastExitCode -ne 0) {
-    Write-Verbose (Get-Content -Path $workingDirectory/error.txt)
-    Write-Verbose "Failed to retrieve package $name@dev.. assuming there is source code changes."
+    Get-Content -Path $workingDirectory/error.txt | Out-Host
+    Write-Hose "Failed to retrieve package $name@dev.. assuming there is source code changes."
     return $true
   }  
   $packageAfter = Get-PackageJsonContentFromPackage -package (Join-Path $workingDirectory $packageAfterName) -workingDirectory $workingDirectory


### PR DESCRIPTION
Write-Verbose apparently doesn't like object[] like Write-Host will accept. This fixes that and also for these errors we go ahead and output them to the logs for better detection so use host instead of verbose now.