### PR TITLE
[dev-tool] bring back --force option for samples publish command

### DIFF
--- a/common/tools/dev-tool/src/commands/samples/publish.ts
+++ b/common/tools/dev-tool/src/commands/samples/publish.ts
@@ -26,6 +26,13 @@ export const commandInfo = makeCommandInfo(
       description: "specify the path of the output directory where the samples will be written",
       shortName: "o",
     },
+    force: {
+      kind: "boolean",
+      description:
+        "force writing of samples, even if the output directory is not empty (will delete everything in the output directory)",
+      shortName: "f",
+      default: false,
+    },
   } as const,
 );
 
@@ -45,7 +52,7 @@ export default leafCommand(commandInfo, async (options) => {
   // This creates the samples output
   try {
     // Gather sample meta-information and use it to assemble a template
-    const factory = await makeSamplesFactory(projectInfo);
+    const factory = await makeSamplesFactory(projectInfo, undefined, { force: options?.force });
 
     // This is where the actual magic of creating the output from the template happens
     await factory(basePath);

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -339,6 +339,9 @@ export async function createTsconfig(projectInfo: ProjectInfo): Promise<string> 
 export async function makeSamplesFactory(
   projectInfo: ProjectInfo,
   sourcePath?: string,
+  options?: {
+    force: boolean;
+  },
 ): Promise<FileTreeFactory> {
   let hadError = false;
 
@@ -390,6 +393,7 @@ export async function makeSamplesFactory(
   }
 
   // We use a tempdir at the outer layer to avoid creating dirty trees
+  const actionIfDestinationDirty = options?.force ? "warn" : "throw";
   return dir(
     versionFolder,
     safeClean(
@@ -439,6 +443,7 @@ export async function makeSamplesFactory(
           ]),
         ),
       ),
+      { actionIfDirty: actionIfDestinationDirty },
     ),
   );
 }


### PR DESCRIPTION
If `--force` is passed to `samples publish` command we log a warning instead of
throwing an error.

This option was removed in the refactoring PR
https://github.com/Azure/azure-sdk-for-js/pull/18556 but no reason is provided.
In fact we still have `--force` and `-f` usage in our NPM scripts today and they
are not doing anything.

This PR brings `--force` option back so that we can use it in intended
scnearios (for example, codegen automation)

Related issue: https://github.com/Azure/azure-sdk-tools/issues/10938#issuecomment-3011673979