### PR TITLE
[engSys] Remove mocha from default min/max tests

### DIFF
--- a/eng/tools/dependency-testing/index.js
+++ b/eng/tools/dependency-testing/index.js
@@ -118,13 +118,6 @@ async function insertPackageJson(
       packageJsonContents.name.replace("@azure-rest/", "azure-rest-") + "-test";
   }
   testPackageJson.type = packageJsonContents.type;
-  if (packageJsonContents.scripts["test:node"].includes("vitest")) {
-    testPackageJson.scripts["test:node"] =
-      "dev-tool run test:vitest -- -c vitest.dependency-test.config.ts --test-timeout 180000 --hook-timeout 180000";
-    testPackageJson.scripts["test:browser"] =
-      "dev-tool run build-test && dev-tool run test:vitest --browser  -- -c vitest.dependency-test.browser.config.ts";
-    testPackageJson.scripts["build"] = "echo skipped.";
-  }
   await usePackageTestTimeout(testPackageJson, packageJsonContents);
 
   testPackageJson.devDependencies = {};

--- a/eng/tools/dependency-testing/templates/package.json
+++ b/eng/tools/dependency-testing/templates/package.json
@@ -7,9 +7,9 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc -p .",
-    "test:browser": "karma start --single-run",
-    "test:node": "mocha --require tsx --require source-map-support/register --reporter mocha-multi-reporter.js  --reporter-option output=test-results.xml --timeout 350000 --full-trace \"dist-esm/**/{,!(browser)/**/}*.spec.js\" --exit",
+    "build": "echo skipped.",
+    "test:browser": "dev-tool run build-test && dev-tool run test:vitest --browser  -- -c vitest.dependency-test.browser.config.ts",
+    "test:node": "dev-tool run test:vitest -- -c vitest.dependency-test.config.ts --test-timeout 180000 --hook-timeout 180000",
     "test": "npm run test:node && echo skipped: npm run test:browser"
   },
   "repository": {


### PR DESCRIPTION
Cleans up remnants of mocha that are no longer in use - now that everyone is on vitest we can default to vitest