### PR TITLE
[Cosmos] Query RU bug

### DIFF
--- a/sdk/cosmosdb/cosmos/src/package.json
+++ b/sdk/cosmosdb/cosmos/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -137,7 +137,6 @@ export class DocumentProducer {
     return false;
   }
 
-
   private _updateStates(err: any, allFetched: boolean): void {
     if (err) {
       this.err = err;
@@ -202,7 +201,7 @@ export class DocumentProducer {
         headerResponse[Constants.HttpHeaders.QueryMetrics][this.targetPartitionKeyRange.id] =
           queryMetrics;
       }
-      return headerResponse
+      return headerResponse;
     } catch (err: any) {
       if (DocumentProducer._needPartitionKeyRangeCacheRefresh(err)) {
         // Split just happend
@@ -301,7 +300,6 @@ export class DocumentProducer {
   /**
    * Retrieve the current element on the DocumentProducer.
    */
-  // TODO: remove headers from the response
   private current(): Response<any> {
     // If something is buffered just give that
     if (this.fetchResults.length > 0) {

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -278,19 +278,20 @@ export class DocumentProducer {
       return { result: undefined, headers: getInitialHeader() };
     }
     const resources: any[] = [];
-    const resHeaders: CosmosHeaders = getInitialHeader();
     try {
       while (this.fetchResults.length > 0) {
-        const { result, headers } = this.current();
+        const { result } = this.current();
         this._updateStates(undefined, result === undefined);
-        mergeHeaders(resHeaders, headers);
         if (result === undefined) {
-          return { result: resources.length > 0 ? resources : undefined, headers: resHeaders };
+          return {
+            result: resources.length > 0 ? resources : undefined,
+            headers: getInitialHeader(),
+          };
         } else {
           resources.push(result);
         }
       }
-      return { result: resources, headers: resHeaders };
+      return { result: resources, headers: getInitialHeader() };
     } catch (err: any) {
       this._updateStates(err, err.item === undefined);
       throw err;

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -177,7 +177,6 @@ export class DocumentProducer {
       this._updateStates(undefined, resources === undefined);
       if (resources !== undefined) {
         // add fetched header to the 1st element in the buffer
-        // TODO: can be removed once we have a way to pass headers in the fetch function
         let addHeaderToFetchResult = true;
         resources.forEach((element: any) => {
           this.fetchResults.push(

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/documentProducer.ts
@@ -16,7 +16,7 @@ import type { Response } from "../request/index.js";
 import { DefaultQueryExecutionContext } from "./defaultQueryExecutionContext.js";
 import type { FetchFunctionCallback } from "./defaultQueryExecutionContext.js";
 import { FetchResult, FetchResultType } from "./FetchResult.js";
-import { getInitialHeader, mergeHeaders } from "./headerUtils.js";
+import { getInitialHeader } from "./headerUtils.js";
 import type { CosmosHeaders } from "./headerUtils.js";
 import type { SqlQuerySpec } from "./index.js";
 

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -173,6 +173,7 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
   private _getAndResetActiveResponseHeaders(): CosmosHeaders {
     const ret = this.respHeaders;
     this.respHeaders = getInitialHeader();
+    console.log("Response Headers: ", ret);
     return ret;
   }
 
@@ -420,7 +421,8 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
               await this.headerSemaphore.take(() => {
                 this._mergeWithActiveResponseHeaders(headers); // Merge the returned headers
                 this.headerSemaphore.leave();
-              });              // if buffer of document producer is filled, add it to the buffered document producers queue
+              });
+              // if buffer of document producer is filled, add it to the buffered document producers queue
               const nextItem = documentProducer.peakNextItem();
               if (nextItem !== undefined) {
                 this.bufferedDocumentProducersQueue.enq(documentProducer);

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/parallelQueryExecutionContextBase.ts
@@ -173,7 +173,6 @@ export abstract class ParallelQueryExecutionContextBase implements ExecutionCont
   private _getAndResetActiveResponseHeaders(): CosmosHeaders {
     const ret = this.respHeaders;
     this.respHeaders = getInitialHeader();
-    console.log("Response Headers: ", ret);
     return ret;
   }
 

--- a/sdk/cosmosdb/cosmos/test/internal/unit/query/parallelQueryExecutionContextBase.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/query/parallelQueryExecutionContextBase.spec.ts
@@ -434,6 +434,7 @@ describe("parallelQueryExecutionContextBase", () => {
     });
   });
 
+  // Test for RU consumption when initial response from document processors is empty
   describe("parallelQueryExecutionContextBase RU Consumption", () => {
     it("should correctly compute RU when initial response from document processors is empty", async () => {
       const tempOptions: FeedOptions = { maxItemCount: 10, maxDegreeOfParallelism: 2 };

--- a/sdk/cosmosdb/cosmos/test/internal/unit/query/parallelQueryExecutionContextBase.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/query/parallelQueryExecutionContextBase.spec.ts
@@ -342,6 +342,63 @@ describe("parallelQueryExecutionContextBase", () => {
       await (context as any).fillBufferFromBufferQueue();
 
       assert.equal(context["buffer"].length, 2);
+      assert.equal(context["respHeaders"]["x-ms-request-charge"], "3.5");
+    });
+
+    it("should correctly compute RU when initial response from document processors is empty", async () => {
+      const options: FeedOptions = { maxItemCount: 10, maxDegreeOfParallelism: 2 };
+      const clientContext = createTestClientContext(cosmosClientOptions, diagnosticLevel); // Mock ClientContext instance
+
+      const mockPartitionKeyRange1 = createMockPartitionKeyRange("0", "", "AA");
+      const mockPartitionKeyRange2 = createMockPartitionKeyRange("1", "AA", "BB");
+      const mockPartitionKeyRange3 = createMockPartitionKeyRange("2", "BB", "FF");
+
+      const fetchAllInternalStub = vi.fn().mockResolvedValue({
+        resources: [mockPartitionKeyRange1, mockPartitionKeyRange2, mockPartitionKeyRange3],
+        headers: { "x-ms-request-charge": "1.23" },
+        code: 200,
+      });
+      vi.spyOn(clientContext, "queryPartitionKeyRanges").mockReturnValue({
+        fetchAllInternal: fetchAllInternalStub, // Add fetchAllInternal to mimic expected structure
+      } as unknown as QueryIterator<PartitionKeyRange>);
+
+      // Define a mock document (resource) returned from queryFeed
+      // const mockDocument1 = createMockDocument(
+      //   "sample-id-1",
+      //   "Sample Document 1",
+      //   "This is the first sample document",
+      // );
+      // const mockDocument2 = createMockDocument(
+      //   "sample-id-2",
+      //   "Sample Document 2",
+      //   "This is the second sample document",
+      // );
+      // Define a stub for queryFeed in clientContext
+
+      vi.spyOn(clientContext, "queryFeed").mockResolvedValue({
+        result: [] as unknown as Resource, // Add result to mimic expected structure
+        headers: {
+          "x-ms-request-charge": "3.5", // Example RU charge
+          "x-ms-continuation": "token-for-next-page", // Continuation token for pagination
+        },
+        code: 200, // Optional status code
+      });
+
+      const context = new TestParallelQueryExecutionContext(
+        clientContext,
+        collectionLink,
+        query,
+        options,
+        partitionedQueryExecutionInfo,
+        correlatedActivityId,
+      );
+      await (context as any).bufferDocumentProducers(createDummyDiagnosticNode());
+
+      // Call fillBufferFromBufferQueue
+      await (context as any).fillBufferFromBufferQueue();
+
+      assert.equal(context["buffer"].length, 0);
+      assert.equal(context["respHeaders"]["x-ms-request-charge"], "7.0");
     });
   });
 
@@ -433,3 +490,117 @@ describe("parallelQueryExecutionContextBase", () => {
     });
   });
 });
+
+// write a test case checking ru values from a partition returning empty respose but ru consumed from it
+// create a set up of container with 5 partition key ranges and select * from c query is made to it and some RU is consumed
+// make it's accounted well in test
+// describe("parallelQueryExecutionContextBase RU Consumption", () => {
+//   const collectionLink = "/dbs/testDb/colls/testCollection"; // Sample collection link
+//   const query = "SELECT * FROM c"; // Example query string or SqlQuerySpec object
+//   const queryInfo: QueryInfo = {
+//     orderBy: ["Ascending"],
+//     rewrittenQuery: "SELECT * FROM c",
+//   } as QueryInfo;
+//   const partitionedQueryExecutionInfo = {
+//     queryRanges: [
+//       {
+//         min: "00",
+//         max: "AA",
+//         isMinInclusive: true, // Whether the minimum value is inclusive
+//         isMaxInclusive: false,
+//       },
+//       {
+//         min: "AA",
+//         max: "BB",
+//         isMinInclusive: true, // Whether the minimum value is inclusive
+//         isMaxInclusive: false,
+//       },
+//       {
+//         min: "BB",
+//         max: "FF",
+//         isMinInclusive: true, // Whether the minimum value is inclusive
+//         isMaxInclusive: false,
+//       },
+//     ],
+//     queryInfo: queryInfo,
+//     partitionedQueryExecutionInfoVersion: 1,
+//   };
+//   const correlatedActivityId = "sample-activity-id"; // Example correlated activity ID
+//   // Mock dependencies for ClientContext
+//   const cosmosClientOptions = {
+//     endpoint: "https://your-cosmos-db.documents.azure.com:443/",
+//     key: "your-cosmos-db-key",
+//     userAgentSuffix: "MockClient",
+//   };
+
+//   const diagnosticLevel = CosmosDbDiagnosticLevel.info;
+
+//   it("should consume RU from a partition returning empty response", async () => {
+//     const options: FeedOptions = { maxItemCount: 10, maxDegreeOfParallelism: 2 };
+//     const clientContext = createTestClientContext(cosmosClientOptions, diagnosticLevel); // Mock ClientContext instance
+
+//     initializeMockPartitionKeyRanges(createMockPartitionKeyRange, clientContext, [
+//       ["", "AA"],
+//       ["AA", "BB"],
+//       ["BB", "FF"],
+//     ]);
+
+//     // Define a mock document (resource) returned from queryFeed
+//     const mockDocument1 = createMockDocument(
+//       "sample-id-1",
+//       "Sample Document 1",
+//       "This is the first sample document",
+//     );
+//     const mockDocument2 = createMockDocument(
+//       "sample-id-2",
+//       "Sample Document 2",
+//       "This is the second sample document",
+//     );
+
+//     // Define a stub for queryFeed in clientContext
+//     vi.spyOn(clientContext, "queryFeed").mockResolvedValue({
+//       result: [mockDocument1, mockDocument2] as unknown as Resource, // Add result to mimic expected structure
+//       headers: {
+//         "x-ms-request-charge": "3.5", // Example RU charge
+//         "x-ms-continuation": "token-for-next-page", // Continuation token for pagination
+//       },
+//       code: 200, // Optional status code
+//     });
+
+//     // Create mock instance of TestParallelQueryExecutionContext
+//     const context = new TestParallelQueryExecutionContext(
+//       clientContext,
+//       collectionLink,
+//       query,
+//       options,
+//       partitionedQueryExecutionInfo,
+//       correlatedActivityId,
+//     );
+//     context["options"] = options;
+
+//     // Call bufferDocumentProducers
+//     await context["bufferDocumentProducers"](createDummyDiagnosticNode());
+
+//     // Simulate a partition returning an empty response but consuming RU
+//     const emptyResponseHeaders = {
+//       "x-ms-request-charge": "1.0", // RU consumed from this partition
+//       "x-ms-continuation": "token-for-next-page", // Continuation token for pagination
+//     };
+
+//     // Mock the bufferMore method to return an empty response with RU consumed
+//     const documentProducer = context["bufferedDocumentProducersQueue"].peek();
+//     vi.spyOn(documentProducer, "bufferMore").mockResolvedValue({
+//       result: [],
+//       headers: emptyResponseHeaders,
+//     });
+
+//     // Call bufferMore to simulate fetching from the partition
+//     const diagnosticNode = createDummyDiagnosticNode();
+//     const headers = await documentProducer.bufferMore(diagnosticNode);
+
+//     // Verify that RU was consumed
+//     assert.equal(headers.headers["x-ms-request-charge"], "1.0");
+//     assert.equal(context["bufferedDocumentProducersQueue"].size(), 1);
+//     assert.equal(context["buffer"].length, 0); // No documents in buffer since response was empty
+//   });
+// });


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR
Currently, document producers that were returning empty responses had their Request Units (RUs) skipped. This change fixes that issue, ensuring that their RUs are now correctly populated.



### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
