### PR TITLE
[engsys] bump node version to 20 for leftover occurrence of v18

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3317,7 +3317,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-playwright@file:projects/arm-playwright.tgz':
-    resolution: {integrity: sha512-TknsVnOCS5n+ivHftV6YVSWr8EMXzm3+I9AZ7O/XTDTArtVFi747Cofwhrnk+KHEWiV/ip+4wVLTrXmp9zR0uA==, tarball: file:projects/arm-playwright.tgz}
+    resolution: {integrity: sha512-MjDvMxrF8v2jkT95h5BXgwh2jqiuXmcIxUkXM59XFWC+Csoic5rGjqmiQ0qEGhMQF+Ycjt3n6mA2+V7JCpzADw==, tarball: file:projects/arm-playwright.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-playwrighttesting@file:projects/arm-playwrighttesting.tgz':
@@ -16198,7 +16198,7 @@ snapshots:
 
   '@rush-temp/arm-playwright@file:projects/arm-playwright.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
-      '@types/node': 18.19.112
+      '@types/node': 20.19.1
       '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       dotenv: 16.5.0
@@ -16206,7 +16206,7 @@ snapshots:
       playwright: 1.53.1
       tslib: 2.8.1
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.112)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/debug'
@@ -27042,27 +27042,6 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@18.19.112)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@18.19.112)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
@@ -27126,20 +27105,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@18.19.112)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.6
-      rollup: 4.44.0
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 18.19.112
-      fsevents: 2.3.3
-      tsx: 4.20.3
-      yaml: 2.8.0
-
   vite@6.3.5(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
@@ -27181,49 +27146,6 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.20.3
       yaml: 2.8.0
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.112)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.0
-      debug: 4.4.1
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@18.19.112)(tsx@4.20.3)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@18.19.112)(tsx@4.20.3)(yaml@2.8.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 18.19.112
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:

--- a/sdk/communication/communication-sms/samples/v1-beta/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1-beta/javascript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Azure Communication Services - SMS client library samples for JavaScript (Beta)",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/sdk/communication/communication-sms/samples/v1-beta/typescript/package.json
+++ b/sdk/communication/communication-sms/samples/v1-beta/typescript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Azure Communication Services - SMS client library samples for TypeScript (Beta)",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/sdk/healthdataaiservices/health-deidentification-rest/samples/v1/javascript/package.json
+++ b/sdk/healthdataaiservices/health-deidentification-rest/samples/v1/javascript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Health Deidentification Service client library samples for JavaScript",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/sdk/healthdataaiservices/health-deidentification-rest/samples/v1/typescript/package.json
+++ b/sdk/healthdataaiservices/health-deidentification-rest/samples/v1/typescript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Health Deidentification Service client library samples for TypeScript",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/samples/v1-beta/javascript/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/samples/v1-beta/javascript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/samples/v1-beta/typescript/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/samples/v1-beta/typescript/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/sdk/playwright/arm-playwright/package.json
+++ b/sdk/playwright/arm-playwright/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta.1",
   "description": "A generated SDK for PlaywrightManagementClient.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -82,7 +82,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "eslint": "^9.9.0",
     "@vitest/browser": "^3.0.9",
     "@vitest/coverage-istanbul": "^3.0.9",


### PR DESCRIPTION
The PR with the old version might be in-flight while we bump to v20