### PR TITLE
[Monitor OpenTelemetry Exporter] Update RP Checks for Statsbeat

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.33 ()
+
+### Bugs Fixed
+
+- Fix auto-detection of RP environment for azure functions.
+
 ## 1.0.0-beta.32 (2025-06-09)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -32,9 +32,7 @@ export class StatsbeatMetrics {
     } else if (process.env.WEBSITE_SITE_NAME && !process.env.FUNCTIONS_WORKER_RUNTIME) {
       // Web apps
       this.resourceProvider = StatsbeatResourceProvider.appsvc;
-      if (process.env.WEBSITE_SITE_NAME) {
-        this.resourceIdentifier = process.env.WEBSITE_SITE_NAME;
-      }
+      this.resourceIdentifier = process.env.WEBSITE_SITE_NAME;
       if (process.env.WEBSITE_HOME_STAMPNAME) {
         this.resourceIdentifier += "/" + process.env.WEBSITE_HOME_STAMPNAME;
       }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -15,6 +15,7 @@ import {
   StatsbeatResourceProvider,
 } from "./types.js";
 import * as os from "node:os";
+import { isAppService, isFunctionApp } from "../../../src/utils/common.js";
 
 export class StatsbeatMetrics {
   protected resourceProvider: string = StatsbeatResourceProvider.unknown;
@@ -29,14 +30,16 @@ export class StatsbeatMetrics {
       // AKS
       this.resourceProvider = StatsbeatResourceProvider.aks;
       this.resourceIdentifier = process.env.AKS_ARM_NAMESPACE_ID;
-    } else if (process.env.WEBSITE_SITE_NAME) {
+    } else if (isAppService()) {
       // Web apps
       this.resourceProvider = StatsbeatResourceProvider.appsvc;
-      this.resourceIdentifier = process.env.WEBSITE_SITE_NAME;
+      if (process.env.WEBSITE_SITE_NAME) {
+        this.resourceIdentifier = process.env.WEBSITE_SITE_NAME;
+      }
       if (process.env.WEBSITE_HOME_STAMPNAME) {
         this.resourceIdentifier += "/" + process.env.WEBSITE_HOME_STAMPNAME;
       }
-    } else if (process.env.FUNCTIONS_WORKER_RUNTIME) {
+    } else if (isFunctionApp()) {
       // Function apps
       this.resourceProvider = StatsbeatResourceProvider.functions;
       if (process.env.WEBSITE_HOSTNAME) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts
@@ -15,7 +15,6 @@ import {
   StatsbeatResourceProvider,
 } from "./types.js";
 import * as os from "node:os";
-import { isAppService, isFunctionApp } from "../../../src/utils/common.js";
 
 export class StatsbeatMetrics {
   protected resourceProvider: string = StatsbeatResourceProvider.unknown;
@@ -30,7 +29,7 @@ export class StatsbeatMetrics {
       // AKS
       this.resourceProvider = StatsbeatResourceProvider.aks;
       this.resourceIdentifier = process.env.AKS_ARM_NAMESPACE_ID;
-    } else if (isAppService()) {
+    } else if (process.env.WEBSITE_SITE_NAME && !process.env.FUNCTIONS_WORKER_RUNTIME) {
       // Web apps
       this.resourceProvider = StatsbeatResourceProvider.appsvc;
       if (process.env.WEBSITE_SITE_NAME) {
@@ -39,7 +38,7 @@ export class StatsbeatMetrics {
       if (process.env.WEBSITE_HOME_STAMPNAME) {
         this.resourceIdentifier += "/" + process.env.WEBSITE_HOME_STAMPNAME;
       }
-    } else if (isFunctionApp()) {
+    } else if (process.env.FUNCTIONS_WORKER_RUNTIME) {
       // Function apps
       this.resourceProvider = StatsbeatResourceProvider.functions;
       if (process.env.WEBSITE_HOSTNAME) {

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -291,3 +291,17 @@ export function shouldCreateResourceMetric(): boolean {
 export function isSyntheticSource(attributes: Attributes): boolean {
   return !!attributes[experimentalOpenTelemetryValues.SYNTHETIC_TYPE];
 }
+
+/**
+ * Get prefix resource provider, vm will considered as "unknown RP"
+ * Web App: "a"
+ * Function App: "f"
+ * non-Web and non-Function APP: "u" (unknown)
+ */
+export const isAppService = (): boolean => {
+  return process.env.WEBSITE_SITE_NAME && !process.env.FUNCTIONS_WORKER_RUNTIME ? true : false;
+};
+
+export const isFunctionApp = (): boolean => {
+  return process.env.FUNCTIONS_WORKER_RUNTIME ? true : false;
+};

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -291,17 +291,3 @@ export function shouldCreateResourceMetric(): boolean {
 export function isSyntheticSource(attributes: Attributes): boolean {
   return !!attributes[experimentalOpenTelemetryValues.SYNTHETIC_TYPE];
 }
-
-/**
- * Get prefix resource provider, vm will considered as "unknown RP"
- * Web App: "a"
- * Function App: "f"
- * non-Web and non-Function APP: "u" (unknown)
- */
-export function isAppService(): boolean {
-  return process.env.WEBSITE_SITE_NAME && !process.env.FUNCTIONS_WORKER_RUNTIME ? true : false;
-};
-
-export function isFunctionApp(): boolean {
-  return process.env.FUNCTIONS_WORKER_RUNTIME ? true : false;
-};

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -298,10 +298,10 @@ export function isSyntheticSource(attributes: Attributes): boolean {
  * Function App: "f"
  * non-Web and non-Function APP: "u" (unknown)
  */
-export const isAppService = (): boolean => {
+export function isAppService(): boolean {
   return process.env.WEBSITE_SITE_NAME && !process.env.FUNCTIONS_WORKER_RUNTIME ? true : false;
 };
 
-export const isFunctionApp = (): boolean => {
+export function isFunctionApp(): boolean {
   return process.env.FUNCTIONS_WORKER_RUNTIME ? true : false;
 };

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -340,7 +340,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
           assert.strictEqual(statsbeat["resourceIdentifier"], "my-test-webapp");
@@ -354,7 +354,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
           assert.strictEqual(statsbeat["resourceIdentifier"], "my-test-webapp/waws-prod-test-001");
@@ -368,7 +368,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           // When no specific environment variables are set, it falls back to VM detection
           assert.strictEqual(statsbeat["resourceProvider"], "vm");
@@ -385,7 +385,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           assert.strictEqual(statsbeat["resourceProvider"], "functions");
           assert.strictEqual(statsbeat["resourceIdentifier"], "my-function-app.azurewebsites.net");
@@ -393,7 +393,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
 
         it("should detect Azure Functions with different worker runtimes", async () => {
           const runtimes = ["node", "python", "dotnet", "java", "powershell"];
-          
+
           for (const runtime of runtimes) {
             const newEnv = <{ [id: string]: string }>{};
             newEnv["WEBSITE_SITE_NAME"] = `my-${runtime}-function`;
@@ -405,11 +405,14 @@ describe("#AzureMonitorStatsbeatExporter", () => {
             // Create a new instance for each test to avoid state pollution
             const testStatsbeat = NetworkStatsbeatMetrics.getInstance(options);
             await testStatsbeat["getResourceProvider"]();
-            
+
             process.env = originalEnv;
             assert.strictEqual(testStatsbeat["resourceProvider"], "functions");
-            assert.strictEqual(testStatsbeat["resourceIdentifier"], `my-${runtime}-function.azurewebsites.net`);
-            
+            assert.strictEqual(
+              testStatsbeat["resourceIdentifier"],
+              `my-${runtime}-function.azurewebsites.net`,
+            );
+
             await testStatsbeat.shutdown();
           }
         });
@@ -423,7 +426,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           // Should be detected as App Service instead
           assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
@@ -446,11 +449,11 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           };
           const testStatsbeat = NetworkStatsbeatMetrics.getInstance(testOptions);
           await testStatsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           assert.strictEqual(testStatsbeat["resourceProvider"], "functions");
           assert.strictEqual(testStatsbeat["resourceIdentifier"], "my-function-app");
-          
+
           await testStatsbeat.shutdown();
         });
       });
@@ -458,16 +461,20 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       describe("Priority and edge cases", () => {
         it("should prioritize AKS detection over App Service", async () => {
           const newEnv = <{ [id: string]: string }>{};
-          newEnv["AKS_ARM_NAMESPACE_ID"] = "/subscriptions/test/resourceGroups/test/providers/Microsoft.ContainerService/managedClusters/test-aks";
+          newEnv["AKS_ARM_NAMESPACE_ID"] =
+            "/subscriptions/test/resourceGroups/test/providers/Microsoft.ContainerService/managedClusters/test-aks";
           newEnv["WEBSITE_SITE_NAME"] = "my-webapp";
           const originalEnv = process.env;
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           assert.strictEqual(statsbeat["resourceProvider"], "aks");
-          assert.strictEqual(statsbeat["resourceIdentifier"], "/subscriptions/test/resourceGroups/test/providers/Microsoft.ContainerService/managedClusters/test-aks");
+          assert.strictEqual(
+            statsbeat["resourceIdentifier"],
+            "/subscriptions/test/resourceGroups/test/providers/Microsoft.ContainerService/managedClusters/test-aks",
+          );
         });
 
         it("should prioritize Functions detection over App Service when both conditions are met", async () => {
@@ -480,7 +487,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           // Should be detected as Functions, not App Service
           assert.strictEqual(statsbeat["resourceProvider"], "functions");
@@ -495,7 +502,7 @@ describe("#AzureMonitorStatsbeatExporter", () => {
           process.env = newEnv;
 
           await statsbeat["getResourceProvider"]();
-          
+
           process.env = originalEnv;
           // With empty environment variables, it falls through to VM detection
           assert.strictEqual(statsbeat["resourceProvider"], "vm");

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -320,6 +320,191 @@ describe("#AzureMonitorStatsbeatExporter", () => {
       });
     });
 
+    describe("App Service and Azure Functions Detection", () => {
+      let statsbeat: NetworkStatsbeatMetrics;
+
+      beforeEach(() => {
+        statsbeat = NetworkStatsbeatMetrics.getInstance(options);
+      });
+
+      afterEach(async () => {
+        await statsbeat.shutdown();
+      });
+
+      describe("isAppService() detection", () => {
+        it("should detect App Service with WEBSITE_SITE_NAME but no FUNCTIONS_WORKER_RUNTIME", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "my-test-webapp";
+          // Explicitly do not set FUNCTIONS_WORKER_RUNTIME
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
+          assert.strictEqual(statsbeat["resourceIdentifier"], "my-test-webapp");
+        });
+
+        it("should include home stamp name in resource identifier when available", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "my-test-webapp";
+          newEnv["WEBSITE_HOME_STAMPNAME"] = "waws-prod-test-001";
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
+          assert.strictEqual(statsbeat["resourceIdentifier"], "my-test-webapp/waws-prod-test-001");
+        });
+
+        it("should not detect App Service when WEBSITE_SITE_NAME is missing", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_HOME_STAMPNAME"] = "waws-prod-test-001";
+          // No WEBSITE_SITE_NAME
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "unknown");
+        });
+      });
+
+      describe("isFunctionApp() detection", () => {
+        it("should detect Azure Functions with both required environment variables", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "my-function-app";
+          newEnv["FUNCTIONS_WORKER_RUNTIME"] = "node";
+          newEnv["WEBSITE_HOSTNAME"] = "my-function-app.azurewebsites.net";
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "functions");
+          assert.strictEqual(statsbeat["resourceIdentifier"], "my-function-app.azurewebsites.net");
+        });
+
+        it("should detect Azure Functions with different worker runtimes", async () => {
+          const runtimes = ["node", "python", "dotnet", "java", "powershell"];
+          
+          for (const runtime of runtimes) {
+            const newEnv = <{ [id: string]: string }>{};
+            newEnv["WEBSITE_SITE_NAME"] = `my-${runtime}-function`;
+            newEnv["FUNCTIONS_WORKER_RUNTIME"] = runtime;
+            newEnv["WEBSITE_HOSTNAME"] = `my-${runtime}-function.azurewebsites.net`;
+            const originalEnv = process.env;
+            process.env = newEnv;
+
+            // Create a new instance for each test to avoid state pollution
+            const testStatsbeat = NetworkStatsbeatMetrics.getInstance(options);
+            await testStatsbeat["getResourceProvider"]();
+            
+            process.env = originalEnv;
+            assert.strictEqual(testStatsbeat["resourceProvider"], "functions");
+            assert.strictEqual(testStatsbeat["resourceIdentifier"], `my-${runtime}-function.azurewebsites.net`);
+            
+            await testStatsbeat.shutdown();
+          }
+        });
+
+        it("should not detect Functions when FUNCTIONS_WORKER_RUNTIME is missing", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "my-function-app";
+          newEnv["WEBSITE_HOSTNAME"] = "my-function-app.azurewebsites.net";
+          // No FUNCTIONS_WORKER_RUNTIME
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          // Should be detected as App Service instead
+          assert.strictEqual(statsbeat["resourceProvider"], "appsvc");
+        });
+
+        it("should not detect Functions when WEBSITE_SITE_NAME is missing", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["FUNCTIONS_WORKER_RUNTIME"] = "node";
+          newEnv["WEBSITE_HOSTNAME"] = "my-function-app.azurewebsites.net";
+          // No WEBSITE_SITE_NAME
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "unknown");
+        });
+
+        it("should handle missing WEBSITE_HOSTNAME gracefully", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "my-function-app";
+          newEnv["FUNCTIONS_WORKER_RUNTIME"] = "node";
+          // No WEBSITE_HOSTNAME
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "functions");
+          assert.strictEqual(statsbeat["resourceIdentifier"], "");
+        });
+      });
+
+      describe("Priority and edge cases", () => {
+        it("should prioritize AKS detection over App Service", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["AKS_ARM_NAMESPACE_ID"] = "/subscriptions/test/resourceGroups/test/providers/Microsoft.ContainerService/managedClusters/test-aks";
+          newEnv["WEBSITE_SITE_NAME"] = "my-webapp";
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "aks");
+          assert.strictEqual(statsbeat["resourceIdentifier"], "/subscriptions/test/resourceGroups/test/providers/Microsoft.ContainerService/managedClusters/test-aks");
+        });
+
+        it("should prioritize Functions detection over App Service when both conditions are met", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "my-function-app";
+          newEnv["FUNCTIONS_WORKER_RUNTIME"] = "node";
+          newEnv["WEBSITE_HOSTNAME"] = "my-function-app.azurewebsites.net";
+          newEnv["WEBSITE_HOME_STAMPNAME"] = "waws-prod-test-001";
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          // Should be detected as Functions, not App Service
+          assert.strictEqual(statsbeat["resourceProvider"], "functions");
+          assert.strictEqual(statsbeat["resourceIdentifier"], "my-function-app.azurewebsites.net");
+        });
+
+        it("should handle empty environment variables gracefully", async () => {
+          const newEnv = <{ [id: string]: string }>{};
+          newEnv["WEBSITE_SITE_NAME"] = "";
+          newEnv["FUNCTIONS_WORKER_RUNTIME"] = "";
+          const originalEnv = process.env;
+          process.env = newEnv;
+
+          await statsbeat["getResourceProvider"]();
+          
+          process.env = originalEnv;
+          assert.strictEqual(statsbeat["resourceProvider"], "unknown");
+        });
+      });
+    });
+
     describe("Track data from statsbeats", () => {
       let statsbeat: NetworkStatsbeatMetrics;
 


### PR DESCRIPTION
### Issues associated with this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This pull request introduces utility functions to improve the detection of resource providers in the `StatsbeatMetrics` class and refactors the logic for identifying App Service and Function App environments. The changes streamline the code and enhance maintainability.

### Enhancements to resource provider detection:

* [`sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts`](diffhunk://#diff-cd480996193513616a585afa0e25d1719ddb1862d3d45e3f13ee7ab00b2e7d24R294-R307): Added two new utility functions, `isAppService` and `isFunctionApp`, to encapsulate the logic for detecting App Service and Function App environments. These functions check specific environment variables to determine the type of resource provider.

### Refactoring in `StatsbeatMetrics`:

* [`sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts`](diffhunk://#diff-3eda58a685d7855920010499bc84ec201c6089b2bfb2b2f77cbd8b22258123bbL32-R42): Updated the `StatsbeatMetrics` class to use the new `isAppService` and `isFunctionApp` utility functions for determining the resource provider. This replaces direct checks of environment variables, improving code readability and reusability.

* [`sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/statsbeatMetrics.ts`](diffhunk://#diff-3eda58a685d7855920010499bc84ec201c6089b2bfb2b2f77cbd8b22258123bbR18): Imported the newly added utility functions `isAppService` and `isFunctionApp` from `common.js`.### Packages impacted by this PR

### Are there test cases added in this PR? _(If not, why?)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
