### PR TITLE
[EngSys] pin dev dependency `@types/node` version to 20.19.1

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,7 +16,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "pg-protocol": "1.8.0"
+    "@types/node": "20.19.1"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -12,73 +12,73 @@ importers:
     dependencies:
       '@rush-temp/abort-controller':
         specifier: file:./projects/abort-controller.tgz
-        version: file:projects/abort-controller.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/abort-controller.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/agrifood-farming':
         specifier: file:./projects/agrifood-farming.tgz
-        version: file:projects/agrifood-farming.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/agrifood-farming.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-agents':
         specifier: file:./projects/ai-agents.tgz
-        version: file:projects/ai-agents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-agents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-anomaly-detector':
         specifier: file:./projects/ai-anomaly-detector.tgz
-        version: file:projects/ai-anomaly-detector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-anomaly-detector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-content-safety':
         specifier: file:./projects/ai-content-safety.tgz
-        version: file:projects/ai-content-safety.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-content-safety.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-document-intelligence':
         specifier: file:./projects/ai-document-intelligence.tgz
-        version: file:projects/ai-document-intelligence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-document-intelligence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-document-translator':
         specifier: file:./projects/ai-document-translator.tgz
-        version: file:projects/ai-document-translator.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-document-translator.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-form-recognizer':
         specifier: file:./projects/ai-form-recognizer.tgz
-        version: file:projects/ai-form-recognizer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-form-recognizer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-inference':
         specifier: file:./projects/ai-inference.tgz
-        version: file:projects/ai-inference.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-inference.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-language-conversations':
         specifier: file:./projects/ai-language-conversations.tgz
-        version: file:projects/ai-language-conversations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-language-conversations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-language-text':
         specifier: file:./projects/ai-language-text.tgz
-        version: file:projects/ai-language-text.tgz(@types/debug@4.1.12)(chai@5.2.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-language-text.tgz(@types/debug@4.1.12)(chai@5.2.1)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-metrics-advisor':
         specifier: file:./projects/ai-metrics-advisor.tgz
-        version: file:projects/ai-metrics-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-metrics-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-projects':
         specifier: file:./projects/ai-projects.tgz
-        version: file:projects/ai-projects.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.2)(yaml@2.8.0)(zod@3.25.67)
+        version: file:projects/ai-projects.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.3)(yaml@2.8.0)(zod@3.25.76)
       '@rush-temp/ai-text-analytics':
         specifier: file:./projects/ai-text-analytics.tgz
-        version: file:projects/ai-text-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-text-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-translation-document':
         specifier: file:./projects/ai-translation-document.tgz
-        version: file:projects/ai-translation-document.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-translation-document.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-translation-text':
         specifier: file:./projects/ai-translation-text.tgz
-        version: file:projects/ai-translation-text.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-translation-text.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-vision-face':
         specifier: file:./projects/ai-vision-face.tgz
-        version: file:projects/ai-vision-face.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-vision-face.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ai-vision-image-analysis':
         specifier: file:./projects/ai-vision-image-analysis.tgz
-        version: file:projects/ai-vision-image-analysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ai-vision-image-analysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/api-management-custom-widgets-scaffolder':
         specifier: file:./projects/api-management-custom-widgets-scaffolder.tgz
         version: file:projects/api-management-custom-widgets-scaffolder.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/api-management-custom-widgets-tools':
         specifier: file:./projects/api-management-custom-widgets-tools.tgz
-        version: file:projects/api-management-custom-widgets-tools.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/api-management-custom-widgets-tools.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/app-configuration':
         specifier: file:./projects/app-configuration.tgz
-        version: file:projects/app-configuration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/app-configuration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-advisor':
         specifier: file:./projects/arm-advisor.tgz
-        version: file:projects/arm-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-agricultureplatform':
         specifier: file:./projects/arm-agricultureplatform.tgz
-        version: file:projects/arm-agricultureplatform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-agricultureplatform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-agrifood':
         specifier: file:./projects/arm-agrifood.tgz
         version: file:projects/arm-agrifood.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -90,892 +90,892 @@ importers:
         version: file:projects/arm-apicenter.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/arm-apimanagement':
         specifier: file:./projects/arm-apimanagement.tgz
-        version: file:projects/arm-apimanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-apimanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appcomplianceautomation':
         specifier: file:./projects/arm-appcomplianceautomation.tgz
-        version: file:projects/arm-appcomplianceautomation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appcomplianceautomation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appconfiguration':
         specifier: file:./projects/arm-appconfiguration.tgz
-        version: file:projects/arm-appconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appcontainers':
         specifier: file:./projects/arm-appcontainers.tgz
-        version: file:projects/arm-appcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appinsights':
         specifier: file:./projects/arm-appinsights.tgz
-        version: file:projects/arm-appinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appservice':
         specifier: file:./projects/arm-appservice.tgz
-        version: file:projects/arm-appservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appservice-1':
         specifier: file:./projects/arm-appservice-1.tgz
-        version: file:projects/arm-appservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-appservice-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-appservice-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-arizeaiobservabilityeval':
         specifier: file:./projects/arm-arizeaiobservabilityeval.tgz
-        version: file:projects/arm-arizeaiobservabilityeval.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-arizeaiobservabilityeval.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-astro':
         specifier: file:./projects/arm-astro.tgz
-        version: file:projects/arm-astro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-astro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-attestation':
         specifier: file:./projects/arm-attestation.tgz
-        version: file:projects/arm-attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-authorization':
         specifier: file:./projects/arm-authorization.tgz
-        version: file:projects/arm-authorization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-authorization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-authorization-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-authorization-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-automanage':
         specifier: file:./projects/arm-automanage.tgz
-        version: file:projects/arm-automanage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-automanage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-automation':
         specifier: file:./projects/arm-automation.tgz
-        version: file:projects/arm-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-avs':
         specifier: file:./projects/arm-avs.tgz
-        version: file:projects/arm-avs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-avs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-azureadexternalidentities':
         specifier: file:./projects/arm-azureadexternalidentities.tgz
-        version: file:projects/arm-azureadexternalidentities.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-azureadexternalidentities.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-azurestack':
         specifier: file:./projects/arm-azurestack.tgz
-        version: file:projects/arm-azurestack.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-azurestack.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-azurestackhci':
         specifier: file:./projects/arm-azurestackhci.tgz
-        version: file:projects/arm-azurestackhci.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-azurestackhci.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-baremetalinfrastructure':
         specifier: file:./projects/arm-baremetalinfrastructure.tgz
-        version: file:projects/arm-baremetalinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-baremetalinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-batch':
         specifier: file:./projects/arm-batch.tgz
-        version: file:projects/arm-batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-billing':
         specifier: file:./projects/arm-billing.tgz
-        version: file:projects/arm-billing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-billing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-billingbenefits':
         specifier: file:./projects/arm-billingbenefits.tgz
-        version: file:projects/arm-billingbenefits.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-billingbenefits.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-botservice':
         specifier: file:./projects/arm-botservice.tgz
-        version: file:projects/arm-botservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-botservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-carbonoptimization':
         specifier: file:./projects/arm-carbonoptimization.tgz
-        version: file:projects/arm-carbonoptimization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-carbonoptimization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-cdn':
         specifier: file:./projects/arm-cdn.tgz
-        version: file:projects/arm-cdn.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-cdn.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-changeanalysis':
         specifier: file:./projects/arm-changeanalysis.tgz
-        version: file:projects/arm-changeanalysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-changeanalysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-changes':
         specifier: file:./projects/arm-changes.tgz
-        version: file:projects/arm-changes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-changes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-chaos':
         specifier: file:./projects/arm-chaos.tgz
-        version: file:projects/arm-chaos.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-chaos.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-cloudhealth':
         specifier: file:./projects/arm-cloudhealth.tgz
-        version: file:projects/arm-cloudhealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-cloudhealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-cognitiveservices':
         specifier: file:./projects/arm-cognitiveservices.tgz
-        version: file:projects/arm-cognitiveservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-cognitiveservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-commerce':
         specifier: file:./projects/arm-commerce.tgz
-        version: file:projects/arm-commerce.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-commerce.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-commerce-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-commerce-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-commitmentplans':
         specifier: file:./projects/arm-commitmentplans.tgz
-        version: file:projects/arm-commitmentplans.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-commitmentplans.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-communication':
         specifier: file:./projects/arm-communication.tgz
-        version: file:projects/arm-communication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-communication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-compute':
         specifier: file:./projects/arm-compute.tgz
-        version: file:projects/arm-compute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-compute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-compute-1':
         specifier: file:./projects/arm-compute-1.tgz
-        version: file:projects/arm-compute-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-compute-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-compute-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-compute-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-compute-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-computefleet':
         specifier: file:./projects/arm-computefleet.tgz
-        version: file:projects/arm-computefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-computefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-computeschedule':
         specifier: file:./projects/arm-computeschedule.tgz
-        version: file:projects/arm-computeschedule.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-computeschedule.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-confidentialledger':
         specifier: file:./projects/arm-confidentialledger.tgz
-        version: file:projects/arm-confidentialledger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-confidentialledger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-confluent':
         specifier: file:./projects/arm-confluent.tgz
-        version: file:projects/arm-confluent.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-confluent.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-connectedcache':
         specifier: file:./projects/arm-connectedcache.tgz
-        version: file:projects/arm-connectedcache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-connectedcache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-connectedvmware':
         specifier: file:./projects/arm-connectedvmware.tgz
-        version: file:projects/arm-connectedvmware.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-connectedvmware.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-consumption':
         specifier: file:./projects/arm-consumption.tgz
-        version: file:projects/arm-consumption.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-consumption.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-containerinstance':
         specifier: file:./projects/arm-containerinstance.tgz
-        version: file:projects/arm-containerinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-containerinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-containerorchestratorruntime':
         specifier: file:./projects/arm-containerorchestratorruntime.tgz
-        version: file:projects/arm-containerorchestratorruntime.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-containerorchestratorruntime.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-containerregistry':
         specifier: file:./projects/arm-containerregistry.tgz
-        version: file:projects/arm-containerregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-containerregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-containerservice':
         specifier: file:./projects/arm-containerservice.tgz
-        version: file:projects/arm-containerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-containerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-containerservice-1':
         specifier: file:./projects/arm-containerservice-1.tgz
-        version: file:projects/arm-containerservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-containerservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-containerservicefleet':
         specifier: file:./projects/arm-containerservicefleet.tgz
-        version: file:projects/arm-containerservicefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-containerservicefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-cosmosdb':
         specifier: file:./projects/arm-cosmosdb.tgz
-        version: file:projects/arm-cosmosdb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-cosmosdb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-cosmosdbforpostgresql':
         specifier: file:./projects/arm-cosmosdbforpostgresql.tgz
-        version: file:projects/arm-cosmosdbforpostgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-cosmosdbforpostgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-costmanagement':
         specifier: file:./projects/arm-costmanagement.tgz
-        version: file:projects/arm-costmanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-costmanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-customerinsights':
         specifier: file:./projects/arm-customerinsights.tgz
-        version: file:projects/arm-customerinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-customerinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dashboard':
         specifier: file:./projects/arm-dashboard.tgz
-        version: file:projects/arm-dashboard.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dashboard.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-databasewatcher':
         specifier: file:./projects/arm-databasewatcher.tgz
-        version: file:projects/arm-databasewatcher.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-databasewatcher.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-databoundaries':
         specifier: file:./projects/arm-databoundaries.tgz
-        version: file:projects/arm-databoundaries.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-databoundaries.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-databox':
         specifier: file:./projects/arm-databox.tgz
-        version: file:projects/arm-databox.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-databox.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-databoxedge':
         specifier: file:./projects/arm-databoxedge.tgz
-        version: file:projects/arm-databoxedge.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-databoxedge.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-databricks':
         specifier: file:./projects/arm-databricks.tgz
-        version: file:projects/arm-databricks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-databricks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-datacatalog':
         specifier: file:./projects/arm-datacatalog.tgz
-        version: file:projects/arm-datacatalog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-datacatalog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-datadog':
         specifier: file:./projects/arm-datadog.tgz
-        version: file:projects/arm-datadog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-datadog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-datafactory':
         specifier: file:./projects/arm-datafactory.tgz
-        version: file:projects/arm-datafactory.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-datafactory.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-datalake-analytics':
         specifier: file:./projects/arm-datalake-analytics.tgz
-        version: file:projects/arm-datalake-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-datalake-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-datamigration':
         specifier: file:./projects/arm-datamigration.tgz
-        version: file:projects/arm-datamigration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-datamigration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dataprotection':
         specifier: file:./projects/arm-dataprotection.tgz
-        version: file:projects/arm-dataprotection.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dataprotection.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-defendereasm':
         specifier: file:./projects/arm-defendereasm.tgz
-        version: file:projects/arm-defendereasm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-defendereasm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dependencymap':
         specifier: file:./projects/arm-dependencymap.tgz
-        version: file:projects/arm-dependencymap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dependencymap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-deploymentmanager':
         specifier: file:./projects/arm-deploymentmanager.tgz
-        version: file:projects/arm-deploymentmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-deploymentmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-desktopvirtualization':
         specifier: file:./projects/arm-desktopvirtualization.tgz
-        version: file:projects/arm-desktopvirtualization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-desktopvirtualization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-devcenter':
         specifier: file:./projects/arm-devcenter.tgz
-        version: file:projects/arm-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-devhub':
         specifier: file:./projects/arm-devhub.tgz
-        version: file:projects/arm-devhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-devhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-deviceprovisioningservices':
         specifier: file:./projects/arm-deviceprovisioningservices.tgz
-        version: file:projects/arm-deviceprovisioningservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-deviceprovisioningservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-deviceregistry':
         specifier: file:./projects/arm-deviceregistry.tgz
-        version: file:projects/arm-deviceregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-deviceregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-deviceupdate':
         specifier: file:./projects/arm-deviceupdate.tgz
-        version: file:projects/arm-deviceupdate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-deviceupdate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-devopsinfrastructure':
         specifier: file:./projects/arm-devopsinfrastructure.tgz
-        version: file:projects/arm-devopsinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-devopsinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-devspaces':
         specifier: file:./projects/arm-devspaces.tgz
-        version: file:projects/arm-devspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-devspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-devtestlabs':
         specifier: file:./projects/arm-devtestlabs.tgz
-        version: file:projects/arm-devtestlabs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-devtestlabs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-digitaltwins':
         specifier: file:./projects/arm-digitaltwins.tgz
-        version: file:projects/arm-digitaltwins.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-digitaltwins.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dns':
         specifier: file:./projects/arm-dns.tgz
-        version: file:projects/arm-dns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dns-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-dns-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dns-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dnsresolver':
         specifier: file:./projects/arm-dnsresolver.tgz
-        version: file:projects/arm-dnsresolver.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dnsresolver.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-domainservices':
         specifier: file:./projects/arm-domainservices.tgz
-        version: file:projects/arm-domainservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-domainservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-durabletask':
         specifier: file:./projects/arm-durabletask.tgz
-        version: file:projects/arm-durabletask.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-durabletask.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-dynatrace':
         specifier: file:./projects/arm-dynatrace.tgz
-        version: file:projects/arm-dynatrace.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-dynatrace.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-edgezones':
         specifier: file:./projects/arm-edgezones.tgz
-        version: file:projects/arm-edgezones.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-edgezones.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-education':
         specifier: file:./projects/arm-education.tgz
-        version: file:projects/arm-education.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-education.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-elastic':
         specifier: file:./projects/arm-elastic.tgz
-        version: file:projects/arm-elastic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-elastic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-elasticsan':
         specifier: file:./projects/arm-elasticsan.tgz
-        version: file:projects/arm-elasticsan.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-elasticsan.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-eventgrid':
         specifier: file:./projects/arm-eventgrid.tgz
-        version: file:projects/arm-eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-eventhub':
         specifier: file:./projects/arm-eventhub.tgz
-        version: file:projects/arm-eventhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-eventhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-eventhub-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-extendedlocation':
         specifier: file:./projects/arm-extendedlocation.tgz
-        version: file:projects/arm-extendedlocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-extendedlocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-fabric':
         specifier: file:./projects/arm-fabric.tgz
-        version: file:projects/arm-fabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-fabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-features':
         specifier: file:./projects/arm-features.tgz
-        version: file:projects/arm-features.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-features.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-fluidrelay':
         specifier: file:./projects/arm-fluidrelay.tgz
-        version: file:projects/arm-fluidrelay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-fluidrelay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-frontdoor':
         specifier: file:./projects/arm-frontdoor.tgz
-        version: file:projects/arm-frontdoor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-frontdoor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-graphservices':
         specifier: file:./projects/arm-graphservices.tgz
-        version: file:projects/arm-graphservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-graphservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-guestconfiguration':
         specifier: file:./projects/arm-guestconfiguration.tgz
-        version: file:projects/arm-guestconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-guestconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hanaonazure':
         specifier: file:./projects/arm-hanaonazure.tgz
-        version: file:projects/arm-hanaonazure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hanaonazure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hardwaresecuritymodules':
         specifier: file:./projects/arm-hardwaresecuritymodules.tgz
-        version: file:projects/arm-hardwaresecuritymodules.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hardwaresecuritymodules.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hdinsight':
         specifier: file:./projects/arm-hdinsight.tgz
-        version: file:projects/arm-hdinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hdinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hdinsightcontainers':
         specifier: file:./projects/arm-hdinsightcontainers.tgz
-        version: file:projects/arm-hdinsightcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hdinsightcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-healthbot':
         specifier: file:./projects/arm-healthbot.tgz
-        version: file:projects/arm-healthbot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-healthbot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-healthcareapis':
         specifier: file:./projects/arm-healthcareapis.tgz
-        version: file:projects/arm-healthcareapis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-healthcareapis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-healthdataaiservices':
         specifier: file:./projects/arm-healthdataaiservices.tgz
-        version: file:projects/arm-healthdataaiservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-healthdataaiservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hybridcompute':
         specifier: file:./projects/arm-hybridcompute.tgz
-        version: file:projects/arm-hybridcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hybridcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hybridconnectivity':
         specifier: file:./projects/arm-hybridconnectivity.tgz
-        version: file:projects/arm-hybridconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hybridconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hybridcontainerservice':
         specifier: file:./projects/arm-hybridcontainerservice.tgz
-        version: file:projects/arm-hybridcontainerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hybridcontainerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hybridkubernetes':
         specifier: file:./projects/arm-hybridkubernetes.tgz
-        version: file:projects/arm-hybridkubernetes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hybridkubernetes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-hybridnetwork':
         specifier: file:./projects/arm-hybridnetwork.tgz
-        version: file:projects/arm-hybridnetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-hybridnetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-imagebuilder':
         specifier: file:./projects/arm-imagebuilder.tgz
-        version: file:projects/arm-imagebuilder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-imagebuilder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-impactreporting':
         specifier: file:./projects/arm-impactreporting.tgz
-        version: file:projects/arm-impactreporting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-impactreporting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-informaticadatamanagement':
         specifier: file:./projects/arm-informaticadatamanagement.tgz
-        version: file:projects/arm-informaticadatamanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-informaticadatamanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-iotcentral':
         specifier: file:./projects/arm-iotcentral.tgz
-        version: file:projects/arm-iotcentral.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-iotcentral.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-iotfirmwaredefense':
         specifier: file:./projects/arm-iotfirmwaredefense.tgz
-        version: file:projects/arm-iotfirmwaredefense.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-iotfirmwaredefense.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-iothub':
         specifier: file:./projects/arm-iothub.tgz
-        version: file:projects/arm-iothub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-iothub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-iothub-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-iothub-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-iotoperations':
         specifier: file:./projects/arm-iotoperations.tgz
-        version: file:projects/arm-iotoperations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-iotoperations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-keyvault':
         specifier: file:./projects/arm-keyvault.tgz
-        version: file:projects/arm-keyvault.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-keyvault.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-keyvault-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-kubernetesconfiguration':
         specifier: file:./projects/arm-kubernetesconfiguration.tgz
-        version: file:projects/arm-kubernetesconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-kubernetesconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-kubernetesconfiguration-extensions':
         specifier: file:./projects/arm-kubernetesconfiguration-extensions.tgz
-        version: file:projects/arm-kubernetesconfiguration-extensions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-kubernetesconfiguration-extensions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-kubernetesconfiguration-extensiontypes':
         specifier: file:./projects/arm-kubernetesconfiguration-extensiontypes.tgz
-        version: file:projects/arm-kubernetesconfiguration-extensiontypes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-kubernetesconfiguration-extensiontypes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-kubernetesconfiguration-fluxconfigurations':
         specifier: file:./projects/arm-kubernetesconfiguration-fluxconfigurations.tgz
-        version: file:projects/arm-kubernetesconfiguration-fluxconfigurations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-kubernetesconfiguration-fluxconfigurations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-kubernetesconfiguration-privatelinkscopes':
         specifier: file:./projects/arm-kubernetesconfiguration-privatelinkscopes.tgz
-        version: file:projects/arm-kubernetesconfiguration-privatelinkscopes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-kubernetesconfiguration-privatelinkscopes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-kusto':
         specifier: file:./projects/arm-kusto.tgz
-        version: file:projects/arm-kusto.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-kusto.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-labservices':
         specifier: file:./projects/arm-labservices.tgz
-        version: file:projects/arm-labservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-labservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-lambdatesthyperexecute':
         specifier: file:./projects/arm-lambdatesthyperexecute.tgz
-        version: file:projects/arm-lambdatesthyperexecute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-lambdatesthyperexecute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-largeinstance':
         specifier: file:./projects/arm-largeinstance.tgz
-        version: file:projects/arm-largeinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-largeinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-links':
         specifier: file:./projects/arm-links.tgz
-        version: file:projects/arm-links.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-links.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-loadtesting':
         specifier: file:./projects/arm-loadtesting.tgz
-        version: file:projects/arm-loadtesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-loadtesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-locks':
         specifier: file:./projects/arm-locks.tgz
-        version: file:projects/arm-locks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-locks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-locks-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-locks-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-locks-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-logic':
         specifier: file:./projects/arm-logic.tgz
-        version: file:projects/arm-logic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-logic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-machinelearning':
         specifier: file:./projects/arm-machinelearning.tgz
-        version: file:projects/arm-machinelearning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-machinelearning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-machinelearningcompute':
         specifier: file:./projects/arm-machinelearningcompute.tgz
-        version: file:projects/arm-machinelearningcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-machinelearningcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-machinelearningexperimentation':
         specifier: file:./projects/arm-machinelearningexperimentation.tgz
-        version: file:projects/arm-machinelearningexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-machinelearningexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-maintenance':
         specifier: file:./projects/arm-maintenance.tgz
-        version: file:projects/arm-maintenance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-maintenance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-managedapplications':
         specifier: file:./projects/arm-managedapplications.tgz
-        version: file:projects/arm-managedapplications.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-managedapplications.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-managednetworkfabric':
         specifier: file:./projects/arm-managednetworkfabric.tgz
-        version: file:projects/arm-managednetworkfabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-managednetworkfabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-managementgroups':
         specifier: file:./projects/arm-managementgroups.tgz
-        version: file:projects/arm-managementgroups.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-managementgroups.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-managementpartner':
         specifier: file:./projects/arm-managementpartner.tgz
-        version: file:projects/arm-managementpartner.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-managementpartner.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-maps':
         specifier: file:./projects/arm-maps.tgz
-        version: file:projects/arm-maps.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-maps.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-mariadb':
         specifier: file:./projects/arm-mariadb.tgz
-        version: file:projects/arm-mariadb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-mariadb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-marketplaceordering':
         specifier: file:./projects/arm-marketplaceordering.tgz
-        version: file:projects/arm-marketplaceordering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-marketplaceordering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-migrate':
         specifier: file:./projects/arm-migrate.tgz
-        version: file:projects/arm-migrate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-migrate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-migrationassessment':
         specifier: file:./projects/arm-migrationassessment.tgz
-        version: file:projects/arm-migrationassessment.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-migrationassessment.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-migrationdiscoverysap':
         specifier: file:./projects/arm-migrationdiscoverysap.tgz
-        version: file:projects/arm-migrationdiscoverysap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-migrationdiscoverysap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-mobilenetwork':
         specifier: file:./projects/arm-mobilenetwork.tgz
-        version: file:projects/arm-mobilenetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-mobilenetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-mongocluster':
         specifier: file:./projects/arm-mongocluster.tgz
-        version: file:projects/arm-mongocluster.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-mongocluster.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-mongodbatlas':
         specifier: file:./projects/arm-mongodbatlas.tgz
-        version: file:projects/arm-mongodbatlas.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-mongodbatlas.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-monitor':
         specifier: file:./projects/arm-monitor.tgz
-        version: file:projects/arm-monitor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-monitor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-monitor-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-monitor-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-msi':
         specifier: file:./projects/arm-msi.tgz
-        version: file:projects/arm-msi.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-msi.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-mysql':
         specifier: file:./projects/arm-mysql.tgz
-        version: file:projects/arm-mysql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-mysql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-mysql-flexible':
         specifier: file:./projects/arm-mysql-flexible.tgz
-        version: file:projects/arm-mysql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-mysql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-neonpostgres':
         specifier: file:./projects/arm-neonpostgres.tgz
-        version: file:projects/arm-neonpostgres.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-neonpostgres.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-netapp':
         specifier: file:./projects/arm-netapp.tgz
-        version: file:projects/arm-netapp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-netapp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-network':
         specifier: file:./projects/arm-network.tgz
-        version: file:projects/arm-network.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-network.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-network-1':
         specifier: file:./projects/arm-network-1.tgz
-        version: file:projects/arm-network-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-network-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-network-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-network-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-network-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-network-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-networkcloud':
         specifier: file:./projects/arm-networkcloud.tgz
-        version: file:projects/arm-networkcloud.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-networkcloud.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-networkfunction':
         specifier: file:./projects/arm-networkfunction.tgz
-        version: file:projects/arm-networkfunction.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-networkfunction.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-newrelicobservability':
         specifier: file:./projects/arm-newrelicobservability.tgz
-        version: file:projects/arm-newrelicobservability.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-newrelicobservability.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-nginx':
         specifier: file:./projects/arm-nginx.tgz
-        version: file:projects/arm-nginx.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-nginx.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-notificationhubs':
         specifier: file:./projects/arm-notificationhubs.tgz
-        version: file:projects/arm-notificationhubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-notificationhubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-oep':
         specifier: file:./projects/arm-oep.tgz
-        version: file:projects/arm-oep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-oep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-onlineexperimentation':
         specifier: file:./projects/arm-onlineexperimentation.tgz
-        version: file:projects/arm-onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-operationalinsights':
         specifier: file:./projects/arm-operationalinsights.tgz
-        version: file:projects/arm-operationalinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-operationalinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-operations':
         specifier: file:./projects/arm-operations.tgz
-        version: file:projects/arm-operations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-operations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-oracledatabase':
         specifier: file:./projects/arm-oracledatabase.tgz
-        version: file:projects/arm-oracledatabase.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-oracledatabase.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-orbital':
         specifier: file:./projects/arm-orbital.tgz
-        version: file:projects/arm-orbital.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-orbital.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-paloaltonetworksngfw':
         specifier: file:./projects/arm-paloaltonetworksngfw.tgz
-        version: file:projects/arm-paloaltonetworksngfw.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-paloaltonetworksngfw.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-peering':
         specifier: file:./projects/arm-peering.tgz
-        version: file:projects/arm-peering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-peering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-pineconevectordb':
         specifier: file:./projects/arm-pineconevectordb.tgz
-        version: file:projects/arm-pineconevectordb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-pineconevectordb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-planetarycomputer':
         specifier: file:./projects/arm-planetarycomputer.tgz
-        version: file:projects/arm-planetarycomputer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-planetarycomputer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-playwrighttesting':
         specifier: file:./projects/arm-playwrighttesting.tgz
-        version: file:projects/arm-playwrighttesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-playwrighttesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-policy':
         specifier: file:./projects/arm-policy.tgz
-        version: file:projects/arm-policy.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-policy.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-policy-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-policy-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-policy-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-policyinsights':
         specifier: file:./projects/arm-policyinsights.tgz
-        version: file:projects/arm-policyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-policyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-portal':
         specifier: file:./projects/arm-portal.tgz
-        version: file:projects/arm-portal.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-portal.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-portalservicescopilot':
         specifier: file:./projects/arm-portalservicescopilot.tgz
-        version: file:projects/arm-portalservicescopilot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-portalservicescopilot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-postgresql':
         specifier: file:./projects/arm-postgresql.tgz
-        version: file:projects/arm-postgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-postgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-postgresql-flexible':
         specifier: file:./projects/arm-postgresql-flexible.tgz
-        version: file:projects/arm-postgresql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-postgresql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-powerbidedicated':
         specifier: file:./projects/arm-powerbidedicated.tgz
-        version: file:projects/arm-powerbidedicated.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-powerbidedicated.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-powerbiembedded':
         specifier: file:./projects/arm-powerbiembedded.tgz
-        version: file:projects/arm-powerbiembedded.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-powerbiembedded.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-privatedns':
         specifier: file:./projects/arm-privatedns.tgz
-        version: file:projects/arm-privatedns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-privatedns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-programmableconnectivity':
         specifier: file:./projects/arm-programmableconnectivity.tgz
-        version: file:projects/arm-programmableconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-programmableconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-purestorageblock':
         specifier: file:./projects/arm-purestorageblock.tgz
-        version: file:projects/arm-purestorageblock.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-purestorageblock.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-purview':
         specifier: file:./projects/arm-purview.tgz
-        version: file:projects/arm-purview.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-purview.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-quantum':
         specifier: file:./projects/arm-quantum.tgz
-        version: file:projects/arm-quantum.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-quantum.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-qumulo':
         specifier: file:./projects/arm-qumulo.tgz
-        version: file:projects/arm-qumulo.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-qumulo.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-quota':
         specifier: file:./projects/arm-quota.tgz
-        version: file:projects/arm-quota.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-quota.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-recoveryservices':
         specifier: file:./projects/arm-recoveryservices.tgz
-        version: file:projects/arm-recoveryservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-recoveryservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-recoveryservices-siterecovery':
         specifier: file:./projects/arm-recoveryservices-siterecovery.tgz
-        version: file:projects/arm-recoveryservices-siterecovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-recoveryservices-siterecovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-recoveryservicesbackup':
         specifier: file:./projects/arm-recoveryservicesbackup.tgz
-        version: file:projects/arm-recoveryservicesbackup.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-recoveryservicesbackup.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-recoveryservicesdatareplication':
         specifier: file:./projects/arm-recoveryservicesdatareplication.tgz
-        version: file:projects/arm-recoveryservicesdatareplication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-recoveryservicesdatareplication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-redhatopenshift':
         specifier: file:./projects/arm-redhatopenshift.tgz
-        version: file:projects/arm-redhatopenshift.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-redhatopenshift.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-rediscache':
         specifier: file:./projects/arm-rediscache.tgz
-        version: file:projects/arm-rediscache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-rediscache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-redisenterprisecache':
         specifier: file:./projects/arm-redisenterprisecache.tgz
-        version: file:projects/arm-redisenterprisecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-redisenterprisecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-relay':
         specifier: file:./projects/arm-relay.tgz
-        version: file:projects/arm-relay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-relay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-reservations':
         specifier: file:./projects/arm-reservations.tgz
-        version: file:projects/arm-reservations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-reservations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resourceconnector':
         specifier: file:./projects/arm-resourceconnector.tgz
-        version: file:projects/arm-resourceconnector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resourceconnector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resourcegraph':
         specifier: file:./projects/arm-resourcegraph.tgz
-        version: file:projects/arm-resourcegraph.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resourcegraph.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resourcehealth':
         specifier: file:./projects/arm-resourcehealth.tgz
-        version: file:projects/arm-resourcehealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resourcehealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resourcemover':
         specifier: file:./projects/arm-resourcemover.tgz
-        version: file:projects/arm-resourcemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resourcemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resources':
         specifier: file:./projects/arm-resources.tgz
-        version: file:projects/arm-resources.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resources.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resources-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-resources-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resources-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resources-subscriptions':
         specifier: file:./projects/arm-resources-subscriptions.tgz
-        version: file:projects/arm-resources-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resources-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resourcesbicep':
         specifier: file:./projects/arm-resourcesbicep.tgz
-        version: file:projects/arm-resourcesbicep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resourcesbicep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-resourcesdeploymentstacks':
         specifier: file:./projects/arm-resourcesdeploymentstacks.tgz
-        version: file:projects/arm-resourcesdeploymentstacks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-resourcesdeploymentstacks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-scvmm':
         specifier: file:./projects/arm-scvmm.tgz
-        version: file:projects/arm-scvmm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-scvmm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-search':
         specifier: file:./projects/arm-search.tgz
-        version: file:projects/arm-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-security':
         specifier: file:./projects/arm-security.tgz
-        version: file:projects/arm-security.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-security.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-securitydevops':
         specifier: file:./projects/arm-securitydevops.tgz
-        version: file:projects/arm-securitydevops.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-securitydevops.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-securityinsight':
         specifier: file:./projects/arm-securityinsight.tgz
-        version: file:projects/arm-securityinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-securityinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-selfhelp':
         specifier: file:./projects/arm-selfhelp.tgz
-        version: file:projects/arm-selfhelp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-selfhelp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-serialconsole':
         specifier: file:./projects/arm-serialconsole.tgz
-        version: file:projects/arm-serialconsole.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-serialconsole.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicebus':
         specifier: file:./projects/arm-servicebus.tgz
-        version: file:projects/arm-servicebus.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicebus.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicefabric':
         specifier: file:./projects/arm-servicefabric.tgz
-        version: file:projects/arm-servicefabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicefabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicefabric-1':
         specifier: file:./projects/arm-servicefabric-1.tgz
-        version: file:projects/arm-servicefabric-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicefabric-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicefabricmanagedclusters':
         specifier: file:./projects/arm-servicefabricmanagedclusters.tgz
-        version: file:projects/arm-servicefabricmanagedclusters.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicefabricmanagedclusters.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicefabricmesh':
         specifier: file:./projects/arm-servicefabricmesh.tgz
-        version: file:projects/arm-servicefabricmesh.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicefabricmesh.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicelinker':
         specifier: file:./projects/arm-servicelinker.tgz
-        version: file:projects/arm-servicelinker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicelinker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicemap':
         specifier: file:./projects/arm-servicemap.tgz
-        version: file:projects/arm-servicemap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicemap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-servicenetworking':
         specifier: file:./projects/arm-servicenetworking.tgz
-        version: file:projects/arm-servicenetworking.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-servicenetworking.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-signalr':
         specifier: file:./projects/arm-signalr.tgz
-        version: file:projects/arm-signalr.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-signalr.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-sitemanager':
         specifier: file:./projects/arm-sitemanager.tgz
-        version: file:projects/arm-sitemanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-sitemanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-sphere':
         specifier: file:./projects/arm-sphere.tgz
-        version: file:projects/arm-sphere.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-sphere.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-springappdiscovery':
         specifier: file:./projects/arm-springappdiscovery.tgz
-        version: file:projects/arm-springappdiscovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-springappdiscovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-sql':
         specifier: file:./projects/arm-sql.tgz
-        version: file:projects/arm-sql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-sql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-sqlvirtualmachine':
         specifier: file:./projects/arm-sqlvirtualmachine.tgz
-        version: file:projects/arm-sqlvirtualmachine.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-sqlvirtualmachine.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-standbypool':
         specifier: file:./projects/arm-standbypool.tgz
-        version: file:projects/arm-standbypool.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-standbypool.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storage':
         specifier: file:./projects/arm-storage.tgz
-        version: file:projects/arm-storage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storage-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-storage-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storage-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storageactions':
         specifier: file:./projects/arm-storageactions.tgz
-        version: file:projects/arm-storageactions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storageactions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storagecache':
         specifier: file:./projects/arm-storagecache.tgz
-        version: file:projects/arm-storagecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storagecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storageimportexport':
         specifier: file:./projects/arm-storageimportexport.tgz
-        version: file:projects/arm-storageimportexport.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storageimportexport.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storagemover':
         specifier: file:./projects/arm-storagemover.tgz
-        version: file:projects/arm-storagemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storagemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storagesync':
         specifier: file:./projects/arm-storagesync.tgz
-        version: file:projects/arm-storagesync.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storagesync.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storsimple1200series':
         specifier: file:./projects/arm-storsimple1200series.tgz
-        version: file:projects/arm-storsimple1200series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storsimple1200series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-storsimple8000series':
         specifier: file:./projects/arm-storsimple8000series.tgz
-        version: file:projects/arm-storsimple8000series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-storsimple8000series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-streamanalytics':
         specifier: file:./projects/arm-streamanalytics.tgz
-        version: file:projects/arm-streamanalytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-streamanalytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-subscriptions':
         specifier: file:./projects/arm-subscriptions.tgz
-        version: file:projects/arm-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid':
         specifier: file:./projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz
-        version: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-support':
         specifier: file:./projects/arm-support.tgz
-        version: file:projects/arm-support.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-support.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-synapse':
         specifier: file:./projects/arm-synapse.tgz
-        version: file:projects/arm-synapse.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-synapse.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-templatespecs':
         specifier: file:./projects/arm-templatespecs.tgz
-        version: file:projects/arm-templatespecs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-templatespecs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-terraform':
         specifier: file:./projects/arm-terraform.tgz
-        version: file:projects/arm-terraform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-terraform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-timeseriesinsights':
         specifier: file:./projects/arm-timeseriesinsights.tgz
-        version: file:projects/arm-timeseriesinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-timeseriesinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-trafficmanager':
         specifier: file:./projects/arm-trafficmanager.tgz
-        version: file:projects/arm-trafficmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-trafficmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-trustedsigning':
         specifier: file:./projects/arm-trustedsigning.tgz
-        version: file:projects/arm-trustedsigning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-trustedsigning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-visualstudio':
         specifier: file:./projects/arm-visualstudio.tgz
-        version: file:projects/arm-visualstudio.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-visualstudio.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-vmwarecloudsimple':
         specifier: file:./projects/arm-vmwarecloudsimple.tgz
-        version: file:projects/arm-vmwarecloudsimple.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-vmwarecloudsimple.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-voiceservices':
         specifier: file:./projects/arm-voiceservices.tgz
-        version: file:projects/arm-voiceservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-voiceservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-webpubsub':
         specifier: file:./projects/arm-webpubsub.tgz
-        version: file:projects/arm-webpubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-webpubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-webservices':
         specifier: file:./projects/arm-webservices.tgz
-        version: file:projects/arm-webservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-webservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-weightsandbiases':
         specifier: file:./projects/arm-weightsandbiases.tgz
-        version: file:projects/arm-weightsandbiases.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-weightsandbiases.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-workloads':
         specifier: file:./projects/arm-workloads.tgz
-        version: file:projects/arm-workloads.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-workloads.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-workloadssapvirtualinstance':
         specifier: file:./projects/arm-workloadssapvirtualinstance.tgz
-        version: file:projects/arm-workloadssapvirtualinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-workloadssapvirtualinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/arm-workspaces':
         specifier: file:./projects/arm-workspaces.tgz
-        version: file:projects/arm-workspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/arm-workspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/attestation':
         specifier: file:./projects/attestation.tgz
-        version: file:projects/attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/batch':
         specifier: file:./projects/batch.tgz
-        version: file:projects/batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-alpha-ids':
         specifier: file:./projects/communication-alpha-ids.tgz
-        version: file:projects/communication-alpha-ids.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-alpha-ids.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-call-automation':
         specifier: file:./projects/communication-call-automation.tgz
-        version: file:projects/communication-call-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-call-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-chat':
         specifier: file:./projects/communication-chat.tgz
-        version: file:projects/communication-chat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-chat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-common':
         specifier: file:./projects/communication-common.tgz
-        version: file:projects/communication-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-email':
         specifier: file:./projects/communication-email.tgz
-        version: file:projects/communication-email.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-email.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-identity':
         specifier: file:./projects/communication-identity.tgz
-        version: file:projects/communication-identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-job-router':
         specifier: file:./projects/communication-job-router.tgz
-        version: file:projects/communication-job-router.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-job-router.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-messages':
         specifier: file:./projects/communication-messages.tgz
-        version: file:projects/communication-messages.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-messages.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-phone-numbers':
         specifier: file:./projects/communication-phone-numbers.tgz
-        version: file:projects/communication-phone-numbers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-phone-numbers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-recipient-verification':
         specifier: file:./projects/communication-recipient-verification.tgz
-        version: file:projects/communication-recipient-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-recipient-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-rooms':
         specifier: file:./projects/communication-rooms.tgz
-        version: file:projects/communication-rooms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-rooms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-short-codes':
         specifier: file:./projects/communication-short-codes.tgz
-        version: file:projects/communication-short-codes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-short-codes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-sms':
         specifier: file:./projects/communication-sms.tgz
-        version: file:projects/communication-sms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-sms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-tiering':
         specifier: file:./projects/communication-tiering.tgz
-        version: file:projects/communication-tiering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-tiering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/communication-toll-free-verification':
         specifier: file:./projects/communication-toll-free-verification.tgz
-        version: file:projects/communication-toll-free-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/communication-toll-free-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/confidential-ledger':
         specifier: file:./projects/confidential-ledger.tgz
         version: file:projects/confidential-ledger.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/container-registry':
         specifier: file:./projects/container-registry.tgz
-        version: file:projects/container-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/container-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-amqp':
         specifier: file:./projects/core-amqp.tgz
-        version: file:projects/core-amqp.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-amqp.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-auth':
         specifier: file:./projects/core-auth.tgz
-        version: file:projects/core-auth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-auth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-client':
         specifier: file:./projects/core-client.tgz
-        version: file:projects/core-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-client-1':
         specifier: file:./projects/core-client-1.tgz
-        version: file:projects/core-client-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-client-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-http-compat':
         specifier: file:./projects/core-http-compat.tgz
-        version: file:projects/core-http-compat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-http-compat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-lro':
         specifier: file:./projects/core-lro.tgz
-        version: file:projects/core-lro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-lro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-paging':
         specifier: file:./projects/core-paging.tgz
-        version: file:projects/core-paging.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-paging.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-rest-pipeline':
         specifier: file:./projects/core-rest-pipeline.tgz
-        version: file:projects/core-rest-pipeline.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-rest-pipeline.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-sse':
         specifier: file:./projects/core-sse.tgz
-        version: file:projects/core-sse.tgz(@types/debug@4.1.12)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-sse.tgz(@types/debug@4.1.12)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-tracing':
         specifier: file:./projects/core-tracing.tgz
-        version: file:projects/core-tracing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-tracing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-util':
         specifier: file:./projects/core-util.tgz
-        version: file:projects/core-util.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-util.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/core-xml':
         specifier: file:./projects/core-xml.tgz
-        version: file:projects/core-xml.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/core-xml.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/cosmos':
         specifier: file:./projects/cosmos.tgz
-        version: file:projects/cosmos.tgz(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/cosmos.tgz(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/create-microsoft-playwright-testing':
         specifier: file:./projects/create-microsoft-playwright-testing.tgz
         version: file:projects/create-microsoft-playwright-testing.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -984,145 +984,145 @@ importers:
         version: file:projects/create-playwright.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/data-tables':
         specifier: file:./projects/data-tables.tgz
-        version: file:projects/data-tables.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/data-tables.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/defender-easm':
         specifier: file:./projects/defender-easm.tgz
-        version: file:projects/defender-easm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/defender-easm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/dev-tool':
         specifier: file:./projects/dev-tool.tgz
         version: file:projects/dev-tool.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)
       '@rush-temp/developer-devcenter':
         specifier: file:./projects/developer-devcenter.tgz
-        version: file:projects/developer-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/developer-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/digital-twins-core':
         specifier: file:./projects/digital-twins-core.tgz
-        version: file:projects/digital-twins-core.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/digital-twins-core.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/eslint-plugin-azure-sdk':
         specifier: file:./projects/eslint-plugin-azure-sdk.tgz
-        version: file:projects/eslint-plugin-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/eslint-plugin-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/event-hubs':
         specifier: file:./projects/event-hubs.tgz
-        version: file:projects/event-hubs.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/event-hubs.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/eventgrid':
         specifier: file:./projects/eventgrid.tgz
-        version: file:projects/eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/eventgrid-namespaces':
         specifier: file:./projects/eventgrid-namespaces.tgz
-        version: file:projects/eventgrid-namespaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/eventgrid-namespaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/eventgrid-systemevents':
         specifier: file:./projects/eventgrid-systemevents.tgz
-        version: file:projects/eventgrid-systemevents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/eventgrid-systemevents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/eventhubs-checkpointstore-blob':
         specifier: file:./projects/eventhubs-checkpointstore-blob.tgz
-        version: file:projects/eventhubs-checkpointstore-blob.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/eventhubs-checkpointstore-blob.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/eventhubs-checkpointstore-table':
         specifier: file:./projects/eventhubs-checkpointstore-table.tgz
-        version: file:projects/eventhubs-checkpointstore-table.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/eventhubs-checkpointstore-table.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/functions-authentication-events':
         specifier: file:./projects/functions-authentication-events.tgz
-        version: file:projects/functions-authentication-events.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/functions-authentication-events.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/health-deidentification':
         specifier: file:./projects/health-deidentification.tgz
-        version: file:projects/health-deidentification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/health-deidentification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/health-insights-cancerprofiling':
         specifier: file:./projects/health-insights-cancerprofiling.tgz
-        version: file:projects/health-insights-cancerprofiling.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/health-insights-cancerprofiling.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/health-insights-clinicalmatching':
         specifier: file:./projects/health-insights-clinicalmatching.tgz
-        version: file:projects/health-insights-clinicalmatching.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/health-insights-clinicalmatching.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/health-insights-radiologyinsights':
         specifier: file:./projects/health-insights-radiologyinsights.tgz
-        version: file:projects/health-insights-radiologyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/health-insights-radiologyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/identity':
         specifier: file:./projects/identity.tgz
-        version: file:projects/identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/identity-broker':
         specifier: file:./projects/identity-broker.tgz
-        version: file:projects/identity-broker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/identity-broker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/identity-cache-persistence':
         specifier: file:./projects/identity-cache-persistence.tgz
-        version: file:projects/identity-cache-persistence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/identity-cache-persistence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/identity-vscode':
         specifier: file:./projects/identity-vscode.tgz
-        version: file:projects/identity-vscode.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/identity-vscode.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/iot-device-update':
         specifier: file:./projects/iot-device-update.tgz
-        version: file:projects/iot-device-update.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/iot-device-update.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/iot-modelsrepository':
         specifier: file:./projects/iot-modelsrepository.tgz
-        version: file:projects/iot-modelsrepository.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/iot-modelsrepository.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/keyvault-admin':
         specifier: file:./projects/keyvault-admin.tgz
-        version: file:projects/keyvault-admin.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/keyvault-admin.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/keyvault-certificates':
         specifier: file:./projects/keyvault-certificates.tgz
-        version: file:projects/keyvault-certificates.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/keyvault-certificates.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/keyvault-common':
         specifier: file:./projects/keyvault-common.tgz
-        version: file:projects/keyvault-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/keyvault-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/keyvault-keys':
         specifier: file:./projects/keyvault-keys.tgz
-        version: file:projects/keyvault-keys.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/keyvault-keys.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/keyvault-secrets':
         specifier: file:./projects/keyvault-secrets.tgz
         version: file:projects/keyvault-secrets.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/load-testing':
         specifier: file:./projects/load-testing.tgz
-        version: file:projects/load-testing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/load-testing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/logger':
         specifier: file:./projects/logger.tgz
-        version: file:projects/logger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/logger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/maps-common':
         specifier: file:./projects/maps-common.tgz
-        version: file:projects/maps-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/maps-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/maps-geolocation':
         specifier: file:./projects/maps-geolocation.tgz
-        version: file:projects/maps-geolocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/maps-geolocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/maps-render':
         specifier: file:./projects/maps-render.tgz
-        version: file:projects/maps-render.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/maps-render.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/maps-route':
         specifier: file:./projects/maps-route.tgz
-        version: file:projects/maps-route.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/maps-route.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/maps-search':
         specifier: file:./projects/maps-search.tgz
-        version: file:projects/maps-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/maps-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/maps-timezone':
         specifier: file:./projects/maps-timezone.tgz
-        version: file:projects/maps-timezone.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/maps-timezone.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/mcp-server':
         specifier: file:./projects/mcp-server.tgz
         version: file:projects/mcp-server.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(yaml@2.8.0)
       '@rush-temp/microsoft-playwright-testing':
         specifier: file:./projects/microsoft-playwright-testing.tgz
-        version: file:projects/microsoft-playwright-testing.tgz(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/microsoft-playwright-testing.tgz(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/mock-hub':
         specifier: file:./projects/mock-hub.tgz
         version: file:projects/mock-hub.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/monitor-ingestion':
         specifier: file:./projects/monitor-ingestion.tgz
-        version: file:projects/monitor-ingestion.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/monitor-ingestion.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/monitor-opentelemetry':
         specifier: file:./projects/monitor-opentelemetry.tgz
         version: file:projects/monitor-opentelemetry.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
       '@rush-temp/monitor-opentelemetry-exporter':
         specifier: file:./projects/monitor-opentelemetry-exporter.tgz
-        version: file:projects/monitor-opentelemetry-exporter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/monitor-opentelemetry-exporter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/monitor-query':
         specifier: file:./projects/monitor-query.tgz
-        version: file:projects/monitor-query.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/monitor-query.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/notification-hubs':
         specifier: file:./projects/notification-hubs.tgz
-        version: file:projects/notification-hubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/notification-hubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/onlineexperimentation':
         specifier: file:./projects/onlineexperimentation.tgz
-        version: file:projects/onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/openai':
         specifier: file:./projects/openai.tgz
-        version: file:projects/openai.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.2)(yaml@2.8.0)
+        version: file:projects/openai.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.3)(yaml@2.8.0)
       '@rush-temp/opentelemetry-instrumentation-azure-sdk':
         specifier: file:./projects/opentelemetry-instrumentation-azure-sdk.tgz
-        version: file:projects/opentelemetry-instrumentation-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/opentelemetry-instrumentation-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/perf-ai-form-recognizer':
         specifier: file:./projects/perf-ai-form-recognizer.tgz
         version: file:projects/perf-ai-form-recognizer.tgz
@@ -1197,118 +1197,118 @@ importers:
         version: file:projects/perf-template.tgz
       '@rush-temp/playwright':
         specifier: file:./projects/playwright.tgz
-        version: file:projects/playwright.tgz(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/playwright.tgz(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/purview-administration':
         specifier: file:./projects/purview-administration.tgz
-        version: file:projects/purview-administration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/purview-administration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/purview-datamap':
         specifier: file:./projects/purview-datamap.tgz
-        version: file:projects/purview-datamap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/purview-datamap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/purview-scanning':
         specifier: file:./projects/purview-scanning.tgz
-        version: file:projects/purview-scanning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/purview-scanning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/purview-sharing':
         specifier: file:./projects/purview-sharing.tgz
-        version: file:projects/purview-sharing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/purview-sharing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/purview-workflow':
         specifier: file:./projects/purview-workflow.tgz
-        version: file:projects/purview-workflow.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/purview-workflow.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/quantum-jobs':
         specifier: file:./projects/quantum-jobs.tgz
-        version: file:projects/quantum-jobs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/quantum-jobs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/schema-registry':
         specifier: file:./projects/schema-registry.tgz
-        version: file:projects/schema-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/schema-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/schema-registry-avro':
         specifier: file:./projects/schema-registry-avro.tgz
-        version: file:projects/schema-registry-avro.tgz(@types/debug@4.1.12)(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/schema-registry-avro.tgz(@types/debug@4.1.12)(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/schema-registry-json':
         specifier: file:./projects/schema-registry-json.tgz
-        version: file:projects/schema-registry-json.tgz(@types/debug@4.1.12)(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/schema-registry-json.tgz(@types/debug@4.1.12)(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/search-documents':
         specifier: file:./projects/search-documents.tgz
-        version: file:projects/search-documents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/search-documents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/service-bus':
         specifier: file:./projects/service-bus.tgz
-        version: file:projects/service-bus.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/service-bus.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-blob':
         specifier: file:./projects/storage-blob.tgz
-        version: file:projects/storage-blob.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-blob.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-blob-changefeed':
         specifier: file:./projects/storage-blob-changefeed.tgz
-        version: file:projects/storage-blob-changefeed.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-blob-changefeed.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-common':
         specifier: file:./projects/storage-common.tgz
-        version: file:projects/storage-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-file-datalake':
         specifier: file:./projects/storage-file-datalake.tgz
-        version: file:projects/storage-file-datalake.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-file-datalake.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-file-share':
         specifier: file:./projects/storage-file-share.tgz
-        version: file:projects/storage-file-share.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-file-share.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-internal-avro':
         specifier: file:./projects/storage-internal-avro.tgz
-        version: file:projects/storage-internal-avro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-internal-avro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/storage-queue':
         specifier: file:./projects/storage-queue.tgz
-        version: file:projects/storage-queue.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/storage-queue.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/synapse-access-control':
         specifier: file:./projects/synapse-access-control.tgz
-        version: file:projects/synapse-access-control.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/synapse-access-control.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/synapse-access-control-1':
         specifier: file:./projects/synapse-access-control-1.tgz
-        version: file:projects/synapse-access-control-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/synapse-access-control-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/synapse-artifacts':
         specifier: file:./projects/synapse-artifacts.tgz
-        version: file:projects/synapse-artifacts.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/synapse-artifacts.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/synapse-managed-private-endpoints':
         specifier: file:./projects/synapse-managed-private-endpoints.tgz
-        version: file:projects/synapse-managed-private-endpoints.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/synapse-managed-private-endpoints.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/synapse-monitoring':
         specifier: file:./projects/synapse-monitoring.tgz
-        version: file:projects/synapse-monitoring.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/synapse-monitoring.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/synapse-spark':
         specifier: file:./projects/synapse-spark.tgz
-        version: file:projects/synapse-spark.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/synapse-spark.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/template':
         specifier: file:./projects/template.tgz
-        version: file:projects/template.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/template.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/template-dpg':
         specifier: file:./projects/template-dpg.tgz
-        version: file:projects/template-dpg.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/template-dpg.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/test-credential':
         specifier: file:./projects/test-credential.tgz
-        version: file:projects/test-credential.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/test-credential.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/test-perf':
         specifier: file:./projects/test-perf.tgz
         version: file:projects/test-perf.tgz
       '@rush-temp/test-recorder':
         specifier: file:./projects/test-recorder.tgz
-        version: file:projects/test-recorder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/test-recorder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/test-utils-vitest':
         specifier: file:./projects/test-utils-vitest.tgz
-        version: file:projects/test-utils-vitest.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/test-utils-vitest.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/ts-http-runtime':
         specifier: file:./projects/ts-http-runtime.tgz
-        version: file:projects/ts-http-runtime.tgz(@types/debug@4.1.12)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/ts-http-runtime.tgz(@types/debug@4.1.12)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/vite-plugin-browser-test-map':
         specifier: file:./projects/vite-plugin-browser-test-map.tgz
         version: file:projects/vite-plugin-browser-test-map.tgz
       '@rush-temp/web-pubsub':
         specifier: file:./projects/web-pubsub.tgz
-        version: file:projects/web-pubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/web-pubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/web-pubsub-client':
         specifier: file:./projects/web-pubsub-client.tgz
-        version: file:projects/web-pubsub-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/web-pubsub-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/web-pubsub-client-protobuf':
         specifier: file:./projects/web-pubsub-client-protobuf.tgz
-        version: file:projects/web-pubsub-client-protobuf.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+        version: file:projects/web-pubsub-client-protobuf.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
       '@rush-temp/web-pubsub-express':
         specifier: file:./projects/web-pubsub-express.tgz
-        version: file:projects/web-pubsub-express.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
-      pg-protocol:
-        specifier: 1.8.0
-        version: 1.8.0
+        version: file:projects/web-pubsub-express.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)
+      '@types/node':
+        specifier: 20.19.1
+        version: 20.19.1
 
 packages:
 
@@ -1332,9 +1332,9 @@ packages:
     resolution: {integrity: sha512-ozTDPBVUDR5eOnMIwhggbnVmOrka4fXCs8n8mvUo4WLLc38kki6bAOByDoVZZPz/pZy2jMt2kwfpvy/UjALj6w==}
     engines: {node: '>=18.0.0'}
 
-  '@azure-rest/core-client@2.4.0':
-    resolution: {integrity: sha512-CjMFBcmnt0YNdRcxSSoZbtZNXudLlicdml7UrPsV03nHiWB+Bq5cu5ctieyaCuRtU7jm7+SOFtiE/g4pBFPKKA==}
-    engines: {node: '>=18.0.0'}
+  '@azure-rest/core-client@2.5.0':
+    resolution: {integrity: sha512-KMVIPxG6ygcQ1M2hKHahF7eddKejYsWTjoLIfTWiqnaj42dBkYzj4+S8rK9xxmlOaEHKZHcMrRbm0NfN4kgwHw==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/abort-controller@1.1.0':
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
@@ -1400,17 +1400,17 @@ packages:
     resolution: {integrity: sha512-nlbkQzD2Jrkwwj01tGETQEj4HV28WXdqIt45DkHtamVeoFFNem/uJIri4dUymzAwgK7c1czGoVobuft8UH5Eig==}
     engines: {node: '>=8.0.0'}
 
-  '@azure/core-amqp@4.3.6':
-    resolution: {integrity: sha512-M8nP/DtrJI5SxlGCweijHSCHq70g1SXdJP1KVweoKRPiBVHbRcmCn9ExGbfUwHor/sKHqqVG7DAzPf0+bOtRSw==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-amqp@4.4.0':
+    resolution: {integrity: sha512-Rqryrb+UnJhQBAXtwrKOzsiF2Rmtia2+Cw7gqoqWTC67utl41oMylDiJ5/Us67QnXA/ZXlu+ITNfzYxBNdptgQ==}
+    engines: {node: '>=20.0.0'}
 
-  '@azure/core-auth@1.9.0':
-    resolution: {integrity: sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-auth@1.10.0':
+    resolution: {integrity: sha512-88Djs5vBvGbHQHf5ZZcaoNHo6Y8BKZkt3cw2iuJIQzLEgH4Ox6Tm4hjFhbqOxyYsgIG/eJbFEHpxRIfEEWv5Ow==}
+    engines: {node: '>=20.0.0'}
 
-  '@azure/core-client@1.9.4':
-    resolution: {integrity: sha512-f7IxTD15Qdux30s2qFARH+JxgwxWLG2Rlr4oSkPGuLWm+1p5y1+C04XGLA0vmX6EtqfutmjvpNmAfgwVIS5hpw==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-client@1.10.0':
+    resolution: {integrity: sha512-O4aP3CLFNodg8eTHXECaH3B3CjicfzkxVtnrfLkOq0XNP7TIECGfHpK/C6vADZkWP75wzmdBnsIA8ksuJMk18g==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/core-http-compat@2.3.0':
     resolution: {integrity: sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==}
@@ -1424,36 +1424,36 @@ packages:
     resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/core-rest-pipeline@1.21.0':
-    resolution: {integrity: sha512-a4MBwe/5WKbq9MIxikzgxLBbruC5qlkFYlBdI7Ev50Y7ib5Vo/Jvt5jnJo7NaWeJ908LCHL0S1Us4UMf1VoTfg==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-rest-pipeline@1.22.0':
+    resolution: {integrity: sha512-OKHmb3/Kpm06HypvB3g6Q3zJuvyXcpxDpCS1PnU8OV6AJgSFaee/covXBcPbWc6XDDxtEPlbi3EMQ6nUiPaQtw==}
+    engines: {node: '>=20.0.0'}
 
-  '@azure/core-sse@2.2.0':
-    resolution: {integrity: sha512-6Xg/CeW0jRyMoWt+puw2x6Qqkml3tr76Cn/oA9goIcUXtsi3ngmTwCVbwqkUWfhsOfo4F+78LGgiswSxTHN0sg==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-sse@2.3.0':
+    resolution: {integrity: sha512-jKhPpdDbVS5GlpadSKIC7V6Q4P2vEcwXi1c4CLTXs01Q/PAITES9v5J/S73+RtCMqQpsX0jGa2yPWwXi9JzdgA==}
+    engines: {node: '>=20.0.0'}
 
-  '@azure/core-tracing@1.2.0':
-    resolution: {integrity: sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-tracing@1.3.0':
+    resolution: {integrity: sha512-+XvmZLLWPe67WXNZo9Oc9CrPj/Tm8QnHR92fFAFdnbzwNdCH1h+7UdpaQgRSBsMY+oW1kHXNUZQLdZ1gHX3ROw==}
+    engines: {node: '>=20.0.0'}
 
-  '@azure/core-util@1.12.0':
-    resolution: {integrity: sha512-13IyjTQgABPARvG90+N2dXpC+hwp466XCdQXPCRlbWHgd3SJd5Q1VvaBGv6k1BIa4MQm6hAF1UBU1m8QUxV8sQ==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-util@1.13.0':
+    resolution: {integrity: sha512-o0psW8QWQ58fq3i24Q1K2XfS/jYTxr7O1HRcyUE9bV9NttLU+kYOH82Ixj8DGlMTOWgxm1Sss2QAfKK5UkSPxw==}
+    engines: {node: '>=20.0.0'}
 
-  '@azure/core-xml@1.4.5':
-    resolution: {integrity: sha512-gT4H8mTaSXRz7eGTuQyq1aIJnJqeXzpOe9Ay7Z3FrCouer14CbV3VzjnJrNrQfbBpGBLO9oy8BmrY75A0p53cA==}
-    engines: {node: '>=18.0.0'}
+  '@azure/core-xml@1.5.0':
+    resolution: {integrity: sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/functions@3.5.1':
     resolution: {integrity: sha512-6UltvJiuVpvHSwLcK/Zc6NfUwlkDLOFFx97BHCJzlWNsfiWwzwmTsxJXg4kE/LemKTHxPpfoPE+kOJ8hAdiKFQ==}
 
-  '@azure/functions@4.7.3':
-    resolution: {integrity: sha512-NwizjL8qcujVq+Yl3iL6TvtEC9v4CWZgipd0UPa5PvM2a5Uiqd1Uk8wGCYPhfskGy+1YpBLyQje1SRdlLzB6Jw==}
+  '@azure/functions@4.7.2':
+    resolution: {integrity: sha512-5ps8yz4gn6oZSzeQbpUreWHFYl/YS03F1Sk/pz7YJphfctRcHuLF5tcrdm9AyRiYzja4Bkd63bju+g/E27opPQ==}
     engines: {node: '>=18.0'}
 
-  '@azure/identity@4.10.1':
-    resolution: {integrity: sha512-YM/z6RxRtFlXUH2egAYF/FDPes+MUE6ZoknjEdaq7ebJMMNUzn9zCJ3bd2ZZZlkP0r1xKa88kolhFH/FGV7JnA==}
-    engines: {node: '>=18.0.0'}
+  '@azure/identity@4.10.2':
+    resolution: {integrity: sha512-Uth4vz0j+fkXCkbvutChUj03PDCokjbC6Wk9JT8hHEUtpy/EurNKAseb3+gO6Zi9VYBvwt61pgbzn1ovk942Qg==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/identity@4.3.0':
     resolution: {integrity: sha512-LHZ58/RsIpIWa4hrrE2YuJ/vzG1Jv9f774RfTTAVDZDriubvJ0/S5u4pnw4akJDlS0TiJb6VMphmVUFsWmgodQ==}
@@ -1467,9 +1467,9 @@ packages:
     resolution: {integrity: sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==}
     engines: {node: '>=18.0.0'}
 
-  '@azure/logger@1.2.0':
-    resolution: {integrity: sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==}
-    engines: {node: '>=18.0.0'}
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/maps-common@1.0.0-beta.2':
     resolution: {integrity: sha512-PB9GlnfojcQ4nf9WXdQvWeAk7gm8P74o+Z5IHz5YLK/W+3vrNrmVVVuFpGOvCPrLjag50UinaZsMBtPtxoiobg==}
@@ -1479,20 +1479,20 @@ packages:
     resolution: {integrity: sha512-OHHEWMB5+Zrix8yKvLVzU3rKDFvh7SOzAzXfICD7YgUXLxfHpTPX2pzOotrri1kskwhHqIj4a5LvhZlIqE7C7g==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-browser@4.13.2':
-    resolution: {integrity: sha512-lS75bF6FYZRwsacKLXc8UYu/jb+gOB7dtZq5938chCvV/zKTFDnzuXxCXhsSUh0p8s/P8ztgbfdueD9lFARQlQ==}
+  '@azure/msal-browser@4.15.0':
+    resolution: {integrity: sha512-+AIGTvpVz+FIx5CsM1y+nW0r/qOb/ChRdM8/Cbp+jKWC0Wdw4ldnwPdYOBi5NaALUQnYITirD9XMZX7LdklEzQ==}
     engines: {node: '>=0.8.0'}
 
   '@azure/msal-common@14.16.0':
     resolution: {integrity: sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@15.7.1':
-    resolution: {integrity: sha512-a0eowoYfRfKZEjbiCoA5bPT3IlWRAdGSvi63OU23Hv+X6EI8gbvXCoeqokUceFMoT9NfRUWTJSx5FiuzruqT8g==}
+  '@azure/msal-common@15.8.1':
+    resolution: {integrity: sha512-ltIlFK5VxeJ5BurE25OsJIfcx1Q3H/IZg2LjV9d4vmH+5t4c1UCyRQ/HgKLgXuCZShs7qfc/TC95GYZfsUsJUQ==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node-extensions@1.5.15':
-    resolution: {integrity: sha512-Ku4sIZVuh7yrL4XR6zFpsqj21DRRUC9OXhQPrWLrbjxiISkeLZqgo8zIc5zO+FwXf/Qt4xeVgbu/gde6fJLzxw==}
+  '@azure/msal-node-extensions@1.5.17':
+    resolution: {integrity: sha512-Td9EgSAdgJrU19+iLXiiqx/vV7jgJV8L78ewmaJa5qakeh1jLTecFpwIFb84H0Tl9oGfzFqQIprPL4DOWIRR3A==}
     engines: {node: '>=16'}
 
   '@azure/msal-node-runtime@0.18.2':
@@ -1502,8 +1502,8 @@ packages:
     resolution: {integrity: sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==}
     engines: {node: '>=16'}
 
-  '@azure/msal-node@3.6.1':
-    resolution: {integrity: sha512-ctcVz4xS+st5KxOlQqgpvA+uDFAa59CvkmumnuhlD2XmNczloKBdCiMQG7/TigSlaeHe01qoOlDjz3TyUAmKUg==}
+  '@azure/msal-node@3.6.3':
+    resolution: {integrity: sha512-95wjsKGyUcAd5tFmQBo5Ug/kOj+hFh/8FsXuxluEvdfbgg6xCimhSP9qnyq6+xIg78/jREkBD1/BSqd7NIDDYQ==}
     engines: {node: '>=16'}
 
   '@azure/openai@1.0.0-beta.12':
@@ -1551,20 +1551,24 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.27.5':
-    resolution: {integrity: sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==}
+  '@babel/compat-data@7.28.0':
+    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.27.4':
-    resolution: {integrity: sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==}
+  '@babel/core@7.28.0':
+    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.27.5':
-    resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
+  '@babel/generator@7.28.0':
+    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.27.1':
@@ -1593,8 +1597,8 @@ packages:
     resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.27.5':
-    resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1606,12 +1610,12 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.27.4':
-    resolution: {integrity: sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==}
+  '@babel/traverse@7.28.0':
+    resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.27.6':
-    resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
+  '@babel/types@7.28.0':
+    resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
     engines: {node: '>=6.9.0'}
 
   '@braidai/lang@1.1.1':
@@ -1625,152 +1629,158 @@ packages:
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
-  '@esbuild/aix-ppc64@0.25.5':
-    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
+  '@esbuild/aix-ppc64@0.25.6':
+    resolution: {integrity: sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.5':
-    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
+  '@esbuild/android-arm64@0.25.6':
+    resolution: {integrity: sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.5':
-    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
+  '@esbuild/android-arm@0.25.6':
+    resolution: {integrity: sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.5':
-    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
+  '@esbuild/android-x64@0.25.6':
+    resolution: {integrity: sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.5':
-    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
+  '@esbuild/darwin-arm64@0.25.6':
+    resolution: {integrity: sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.5':
-    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
+  '@esbuild/darwin-x64@0.25.6':
+    resolution: {integrity: sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.5':
-    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
+  '@esbuild/freebsd-arm64@0.25.6':
+    resolution: {integrity: sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.5':
-    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
+  '@esbuild/freebsd-x64@0.25.6':
+    resolution: {integrity: sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.5':
-    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
+  '@esbuild/linux-arm64@0.25.6':
+    resolution: {integrity: sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.5':
-    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
+  '@esbuild/linux-arm@0.25.6':
+    resolution: {integrity: sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.5':
-    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
+  '@esbuild/linux-ia32@0.25.6':
+    resolution: {integrity: sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.5':
-    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
+  '@esbuild/linux-loong64@0.25.6':
+    resolution: {integrity: sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.5':
-    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
+  '@esbuild/linux-mips64el@0.25.6':
+    resolution: {integrity: sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.5':
-    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
+  '@esbuild/linux-ppc64@0.25.6':
+    resolution: {integrity: sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.5':
-    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
+  '@esbuild/linux-riscv64@0.25.6':
+    resolution: {integrity: sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.5':
-    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
+  '@esbuild/linux-s390x@0.25.6':
+    resolution: {integrity: sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.5':
-    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
+  '@esbuild/linux-x64@0.25.6':
+    resolution: {integrity: sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
+  '@esbuild/netbsd-arm64@0.25.6':
+    resolution: {integrity: sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.5':
-    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
+  '@esbuild/netbsd-x64@0.25.6':
+    resolution: {integrity: sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
+  '@esbuild/openbsd-arm64@0.25.6':
+    resolution: {integrity: sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.5':
-    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
+  '@esbuild/openbsd-x64@0.25.6':
+    resolution: {integrity: sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.5':
-    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
+  '@esbuild/openharmony-arm64@0.25.6':
+    resolution: {integrity: sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.6':
+    resolution: {integrity: sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.5':
-    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
+  '@esbuild/win32-arm64@0.25.6':
+    resolution: {integrity: sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.5':
-    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
+  '@esbuild/win32-ia32@0.25.6':
+    resolution: {integrity: sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.5':
-    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
+  '@esbuild/win32-x64@0.25.6':
+    resolution: {integrity: sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1785,46 +1795,50 @@ packages:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/compat@1.3.0':
-    resolution: {integrity: sha512-ZBygRBqpDYiIHsN+d1WyHn3TYgzgpzLEcgJUxTATyiInQbKZz6wZb6+ljwdg8xeeOe4v03z6Uh6lELiw0/mVhQ==}
+  '@eslint/compat@1.3.1':
+    resolution: {integrity: sha512-k8MHony59I5EPic6EQTCNOuPoVBnoYXkP+20xvwFjN7t0qI3ImyvyBgg+hIVPwC8JaxVjjUZld+cLfBLFDLucg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^9.10.0
+      eslint: ^8.40 || 9
     peerDependenciesMeta:
       eslint:
         optional: true
 
-  '@eslint/config-array@0.20.1':
-    resolution: {integrity: sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==}
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.2.3':
-    resolution: {integrity: sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==}
+  '@eslint/config-helpers@0.3.0':
+    resolution: {integrity: sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@0.14.0':
     resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.15.0':
-    resolution: {integrity: sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==}
+  '@eslint/core@0.15.1':
+    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.29.0':
-    resolution: {integrity: sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==}
+  '@eslint/js@9.30.1':
+    resolution: {integrity: sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.3.2':
-    resolution: {integrity: sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==}
+  '@eslint/plugin-kit@0.3.3':
+    resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
@@ -1879,23 +1893,18 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
 
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -1941,8 +1950,8 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@modelcontextprotocol/sdk@1.13.1':
-    resolution: {integrity: sha512-8q6+9aF0yA39/qWT/uaIj6zTpC+Qu07DnN/lb9mjoquCJsAh6l3HyYqc9O3t2j7GilseOQOQimLg7W3By6jqvg==}
+  '@modelcontextprotocol/sdk@1.15.1':
+    resolution: {integrity: sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w==}
     engines: {node: '>=18'}
 
   '@mswjs/interceptors@0.37.6':
@@ -2328,8 +2337,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.53.1':
-    resolution: {integrity: sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==}
+  '@playwright/test@1.54.0':
+    resolution: {integrity: sha512-6Mnd5daQmLivaLu5kxUg6FxPtXY4sXsS5SUwKjWNy4ISe4pKraNHoFxcsaTFiNUULbjy0Vlb5HT86QuM0Jy1pQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2393,103 +2402,103 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.44.0':
-    resolution: {integrity: sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==}
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.44.0':
-    resolution: {integrity: sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==}
+  '@rollup/rollup-android-arm64@4.44.2':
+    resolution: {integrity: sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.44.0':
-    resolution: {integrity: sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==}
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    resolution: {integrity: sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.44.0':
-    resolution: {integrity: sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==}
+  '@rollup/rollup-darwin-x64@4.44.2':
+    resolution: {integrity: sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.44.0':
-    resolution: {integrity: sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==}
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    resolution: {integrity: sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.44.0':
-    resolution: {integrity: sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==}
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    resolution: {integrity: sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.0':
-    resolution: {integrity: sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.44.0':
-    resolution: {integrity: sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.0':
-    resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.44.0':
-    resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==}
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
-    resolution: {integrity: sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
-    resolution: {integrity: sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.0':
-    resolution: {integrity: sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.44.0':
-    resolution: {integrity: sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==}
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.0':
-    resolution: {integrity: sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==}
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.44.0':
-    resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==}
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.44.0':
-    resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==}
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.0':
-    resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==}
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.0':
-    resolution: {integrity: sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==}
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    resolution: {integrity: sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.44.0':
-    resolution: {integrity: sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==}
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
     cpu: [x64]
     os: [win32]
 
@@ -3026,7 +3035,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-healthdataaiservices@file:projects/arm-healthdataaiservices.tgz':
-    resolution: {integrity: sha512-ncFSxPr2dOSv8Zo3M9PFoj9btfnOZR6ZAecLBNlVIsOUvsLp2FJNSPZhCcabifZk6MUyt9hstX/NtdCu9xW0kg==, tarball: file:projects/arm-healthdataaiservices.tgz}
+    resolution: {integrity: sha512-7fXlTSNPtPfgXYTf56hq2kCqX0cCV32g3h3F5kQ5Fl5BXQtDXmPps9zaqMcM0pfu/juhlUKvhSyc9Z6OQ8NNhQ==, tarball: file:projects/arm-healthdataaiservices.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-hybridcompute@file:projects/arm-hybridcompute.tgz':
@@ -3690,7 +3699,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/communication-messages@file:projects/communication-messages.tgz':
-    resolution: {integrity: sha512-rMyHoxq2zFmo39zvDMMTMKubpWS2HStbC2TDj8wFQGj39hQgZYsUQnsSnYQOt0kkyYnNWAcYO1WVgm9A1NVBcA==, tarball: file:projects/communication-messages.tgz}
+    resolution: {integrity: sha512-YuPOBVyoiYI/L8Bfmq5RabUeZVFiveF9etfuxYxm2KvlBzrYEMQbMyaIuvfEJELZ5oHuZt6Vuo2IRsDnaXWA8g==, tarball: file:projects/communication-messages.tgz}
     version: 0.0.0
 
   '@rush-temp/communication-phone-numbers@file:projects/communication-phone-numbers.tgz':
@@ -3742,7 +3751,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/core-client@file:projects/core-client.tgz':
-    resolution: {integrity: sha512-UyeSJ+/ZkAnSAq54EmRX2Ip+blZZd4aI6/bJ5l2ALDjZqYbBwcYSSArS2XNrT+Be8xkgbx5CzbY6dffkuzeO0A==, tarball: file:projects/core-client.tgz}
+    resolution: {integrity: sha512-wwEaAKTTOaw492jYmpbqQ1mpsstM7ezYvwWR4rumam3qC8rGn+iUV+M071Pm8TxrpgdhxXNsYmXvIfbg/xVsIA==, tarball: file:projects/core-client.tgz}
     version: 0.0.0
 
   '@rush-temp/core-http-compat@file:projects/core-http-compat.tgz':
@@ -3758,7 +3767,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/core-rest-pipeline@file:projects/core-rest-pipeline.tgz':
-    resolution: {integrity: sha512-Bpla+KVOgVM1xtbGFsJVZWAI7kraIFB9uh79CPt4qC5cmvBImOl+MpKB2wm8biOL2J0T0uyOTKbs6MlDfE9g2w==, tarball: file:projects/core-rest-pipeline.tgz}
+    resolution: {integrity: sha512-s6Cj6bp3ThsPCtJyZnlnIdojKvlAzjZkWMDVaZ1Lr3wheYteoXIeoSwGhdpqizJ0pugvG1wQujd9AodkOK6pSw==, tarball: file:projects/core-rest-pipeline.tgz}
     version: 0.0.0
 
   '@rush-temp/core-sse@file:projects/core-sse.tgz':
@@ -3770,7 +3779,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/core-util@file:projects/core-util.tgz':
-    resolution: {integrity: sha512-QJok4GxeFpk+koNvwkWfW2sEMK+tXL8Rb93kmUbZ0jKDxXb25DODGz4CzPlsEzd3bFo/F3MSYVnQJ78YAUjsOg==, tarball: file:projects/core-util.tgz}
+    resolution: {integrity: sha512-K7ZZ7dPOrauX8eGFeXGeRwgIUsB9LY6CWyby2QDYgqccDUZ10o7ypfzlRctS3oKIf4FH/d7RkUXe7X+Dq6+aug==, tarball: file:projects/core-util.tgz}
     version: 0.0.0
 
   '@rush-temp/core-xml@file:projects/core-xml.tgz':
@@ -3906,7 +3915,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/logger@file:projects/logger.tgz':
-    resolution: {integrity: sha512-NsZ2s2+ZP3lO2ZdvQY5HWjbToyv2C4kIrotHI0Kv6O16CuM2RcYgtM7PrYM9qkQzMhpvhap769U0gc6jRKk1fA==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-gAsRqzdkeo6K0bAWGNQ5XqbsGgpFZPqDiZAqCcHcym1UcGsnUreCCRZKVM6LftNdPNdLI+Hb0RYOqptPZ2GjQw==, tarball: file:projects/logger.tgz}
     version: 0.0.0
 
   '@rush-temp/maps-common@file:projects/maps-common.tgz':
@@ -4299,8 +4308,8 @@ packages:
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express-serve-static-core@5.0.6':
-    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+  '@types/express-serve-static-core@5.0.7':
+    resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
 
   '@types/express@4.17.23':
     resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
@@ -4347,8 +4356,9 @@ packages:
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
-  '@types/minimatch@5.1.2':
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+  '@types/minimatch@6.0.0':
+    resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
+    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -4365,17 +4375,14 @@ packages:
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
 
-  '@types/node-forge@1.3.11':
-    resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
+  '@types/node-forge@1.3.12':
+    resolution: {integrity: sha512-a0ToKlRVnUw3aXKQq2F+krxZKq7B8LEQijzPn5RdFAMatARD2JX9o8FBpMXOOrjob0uc13aN+V/AXniOXW4d9A==}
 
-  '@types/node@18.19.112':
-    resolution: {integrity: sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==}
+  '@types/node@18.19.117':
+    resolution: {integrity: sha512-hcxGs9TfQGghOM8atpRT+bBMUX7V8WosdYt98bQ59wUToJck55eCOlemJ+0FpOZOQw5ff7LSi9+IO56KvYEFyQ==}
 
   '@types/node@20.19.1':
     resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
-
-  '@types/node@22.7.9':
-    resolution: {integrity: sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4508,9 +4515,9 @@ packages:
     resolution: {integrity: sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typespec/ts-http-runtime@0.2.3':
-    resolution: {integrity: sha512-oRhjSzcVjX8ExyaF8hC0zzTqxlVuRlgMHL/Bh4w3xB9+wjbm0FpXylVU/lBrn+kgphwYTrOk3tp+AVShGmlYCg==}
-    engines: {node: '>=18.0.0'}
+  '@typespec/ts-http-runtime@0.3.0':
+    resolution: {integrity: sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==}
+    engines: {node: '>=20.0.0'}
 
   '@vitest/browser@3.2.4':
     resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
@@ -4588,8 +4595,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.3:
-    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
   agentkeepalive@4.6.0:
@@ -4698,8 +4705,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  avsc@5.7.7:
-    resolution: {integrity: sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ==}
+  avsc@5.7.8:
+    resolution: {integrity: sha512-6SyyCw6XzdiNrkJ3UF9dIj0cVexNQAGxwjZ69CRgEneBxdDKjjc2IdfEJD11iP4BfwQWrL8HwR04bx/Y3uUNEA==}
     engines: {node: '>=0.11'}
 
   balanced-match@1.0.2:
@@ -4736,16 +4743,13 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.25.0:
-    resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
+  browserslist@4.25.1:
+    resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -4793,8 +4797,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001724:
-    resolution: {integrity: sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA==}
+  caniuse-lite@1.0.30001727:
+    resolution: {integrity: sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==}
 
   catharsis@0.9.0:
     resolution: {integrity: sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==}
@@ -4810,9 +4814,9 @@ packages:
     peerDependencies:
       chai: '>= 5'
 
-  chai@5.2.0:
-    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
-    engines: {node: '>=12'}
+  chai@5.2.1:
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -5079,8 +5083,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dotenv@16.5.0:
-    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -5099,8 +5103,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.172:
-    resolution: {integrity: sha512-fnKW9dGgmBfsebbYognQSv0CGGLFH1a5iV9EDYTBwmAQn+whbzHbLFlC+3XbHc8xaNtpO0etm8LOcRXs1qMRkQ==}
+  electron-to-chromium@1.5.182:
+    resolution: {integrity: sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -5122,8 +5126,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.18.1:
-    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+  enhanced-resolve@5.18.2:
+    resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -5156,8 +5160,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.25.5:
-    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
+  esbuild@0.25.6:
+    resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5203,8 +5207,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-n@17.20.0:
-    resolution: {integrity: sha512-IRSoatgB/NQJZG5EeTbv/iAx1byOGdbbyhQrNvWdCfTnmPxUT0ao9/eGOeG7ljD8wJBsxwE8f6tES5Db0FRKEw==}
+  eslint-plugin-n@17.21.0:
+    resolution: {integrity: sha512-1+iZ8We4ZlwVMtb/DcHG3y5/bZOdazIpa/4TySo22MLKdwrLcfrX0hbadnCvykSQCCmkAnWmIP8jZVb2AAq29A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
@@ -5234,8 +5238,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.29.0:
-    resolution: {integrity: sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==}
+  eslint@9.30.1:
+    resolution: {integrity: sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -5295,9 +5299,9 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.2:
-    resolution: {integrity: sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==}
-    engines: {node: '>=18.0.0'}
+  eventsource-parser@3.0.3:
+    resolution: {integrity: sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==}
+    engines: {node: '>=20.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
@@ -5307,8 +5311,8 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
-  expect-type@1.2.1:
-    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
@@ -5504,10 +5508,6 @@ packages:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
     deprecated: Glob versions prior to v9 are no longer supported
-
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -5862,9 +5862,6 @@ packages:
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
-
-  karma-source-map-support@1.4.0:
-    resolution: {integrity: sha512-RsBECncGO17KAoJCYXjv+ckIz+Ii9NCi+9enk+rq6XC81ezYkb4/RHE6CTXdA7IOJqoF3wcaLfVG0CPmE5ca6A==}
 
   keytar@7.9.0:
     resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
@@ -6412,16 +6409,16 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@2.0.0:
-    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-protocol@1.8.0:
-    resolution: {integrity: sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==}
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -6442,13 +6439,13 @@ packages:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
-  playwright-core@1.53.1:
-    resolution: {integrity: sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==}
+  playwright-core@1.54.0:
+    resolution: {integrity: sha512-uiWpWaJh3R3etpJ0QrpligEMl62Dk1iSAB6NUXylvmQz+e3eipXHDHvOvydDAssb5Oqo0E818qdn0L9GcJSTyA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.53.1:
-    resolution: {integrity: sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==}
+  playwright@1.54.0:
+    resolution: {integrity: sha512-y9yzHmXRwEUOpghM7XGcA38GjWuTOUMaTIcm/5rHcYVjh5MSp9qQMRRMc/+p1cx+csoPnX4wkxAF61v5VKirxg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6493,8 +6490,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.6.0:
-    resolution: {integrity: sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6664,8 +6661,8 @@ packages:
     resolution: {integrity: sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==}
     engines: {node: '>=8.3'}
 
-  rollup@4.44.0:
-    resolution: {integrity: sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==}
+  rollup@4.44.2:
+    resolution: {integrity: sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6814,9 +6811,6 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -7150,14 +7144,15 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.10.0:
-    resolution: {integrity: sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==}
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  undici@7.11.0:
+    resolution: {integrity: sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -7226,19 +7221,19 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.3.5:
-    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vite@7.0.4:
+    resolution: {integrity: sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
-      less: '*'
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -7360,8 +7355,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7422,20 +7417,20 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  zod-to-json-schema@3.24.5:
-    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.25.67:
-    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@andrewbranch/untar.js@1.0.3': {}
 
@@ -7463,21 +7458,21 @@ snapshots:
   '@azure-rest/core-client@1.4.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure-rest/core-client@2.4.0':
+  '@azure-rest/core-client@2.5.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@typespec/ts-http-runtime': 0.2.3
+      '@azure/core-auth': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7493,15 +7488,15 @@ snapshots:
   '@azure/app-configuration@1.8.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-http-compat': 2.3.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7509,11 +7504,11 @@ snapshots:
   '@azure/arm-cognitiveservices@7.6.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7521,11 +7516,11 @@ snapshots:
   '@azure/arm-cosmosdb@16.0.0-beta.6':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7533,11 +7528,11 @@ snapshots:
   '@azure/arm-eventhub@5.2.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7545,11 +7540,11 @@ snapshots:
   '@azure/arm-network@32.2.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7557,11 +7552,11 @@ snapshots:
   '@azure/arm-network@33.5.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7569,11 +7564,11 @@ snapshots:
   '@azure/arm-recoveryservices@5.4.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7581,11 +7576,11 @@ snapshots:
   '@azure/arm-resources@5.2.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7593,11 +7588,11 @@ snapshots:
   '@azure/arm-search@3.2.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7605,23 +7600,23 @@ snapshots:
   '@azure/arm-servicebus@6.1.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/communication-common@2.4.0':
     dependencies:
-      '@azure-rest/core-client': 2.4.0
+      '@azure-rest/core-client': 2.5.0
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
       events: 3.3.0
       jwt-decode: 4.0.0
       tslib: 2.8.1
@@ -7632,13 +7627,13 @@ snapshots:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/communication-common': 2.4.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7647,12 +7642,12 @@ snapshots:
   '@azure/communication-signaling@1.0.0-beta.31':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
       uuid: 8.3.2
@@ -7662,49 +7657,50 @@ snapshots:
   '@azure/communication-signaling@1.0.0-beta.34':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-amqp@4.3.6':
+  '@azure/core-amqp@4.4.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       buffer: 6.0.3
       events: 3.3.0
       process: 0.11.10
       rhea: 3.0.4
       rhea-promise: 3.0.3
       tslib: 2.8.1
+      util: 0.12.5
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-auth@1.9.0':
+  '@azure/core-auth@1.10.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0
+      '@azure/core-util': 1.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-client@1.9.4':
+  '@azure/core-client@1.10.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7712,16 +7708,16 @@ snapshots:
   '@azure/core-http-compat@2.3.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
     transitivePeerDependencies:
       - supports-color
 
   '@azure/core-lro@2.7.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7730,35 +7726,35 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-rest-pipeline@1.21.0':
+  '@azure/core-rest-pipeline@1.22.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
-      '@typespec/ts-http-runtime': 0.2.3
+      '@azure/core-auth': 1.10.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-sse@2.2.0':
+  '@azure/core-sse@2.3.0':
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-tracing@1.2.0':
+  '@azure/core-tracing@1.3.0':
     dependencies:
       tslib: 2.8.1
 
-  '@azure/core-util@1.12.0':
+  '@azure/core-util@1.13.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.2.3
+      '@typespec/ts-http-runtime': 0.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/core-xml@1.4.5':
+  '@azure/core-xml@1.5.0':
     dependencies:
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
@@ -7769,23 +7765,23 @@ snapshots:
       long: 4.0.0
       uuid: 8.3.2
 
-  '@azure/functions@4.7.3':
+  '@azure/functions@4.7.2':
     dependencies:
       cookie: 0.7.2
       long: 4.0.0
-      undici: 7.10.0
+      undici: 5.29.0
 
-  '@azure/identity@4.10.1':
+  '@azure/identity@4.10.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
-      '@azure/msal-browser': 4.13.2
-      '@azure/msal-node': 3.6.1
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 4.15.0
+      '@azure/msal-node': 3.6.3
       open: 10.1.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7794,12 +7790,12 @@ snapshots:
   '@azure/identity@4.3.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       '@azure/msal-browser': 3.28.1
       '@azure/msal-node': 2.16.2
       events: 3.3.0
@@ -7813,36 +7809,36 @@ snapshots:
   '@azure/keyvault-common@2.0.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/keyvault-keys@4.10.0':
     dependencies:
-      '@azure-rest/core-client': 2.4.0
+      '@azure-rest/core-client': 2.5.0
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
+      '@azure/core-auth': 1.10.0
       '@azure/core-http-compat': 2.3.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
       '@azure/keyvault-common': 2.0.0
-      '@azure/logger': 1.2.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/logger@1.2.0':
+  '@azure/logger@1.3.0':
     dependencies:
-      '@typespec/ts-http-runtime': 0.2.3
+      '@typespec/ts-http-runtime': 0.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7850,10 +7846,10 @@ snapshots:
   '@azure/maps-common@1.0.0-beta.2':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
-      '@azure/core-rest-pipeline': 1.21.0
+      '@azure/core-rest-pipeline': 1.22.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7861,17 +7857,17 @@ snapshots:
     dependencies:
       '@azure/msal-common': 14.16.0
 
-  '@azure/msal-browser@4.13.2':
+  '@azure/msal-browser@4.15.0':
     dependencies:
-      '@azure/msal-common': 15.7.1
+      '@azure/msal-common': 15.8.1
 
   '@azure/msal-common@14.16.0': {}
 
-  '@azure/msal-common@15.7.1': {}
+  '@azure/msal-common@15.8.1': {}
 
-  '@azure/msal-node-extensions@1.5.15':
+  '@azure/msal-node-extensions@1.5.17':
     dependencies:
-      '@azure/msal-common': 15.7.1
+      '@azure/msal-common': 15.8.1
       '@azure/msal-node-runtime': 0.18.2
       keytar: 7.9.0
 
@@ -7883,28 +7879,28 @@ snapshots:
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
 
-  '@azure/msal-node@3.6.1':
+  '@azure/msal-node@3.6.3':
     dependencies:
-      '@azure/msal-common': 15.7.1
+      '@azure/msal-common': 15.8.1
       jsonwebtoken: 9.0.2
       uuid: 8.3.2
 
   '@azure/openai@1.0.0-beta.12':
     dependencies:
       '@azure-rest/core-client': 1.4.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-sse': 2.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-sse': 2.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0-beta.7':
     dependencies:
-      '@azure/core-tracing': 1.2.0
-      '@azure/logger': 1.2.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/logger': 1.3.0
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.53.0(@opentelemetry/api@1.9.0)
@@ -7914,26 +7910,26 @@ snapshots:
 
   '@azure/schema-registry@1.3.0':
     dependencies:
-      '@azure-rest/core-client': 2.4.0
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/logger': 1.2.0
+      '@azure-rest/core-client': 2.5.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@azure/search-documents@12.1.0':
     dependencies:
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-http-compat': 2.3.0
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7942,15 +7938,15 @@ snapshots:
   '@azure/service-bus@7.9.5':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-amqp': 4.3.6
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-amqp': 4.4.0
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/core-xml': 1.4.5
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/core-xml': 1.5.0
+      '@azure/logger': 1.3.0
       '@types/is-buffer': 2.0.2
       buffer: 6.0.3
       is-buffer: 2.0.5
@@ -7965,16 +7961,16 @@ snapshots:
   '@azure/storage-blob@12.27.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-http-compat': 2.3.0
       '@azure/core-lro': 2.7.2
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/core-xml': 1.4.5
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/core-xml': 1.5.0
+      '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7983,15 +7979,15 @@ snapshots:
   '@azure/storage-file-datalake@12.26.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-http-compat': 2.3.0
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/core-xml': 1.4.5
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/core-xml': 1.5.0
+      '@azure/logger': 1.3.0
       '@azure/storage-blob': 12.27.0
       events: 3.3.0
       tslib: 2.8.1
@@ -8001,15 +7997,15 @@ snapshots:
   '@azure/storage-file-share@12.27.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-http-compat': 2.3.0
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/core-util': 1.12.0
-      '@azure/core-xml': 1.4.5
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/core-util': 1.13.0
+      '@azure/core-xml': 1.5.0
+      '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -8017,12 +8013,12 @@ snapshots:
 
   '@azure/template@1.0.13-beta.1':
     dependencies:
-      '@azure/core-auth': 1.9.0
-      '@azure/core-client': 1.9.4
+      '@azure/core-auth': 1.10.0
+      '@azure/core-client': 1.10.0
       '@azure/core-lro': 2.7.2
-      '@azure/core-rest-pipeline': 1.21.0
-      '@azure/core-tracing': 1.2.0
-      '@azure/logger': 1.2.0
+      '@azure/core-rest-pipeline': 1.22.0
+      '@azure/core-tracing': 1.3.0
+      '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -8030,8 +8026,8 @@ snapshots:
   '@azure/web-pubsub-client@1.0.0-beta.2':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-util': 1.12.0
-      '@azure/logger': 1.2.0
+      '@azure/core-util': 1.13.0
+      '@azure/logger': 1.3.0
       buffer: 6.0.3
       tslib: 2.8.1
       ws: 7.5.10
@@ -8046,20 +8042,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.27.5': {}
+  '@babel/compat-data@7.28.0': {}
 
-  '@babel/core@7.27.4':
+  '@babel/core@7.28.0':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.27.5
+      '@babel/generator': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.27.4)
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
       '@babel/helpers': 7.27.6
-      '@babel/parser': 7.27.5
+      '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.0
       convert-source-map: 2.0.0
       debug: 4.4.1
       gensync: 1.0.0-beta.2
@@ -8068,35 +8064,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.27.5':
+  '@babel/generator@7.28.0':
     dependencies:
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.6
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.0
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.1.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/compat-data': 7.27.5
+      '@babel/compat-data': 7.28.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.0
+      browserslist: 4.25.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-globals@7.28.0': {}
+
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
+      '@babel/traverse': 7.28.0
+      '@babel/types': 7.28.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.3(@babel/core@7.27.4)':
+  '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
     dependencies:
-      '@babel/core': 7.27.4
+      '@babel/core': 7.28.0
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.27.4
+      '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8109,33 +8107,33 @@ snapshots:
   '@babel/helpers@7.27.6':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.0
 
-  '@babel/parser@7.27.5':
+  '@babel/parser@7.28.0':
     dependencies:
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.0
 
   '@babel/runtime@7.27.6': {}
 
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.6
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.0
 
-  '@babel/traverse@7.27.4':
+  '@babel/traverse@7.28.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.27.5
-      '@babel/parser': 7.27.5
+      '@babel/generator': 7.28.0
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.0
       debug: 4.4.1
-      globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.27.6':
+  '@babel/types@7.28.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -8147,93 +8145,96 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@esbuild/aix-ppc64@0.25.5':
+  '@esbuild/aix-ppc64@0.25.6':
     optional: true
 
-  '@esbuild/android-arm64@0.25.5':
+  '@esbuild/android-arm64@0.25.6':
     optional: true
 
-  '@esbuild/android-arm@0.25.5':
+  '@esbuild/android-arm@0.25.6':
     optional: true
 
-  '@esbuild/android-x64@0.25.5':
+  '@esbuild/android-x64@0.25.6':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.5':
+  '@esbuild/darwin-arm64@0.25.6':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.5':
+  '@esbuild/darwin-x64@0.25.6':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.5':
+  '@esbuild/freebsd-arm64@0.25.6':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.5':
+  '@esbuild/freebsd-x64@0.25.6':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.5':
+  '@esbuild/linux-arm64@0.25.6':
     optional: true
 
-  '@esbuild/linux-arm@0.25.5':
+  '@esbuild/linux-arm@0.25.6':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.5':
+  '@esbuild/linux-ia32@0.25.6':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.5':
+  '@esbuild/linux-loong64@0.25.6':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.5':
+  '@esbuild/linux-mips64el@0.25.6':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.5':
+  '@esbuild/linux-ppc64@0.25.6':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.5':
+  '@esbuild/linux-riscv64@0.25.6':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.5':
+  '@esbuild/linux-s390x@0.25.6':
     optional: true
 
-  '@esbuild/linux-x64@0.25.5':
+  '@esbuild/linux-x64@0.25.6':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.5':
+  '@esbuild/netbsd-arm64@0.25.6':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.5':
+  '@esbuild/netbsd-x64@0.25.6':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.5':
+  '@esbuild/openbsd-arm64@0.25.6':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.5':
+  '@esbuild/openbsd-x64@0.25.6':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.5':
+  '@esbuild/openharmony-arm64@0.25.6':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.5':
+  '@esbuild/sunos-x64@0.25.6':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.5':
+  '@esbuild/win32-arm64@0.25.6':
     optional: true
 
-  '@esbuild/win32-x64@0.25.5':
+  '@esbuild/win32-ia32@0.25.6':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
+  '@esbuild/win32-x64@0.25.6':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.30.1)':
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.30.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.3.0(eslint@9.29.0)':
+  '@eslint/compat@1.3.1(eslint@9.30.1)':
     optionalDependencies:
-      eslint: 9.29.0
+      eslint: 9.30.1
 
-  '@eslint/config-array@0.20.1':
+  '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.1
@@ -8241,13 +8242,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.2.3': {}
+  '@eslint/config-helpers@0.3.0': {}
 
   '@eslint/core@0.14.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/core@0.15.0':
+  '@eslint/core@0.15.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -8265,14 +8266,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.29.0': {}
+  '@eslint/js@9.30.1': {}
 
   '@eslint/object-schema@2.1.6': {}
 
-  '@eslint/plugin-kit@0.3.2':
+  '@eslint/plugin-kit@0.3.3':
     dependencies:
-      '@eslint/core': 0.15.0
+      '@eslint/core': 0.15.1
       levn: 0.4.1
+
+  '@fastify/busboy@2.1.1': {}
 
   '@grpc/grpc-js@1.13.4':
     dependencies:
@@ -8322,22 +8325,19 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jridgewell/gen-mapping@0.3.8':
+  '@jridgewell/gen-mapping@0.3.12':
     dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/set-array@1.2.1': {}
+  '@jridgewell/sourcemap-codec@1.5.4': {}
 
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/trace-mapping@0.3.25':
+  '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -8402,19 +8402,20 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@modelcontextprotocol/sdk@1.13.1':
+  '@modelcontextprotocol/sdk@1.15.1':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
+      eventsource-parser: 3.0.3
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
-      zod: 3.25.67
-      zod-to-json-schema: 3.24.5(zod@3.25.67)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -8913,9 +8914,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.53.1':
+  '@playwright/test@1.54.0':
     dependencies:
-      playwright: 1.53.1
+      playwright: 1.54.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8942,99 +8943,99 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.44.0)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.44.2)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.44.0)
+      '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
       estree-walker: 2.0.2
       magic-string: 0.30.17
     optionalDependencies:
-      rollup: 4.44.0
+      rollup: 4.44.2
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@4.44.0)':
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.44.2)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.44.0)
+      '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.44.0
+      rollup: 4.44.2
 
-  '@rollup/pluginutils@5.2.0(rollup@4.44.0)':
+  '@rollup/pluginutils@5.2.0(rollup@4.44.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.44.0
+      rollup: 4.44.2
 
-  '@rollup/rollup-android-arm-eabi@4.44.0':
+  '@rollup/rollup-android-arm-eabi@4.44.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.44.0':
+  '@rollup/rollup-android-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.44.0':
+  '@rollup/rollup-darwin-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.44.0':
+  '@rollup/rollup-darwin-x64@4.44.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.44.0':
+  '@rollup/rollup-freebsd-arm64@4.44.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.44.0':
+  '@rollup/rollup-freebsd-x64@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.44.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.44.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.44.0':
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.44.0':
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.44.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.44.0':
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.44.0':
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.44.0':
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.44.0':
+  '@rollup/rollup-linux-x64-musl@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.44.0':
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.44.0':
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.44.0':
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
 
-  '@rush-temp/abort-controller@file:projects/abort-controller.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/abort-controller@file:projects/abort-controller.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9062,15 +9063,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/agrifood-farming@file:projects/agrifood-farming.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/agrifood-farming@file:projects/agrifood-farming.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9098,18 +9099,18 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-agents@file:projects/ai-agents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-agents@file:projects/ai-agents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.57.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      prettier: 3.6.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      prettier: 3.6.2
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9137,17 +9138,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-anomaly-detector@file:projects/ai-anomaly-detector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-anomaly-detector@file:projects/ai-anomaly-detector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
       csv-parse: 5.6.0
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9175,15 +9176,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-content-safety@file:projects/ai-content-safety.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-content-safety@file:projects/ai-content-safety.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       rollup-plugin-copy: 3.5.0
       tslib: 2.8.1
       typescript: 5.8.3
@@ -9212,15 +9213,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-document-intelligence@file:projects/ai-document-intelligence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-document-intelligence@file:projects/ai-document-intelligence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9248,14 +9249,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-document-translator@file:projects/ai-document-translator.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-document-translator@file:projects/ai-document-translator.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9283,20 +9284,20 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-form-recognizer@file:projects/ai-form-recognizer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-form-recognizer@file:projects/ai-form-recognizer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@azure/core-lro': 2.7.2
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.44.0)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.44.2)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       magic-string: 0.30.17
-      playwright: 1.53.1
-      prettier: 3.6.0
-      rollup: 4.44.0
+      playwright: 1.54.0
+      prettier: 3.6.2
+      rollup: 4.44.2
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9324,7 +9325,7 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-inference@file:projects/ai-inference.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-inference@file:projects/ai-inference.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.7
@@ -9332,12 +9333,12 @@ snapshots:
       '@opentelemetry/instrumentation': 0.200.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9365,16 +9366,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-language-conversations@file:projects/ai-language-conversations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-language-conversations@file:projects/ai-language-conversations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9402,19 +9403,19 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-language-text@file:projects/ai-language-text.tgz(@types/debug@4.1.12)(chai@5.2.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-language-text@file:projects/ai-language-text.tgz(@types/debug@4.1.12)(chai@5.2.1)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@azure/core-lro': 2.7.2
       '@azure/storage-blob': 12.27.0
       '@types/node': 20.19.1
       '@types/unzipper': 0.10.11
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      chai-exclude: 3.0.1(chai@5.2.0)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      chai-exclude: 3.0.1(chai@5.2.1)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       unzipper: 0.12.3
@@ -9444,15 +9445,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-metrics-advisor@file:projects/ai-metrics-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-metrics-advisor@file:projects/ai-metrics-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9480,7 +9481,7 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-projects@file:projects/ai-projects.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.2)(yaml@2.8.0)(zod@3.25.67)':
+  '@rush-temp/ai-projects@file:projects/ai-projects.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.3)(yaml@2.8.0)(zod@3.25.76)':
     dependencies:
       '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.7
       '@azure/storage-blob': 12.27.0
@@ -9488,12 +9489,12 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      openai: 4.104.0(ws@8.18.2)(zod@3.25.67)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      openai: 4.104.0(ws@8.18.3)(zod@3.25.76)
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9524,16 +9525,16 @@ snapshots:
       - yaml
       - zod
 
-  '@rush-temp/ai-text-analytics@file:projects/ai-text-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-text-analytics@file:projects/ai-text-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9561,17 +9562,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-translation-document@file:projects/ai-translation-document.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-translation-document@file:projects/ai-translation-document.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@azure/storage-blob': 12.27.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9599,16 +9600,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-translation-text@file:projects/ai-translation-text.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-translation-text@file:projects/ai-translation-text.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9636,15 +9637,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-vision-face@file:projects/ai-vision-face.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-vision-face@file:projects/ai-vision-face.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      prettier: 3.6.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      prettier: 3.6.2
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9672,15 +9673,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ai-vision-image-analysis@file:projects/ai-vision-image-analysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ai-vision-image-analysis@file:projects/ai-vision-image-analysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9710,7 +9711,7 @@ snapshots:
 
   '@rush-temp/api-management-custom-widgets-scaffolder@file:projects/api-management-custom-widgets-scaffolder.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)':
     dependencies:
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.44.0)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.44.2)
       '@types/inquirer': 9.0.8
       '@types/mustache': 4.2.6
       '@types/node': 20.19.1
@@ -9718,13 +9719,13 @@ snapshots:
       '@types/yargs-parser': 21.0.3
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       chalk: 4.1.2
-      eslint: 9.29.0
+      eslint: 9.30.1
       glob: 10.4.5
       inquirer: 9.3.7
       magic-string: 0.30.17
       mustache: 4.2.0
-      prettier: 3.6.0
-      rollup: 4.44.0
+      prettier: 3.6.2
+      rollup: 4.44.2
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9750,16 +9751,16 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/api-management-custom-widgets-tools@file:projects/api-management-custom-widgets-tools.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/api-management-custom-widgets-tools@file:projects/api-management-custom-widgets-tools.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure/storage-blob': 12.27.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       mime: 4.0.7
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9787,16 +9788,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/app-configuration@file:projects/app-configuration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/app-configuration@file:projects/app-configuration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       nock: 13.5.6
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9824,13 +9825,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-advisor@file:projects/arm-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-advisor@file:projects/arm-advisor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9858,14 +9859,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-agricultureplatform@file:projects/arm-agricultureplatform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-agricultureplatform@file:projects/arm-agricultureplatform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9954,7 +9955,7 @@ snapshots:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
+      dotenv: 16.6.1
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -9978,14 +9979,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/arm-apimanagement@file:projects/arm-apimanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-apimanagement@file:projects/arm-apimanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10013,14 +10014,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-appcomplianceautomation@file:projects/arm-appcomplianceautomation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-appcomplianceautomation@file:projects/arm-appcomplianceautomation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10048,14 +10049,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-appconfiguration@file:projects/arm-appconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-appconfiguration@file:projects/arm-appconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10083,14 +10084,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-appcontainers@file:projects/arm-appcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-appcontainers@file:projects/arm-appcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10118,13 +10119,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-appinsights@file:projects/arm-appinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-appinsights@file:projects/arm-appinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10152,49 +10153,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-appservice-1@file:projects/arm-appservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-appservice-profile-2020-09-01-hybrid@file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-appservice-1@file:projects/arm-appservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10222,15 +10188,50 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-appservice@file:projects/arm-appservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-appservice-profile-2020-09-01-hybrid@file:projects/arm-appservice-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-appservice@file:projects/arm-appservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10258,14 +10259,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-arizeaiobservabilityeval@file:projects/arm-arizeaiobservabilityeval.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-arizeaiobservabilityeval@file:projects/arm-arizeaiobservabilityeval.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10293,116 +10294,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-astro@file:projects/arm-astro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-attestation@file:projects/arm-attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-authorization-profile-2020-09-01-hybrid@file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-authorization@file:projects/arm-authorization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-astro@file:projects/arm-astro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10430,13 +10329,12 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-automanage@file:projects/arm-automanage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-attestation@file:projects/arm-attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10464,49 +10362,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-automation@file:projects/arm-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-avs@file:projects/arm-avs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-authorization-profile-2020-09-01-hybrid@file:projects/arm-authorization-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10534,13 +10396,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-azureadexternalidentities@file:projects/arm-azureadexternalidentities.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-authorization@file:projects/arm-authorization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10568,12 +10431,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-azurestack@file:projects/arm-azurestack.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-automanage@file:projects/arm-automanage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10601,49 +10465,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-azurestackhci@file:projects/arm-azurestackhci.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-baremetalinfrastructure@file:projects/arm-baremetalinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-automation@file:projects/arm-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10671,14 +10500,48 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-batch@file:projects/arm-batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-avs@file:projects/arm-avs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-azureadexternalidentities@file:projects/arm-azureadexternalidentities.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10706,14 +10569,47 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-billing@file:projects/arm-billing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-azurestack@file:projects/arm-azurestack.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-azurestackhci@file:projects/arm-azurestackhci.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10741,13 +10637,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-billingbenefits@file:projects/arm-billingbenefits.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-baremetalinfrastructure@file:projects/arm-baremetalinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10775,14 +10672,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-botservice@file:projects/arm-botservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-batch@file:projects/arm-batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10810,49 +10707,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-carbonoptimization@file:projects/arm-carbonoptimization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-cdn@file:projects/arm-cdn.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-billing@file:projects/arm-billing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10880,12 +10742,83 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-changeanalysis@file:projects/arm-changeanalysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-billingbenefits@file:projects/arm-billingbenefits.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-botservice@file:projects/arm-botservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-carbonoptimization@file:projects/arm-carbonoptimization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10913,12 +10846,47 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-changes@file:projects/arm-changes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-cdn@file:projects/arm-cdn.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-changeanalysis@file:projects/arm-changeanalysis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10946,15 +10914,48 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-chaos@file:projects/arm-chaos.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-changes@file:projects/arm-changes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-chaos@file:projects/arm-chaos.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cosmosdb': 16.0.0-beta.6
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -10982,14 +10983,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-cloudhealth@file:projects/arm-cloudhealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-cloudhealth@file:projects/arm-cloudhealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11017,149 +11018,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-cognitiveservices@file:projects/arm-cognitiveservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-commerce-profile-2020-09-01-hybrid@file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-commerce@file:projects/arm-commerce.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-commitmentplans@file:projects/arm-commitmentplans.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-communication@file:projects/arm-communication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-cognitiveservices@file:projects/arm-cognitiveservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11187,15 +11053,150 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-compute-1@file:projects/arm-compute-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-commerce-profile-2020-09-01-hybrid@file:projects/arm-commerce-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-commerce@file:projects/arm-commerce.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-commitmentplans@file:projects/arm-commitmentplans.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-communication@file:projects/arm-communication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-compute-1@file:projects/arm-compute-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11223,14 +11224,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-compute-profile-2020-09-01-hybrid@file:projects/arm-compute-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-compute-profile-2020-09-01-hybrid@file:projects/arm-compute-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11258,16 +11259,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-compute@file:projects/arm-compute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-compute@file:projects/arm-compute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-network': 32.2.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11295,14 +11296,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-computefleet@file:projects/arm-computefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-computefleet@file:projects/arm-computefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11330,14 +11331,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-computeschedule@file:projects/arm-computeschedule.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-computeschedule@file:projects/arm-computeschedule.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11365,14 +11366,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-confidentialledger@file:projects/arm-confidentialledger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-confidentialledger@file:projects/arm-confidentialledger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11400,14 +11401,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-confluent@file:projects/arm-confluent.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-confluent@file:projects/arm-confluent.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11435,14 +11436,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-connectedcache@file:projects/arm-connectedcache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-connectedcache@file:projects/arm-connectedcache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11470,83 +11471,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-connectedvmware@file:projects/arm-connectedvmware.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-consumption@file:projects/arm-consumption.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-containerinstance@file:projects/arm-containerinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-connectedvmware@file:projects/arm-connectedvmware.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11574,14 +11506,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-containerorchestratorruntime@file:projects/arm-containerorchestratorruntime.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-consumption@file:projects/arm-consumption.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11609,49 +11540,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-containerregistry@file:projects/arm-containerregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-containerservice-1@file:projects/arm-containerservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-containerinstance@file:projects/arm-containerinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11679,16 +11575,121 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-containerservice@file:projects/arm-containerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-containerorchestratorruntime@file:projects/arm-containerorchestratorruntime.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-containerregistry@file:projects/arm-containerregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-containerservice-1@file:projects/arm-containerservice-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-containerservice@file:projects/arm-containerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11716,14 +11717,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-containerservicefleet@file:projects/arm-containerservicefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-containerservicefleet@file:projects/arm-containerservicefleet.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11751,49 +11752,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-cosmosdb@file:projects/arm-cosmosdb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-cosmosdbforpostgresql@file:projects/arm-cosmosdbforpostgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-cosmosdb@file:projects/arm-cosmosdb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11821,14 +11787,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-costmanagement@file:projects/arm-costmanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-cosmosdbforpostgresql@file:projects/arm-cosmosdbforpostgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11856,13 +11822,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-customerinsights@file:projects/arm-customerinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-costmanagement@file:projects/arm-costmanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11890,14 +11857,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-dashboard@file:projects/arm-dashboard.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-customerinsights@file:projects/arm-customerinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11925,14 +11891,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-databasewatcher@file:projects/arm-databasewatcher.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dashboard@file:projects/arm-dashboard.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-databasewatcher@file:projects/arm-databasewatcher.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11960,13 +11961,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-databoundaries@file:projects/arm-databoundaries.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-databoundaries@file:projects/arm-databoundaries.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -11994,14 +11995,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-databox@file:projects/arm-databox.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-databox@file:projects/arm-databox.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12029,14 +12030,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid@file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-databoxedge-profile-2020-09-01-hybrid@file:projects/arm-databoxedge-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12064,13 +12065,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-databoxedge@file:projects/arm-databoxedge.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-databoxedge@file:projects/arm-databoxedge.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12098,14 +12099,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-databricks@file:projects/arm-databricks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-databricks@file:projects/arm-databricks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12133,13 +12134,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-datacatalog@file:projects/arm-datacatalog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-datacatalog@file:projects/arm-datacatalog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12167,14 +12168,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-datadog@file:projects/arm-datadog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-datadog@file:projects/arm-datadog.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12202,14 +12203,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-datafactory@file:projects/arm-datafactory.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-datafactory@file:projects/arm-datafactory.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12237,13 +12238,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-datalake-analytics@file:projects/arm-datalake-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-datalake-analytics@file:projects/arm-datalake-analytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12271,13 +12272,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-datamigration@file:projects/arm-datamigration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-datamigration@file:projects/arm-datamigration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12305,14 +12306,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-dataprotection@file:projects/arm-dataprotection.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dataprotection@file:projects/arm-dataprotection.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12340,14 +12341,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-defendereasm@file:projects/arm-defendereasm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-defendereasm@file:projects/arm-defendereasm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12375,14 +12376,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-dependencymap@file:projects/arm-dependencymap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dependencymap@file:projects/arm-dependencymap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12410,82 +12411,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-deploymentmanager@file:projects/arm-deploymentmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-desktopvirtualization@file:projects/arm-desktopvirtualization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-devcenter@file:projects/arm-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-deploymentmanager@file:projects/arm-deploymentmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12513,13 +12445,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-devhub@file:projects/arm-devhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-desktopvirtualization@file:projects/arm-desktopvirtualization.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12547,14 +12479,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-deviceprovisioningservices@file:projects/arm-deviceprovisioningservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-devcenter@file:projects/arm-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12582,14 +12514,83 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-deviceregistry@file:projects/arm-deviceregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-devhub@file:projects/arm-devhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-deviceprovisioningservices@file:projects/arm-deviceprovisioningservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-deviceregistry@file:projects/arm-deviceregistry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12617,14 +12618,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-deviceupdate@file:projects/arm-deviceupdate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-deviceupdate@file:projects/arm-deviceupdate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12652,14 +12653,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-devopsinfrastructure@file:projects/arm-devopsinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-devopsinfrastructure@file:projects/arm-devopsinfrastructure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12687,47 +12688,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-devspaces@file:projects/arm-devspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-devtestlabs@file:projects/arm-devtestlabs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-devspaces@file:projects/arm-devspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12755,14 +12722,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-digitaltwins@file:projects/arm-digitaltwins.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-devtestlabs@file:projects/arm-devtestlabs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12790,14 +12756,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-dns-profile-2020-09-01-hybrid@file:projects/arm-dns-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-digitaltwins@file:projects/arm-digitaltwins.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12825,14 +12791,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-dns@file:projects/arm-dns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dns-profile-2020-09-01-hybrid@file:projects/arm-dns-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12860,14 +12826,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-dnsresolver@file:projects/arm-dnsresolver.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dns@file:projects/arm-dns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12895,13 +12861,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-domainservices@file:projects/arm-domainservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dnsresolver@file:projects/arm-dnsresolver.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12929,49 +12896,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-durabletask@file:projects/arm-durabletask.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-dynatrace@file:projects/arm-dynatrace.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-domainservices@file:projects/arm-domainservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -12999,14 +12930,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-edgezones@file:projects/arm-edgezones.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-durabletask@file:projects/arm-durabletask.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13034,48 +12965,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-education@file:projects/arm-education.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-elastic@file:projects/arm-elastic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-dynatrace@file:projects/arm-dynatrace.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13103,14 +13000,83 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-elasticsan@file:projects/arm-elasticsan.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-edgezones@file:projects/arm-edgezones.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-education@file:projects/arm-education.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-elastic@file:projects/arm-elastic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13138,14 +13104,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-eventgrid@file:projects/arm-eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-elasticsan@file:projects/arm-elasticsan.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13173,14 +13139,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid@file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-eventgrid@file:projects/arm-eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13208,15 +13174,50 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-eventhub@file:projects/arm-eventhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-eventhub-profile-2020-09-01-hybrid@file:projects/arm-eventhub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-eventhub@file:projects/arm-eventhub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13244,14 +13245,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-extendedlocation@file:projects/arm-extendedlocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-extendedlocation@file:projects/arm-extendedlocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13279,15 +13280,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-fabric@file:projects/arm-fabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-fabric@file:projects/arm-fabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      prettier: 3.6.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      prettier: 3.6.2
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13315,12 +13316,12 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-features@file:projects/arm-features.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-features@file:projects/arm-features.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13348,13 +13349,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-fluidrelay@file:projects/arm-fluidrelay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-fluidrelay@file:projects/arm-fluidrelay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13382,49 +13383,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-frontdoor@file:projects/arm-frontdoor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-graphservices@file:projects/arm-graphservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-frontdoor@file:projects/arm-frontdoor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13452,47 +13418,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-guestconfiguration@file:projects/arm-guestconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-hanaonazure@file:projects/arm-hanaonazure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-graphservices@file:projects/arm-graphservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13520,16 +13453,84 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hardwaresecuritymodules@file:projects/arm-hardwaresecuritymodules.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-guestconfiguration@file:projects/arm-guestconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-hanaonazure@file:projects/arm-hanaonazure.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-hardwaresecuritymodules@file:projects/arm-hardwaresecuritymodules.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       cross-env: 7.0.3
-      dotenv: 16.5.0
+      dotenv: 16.6.1
       mkdirp: 3.0.1
-      playwright: 1.53.1
+      playwright: 1.54.0
       rimraf: 5.0.10
       tslib: 2.8.1
       typescript: 5.8.3
@@ -13558,14 +13559,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hdinsight@file:projects/arm-hdinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hdinsight@file:projects/arm-hdinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13593,14 +13594,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hdinsightcontainers@file:projects/arm-hdinsightcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hdinsightcontainers@file:projects/arm-hdinsightcontainers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13628,13 +13629,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-healthbot@file:projects/arm-healthbot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-healthbot@file:projects/arm-healthbot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13662,14 +13663,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-healthcareapis@file:projects/arm-healthcareapis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-healthcareapis@file:projects/arm-healthcareapis.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13697,16 +13698,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-healthdataaiservices@file:projects/arm-healthdataaiservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-healthdataaiservices@file:projects/arm-healthdataaiservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@microsoft/api-extractor': 7.52.8(@types/node@20.19.1)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tshy: 3.0.2
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13734,14 +13733,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hybridcompute@file:projects/arm-hybridcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hybridcompute@file:projects/arm-hybridcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13769,14 +13768,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hybridconnectivity@file:projects/arm-hybridconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hybridconnectivity@file:projects/arm-hybridconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13804,14 +13803,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hybridcontainerservice@file:projects/arm-hybridcontainerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hybridcontainerservice@file:projects/arm-hybridcontainerservice.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13839,14 +13838,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hybridkubernetes@file:projects/arm-hybridkubernetes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hybridkubernetes@file:projects/arm-hybridkubernetes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13874,14 +13873,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-hybridnetwork@file:projects/arm-hybridnetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-hybridnetwork@file:projects/arm-hybridnetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13909,14 +13908,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-imagebuilder@file:projects/arm-imagebuilder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-imagebuilder@file:projects/arm-imagebuilder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13944,14 +13943,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-impactreporting@file:projects/arm-impactreporting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-impactreporting@file:projects/arm-impactreporting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -13979,14 +13978,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-informaticadatamanagement@file:projects/arm-informaticadatamanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-informaticadatamanagement@file:projects/arm-informaticadatamanagement.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14014,13 +14013,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-iotcentral@file:projects/arm-iotcentral.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-iotcentral@file:projects/arm-iotcentral.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14048,14 +14047,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-iotfirmwaredefense@file:projects/arm-iotfirmwaredefense.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-iotfirmwaredefense@file:projects/arm-iotfirmwaredefense.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14083,49 +14082,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-iothub-profile-2020-09-01-hybrid@file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-iothub@file:projects/arm-iothub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-iothub-profile-2020-09-01-hybrid@file:projects/arm-iothub-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14153,49 +14117,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-iotoperations@file:projects/arm-iotoperations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid@file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-iothub@file:projects/arm-iothub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14223,14 +14152,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-keyvault@file:projects/arm-keyvault.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-iotoperations@file:projects/arm-iotoperations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-keyvault-profile-2020-09-01-hybrid@file:projects/arm-keyvault-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14258,14 +14222,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-kubernetesconfiguration-extensions@file:projects/arm-kubernetesconfiguration-extensions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-keyvault@file:projects/arm-keyvault.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14293,48 +14257,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-kubernetesconfiguration-extensiontypes@file:projects/arm-kubernetesconfiguration-extensiontypes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-kubernetesconfiguration-fluxconfigurations@file:projects/arm-kubernetesconfiguration-fluxconfigurations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-kubernetesconfiguration-extensions@file:projects/arm-kubernetesconfiguration-extensions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14362,14 +14292,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-kubernetesconfiguration-privatelinkscopes@file:projects/arm-kubernetesconfiguration-privatelinkscopes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-kubernetesconfiguration-extensiontypes@file:projects/arm-kubernetesconfiguration-extensiontypes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14397,14 +14326,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-kubernetesconfiguration@file:projects/arm-kubernetesconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-kubernetesconfiguration-fluxconfigurations@file:projects/arm-kubernetesconfiguration-fluxconfigurations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14432,14 +14361,84 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-kusto@file:projects/arm-kusto.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-kubernetesconfiguration-privatelinkscopes@file:projects/arm-kubernetesconfiguration-privatelinkscopes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-kubernetesconfiguration@file:projects/arm-kubernetesconfiguration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-kusto@file:projects/arm-kusto.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14467,14 +14466,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-labservices@file:projects/arm-labservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-labservices@file:projects/arm-labservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14502,14 +14501,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-lambdatesthyperexecute@file:projects/arm-lambdatesthyperexecute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-lambdatesthyperexecute@file:projects/arm-lambdatesthyperexecute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14537,14 +14536,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-largeinstance@file:projects/arm-largeinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-largeinstance@file:projects/arm-largeinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14572,13 +14571,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-links@file:projects/arm-links.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-links@file:projects/arm-links.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-resources': 5.2.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14606,14 +14605,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-loadtesting@file:projects/arm-loadtesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-loadtesting@file:projects/arm-loadtesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14641,13 +14640,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-locks-profile-2020-09-01-hybrid@file:projects/arm-locks-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-locks-profile-2020-09-01-hybrid@file:projects/arm-locks-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14675,12 +14674,12 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-locks@file:projects/arm-locks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-locks@file:projects/arm-locks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14708,49 +14707,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-logic@file:projects/arm-logic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-machinelearning@file:projects/arm-machinelearning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-logic@file:projects/arm-logic.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14778,13 +14742,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-machinelearningcompute@file:projects/arm-machinelearningcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-machinelearning@file:projects/arm-machinelearning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14812,82 +14777,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-machinelearningexperimentation@file:projects/arm-machinelearningexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-maintenance@file:projects/arm-maintenance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-managedapplications@file:projects/arm-managedapplications.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-machinelearningcompute@file:projects/arm-machinelearningcompute.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14915,14 +14811,82 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-managednetworkfabric@file:projects/arm-managednetworkfabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-machinelearningexperimentation@file:projects/arm-machinelearningexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-maintenance@file:projects/arm-maintenance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-managedapplications@file:projects/arm-managedapplications.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14950,13 +14914,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-managementgroups@file:projects/arm-managementgroups.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-managednetworkfabric@file:projects/arm-managednetworkfabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -14984,81 +14949,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-managementpartner@file:projects/arm-managementpartner.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-maps@file:projects/arm-maps.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-mariadb@file:projects/arm-mariadb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-managementgroups@file:projects/arm-managementgroups.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15086,13 +14983,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-marketplaceordering@file:projects/arm-marketplaceordering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-managementpartner@file:projects/arm-managementpartner.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15120,13 +15017,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-migrate@file:projects/arm-migrate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-maps@file:projects/arm-maps.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15154,49 +15051,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-migrationassessment@file:projects/arm-migrationassessment.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-migrationdiscoverysap@file:projects/arm-migrationdiscoverysap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-mariadb@file:projects/arm-mariadb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15224,14 +15085,82 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-mobilenetwork@file:projects/arm-mobilenetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-marketplaceordering@file:projects/arm-marketplaceordering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-migrate@file:projects/arm-migrate.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-migrationassessment@file:projects/arm-migrationassessment.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15259,15 +15188,85 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-mongocluster@file:projects/arm-mongocluster.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-migrationdiscoverysap@file:projects/arm-migrationdiscoverysap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-mobilenetwork@file:projects/arm-mobilenetwork.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-mongocluster@file:projects/arm-mongocluster.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-network': 33.5.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15295,14 +15294,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-mongodbatlas@file:projects/arm-mongodbatlas.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-mongodbatlas@file:projects/arm-mongodbatlas.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15330,13 +15329,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-monitor-profile-2020-09-01-hybrid@file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-monitor-profile-2020-09-01-hybrid@file:projects/arm-monitor-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15364,15 +15363,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-monitor@file:projects/arm-monitor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-monitor@file:projects/arm-monitor.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-eventhub': 5.2.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15400,13 +15399,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-msi@file:projects/arm-msi.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-msi@file:projects/arm-msi.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15434,48 +15433,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-mysql-flexible@file:projects/arm-mysql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-mysql@file:projects/arm-mysql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-mysql-flexible@file:projects/arm-mysql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15503,49 +15468,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-neonpostgres@file:projects/arm-neonpostgres.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-netapp@file:projects/arm-netapp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-mysql@file:projects/arm-mysql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15573,14 +15502,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-network-1@file:projects/arm-network-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-neonpostgres@file:projects/arm-neonpostgres.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-netapp@file:projects/arm-netapp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15608,14 +15572,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-network-profile-2020-09-01-hybrid@file:projects/arm-network-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-network-1@file:projects/arm-network-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15643,16 +15607,51 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-network@file:projects/arm-network.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-network-profile-2020-09-01-hybrid@file:projects/arm-network-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-network@file:projects/arm-network.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15680,14 +15679,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-networkcloud@file:projects/arm-networkcloud.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-networkcloud@file:projects/arm-networkcloud.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15715,13 +15714,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-networkfunction@file:projects/arm-networkfunction.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-networkfunction@file:projects/arm-networkfunction.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15749,14 +15748,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-newrelicobservability@file:projects/arm-newrelicobservability.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-newrelicobservability@file:projects/arm-newrelicobservability.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15784,14 +15783,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-nginx@file:projects/arm-nginx.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-nginx@file:projects/arm-nginx.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15819,14 +15818,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-notificationhubs@file:projects/arm-notificationhubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-notificationhubs@file:projects/arm-notificationhubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15854,13 +15853,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-oep@file:projects/arm-oep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-oep@file:projects/arm-oep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15888,14 +15887,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-onlineexperimentation@file:projects/arm-onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-onlineexperimentation@file:projects/arm-onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15923,48 +15922,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-operationalinsights@file:projects/arm-operationalinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-operations@file:projects/arm-operations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-operationalinsights@file:projects/arm-operationalinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -15992,49 +15957,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-oracledatabase@file:projects/arm-oracledatabase.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-orbital@file:projects/arm-orbital.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-operations@file:projects/arm-operations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16062,14 +15991,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-paloaltonetworksngfw@file:projects/arm-paloaltonetworksngfw.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-oracledatabase@file:projects/arm-oracledatabase.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-orbital@file:projects/arm-orbital.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16097,12 +16061,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-peering@file:projects/arm-peering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-paloaltonetworksngfw@file:projects/arm-paloaltonetworksngfw.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
+      '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16130,14 +16096,47 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-pineconevectordb@file:projects/arm-pineconevectordb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-peering@file:projects/arm-peering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-pineconevectordb@file:projects/arm-pineconevectordb.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16165,14 +16164,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-planetarycomputer@file:projects/arm-planetarycomputer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-planetarycomputer@file:projects/arm-planetarycomputer.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16200,14 +16199,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-playwrighttesting@file:projects/arm-playwrighttesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-playwrighttesting@file:projects/arm-playwrighttesting.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16235,13 +16234,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-policy-profile-2020-09-01-hybrid@file:projects/arm-policy-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-policy-profile-2020-09-01-hybrid@file:projects/arm-policy-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16269,13 +16268,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-policy@file:projects/arm-policy.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-policy@file:projects/arm-policy.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16303,14 +16302,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-policyinsights@file:projects/arm-policyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-policyinsights@file:projects/arm-policyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16338,13 +16337,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-portal@file:projects/arm-portal.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-portal@file:projects/arm-portal.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16372,14 +16371,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-portalservicescopilot@file:projects/arm-portalservicescopilot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-portalservicescopilot@file:projects/arm-portalservicescopilot.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16407,14 +16406,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-postgresql-flexible@file:projects/arm-postgresql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-postgresql-flexible@file:projects/arm-postgresql-flexible.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16442,13 +16441,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-postgresql@file:projects/arm-postgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-postgresql@file:projects/arm-postgresql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16476,14 +16475,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-powerbidedicated@file:projects/arm-powerbidedicated.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-powerbidedicated@file:projects/arm-powerbidedicated.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16511,13 +16510,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-powerbiembedded@file:projects/arm-powerbiembedded.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-powerbiembedded@file:projects/arm-powerbiembedded.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16545,14 +16544,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-privatedns@file:projects/arm-privatedns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-privatedns@file:projects/arm-privatedns.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16580,14 +16579,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-programmableconnectivity@file:projects/arm-programmableconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-programmableconnectivity@file:projects/arm-programmableconnectivity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16615,14 +16614,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-purestorageblock@file:projects/arm-purestorageblock.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-purestorageblock@file:projects/arm-purestorageblock.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16650,48 +16649,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-purview@file:projects/arm-purview.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-quantum@file:projects/arm-quantum.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-purview@file:projects/arm-purview.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16719,14 +16683,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-qumulo@file:projects/arm-qumulo.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-quantum@file:projects/arm-quantum.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16754,14 +16718,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-quota@file:projects/arm-quota.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-qumulo@file:projects/arm-qumulo.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-quota@file:projects/arm-quota.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16789,14 +16788,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-recoveryservices-siterecovery@file:projects/arm-recoveryservices-siterecovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-recoveryservices-siterecovery@file:projects/arm-recoveryservices-siterecovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16824,14 +16823,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-recoveryservices@file:projects/arm-recoveryservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-recoveryservices@file:projects/arm-recoveryservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16859,15 +16858,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-recoveryservicesbackup@file:projects/arm-recoveryservicesbackup.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-recoveryservicesbackup@file:projects/arm-recoveryservicesbackup.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-recoveryservices': 5.4.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16895,14 +16894,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-recoveryservicesdatareplication@file:projects/arm-recoveryservicesdatareplication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-recoveryservicesdatareplication@file:projects/arm-recoveryservicesdatareplication.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16930,14 +16929,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-redhatopenshift@file:projects/arm-redhatopenshift.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-redhatopenshift@file:projects/arm-redhatopenshift.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -16965,15 +16964,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-rediscache@file:projects/arm-rediscache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-rediscache@file:projects/arm-rediscache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-network': 32.2.0
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.6.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17001,14 +17000,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-redisenterprisecache@file:projects/arm-redisenterprisecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-redisenterprisecache@file:projects/arm-redisenterprisecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17036,14 +17035,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-relay@file:projects/arm-relay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-relay@file:projects/arm-relay.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17071,14 +17070,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-reservations@file:projects/arm-reservations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-reservations@file:projects/arm-reservations.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17106,14 +17105,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resourceconnector@file:projects/arm-resourceconnector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resourceconnector@file:projects/arm-resourceconnector.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17141,12 +17140,12 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resourcegraph@file:projects/arm-resourcegraph.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resourcegraph@file:projects/arm-resourcegraph.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17174,13 +17173,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resourcehealth@file:projects/arm-resourcehealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resourcehealth@file:projects/arm-resourcehealth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17208,49 +17207,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resourcemover@file:projects/arm-resourcemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-resources-profile-2020-09-01-hybrid@file:projects/arm-resources-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resourcemover@file:projects/arm-resourcemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17278,48 +17242,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resources-subscriptions@file:projects/arm-resources-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-resources@file:projects/arm-resources.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resources-profile-2020-09-01-hybrid@file:projects/arm-resources-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17347,14 +17277,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resourcesbicep@file:projects/arm-resourcesbicep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resources-subscriptions@file:projects/arm-resources-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17382,49 +17311,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-resourcesdeploymentstacks@file:projects/arm-resourcesdeploymentstacks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-scvmm@file:projects/arm-scvmm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resources@file:projects/arm-resources.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17452,14 +17346,119 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-search@file:projects/arm-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-resourcesbicep@file:projects/arm-resourcesbicep.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-resourcesdeploymentstacks@file:projects/arm-resourcesdeploymentstacks.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-scvmm@file:projects/arm-scvmm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-search@file:projects/arm-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17487,14 +17486,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-security@file:projects/arm-security.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-security@file:projects/arm-security.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17522,14 +17521,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-securitydevops@file:projects/arm-securitydevops.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-securitydevops@file:projects/arm-securitydevops.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17557,14 +17556,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-securityinsight@file:projects/arm-securityinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-securityinsight@file:projects/arm-securityinsight.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17592,14 +17591,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-selfhelp@file:projects/arm-selfhelp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-selfhelp@file:projects/arm-selfhelp.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17627,12 +17626,12 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-serialconsole@file:projects/arm-serialconsole.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-serialconsole@file:projects/arm-serialconsole.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17660,49 +17659,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicebus@file:projects/arm-servicebus.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-servicefabric-1@file:projects/arm-servicefabric-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicebus@file:projects/arm-servicebus.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17730,16 +17694,51 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicefabric@file:projects/arm-servicefabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicefabric-1@file:projects/arm-servicefabric-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-servicefabric@file:projects/arm-servicefabric.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17767,14 +17766,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicefabricmanagedclusters@file:projects/arm-servicefabricmanagedclusters.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicefabricmanagedclusters@file:projects/arm-servicefabricmanagedclusters.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17802,13 +17801,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicefabricmesh@file:projects/arm-servicefabricmesh.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicefabricmesh@file:projects/arm-servicefabricmesh.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17836,14 +17835,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicelinker@file:projects/arm-servicelinker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicelinker@file:projects/arm-servicelinker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17871,13 +17870,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicemap@file:projects/arm-servicemap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicemap@file:projects/arm-servicemap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17905,14 +17904,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-servicenetworking@file:projects/arm-servicenetworking.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-servicenetworking@file:projects/arm-servicenetworking.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -17940,84 +17939,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-signalr@file:projects/arm-signalr.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-sitemanager@file:projects/arm-sitemanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-sphere@file:projects/arm-sphere.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-signalr@file:projects/arm-signalr.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18045,14 +17974,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-springappdiscovery@file:projects/arm-springappdiscovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-sitemanager@file:projects/arm-sitemanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-sphere@file:projects/arm-sphere.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18080,14 +18044,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-sql@file:projects/arm-sql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-springappdiscovery@file:projects/arm-springappdiscovery.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18115,14 +18079,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-sqlvirtualmachine@file:projects/arm-sqlvirtualmachine.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-sql@file:projects/arm-sql.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18150,49 +18114,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-standbypool@file:projects/arm-standbypool.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-storage-profile-2020-09-01-hybrid@file:projects/arm-storage-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-sqlvirtualmachine@file:projects/arm-sqlvirtualmachine.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18220,14 +18149,49 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storage@file:projects/arm-storage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-standbypool@file:projects/arm-standbypool.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-storage-profile-2020-09-01-hybrid@file:projects/arm-storage-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18255,14 +18219,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storageactions@file:projects/arm-storageactions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storage@file:projects/arm-storage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18290,14 +18254,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storagecache@file:projects/arm-storagecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storageactions@file:projects/arm-storageactions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18325,48 +18289,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storageimportexport@file:projects/arm-storageimportexport.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-storagemover@file:projects/arm-storagemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storagecache@file:projects/arm-storagecache.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18394,13 +18324,48 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storagesync@file:projects/arm-storagesync.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storageimportexport@file:projects/arm-storageimportexport.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-storagemover@file:projects/arm-storagemover.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18428,13 +18393,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storsimple1200series@file:projects/arm-storsimple1200series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storagesync@file:projects/arm-storagesync.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18462,13 +18427,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-storsimple8000series@file:projects/arm-storsimple8000series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storsimple1200series@file:projects/arm-storsimple1200series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18496,14 +18461,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-streamanalytics@file:projects/arm-streamanalytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-storsimple8000series@file:projects/arm-storsimple8000series.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18531,47 +18495,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid@file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-subscriptions@file:projects/arm-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-streamanalytics@file:projects/arm-streamanalytics.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18599,14 +18530,47 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-support@file:projects/arm-support.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-subscriptions-profile-2020-09-01-hybrid@file:projects/arm-subscriptions-profile-2020-09-01-hybrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-subscriptions@file:projects/arm-subscriptions.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18634,14 +18598,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-synapse@file:projects/arm-synapse.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-support@file:projects/arm-support.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18669,82 +18633,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-templatespecs@file:projects/arm-templatespecs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-terraform@file:projects/arm-terraform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-timeseriesinsights@file:projects/arm-timeseriesinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-synapse@file:projects/arm-synapse.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18772,13 +18668,12 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-trafficmanager@file:projects/arm-trafficmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-templatespecs@file:projects/arm-templatespecs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18806,14 +18701,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-trustedsigning@file:projects/arm-trustedsigning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-terraform@file:projects/arm-terraform.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18841,48 +18736,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-visualstudio@file:projects/arm-visualstudio.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-vmwarecloudsimple@file:projects/arm-vmwarecloudsimple.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-timeseriesinsights@file:projects/arm-timeseriesinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18910,14 +18771,82 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-voiceservices@file:projects/arm-voiceservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-trafficmanager@file:projects/arm-trafficmanager.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-trustedsigning@file:projects/arm-trustedsigning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-visualstudio@file:projects/arm-visualstudio.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18945,14 +18874,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-webpubsub@file:projects/arm-webpubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-vmwarecloudsimple@file:projects/arm-vmwarecloudsimple.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -18980,13 +18909,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-webservices@file:projects/arm-webservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-voiceservices@file:projects/arm-voiceservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19014,49 +18944,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-weightsandbiases@file:projects/arm-weightsandbiases.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/arm-workloads@file:projects/arm-workloads.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-webpubsub@file:projects/arm-webpubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19084,14 +18979,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-workloadssapvirtualinstance@file:projects/arm-workloadssapvirtualinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-webservices@file:projects/arm-webservices.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
+      '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19119,12 +19013,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/arm-workspaces@file:projects/arm-workspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-weightsandbiases@file:projects/arm-weightsandbiases.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19152,16 +19048,119 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/attestation@file:projects/attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/arm-workloads@file:projects/arm-workloads.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-workloadssapvirtualinstance@file:projects/arm-workloadssapvirtualinstance.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/arm-workspaces@file:projects/arm-workspaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/attestation@file:projects/attestation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       jsrsasign: 11.1.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       safe-buffer: 5.2.1
       tslib: 2.8.1
       typescript: 5.8.3
@@ -19190,15 +19189,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/batch@file:projects/batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/batch@file:projects/batch.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       moment: 2.30.1
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19226,15 +19225,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-alpha-ids@file:projects/communication-alpha-ids.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-alpha-ids@file:projects/communication-alpha-ids.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19262,18 +19261,18 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-call-automation@file:projects/communication-call-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-call-automation@file:projects/communication-call-automation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/communication-identity': 1.3.1
       '@azure/service-bus': 7.9.5
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
       inherits: 2.0.4
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19301,17 +19300,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-chat@file:projects/communication-chat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-chat@file:projects/communication-chat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/communication-identity': 1.3.1
       '@azure/communication-signaling': 1.0.0-beta.34
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19339,18 +19338,18 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-common@file:projects/communication-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-common@file:projects/communication-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/identity': 4.3.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       events: 3.3.0
       jwt-decode: 4.0.0
       mockdate: 3.0.5
       nock: 14.0.1
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19378,15 +19377,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-email@file:projects/communication-email.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-email@file:projects/communication-email.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19414,17 +19413,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-identity@file:projects/communication-identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-identity@file:projects/communication-identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/msal-node': 2.16.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19452,15 +19451,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-job-router@file:projects/communication-job-router.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-job-router@file:projects/communication-job-router.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19488,18 +19487,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-messages@file:projects/communication-messages.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-messages@file:projects/communication-messages.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/communication-signaling': 1.0.0-beta.31
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      karma-source-map-support: 1.4.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19527,16 +19525,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-phone-numbers@file:projects/communication-phone-numbers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-phone-numbers@file:projects/communication-phone-numbers.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19564,16 +19562,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-recipient-verification@file:projects/communication-recipient-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-recipient-verification@file:projects/communication-recipient-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19601,15 +19599,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-rooms@file:projects/communication-rooms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-rooms@file:projects/communication-rooms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/communication-identity': 1.3.1
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19637,16 +19635,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-short-codes@file:projects/communication-short-codes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-short-codes@file:projects/communication-short-codes.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19674,15 +19672,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-sms@file:projects/communication-sms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-sms@file:projects/communication-sms.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19710,52 +19708,52 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/communication-tiering@file:projects/communication-tiering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      events: 3.3.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/communication-toll-free-verification@file:projects/communication-toll-free-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/communication-tiering@file:projects/communication-tiering.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      events: 3.3.0
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/communication-toll-free-verification@file:projects/communication-toll-free-verification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19787,8 +19785,8 @@ snapshots:
     dependencies:
       '@types/node': 20.19.1
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19812,14 +19810,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/container-registry@file:projects/container-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/container-registry@file:projects/container-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19847,19 +19845,19 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-amqp@file:projects/core-amqp.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-amqp@file:projects/core-amqp.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
       '@types/ws': 8.18.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       process: 0.11.10
       rhea: 3.0.4
       rhea-promise: 3.0.3
@@ -19867,7 +19865,7 @@ snapshots:
       typescript: 5.8.3
       util: 0.12.5
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-      ws: 8.18.2
+      ws: 8.18.3
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -19892,13 +19890,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-auth@file:projects/core-auth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-auth@file:projects/core-auth.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19926,13 +19924,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-client-1@file:projects/core-client-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-client-1@file:projects/core-client-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19960,13 +19958,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-client@file:projects/core-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-client@file:projects/core-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -19994,13 +19992,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-http-compat@file:projects/core-http-compat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-http-compat@file:projects/core-http-compat.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
@@ -20027,13 +20025,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-lro@file:projects/core-lro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-lro@file:projects/core-lro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20061,13 +20059,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-paging@file:projects/core-paging.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-paging@file:projects/core-paging.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20095,13 +20093,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-rest-pipeline@file:projects/core-rest-pipeline.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-rest-pipeline@file:projects/core-rest-pipeline.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20129,16 +20127,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-sse@file:projects/core-sse.tgz(@types/debug@4.1.12)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-sse@file:projects/core-sse.tgz(@types/debug@4.1.12)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/express': 4.17.23
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       express: 4.21.2
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       tsx: 4.20.3
       typescript: 5.8.3
@@ -20166,13 +20164,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-tracing@file:projects/core-tracing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-tracing@file:projects/core-tracing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20200,13 +20198,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-util@file:projects/core-util.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-util@file:projects/core-util.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20234,15 +20232,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/core-xml@file:projects/core-xml.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/core-xml@file:projects/core-xml.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
       '@types/trusted-types': 2.0.7
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       fast-xml-parser: 5.2.5
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20270,20 +20268,20 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/cosmos@file:projects/cosmos.tgz(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/cosmos@file:projects/cosmos.tgz(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
       '@types/priorityqueuejs': 1.0.4
       '@types/semaphore': 1.1.4
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       assertion-error: 2.0.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       fast-json-stable-stringify: 2.1.0
       nock: 13.5.6
-      playwright: 1.53.1
+      playwright: 1.54.0
       priorityqueuejs: 2.0.0
       semaphore: 1.1.0
       tslib: 2.8.1
@@ -20317,7 +20315,7 @@ snapshots:
       '@types/node': 20.19.1
       '@types/prompts': 2.4.9
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       prompts: 2.4.2
       tslib: 2.8.1
       typescript: 5.8.3
@@ -20347,7 +20345,7 @@ snapshots:
       '@types/node': 20.19.1
       '@types/prompts': 2.4.9
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       prompts: 2.4.2
       tslib: 2.8.1
       typescript: 5.8.3
@@ -20372,14 +20370,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/data-tables@file:projects/data-tables.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/data-tables@file:projects/data-tables.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20407,14 +20405,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/defender-easm@file:projects/defender-easm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/defender-easm@file:projects/defender-easm.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20447,12 +20445,12 @@ snapshots:
       '@_ts/max': typescript@5.8.3
       '@_ts/min': typescript@4.2.4
       '@arethetypeswrong/cli': 0.17.4
-      '@azure/identity': 4.10.1
-      '@eslint/js': 9.29.0
+      '@azure/identity': 4.10.2
+      '@eslint/js': 9.30.1
       '@microsoft/api-extractor': 7.52.8(@types/node@20.19.1)
       '@microsoft/api-extractor-model': 7.30.6(@types/node@20.19.1)
       '@types/express': 5.0.3
-      '@types/express-serve-static-core': 5.0.6
+      '@types/express-serve-static-core': 5.0.7
       '@types/fs-extra': 11.0.4
       '@types/minimist': 1.2.5
       '@types/node': 20.19.1
@@ -20464,14 +20462,14 @@ snapshots:
       chalk: 4.1.2
       concurrently: 8.2.2
       cross-env: 7.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       express: 5.1.0
       fs-extra: 11.3.0
       memfs: 4.17.2
       minimist: 1.2.8
       mkdirp: 3.0.1
-      prettier: 3.6.0
+      prettier: 3.6.2
       rimraf: 5.0.10
       semver: 7.7.2
       strip-json-comments: 5.0.2
@@ -20481,7 +20479,7 @@ snapshots:
       tslib: 2.8.1
       tsx: 4.19.3
       typescript: 5.8.3
-      typescript-eslint: 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      typescript-eslint: 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       unzipper: 0.12.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.19.3)(yaml@2.8.0)
       yaml: 2.8.0
@@ -20503,14 +20501,14 @@ snapshots:
       - supports-color
       - terser
 
-  '@rush-temp/developer-devcenter@file:projects/developer-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/developer-devcenter@file:projects/developer-devcenter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20538,15 +20536,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/digital-twins-core@file:projects/digital-twins-core.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/digital-twins-core@file:projects/digital-twins-core.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20574,36 +20572,36 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/eslint-plugin-azure-sdk@file:projects/eslint-plugin-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/eslint-plugin-azure-sdk@file:projects/eslint-plugin-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@eslint/compat': 1.3.0(eslint@9.29.0)
+      '@eslint/compat': 1.3.1(eslint@9.30.1)
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.29.0
+      '@eslint/js': 9.30.1
       '@types/eslint': 9.6.1
       '@types/eslint-config-prettier': 6.11.3
       '@types/estree': 1.0.8
       '@types/node': 20.19.1
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/rule-tester': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/rule-tester': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      eslint-config-prettier: 10.1.5(eslint@9.29.0)
-      eslint-plugin-n: 17.20.0(eslint@9.29.0)(typescript@5.8.3)
+      eslint: 9.30.1
+      eslint-config-prettier: 10.1.5(eslint@9.30.1)
+      eslint-plugin-n: 17.21.0(eslint@9.30.1)(typescript@5.8.3)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-promise: 7.2.1(eslint@9.29.0)
+      eslint-plugin-promise: 7.2.1(eslint@9.30.1)
       eslint-plugin-tsdoc: 0.4.0
       glob: 10.4.5
-      playwright: 1.53.1
-      prettier: 3.6.0
+      playwright: 1.54.0
+      prettier: 3.6.2
       rimraf: 5.0.10
       tshy: 3.0.2
       tslib: 2.8.1
       typescript: 5.8.3
-      typescript-eslint: 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      typescript-eslint: 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -20629,35 +20627,35 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/event-hubs@file:projects/event-hubs.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/event-hubs@file:projects/event-hubs.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/chai-as-promised': 8.0.2
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@types/node-forge': 1.3.11
+      '@types/node-forge': 1.3.12
       '@types/ws': 7.4.7
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      chai: 5.2.0
-      chai-as-promised: 8.0.1(chai@5.2.0)
-      chai-exclude: 3.0.1(chai@5.2.0)
+      chai: 5.2.1
+      chai-as-promised: 8.0.1(chai@5.2.1)
+      chai-exclude: 3.0.1(chai@5.2.1)
       copyfiles: 2.4.1
       debug: 4.4.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       https-proxy-agent: 7.0.6
       is-buffer: 2.0.5
       node-forge: 1.3.1
-      playwright: 1.53.1
+      playwright: 1.54.0
       process: 0.11.10
       rhea-promise: 3.0.3
       tslib: 2.8.1
       typescript: 5.8.3
       util: 0.12.5
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-      ws: 8.18.2
+      ws: 8.18.3
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -20682,15 +20680,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/eventgrid-namespaces@file:projects/eventgrid-namespaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/eventgrid-namespaces@file:projects/eventgrid-namespaces.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20718,13 +20716,13 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/eventgrid-systemevents@file:projects/eventgrid-systemevents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/eventgrid-systemevents@file:projects/eventgrid-systemevents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20752,15 +20750,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/eventgrid@file:projects/eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/eventgrid@file:projects/eventgrid.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/service-bus': 7.9.5
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20788,22 +20786,22 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/eventhubs-checkpointstore-blob@file:projects/eventhubs-checkpointstore-blob.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/eventhubs-checkpointstore-blob@file:projects/eventhubs-checkpointstore-blob.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/storage-blob': 12.27.0
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/chai-as-promised': 8.0.2
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      chai: 5.2.0
-      chai-as-promised: 8.0.1(chai@5.2.0)
+      chai: 5.2.1
+      chai-as-promised: 8.0.1(chai@5.2.1)
       debug: 4.4.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       process: 0.11.10
       stream: 0.0.3
       tslib: 2.8.1
@@ -20833,21 +20831,21 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/eventhubs-checkpointstore-table@file:projects/eventhubs-checkpointstore-table.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/eventhubs-checkpointstore-table@file:projects/eventhubs-checkpointstore-table.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/chai-as-promised': 8.0.2
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      chai: 5.2.0
-      chai-as-promised: 8.0.1(chai@5.2.0)
+      chai: 5.2.1
+      chai-as-promised: 8.0.1(chai@5.2.1)
       debug: 4.4.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       process: 0.11.10
       stream: 0.0.3
       tslib: 2.8.1
@@ -20877,15 +20875,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/functions-authentication-events@file:projects/functions-authentication-events.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/functions-authentication-events@file:projects/functions-authentication-events.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/functions': 3.5.1
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20913,15 +20911,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/health-deidentification@file:projects/health-deidentification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/health-deidentification@file:projects/health-deidentification.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       loupe: 3.1.4
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20949,16 +20947,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/health-insights-cancerprofiling@file:projects/health-insights-cancerprofiling.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/health-insights-cancerprofiling@file:projects/health-insights-cancerprofiling.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -20986,16 +20984,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/health-insights-clinicalmatching@file:projects/health-insights-clinicalmatching.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/health-insights-clinicalmatching@file:projects/health-insights-clinicalmatching.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21023,15 +21021,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/health-insights-radiologyinsights@file:projects/health-insights-radiologyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/health-insights-radiologyinsights@file:projects/health-insights-radiologyinsights.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21059,16 +21057,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/identity-broker@file:projects/identity-broker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/identity-broker@file:projects/identity-broker.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/msal-node': 3.6.1
-      '@azure/msal-node-extensions': 1.5.15
+      '@azure/msal-node': 3.6.3
+      '@azure/msal-node-extensions': 1.5.17
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21096,17 +21094,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/identity-cache-persistence@file:projects/identity-cache-persistence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/identity-cache-persistence@file:projects/identity-cache-persistence.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@azure/msal-node': 3.6.1
-      '@azure/msal-node-extensions': 1.5.15
+      '@azure/msal-node': 3.6.3
+      '@azure/msal-node-extensions': 1.5.17
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       keytar: 7.9.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21134,15 +21132,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/identity-vscode@file:projects/identity-vscode.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/identity-vscode@file:projects/identity-vscode.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       keytar: 7.9.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21170,23 +21168,23 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/identity@file:projects/identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/identity@file:projects/identity.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/keyvault-keys': 4.10.0
-      '@azure/msal-browser': 4.13.2
-      '@azure/msal-node': 3.6.1
+      '@azure/msal-browser': 4.15.0
+      '@azure/msal-node': 3.6.3
       '@types/jsonwebtoken': 9.0.10
       '@types/ms': 2.1.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       assertion-error: 2.0.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       jsonwebtoken: 9.0.2
       ms: 2.1.3
       open: 10.1.2
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21214,14 +21212,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/iot-device-update@file:projects/iot-device-update.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/iot-device-update@file:projects/iot-device-update.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21249,14 +21247,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/iot-modelsrepository@file:projects/iot-modelsrepository.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/iot-modelsrepository@file:projects/iot-modelsrepository.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21284,14 +21282,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/keyvault-admin@file:projects/keyvault-admin.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/keyvault-admin@file:projects/keyvault-admin.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21319,85 +21317,85 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/keyvault-certificates@file:projects/keyvault-certificates.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/keyvault-common@file:projects/keyvault-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/keyvault-keys@file:projects/keyvault-keys.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/keyvault-certificates@file:projects/keyvault-certificates.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/keyvault-common@file:projects/keyvault-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/keyvault-keys@file:projects/keyvault-keys.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21430,9 +21428,9 @@ snapshots:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21456,16 +21454,16 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/load-testing@file:projects/load-testing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/load-testing@file:projects/load-testing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21493,14 +21491,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/logger@file:projects/logger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/logger@file:projects/logger.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21528,14 +21526,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/maps-common@file:projects/maps-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/maps-common@file:projects/maps-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21563,16 +21561,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/maps-geolocation@file:projects/maps-geolocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/maps-geolocation@file:projects/maps-geolocation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21600,16 +21598,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/maps-render@file:projects/maps-render.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/maps-render@file:projects/maps-render.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21637,17 +21635,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/maps-route@file:projects/maps-route.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/maps-route@file:projects/maps-route.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure-rest/core-client': 1.4.0
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21675,17 +21673,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/maps-search@file:projects/maps-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/maps-search@file:projects/maps-search.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21713,17 +21711,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/maps-timezone@file:projects/maps-timezone.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/maps-timezone@file:projects/maps-timezone.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/maps-common': 1.0.0-beta.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21753,16 +21751,16 @@ snapshots:
 
   '@rush-temp/mcp-server@file:projects/mcp-server.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(yaml@2.8.0)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.13.1
+      '@modelcontextprotocol/sdk': 1.15.1
       '@types/node': 20.19.1
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       '@vitest/expect': 3.2.4
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tsx: 4.19.3
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.19.3)(yaml@2.8.0)
-      zod: 3.25.67
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/debug'
@@ -21782,16 +21780,16 @@ snapshots:
       - terser
       - yaml
 
-  '@rush-temp/microsoft-playwright-testing@file:projects/microsoft-playwright-testing.tgz(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/microsoft-playwright-testing@file:projects/microsoft-playwright-testing.tgz(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/storage-blob': 12.27.0
-      '@playwright/test': 1.53.1
+      '@playwright/test': 1.54.0
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21822,9 +21820,9 @@ snapshots:
     dependencies:
       '@types/node': 20.19.1
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       rhea: 3.0.4
       tslib: 2.8.1
       typescript: 5.8.3
@@ -21849,16 +21847,16 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/monitor-ingestion@file:projects/monitor-ingestion.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/monitor-ingestion@file:projects/monitor-ingestion.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
       '@types/pako': 2.0.3
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       pako: 2.1.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21886,7 +21884,7 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/monitor-opentelemetry-exporter@file:projects/monitor-opentelemetry-exporter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/monitor-opentelemetry-exporter@file:projects/monitor-opentelemetry-exporter.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.200.0
@@ -21900,12 +21898,12 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.34.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       nock: 13.5.6
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21935,7 +21933,7 @@ snapshots:
 
   '@rush-temp/monitor-opentelemetry@file:projects/monitor-opentelemetry.tgz(@types/debug@4.1.12)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)':
     dependencies:
-      '@azure/functions': 4.7.3
+      '@azure/functions': 4.7.2
       '@azure/functions-old': '@azure/functions@3.5.1'
       '@microsoft/applicationinsights-web-snippet': 1.2.2
       '@opentelemetry/api': 1.9.0
@@ -21961,8 +21959,8 @@ snapshots:
       '@opentelemetry/winston-transport': 0.11.0
       '@types/node': 20.19.1
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -21986,17 +21984,17 @@ snapshots:
       - tsx
       - yaml
 
-  '@rush-temp/monitor-query@file:projects/monitor-query.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/monitor-query@file:projects/monitor-query.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22024,14 +22022,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/notification-hubs@file:projects/notification-hubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/notification-hubs@file:projects/notification-hubs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22059,14 +22057,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/onlineexperimentation@file:projects/onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/onlineexperimentation@file:projects/onlineexperimentation.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22094,22 +22092,22 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/openai@file:projects/openai.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.2)(yaml@2.8.0)':
+  '@rush-temp/openai@file:projects/openai.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(ws@8.18.3)(yaml@2.8.0)':
     dependencies:
       '@azure/arm-cognitiveservices': 7.6.0
       '@azure/arm-search': 3.2.0
       '@azure/search-documents': 12.1.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      openai: 4.104.0(ws@8.18.2)(zod@3.25.67)
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      openai: 4.104.0(ws@8.18.3)(zod@3.25.76)
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-      zod: 3.25.67
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/debug'
@@ -22136,7 +22134,7 @@ snapshots:
       - ws
       - yaml
 
-  '@rush-temp/opentelemetry-instrumentation-azure-sdk@file:projects/opentelemetry-instrumentation-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/opentelemetry-instrumentation-azure-sdk@file:projects/opentelemetry-instrumentation-azure-sdk.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
@@ -22145,11 +22143,11 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-web': 2.0.1(@opentelemetry/api@1.9.0)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22180,8 +22178,8 @@ snapshots:
   '@rush-temp/perf-ai-form-recognizer@file:projects/perf-ai-form-recognizer.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22191,8 +22189,8 @@ snapshots:
   '@rush-temp/perf-ai-language-text@file:projects/perf-ai-language-text.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22202,8 +22200,8 @@ snapshots:
   '@rush-temp/perf-ai-metrics-advisor@file:projects/perf-ai-metrics-advisor.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22213,8 +22211,8 @@ snapshots:
   '@rush-temp/perf-ai-text-analytics@file:projects/perf-ai-text-analytics.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22225,8 +22223,8 @@ snapshots:
     dependencies:
       '@azure/app-configuration': 1.8.0
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22236,8 +22234,8 @@ snapshots:
   '@rush-temp/perf-container-registry@file:projects/perf-container-registry.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22249,12 +22247,12 @@ snapshots:
       '@types/express': 4.17.23
       '@types/node': 20.19.1
       concurrently: 8.2.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       express: 4.21.2
       tslib: 2.8.1
       typescript: 5.8.3
-      undici: 7.10.0
+      undici: 7.11.0
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -22262,8 +22260,8 @@ snapshots:
   '@rush-temp/perf-data-tables@file:projects/perf-data-tables.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22273,8 +22271,8 @@ snapshots:
   '@rush-temp/perf-event-hubs@file:projects/perf-event-hubs.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       moment: 2.30.1
       tslib: 2.8.1
       typescript: 5.8.3
@@ -22285,8 +22283,8 @@ snapshots:
   '@rush-temp/perf-eventgrid@file:projects/perf-eventgrid.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22296,8 +22294,8 @@ snapshots:
   '@rush-temp/perf-identity@file:projects/perf-identity.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22307,8 +22305,8 @@ snapshots:
   '@rush-temp/perf-keyvault-certificates@file:projects/perf-keyvault-certificates.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22318,8 +22316,8 @@ snapshots:
   '@rush-temp/perf-keyvault-keys@file:projects/perf-keyvault-keys.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22329,8 +22327,8 @@ snapshots:
   '@rush-temp/perf-keyvault-secrets@file:projects/perf-keyvault-secrets.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22340,8 +22338,8 @@ snapshots:
   '@rush-temp/perf-monitor-ingestion@file:projects/perf-monitor-ingestion.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22354,8 +22352,8 @@ snapshots:
       '@opentelemetry/api-logs': 0.57.2
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.0)
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22365,8 +22363,8 @@ snapshots:
   '@rush-temp/perf-monitor-query@file:projects/perf-monitor-query.tgz':
     dependencies:
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22377,8 +22375,8 @@ snapshots:
     dependencies:
       '@azure/schema-registry': 1.3.0
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22389,8 +22387,8 @@ snapshots:
     dependencies:
       '@azure/search-documents': 12.1.0
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22401,8 +22399,8 @@ snapshots:
     dependencies:
       '@azure/service-bus': 7.9.5
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22413,8 +22411,8 @@ snapshots:
     dependencies:
       '@azure/storage-blob': 12.27.0
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22425,8 +22423,8 @@ snapshots:
     dependencies:
       '@azure/storage-file-datalake': 12.26.0
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22437,8 +22435,8 @@ snapshots:
     dependencies:
       '@azure/storage-file-share': 12.27.0
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -22450,23 +22448,23 @@ snapshots:
       '@azure/app-configuration': 1.8.0
       '@azure/template': 1.0.13-beta.1
       '@types/node': 20.19.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       tslib: 2.8.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
       - supports-color
 
-  '@rush-temp/playwright@file:projects/playwright.tgz(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/playwright@file:projects/playwright.tgz(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@playwright/test': 1.53.1
+      '@playwright/test': 1.54.0
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22493,14 +22491,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/purview-administration@file:projects/purview-administration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/purview-administration@file:projects/purview-administration.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22528,15 +22526,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/purview-datamap@file:projects/purview-datamap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/purview-datamap@file:projects/purview-datamap.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22564,14 +22562,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/purview-scanning@file:projects/purview-scanning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/purview-scanning@file:projects/purview-scanning.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22599,51 +22597,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/purview-sharing@file:projects/purview-sharing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/purview-sharing@file:projects/purview-sharing.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/purview-workflow@file:projects/purview-workflow.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22671,16 +22633,52 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/quantum-jobs@file:projects/quantum-jobs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/purview-workflow@file:projects/purview-workflow.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      autorest: 3.7.2
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/quantum-jobs@file:projects/quantum-jobs.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/storage-blob': 12.27.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       autorest: 3.7.2
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22708,19 +22706,19 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/schema-registry-avro@file:projects/schema-registry-avro.tgz(@types/debug@4.1.12)(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/schema-registry-avro@file:projects/schema-registry-avro.tgz(@types/debug@4.1.12)(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/schema-registry': 1.3.0
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      avsc: 5.7.7
+      avsc: 5.7.8
       buffer: 6.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       lru-cache: 11.1.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       process: 0.11.10
       stream: 0.0.3
       tslib: 2.8.1
@@ -22751,19 +22749,19 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/schema-registry-json@file:projects/schema-registry-json.tgz(@types/debug@4.1.12)(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/schema-registry-json@file:projects/schema-registry-json.tgz(@types/debug@4.1.12)(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/schema-registry': 1.3.0
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       ajv: 8.17.1
       buffer: 6.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       lru-cache: 11.1.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22792,14 +22790,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/schema-registry@file:projects/schema-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/schema-registry@file:projects/schema-registry.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22827,16 +22825,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/search-documents@file:projects/search-documents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/search-documents@file:projects/search-documents.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/openai': 1.0.0-beta.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       type-plus: 7.6.2
       typescript: 5.8.3
@@ -22865,37 +22863,37 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/service-bus@file:projects/service-bus.tgz(rollup@4.44.0)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/service-bus@file:projects/service-bus.tgz(rollup@4.44.2)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/arm-servicebus': 6.1.0
-      '@rollup/plugin-inject': 5.0.5(rollup@4.44.0)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.44.2)
       '@types/chai-as-promised': 8.0.2
       '@types/debug': 4.1.12
       '@types/is-buffer': 2.0.2
       '@types/node': 20.19.1
       '@types/ws': 7.4.7
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      chai: 5.2.0
-      chai-as-promised: 8.0.1(chai@5.2.0)
-      chai-exclude: 3.0.1(chai@5.2.0)
+      chai: 5.2.1
+      chai-as-promised: 8.0.1(chai@5.2.1)
+      chai-exclude: 3.0.1(chai@5.2.1)
       debug: 4.4.1
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
       https-proxy-agent: 7.0.6
       is-buffer: 2.0.5
       jssha: 3.3.1
       long: 5.3.2
-      playwright: 1.53.1
+      playwright: 1.54.0
       process: 0.11.10
       rhea-promise: 3.0.3
       tslib: 2.8.1
       typescript: 5.8.3
       util: 0.12.5
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-      ws: 8.18.2
+      ws: 8.18.3
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/ui'
@@ -22920,16 +22918,16 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-blob-changefeed@file:projects/storage-blob-changefeed.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-blob-changefeed@file:projects/storage-blob-changefeed.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/storage-blob': 12.27.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22957,17 +22955,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-blob@file:projects/storage-blob.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-blob@file:projects/storage-blob.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@azure/storage-file-share': 12.27.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -22995,14 +22993,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-common@file:projects/storage-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-common@file:projects/storage-common.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.7.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23030,15 +23028,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-file-datalake@file:projects/storage-file-datalake.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-file-datalake@file:projects/storage-file-datalake.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23066,15 +23064,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-file-share@file:projects/storage-file-share.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-file-share@file:projects/storage-file-share.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23102,15 +23100,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-internal-avro@file:projects/storage-internal-avro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-internal-avro@file:projects/storage-internal-avro.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23138,14 +23136,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/storage-queue@file:projects/storage-queue.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/storage-queue@file:projects/storage-queue.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23173,14 +23171,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/synapse-access-control-1@file:projects/synapse-access-control-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/synapse-access-control-1@file:projects/synapse-access-control-1.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23208,14 +23206,14 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/synapse-access-control@file:projects/synapse-access-control.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/synapse-access-control@file:projects/synapse-access-control.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23243,190 +23241,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/synapse-artifacts@file:projects/synapse-artifacts.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@azure/core-lro': 2.7.2
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/synapse-managed-private-endpoints@file:projects/synapse-managed-private-endpoints.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/synapse-monitoring@file:projects/synapse-monitoring.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/synapse-spark@file:projects/synapse-spark.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/template-dpg@file:projects/template-dpg.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
-    dependencies:
-      '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@types/debug'
-      - '@vitest/ui'
-      - bufferutil
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - lightningcss
-      - msw
-      - safaridriver
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - utf-8-validate
-      - vite
-      - webdriverio
-      - yaml
-
-  '@rush-temp/template@file:projects/template.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/synapse-artifacts@file:projects/synapse-artifacts.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/core-lro': 2.7.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23454,13 +23277,188 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/test-credential@file:projects/test-credential.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/synapse-managed-private-endpoints@file:projects/synapse-managed-private-endpoints.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
-      playwright: 1.53.1
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/synapse-monitoring@file:projects/synapse-monitoring.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/synapse-spark@file:projects/synapse-spark.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/template-dpg@file:projects/template-dpg.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/template@file:projects/template.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@azure/core-lro': 2.7.2
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      dotenv: 16.6.1
+      eslint: 9.30.1
+      playwright: 1.54.0
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - safaridriver
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - utf-8-validate
+      - vite
+      - webdriverio
+      - yaml
+
+  '@rush-temp/test-credential@file:projects/test-credential.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+    dependencies:
+      '@types/node': 20.19.1
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23493,7 +23491,7 @@ snapshots:
       '@types/fs-extra': 11.0.4
       '@types/minimist': 1.2.5
       '@types/node': 20.19.1
-      eslint: 9.29.0
+      eslint: 9.30.1
       fs-extra: 11.3.0
       minimist: 1.2.8
       tslib: 2.8.1
@@ -23502,15 +23500,15 @@ snapshots:
       - jiti
       - supports-color
 
-  '@rush-temp/test-recorder@file:projects/test-recorder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/test-recorder@file:projects/test-recorder.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       concurrently: 8.2.2
-      eslint: 9.29.0
+      eslint: 9.30.1
       express: 4.21.2
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23538,15 +23536,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/test-utils-vitest@file:projects/test-utils-vitest.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/test-utils-vitest@file:projects/test-utils-vitest.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       '@vitest/expect': 3.2.4
-      eslint: 9.29.0
-      playwright: 1.53.1
+      eslint: 9.30.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23574,15 +23572,15 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/ts-http-runtime@file:projects/ts-http-runtime.tgz(@types/debug@4.1.12)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/ts-http-runtime@file:projects/ts-http-runtime.tgz(@types/debug@4.1.12)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      eslint: 9.29.0
+      eslint: 9.30.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       tsx: 4.20.3
       typescript: 5.8.3
@@ -23612,30 +23610,30 @@ snapshots:
 
   '@rush-temp/vite-plugin-browser-test-map@file:projects/vite-plugin-browser-test-map.tgz':
     dependencies:
-      '@eslint/js': 9.29.0
+      '@eslint/js': 9.30.1
       '@types/node': 20.19.1
-      eslint: 9.29.0
-      prettier: 3.6.0
+      eslint: 9.30.1
+      prettier: 3.6.2
       rimraf: 5.0.10
       tslib: 2.8.1
       typescript: 5.8.3
-      typescript-eslint: 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      typescript-eslint: 8.34.1(eslint@9.30.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - jiti
       - supports-color
 
-  '@rush-temp/web-pubsub-client-protobuf@file:projects/web-pubsub-client-protobuf.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/web-pubsub-client-protobuf@file:projects/web-pubsub-client-protobuf.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/web-pubsub-client': 1.0.0-beta.2
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       cpy-cli: 5.0.0
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       long: 5.3.2
       move-file-cli: 3.0.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       protobufjs: 7.5.3
       protobufjs-cli: 1.1.3(protobufjs@7.5.3)
       tslib: 2.8.1
@@ -23665,17 +23663,17 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/web-pubsub-client@file:projects/web-pubsub-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/web-pubsub-client@file:projects/web-pubsub-client.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/node': 20.19.1
       '@types/ws': 7.4.7
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       buffer: 6.0.3
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       events: 3.3.0
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23704,18 +23702,18 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/web-pubsub-express@file:projects/web-pubsub-express.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/web-pubsub-express@file:projects/web-pubsub-express.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/express': 4.17.23
       '@types/express-serve-static-core': 4.19.6
       '@types/jsonwebtoken': 9.0.10
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       express: 4.21.2
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
@@ -23743,21 +23741,21 @@ snapshots:
       - webdriverio
       - yaml
 
-  '@rush-temp/web-pubsub@file:projects/web-pubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
+  '@rush-temp/web-pubsub@file:projects/web-pubsub.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@types/jsonwebtoken': 9.0.10
       '@types/node': 20.19.1
       '@types/ws': 8.18.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
-      dotenv: 16.5.0
-      eslint: 9.29.0
+      dotenv: 16.6.1
+      eslint: 9.30.1
       jsonwebtoken: 9.0.2
-      playwright: 1.53.1
+      playwright: 1.54.0
       tslib: 2.8.1
       typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-      ws: 8.18.2
+      ws: 8.18.3
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/debug'
@@ -23846,11 +23844,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/chai-as-promised@8.0.2':
     dependencies:
@@ -23862,7 +23860,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/debug@4.1.12':
     dependencies:
@@ -23881,14 +23879,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
 
-  '@types/express-serve-static-core@5.0.6':
+  '@types/express-serve-static-core@5.0.7':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -23903,22 +23901,22 @@ snapshots:
   '@types/express@5.0.3':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.0.6
+      '@types/express-serve-static-core': 5.0.7
       '@types/serve-static': 1.15.8
 
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/glob@7.2.0':
     dependencies:
-      '@types/minimatch': 5.1.2
-      '@types/node': 22.7.9
+      '@types/minimatch': 6.0.0
+      '@types/node': 20.19.1
 
   '@types/http-errors@2.0.5': {}
 
@@ -23929,18 +23927,18 @@ snapshots:
 
   '@types/is-buffer@2.0.2':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/json-schema@7.0.15': {}
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/linkify-it@5.0.0': {}
 
@@ -23953,7 +23951,9 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
-  '@types/minimatch@5.1.2': {}
+  '@types/minimatch@6.0.0':
+    dependencies:
+      minimatch: 10.0.3
 
   '@types/minimist@1.2.5': {}
 
@@ -23963,28 +23963,24 @@ snapshots:
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
       form-data: 4.0.3
 
-  '@types/node-forge@1.3.11':
+  '@types/node-forge@1.3.12':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
-  '@types/node@18.19.112':
+  '@types/node@18.19.117':
     dependencies:
       undici-types: 5.26.5
 
   '@types/node@20.19.1':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@22.7.9':
-    dependencies:
-      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -23996,15 +23992,15 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 22.7.9
-      pg-protocol: 1.8.0
+      '@types/node': 20.19.1
+      pg-protocol: 1.10.3
       pg-types: 2.2.0
 
   '@types/priorityqueuejs@1.0.4': {}
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
       kleur: 3.0.3
 
   '@types/qs@6.14.0': {}
@@ -24020,19 +24016,19 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
       '@types/send': 0.17.5
 
   '@types/shimmer@1.2.0': {}
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/triple-beam@1.3.5': {}
 
@@ -24040,15 +24036,15 @@ snapshots:
 
   '@types/unzipper@0.10.11':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -24056,15 +24052,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
-      eslint: 9.29.0
+      eslint: 9.30.1
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -24073,14 +24069,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.34.1(eslint@9.30.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.30.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -24094,13 +24090,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/rule-tester@8.34.1(eslint@9.30.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       ajv: 6.12.6
-      eslint: 9.29.0
+      eslint: 9.30.1
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.7.2
@@ -24117,12 +24113,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@9.30.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.30.1
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -24146,13 +24142,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@9.30.1)(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      eslint: 9.29.0
+      eslint: 9.30.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -24162,7 +24158,7 @@ snapshots:
       '@typescript-eslint/types': 8.34.1
       eslint-visitor-keys: 4.2.1
 
-  '@typespec/ts-http-runtime@0.2.3':
+  '@typespec/ts-http-runtime@0.3.0':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -24170,19 +24166,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
-      ws: 8.18.2
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+      ws: 8.18.3
     optionalDependencies:
-      playwright: 1.53.1
+      playwright: 1.54.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -24201,7 +24197,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24210,16 +24206,16 @@ snapshots:
       '@types/chai': 5.2.2
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.0
+      chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -24271,7 +24267,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.3: {}
+  agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -24288,7 +24284,7 @@ snapshots:
 
   ajv-formats@3.0.1:
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.13.0
 
   ajv@6.12.6:
     dependencies:
@@ -24373,7 +24369,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  avsc@5.7.7: {}
+  avsc@5.7.8: {}
 
   balanced-match@1.0.2: {}
 
@@ -24431,16 +24427,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.25.0:
+  browserslist@4.25.1:
     dependencies:
-      caniuse-lite: 1.0.30001724
-      electron-to-chromium: 1.5.172
+      caniuse-lite: 1.0.30001727
+      electron-to-chromium: 1.5.182
       node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.0)
+      update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
   buffer-equal-constant-time@1.0.1: {}
-
-  buffer-from@1.1.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -24490,29 +24484,29 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001724: {}
+  caniuse-lite@1.0.30001727: {}
 
   catharsis@0.9.0:
     dependencies:
       lodash: 4.17.21
 
-  chai-as-promised@8.0.1(chai@5.2.0):
+  chai-as-promised@8.0.1(chai@5.2.1):
     dependencies:
-      chai: 5.2.0
+      chai: 5.2.1
       check-error: 2.1.1
 
-  chai-exclude@3.0.1(chai@5.2.0):
+  chai-exclude@3.0.1(chai@5.2.1):
     dependencies:
-      chai: 5.2.0
+      chai: 5.2.1
       fclone: 1.0.11
 
-  chai@5.2.0:
+  chai@5.2.1:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
       loupe: 3.1.4
-      pathval: 2.0.0
+      pathval: 2.0.1
 
   chalk@4.1.2:
     dependencies:
@@ -24759,7 +24753,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dotenv@16.5.0: {}
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -24779,7 +24773,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.172: {}
+  electron-to-chromium@1.5.182: {}
 
   emoji-regex@8.0.0: {}
 
@@ -24795,7 +24789,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.18.1:
+  enhanced-resolve@5.18.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
@@ -24825,33 +24819,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.25.5:
+  esbuild@0.25.6:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.5
-      '@esbuild/android-arm': 0.25.5
-      '@esbuild/android-arm64': 0.25.5
-      '@esbuild/android-x64': 0.25.5
-      '@esbuild/darwin-arm64': 0.25.5
-      '@esbuild/darwin-x64': 0.25.5
-      '@esbuild/freebsd-arm64': 0.25.5
-      '@esbuild/freebsd-x64': 0.25.5
-      '@esbuild/linux-arm': 0.25.5
-      '@esbuild/linux-arm64': 0.25.5
-      '@esbuild/linux-ia32': 0.25.5
-      '@esbuild/linux-loong64': 0.25.5
-      '@esbuild/linux-mips64el': 0.25.5
-      '@esbuild/linux-ppc64': 0.25.5
-      '@esbuild/linux-riscv64': 0.25.5
-      '@esbuild/linux-s390x': 0.25.5
-      '@esbuild/linux-x64': 0.25.5
-      '@esbuild/netbsd-arm64': 0.25.5
-      '@esbuild/netbsd-x64': 0.25.5
-      '@esbuild/openbsd-arm64': 0.25.5
-      '@esbuild/openbsd-x64': 0.25.5
-      '@esbuild/sunos-x64': 0.25.5
-      '@esbuild/win32-arm64': 0.25.5
-      '@esbuild/win32-ia32': 0.25.5
-      '@esbuild/win32-x64': 0.25.5
+      '@esbuild/aix-ppc64': 0.25.6
+      '@esbuild/android-arm': 0.25.6
+      '@esbuild/android-arm64': 0.25.6
+      '@esbuild/android-x64': 0.25.6
+      '@esbuild/darwin-arm64': 0.25.6
+      '@esbuild/darwin-x64': 0.25.6
+      '@esbuild/freebsd-arm64': 0.25.6
+      '@esbuild/freebsd-x64': 0.25.6
+      '@esbuild/linux-arm': 0.25.6
+      '@esbuild/linux-arm64': 0.25.6
+      '@esbuild/linux-ia32': 0.25.6
+      '@esbuild/linux-loong64': 0.25.6
+      '@esbuild/linux-mips64el': 0.25.6
+      '@esbuild/linux-ppc64': 0.25.6
+      '@esbuild/linux-riscv64': 0.25.6
+      '@esbuild/linux-s390x': 0.25.6
+      '@esbuild/linux-x64': 0.25.6
+      '@esbuild/netbsd-arm64': 0.25.6
+      '@esbuild/netbsd-x64': 0.25.6
+      '@esbuild/openbsd-arm64': 0.25.6
+      '@esbuild/openbsd-x64': 0.25.6
+      '@esbuild/openharmony-arm64': 0.25.6
+      '@esbuild/sunos-x64': 0.25.6
+      '@esbuild/win32-arm64': 0.25.6
+      '@esbuild/win32-ia32': 0.25.6
+      '@esbuild/win32-x64': 0.25.6
 
   escalade@3.2.0: {}
 
@@ -24872,29 +24867,28 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.29.0):
+  eslint-compat-utils@0.5.1(eslint@9.30.1):
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.30.1
       semver: 7.7.2
 
-  eslint-config-prettier@10.1.5(eslint@9.29.0):
+  eslint-config-prettier@10.1.5(eslint@9.30.1):
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.30.1
 
-  eslint-plugin-es-x@7.8.0(eslint@9.29.0):
+  eslint-plugin-es-x@7.8.0(eslint@9.30.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.29.0
-      eslint-compat-utils: 0.5.1(eslint@9.29.0)
+      eslint: 9.30.1
+      eslint-compat-utils: 0.5.1(eslint@9.30.1)
 
-  eslint-plugin-n@17.20.0(eslint@9.29.0)(typescript@5.8.3):
+  eslint-plugin-n@17.21.0(eslint@9.30.1)(typescript@5.8.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      enhanced-resolve: 5.18.1
-      eslint: 9.29.0
-      eslint-plugin-es-x: 7.8.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
+      enhanced-resolve: 5.18.2
+      eslint: 9.30.1
+      eslint-plugin-es-x: 7.8.0(eslint@9.30.1)
       get-tsconfig: 4.10.1
       globals: 15.15.0
       ignore: 5.3.2
@@ -24902,15 +24896,14 @@ snapshots:
       semver: 7.7.2
       ts-declaration-location: 1.0.7(typescript@5.8.3)
     transitivePeerDependencies:
-      - supports-color
       - typescript
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-promise@7.2.1(eslint@9.29.0):
+  eslint-plugin-promise@7.2.1(eslint@9.30.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
-      eslint: 9.29.0
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
+      eslint: 9.30.1
 
   eslint-plugin-tsdoc@0.4.0:
     dependencies:
@@ -24926,16 +24919,16 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0:
+  eslint@9.30.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.20.1
-      '@eslint/config-helpers': 0.2.3
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.0
       '@eslint/core': 0.14.0
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.29.0
-      '@eslint/plugin-kit': 0.3.2
+      '@eslint/js': 9.30.1
+      '@eslint/plugin-kit': 0.3.3
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -25006,15 +24999,15 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.2: {}
+  eventsource-parser@3.0.3: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.2
+      eventsource-parser: 3.0.3
 
   expand-template@2.0.3: {}
 
-  expect-type@1.2.1: {}
+  expect-type@1.2.2: {}
 
   express-rate-limit@7.5.1(express@5.1.0):
     dependencies:
@@ -25294,8 +25287,6 @@ snapshots:
       minimatch: 5.1.6
       once: 1.4.0
 
-  globals@11.12.0: {}
-
   globals@14.0.0: {}
 
   globals@15.15.0: {}
@@ -25361,14 +25352,14 @@ snapshots:
 
   http-proxy-agent@7.0.2:
     dependencies:
-      agent-base: 7.1.3
+      agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
-      agent-base: 7.1.3
+      agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -25524,8 +25515,8 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.27.4
-      '@babel/parser': 7.27.5
+      '@babel/core': 7.28.0
+      '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.2
@@ -25540,7 +25531,7 @@ snapshots:
 
   istanbul-lib-source-maps@5.0.6:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       debug: 4.4.1
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
@@ -25577,7 +25568,7 @@ snapshots:
 
   jsdoc@4.0.4:
     dependencies:
-      '@babel/parser': 7.27.5
+      '@babel/parser': 7.28.0
       '@jsdoc/salty': 0.2.9
       '@types/markdown-it': 14.1.2
       bluebird: 3.7.2
@@ -25661,10 +25652,6 @@ snapshots:
       safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
-
-  karma-source-map-support@1.4.0:
-    dependencies:
-      source-map-support: 0.5.21
 
   keytar@7.9.0:
     dependencies:
@@ -25759,12 +25746,12 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.6
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.0
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -26036,9 +26023,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@8.18.2)(zod@3.25.67):
+  openai@4.104.0(ws@8.18.3)(zod@3.25.76):
     dependencies:
-      '@types/node': 18.19.112
+      '@types/node': 18.19.117
       '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -26046,8 +26033,8 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.18.2
-      zod: 3.25.67
+      ws: 8.18.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
@@ -26164,11 +26151,11 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.0: {}
+  pathval@2.0.1: {}
 
   pg-int8@1.0.1: {}
 
-  pg-protocol@1.8.0: {}
+  pg-protocol@1.10.3: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -26186,11 +26173,11 @@ snapshots:
 
   pkce-challenge@5.0.0: {}
 
-  playwright-core@1.53.1: {}
+  playwright-core@1.54.0: {}
 
-  playwright@1.53.1:
+  playwright@1.54.0:
     dependencies:
-      playwright-core: 1.53.1
+      playwright-core: 1.54.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -26233,7 +26220,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.6.0: {}
+  prettier@3.6.2: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -26280,7 +26267,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.7.9
+      '@types/node': 20.19.1
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -26448,30 +26435,30 @@ snapshots:
       globby: 10.0.1
       is-plain-object: 3.0.1
 
-  rollup@4.44.0:
+  rollup@4.44.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.44.0
-      '@rollup/rollup-android-arm64': 4.44.0
-      '@rollup/rollup-darwin-arm64': 4.44.0
-      '@rollup/rollup-darwin-x64': 4.44.0
-      '@rollup/rollup-freebsd-arm64': 4.44.0
-      '@rollup/rollup-freebsd-x64': 4.44.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.44.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.44.0
-      '@rollup/rollup-linux-arm64-gnu': 4.44.0
-      '@rollup/rollup-linux-arm64-musl': 4.44.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.44.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.44.0
-      '@rollup/rollup-linux-riscv64-musl': 4.44.0
-      '@rollup/rollup-linux-s390x-gnu': 4.44.0
-      '@rollup/rollup-linux-x64-gnu': 4.44.0
-      '@rollup/rollup-linux-x64-musl': 4.44.0
-      '@rollup/rollup-win32-arm64-msvc': 4.44.0
-      '@rollup/rollup-win32-ia32-msvc': 4.44.0
-      '@rollup/rollup-win32-x64-msvc': 4.44.0
+      '@rollup/rollup-android-arm-eabi': 4.44.2
+      '@rollup/rollup-android-arm64': 4.44.2
+      '@rollup/rollup-darwin-arm64': 4.44.2
+      '@rollup/rollup-darwin-x64': 4.44.2
+      '@rollup/rollup-freebsd-arm64': 4.44.2
+      '@rollup/rollup-freebsd-x64': 4.44.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.44.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.44.2
+      '@rollup/rollup-linux-arm64-gnu': 4.44.2
+      '@rollup/rollup-linux-arm64-musl': 4.44.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.44.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-musl': 4.44.2
+      '@rollup/rollup-linux-s390x-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-musl': 4.44.2
+      '@rollup/rollup-win32-arm64-msvc': 4.44.2
+      '@rollup/rollup-win32-ia32-msvc': 4.44.2
+      '@rollup/rollup-win32-x64-msvc': 4.44.2
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -26648,11 +26635,6 @@ snapshots:
   slash@4.0.0: {}
 
   source-map-js@1.2.1: {}
-
-  source-map-support@0.5.21:
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
 
   source-map@0.6.1: {}
 
@@ -26889,14 +26871,14 @@ snapshots:
 
   tsx@4.19.3:
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
 
   tsx@4.20.3:
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
@@ -26933,12 +26915,12 @@ snapshots:
       tersify: 3.12.1
       unpartial: 1.0.5
 
-  typescript-eslint@8.34.1(eslint@9.29.0)(typescript@5.8.3):
+  typescript-eslint@8.34.1(eslint@9.30.1)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      eslint: 9.29.0
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.30.1)(typescript@5.8.3)
+      eslint: 9.30.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -26963,11 +26945,13 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@6.19.8: {}
-
   undici-types@6.21.0: {}
 
-  undici@7.10.0: {}
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@7.11.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -26989,9 +26973,9 @@ snapshots:
       graceful-fs: 4.2.11
       node-int64: 0.4.0
 
-  update-browserslist-db@1.1.3(browserslist@4.25.0):
+  update-browserslist-db@1.1.3(browserslist@4.25.1):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -27028,7 +27012,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -27049,7 +27033,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -27064,34 +27048,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0):
+  vite@7.0.4(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite@6.3.5(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.0
+      rollup: 4.44.2
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.19.1
@@ -27099,30 +27062,16 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.0
 
-  vite@6.3.5(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0):
+  vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
-      esbuild: 0.25.5
+      esbuild: 0.25.6
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.6
-      rollup: 4.44.0
+      rollup: 4.44.2
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.19.1
-      fsevents: 2.3.3
-      tsx: 4.20.3
-      yaml: 2.8.0
-
-  vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.6
-      rollup: 4.44.0
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 22.7.9
       fsevents: 2.3.3
       tsx: 4.20.3
       yaml: 2.8.0
@@ -27131,15 +27080,15 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.0
+      chai: 5.2.1
       debug: 4.4.1
-      expect-type: 1.2.1
+      expect-type: 1.2.2
       magic-string: 0.30.17
       pathe: 2.0.3
       picomatch: 4.0.2
@@ -27149,13 +27098,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less
@@ -27174,15 +27123,15 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.0
+      chai: 5.2.1
       debug: 4.4.1
-      expect-type: 1.2.1
+      expect-type: 1.2.2
       magic-string: 0.30.17
       pathe: 2.0.3
       picomatch: 4.0.2
@@ -27192,56 +27141,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.19.1
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.7.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.0
-      debug: 4.4.1
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 22.7.9
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.0.4(@types/node@20.19.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less
@@ -27320,7 +27226,7 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.18.2: {}
+  ws@8.18.3: {}
 
   xmlcreate@2.0.4: {}
 
@@ -27364,8 +27270,8 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  zod-to-json-schema@3.24.5(zod@3.25.67):
+  zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
-      zod: 3.25.67
+      zod: 3.25.76
 
-  zod@3.25.67: {}
+  zod@3.25.76: {}


### PR DESCRIPTION
temporarily to work around https://github.com/TooTallNate/proxy-agents/issues/379

Our transitive dependency `agent-base`'s type definitions are no longer compatible with recent `@types/node` versions, causing errors like following.  This PR pins the version temporarily so that we can upgrade other dependencies via `rush update --full`.

```
../../../common/temp/node_modules/.pnpm/agent-base@7.1.3/node_modules/agent-base/dist/index.d.ts(33,5): error TS2416: Property 'getName' in type 'Agent' is not assignable to the same property in base type 'Agent'.
  Type '(options: AgentConnectOpts) => string' is not assignable to type '(options?: AgentGetNameOptions | undefined) => string'.
    Types of parameters 'options' and 'options' are incompatible.
      Type 'AgentGetNameOptions | undefined' is not assignable to type 'AgentConnectOpts'.
        Type 'undefined' is not assignable to type 'AgentConnectOpts'.
```