### PR TITLE
[Identity] Add broker flow to DAC chain

### DIFF
--- a/sdk/identity/identity-broker/README.md
+++ b/sdk/identity/identity-broker/README.md
@@ -72,6 +72,17 @@ const credential = new InteractiveBrowserCredential({
 
 After calling `useIdentityPlugin`, the native broker plugin is registered to the `@azure/identity` package and will be available on the `InteractiveBrowserCredential` that supports WAM broker authentication. This credential has `brokerOptions` in the constructor options.
 
+**Notes**: As of `@azure/identity` version 4.11.0-beta.1, `DefaultAzureCredential` provides support to sign-in via the Windows Web Account Manager. Enable native broker in your program as follows:
+
+```ts snippet:using_plugins_dac
+import { useIdentityPlugin, DefaultAzureCredential } from "@azure/identity";
+import { nativeBrokerPlugin } from "@azure/identity-broker";
+
+useIdentityPlugin(nativeBrokerPlugin);
+
+const credential = new DefaultAzureCredential();
+```
+
 ## Examples
 
 Once the plugin is registered, you can enable WAM broker authentication by passing `brokerOptions` with an `enabled` property set to `true` to a credential constructor. In the following example, we use the `InteractiveBrowserCredential`.

--- a/sdk/identity/identity-broker/test/snippets.spec.ts
+++ b/sdk/identity/identity-broker/test/snippets.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { InteractiveBrowserCredential, useIdentityPlugin } from "@azure/identity";
+import {
+  InteractiveBrowserCredential,
+  useIdentityPlugin,
+  DefaultAzureCredential,
+} from "@azure/identity";
 import { nativeBrokerPlugin } from "@azure/identity-broker";
 import { setLogLevel } from "@azure/logger";
 import { describe, it } from "vitest";
@@ -21,6 +25,13 @@ describe("snippets", function () {
         parentWindowHandle: new Uint8Array(0), // This should be a handle to the parent window
       },
     });
+  });
+
+  it("using_plugins_dac", async function () {
+    useIdentityPlugin(nativeBrokerPlugin);
+    // @ts-preserve-whitespace
+    // @ts-ignore
+    const credential = new DefaultAzureCredential();
   });
 
   it("usage_example", async function () {

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- `DefaultAzureCredential` now supports authentication with the currently signed-in Windows account when the `@azure/identity-broker` package is installed and configured with `useIdentityPlugin`. This auth mechanism is added at the end of the `DefaultAzureCredential` credential chain. [#35213](https://github.com/Azure/azure-sdk-for-js/pull/35213)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -316,7 +316,7 @@ The Azure Identity library offers both in-memory and persistent disk caching. Fo
 
 ## Brokered authentication
 
-An authentication broker is an application that runs on a user’s machine and manages the authentication handshakes and token maintenance for connected accounts. Currently, only the Windows Web Account Manager (WAM) is supported. To enable support, use the [`@azure/identity-broker`][azure_identity_broker] package. For details on authenticating using WAM, see the [broker plugin documentation][azure_identity_broker_readme].
+An authentication broker is an application that runs on a user’s machine and manages the authentication handshakes and token maintenance for connected accounts. Currently, only the Windows Web Account Manager (WAM) is supported. Broker authentication is used by `DefaultAzureCredential` to enable secure sign-in via the WAM. To enable support, use the [`@azure/identity-broker`][azure_identity_broker] package. For details on authenticating using WAM, see the [broker plugin documentation][azure_identity_broker_readme].
 
 ## Troubleshooting
 

--- a/sdk/identity/identity/TROUBLESHOOTING.md
+++ b/sdk/identity/identity/TROUBLESHOOTING.md
@@ -436,9 +436,15 @@ If the preceding command isn't working properly, follow the instructions to reso
 
 ## Troubleshoot Web Account Manager and Microsoft account login issues
 
+Broker authentication is used by `DefaultAzureCredential` to enable secure sign-in via the Windows Web Account Manager (WAM). This mechanism requires the `@azure/identity-broker` dependency and is currently only supported on Windows.
+
 | Error Message | Description                                           | Mitigation                                                                                                                                                                |
 | ------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | AADSTS50011   | The application is missing the expected redirect URI. | Ensure that one of redirect URIs registered for the Microsoft Entra application matches the following URI pattern: `ms-appx-web://Microsoft.AAD.BrokerPlugin/{client_id}` |
+| `CredentialUnavailableException: Failed to acquire token using broker authentication` | An unexpected error occurred while getting token with the broker authentication flow. | Check the inner exception for more details. Ensure your environment meets all requirements for broker authentication (Windows OS, correct dependencies, and configuration). |
+
+> [!NOTE] 
+> Brokered authentication is currently only supported on Windows. macOS and Linux are not yet supported.
 
 ### Unable to log in with Microsoft account (MSA) on Windows
 

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -107,7 +107,7 @@
   },
   "type": "module",
   "tshy": {
-    "project": "./tsconfig.src.json",
+    "project": "../../../tsconfig.src.build.json",
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"

--- a/sdk/identity/identity/review/identity-browser.api.diff.md
+++ b/sdk/identity/identity/review/identity-browser.api.diff.md
@@ -79,7 +79,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface AzurePowerShellCredentialOptions extends MultiTenantTokenCredentialOptions {
-@@ -173,10 +178,11 @@
+@@ -173,22 +178,22 @@
  }
  
  // @public
@@ -93,7 +93,22 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface ClientAssertionCredentialOptions extends MultiTenantTokenCredentialOptions, CredentialPersistenceOptions, AuthorityValidationOptions {
-@@ -212,9 +218,9 @@
+ }
+ 
+ // @public
+ export class ClientCertificateCredential implements TokenCredential {
+-    constructor(tenantId: string, clientId: string, certificatePath: string, options?: ClientCertificateCredentialOptions);
+-    constructor(tenantId: string, clientId: string, configuration: ClientCertificatePEMCertificatePath, options?: ClientCertificateCredentialOptions);
+-    constructor(tenantId: string, clientId: string, configuration: ClientCertificatePEMCertificate, options?: ClientCertificateCredentialOptions);
+-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
++    constructor();
++    // (undocumented)
++    getToken(): Promise<AccessToken | null>;
+ }
+ 
+ // @public
+ export interface ClientCertificateCredentialOptions extends MultiTenantTokenCredentialOptions, CredentialPersistenceOptions, AuthorityValidationOptions {
+@@ -212,9 +217,9 @@
  
  // @public
  export class ClientSecretCredential implements TokenCredential {
@@ -104,7 +119,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface ClientSecretCredentialOptions extends MultiTenantTokenCredentialOptions, CredentialPersistenceOptions, AuthorityValidationOptions {
-@@ -236,11 +242,11 @@
+@@ -236,11 +241,11 @@
  export const CredentialUnavailableErrorName = "CredentialUnavailableError";
  
  // @public
@@ -119,7 +134,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface DefaultAzureCredentialClientIdOptions extends DefaultAzureCredentialOptions {
-@@ -263,11 +269,11 @@
+@@ -263,11 +268,11 @@
  export function deserializeAuthenticationRecord(serializedRecord: string): AuthenticationRecord;
  
  // @public
@@ -134,7 +149,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface DeviceCodeCredentialOptions extends InteractiveCredentialOptions, CredentialPersistenceOptions {
-@@ -287,10 +293,11 @@
+@@ -287,10 +292,11 @@
  export type DeviceCodePromptCallback = (deviceCodeInfo: DeviceCodeInfo) => void;
  
  // @public
@@ -148,7 +163,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface EnvironmentCredentialOptions extends MultiTenantTokenCredentialOptions, AuthorityValidationOptions {
-@@ -326,9 +333,9 @@
+@@ -326,9 +332,9 @@
  export type IdentityPlugin = (context: unknown) => void;
  
  // @public
@@ -159,7 +174,27 @@ For the complete API surface, see the corresponding -node.api.md file.
      getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
  }
  
-@@ -388,12 +395,11 @@
+@@ -357,15 +363,13 @@
+ 
+ // @public
+ export const logger: AzureLogger;
+ 
+-// @public
++// @public (undocumented)
+ export class ManagedIdentityCredential implements TokenCredential {
+-    constructor(clientId: string, options?: TokenCredentialOptions);
+-    constructor(options?: ManagedIdentityCredentialClientIdOptions);
+-    constructor(options?: ManagedIdentityCredentialResourceIdOptions);
+-    constructor(options?: ManagedIdentityCredentialObjectIdOptions);
+-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
++    constructor();
++    // (undocumented)
++    getToken(): Promise<AccessToken | null>;
+ }
+ 
+ // @public
+ export interface ManagedIdentityCredentialClientIdOptions extends TokenCredentialOptions {
+@@ -388,12 +392,11 @@
  }
  
  // @public
@@ -175,7 +210,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export interface OnBehalfOfCredentialAssertionOptions {
-@@ -443,25 +449,26 @@
+@@ -443,25 +446,26 @@
          enableUnsafeSupportLogging?: boolean;
      };
  }
@@ -208,5 +243,18 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public @deprecated
  export interface VisualStudioCodeCredentialOptions extends MultiTenantTokenCredentialOptions {
+@@ -469,10 +473,10 @@
+ }
+ 
+ // @public
+ export class WorkloadIdentityCredential implements TokenCredential {
+-    constructor(options?: WorkloadIdentityCredentialOptions);
+-    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken>;
++    constructor();
++    getToken(): Promise<AccessToken | null>;
+ }
+ 
+ // @public
+ export interface WorkloadIdentityCredentialOptions extends MultiTenantTokenCredentialOptions, AuthorityValidationOptions {
 
 ```

--- a/sdk/identity/identity/src/credentials/brokerCredential.ts
+++ b/sdk/identity/identity/src/credentials/brokerCredential.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
+import {
+  processMultiTenantRequest,
+  resolveAdditionallyAllowedTenantIds,
+  resolveTenantId,
+} from "../util/tenantIdUtils.js";
+
+import { credentialLogger, formatError } from "../util/logging.js";
+import { ensureScopes } from "../util/scopeUtils.js";
+import { tracingClient } from "../util/tracing.js";
+import type { MsalClient, MsalClientOptions } from "../msal/nodeFlows/msalClient.js";
+import { createMsalClient } from "../msal/nodeFlows/msalClient.js";
+import { DeveloperSignOnClientId } from "../constants.js";
+import { TokenCredentialOptions } from "../tokenCredentialOptions.js";
+import { MultiTenantTokenCredentialOptions } from "./multiTenantTokenCredentialOptions.js";
+import { CredentialUnavailableError } from "../errors.js";
+
+const logger = credentialLogger("BrokerCredential");
+
+/**
+ * Enables authentication to Microsoft Entra ID using WAM (Web Account Manager) broker.
+ * This credential extends InteractiveBrowserCredential and provides additional broker-specific functionality.
+ */
+export class BrokerCredential implements TokenCredential {
+  private brokerMsalClient: MsalClient;
+  private brokerTenantId?: string;
+  private brokerAdditionallyAllowedTenantIds: string[];
+
+  /**
+   * Creates an instance of BrokerCredential with the required broker options.
+   *
+   * This credential uses WAM (Web Account Manager) for authentication, which provides
+   * better security and user experience on Windows platforms.
+   *
+   * @param options - Options for configuring the broker credential, including required broker options.
+   */
+  constructor(
+    options: { tenantId?: string } & TokenCredentialOptions & MultiTenantTokenCredentialOptions,
+  ) {
+    this.brokerTenantId = resolveTenantId(logger, options.tenantId);
+    this.brokerAdditionallyAllowedTenantIds = resolveAdditionallyAllowedTenantIds(
+      options?.additionallyAllowedTenants,
+    );
+    const msalClientOptions: MsalClientOptions = {
+      ...options,
+      tokenCredentialOptions: options,
+      logger,
+      brokerOptions: {
+        enabled: true,
+        parentWindowHandle: new Uint8Array(0),
+        useDefaultBrokerAccount: true,
+      },
+    };
+
+    this.brokerMsalClient = createMsalClient(
+      DeveloperSignOnClientId,
+      this.brokerTenantId,
+      msalClientOptions,
+    );
+  }
+
+  /**
+   * Authenticates with Microsoft Entra ID using WAM broker and returns an access token if successful.
+   * If authentication fails, a {@link CredentialUnavailableError} will be thrown with the details of the failure.
+   *
+   * This method extends the base getToken method to support silentAuthenticationOnly option
+   * when using broker authentication.
+   *
+   * @param scopes - The list of scopes for which the token will have access.
+   * @param options - The options used to configure the token request, including silentAuthenticationOnly option.
+   */
+  async getToken(scopes: string | string[], options: GetTokenOptions = {}): Promise<AccessToken> {
+    return tracingClient.withSpan(
+      `${this.constructor.name}.getToken`,
+      options,
+      async (newOptions) => {
+        newOptions.tenantId = processMultiTenantRequest(
+          this.brokerTenantId,
+          newOptions,
+          this.brokerAdditionallyAllowedTenantIds,
+          logger,
+        );
+
+        const arrayScopes = ensureScopes(scopes);
+        try {
+          return this.brokerMsalClient.getBrokeredToken(arrayScopes, true, {
+            ...newOptions,
+            disableAutomaticAuthentication: true,
+          });
+        } catch (e: any) {
+          logger.getToken.info(formatError(arrayScopes, e));
+          throw new CredentialUnavailableError(
+            "Failed to acquire token using broker authentication",
+            { cause: e },
+          );
+        }
+      },
+    );
+  }
+}

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -21,6 +21,7 @@ import type { TokenCredential } from "@azure/core-auth";
 import { WorkloadIdentityCredential } from "./workloadIdentityCredential.js";
 import type { WorkloadIdentityCredentialOptions } from "./workloadIdentityCredentialOptions.js";
 import { credentialLogger } from "../util/logging.js";
+import { BrokerCredential } from "./brokerCredential.js";
 
 const logger = credentialLogger("DefaultAzureCredential");
 
@@ -161,6 +162,21 @@ function createDefaultAzurePowershellCredential(
 }
 
 /**
+ * Creates a BrokerCredential instance with the provided options.
+ * This credential uses the Windows Authentication Manager (WAM) broker for authentication.
+ * It will only attempt to authenticate silently using the default broker account
+ *
+ * @param options - Options for configuring the credential.
+ *
+ * @internal
+ */
+export function createDefaultBrokerCredential(
+  options: DefaultAzureCredentialOptions = {},
+): TokenCredential {
+  return new BrokerCredential(options);
+}
+
+/**
  * Creates an {@link EnvironmentCredential} from the provided options.
  * @param options - Options to configure the credential.
  *
@@ -241,6 +257,7 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
       createDefaultAzureCliCredential,
       createDefaultAzurePowershellCredential,
       createDefaultAzureDeveloperCliCredential,
+      createDefaultBrokerCredential,
     ];
     const prodCredentialFunctions = [
       createEnvironmentCredential,

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -196,6 +196,20 @@ export interface MsalClient {
    * An authentication record could be loaded by calling the `getToken` method, or by providing an `authenticationRecord` when creating a credential.
    */
   getActiveAccount(): AuthenticationRecord | undefined;
+
+  /**
+   * Retrieves an access token using brokered authentication.
+   *
+   * @param scopes - The scopes for which the access token is requested. These represent the resources that the application wants to access.
+   * @param useDefaultBrokerAccount - Whether to use the default broker account for authentication.
+   * @param options - Additional options that may be provided to the method.
+   * @returns An access token.
+   */
+  getBrokeredToken(
+    scopes: string[],
+    useDefaultBrokerAccount: boolean,
+    options?: GetTokenInteractiveOptions,
+  ): Promise<AccessToken>;
 }
 
 /**
@@ -747,6 +761,121 @@ export function createMsalClient(
     }
   }
 
+  /**
+   * Creates a base interactive request configuration for MSAL interactive authentication.
+   * This is shared between interactive and brokered authentication flows.
+   *
+   * @internal
+   */
+  function createBaseInteractiveRequest(
+    scopes: string[],
+    options: GetTokenInteractiveOptions,
+  ): msal.InteractiveRequest {
+    return {
+      openBrowser: async (url) => {
+        const open = await import("open");
+        await open.default(url, { wait: true, newInstance: true });
+      },
+      scopes,
+      authority: calculateRequestAuthority(options),
+      claims: options?.claims,
+      loginHint: options?.loginHint,
+      errorTemplate: options?.browserCustomizationOptions?.errorMessage,
+      successTemplate: options?.browserCustomizationOptions?.successMessage,
+      prompt: options?.loginHint ? "login" : "select_account",
+    };
+  }
+
+  /**
+   * @internal
+   */
+  async function getBrokeredTokenInternal(
+    scopes: string[],
+    useDefaultBrokerAccount: boolean,
+    options: GetTokenInteractiveOptions = {},
+  ): Promise<msal.AuthenticationResult> {
+    msalLogger.verbose("Authentication will resume through the broker");
+
+    const app = await getPublicApp(options);
+
+    const interactiveRequest = createBaseInteractiveRequest(scopes, options);
+    if (state.pluginConfiguration.broker.parentWindowHandle) {
+      interactiveRequest.windowHandle = Buffer.from(
+        state.pluginConfiguration.broker.parentWindowHandle,
+      );
+    } else {
+      // this is a bug, as the pluginConfiguration handler should validate this case.
+      msalLogger.warning(
+        "Parent window handle is not specified for the broker. This may cause unexpected behavior. Please provide the parentWindowHandle.",
+      );
+    }
+
+    if (state.pluginConfiguration.broker.enableMsaPassthrough) {
+      (interactiveRequest.tokenQueryParameters ??= {})["msal_request_type"] =
+        "consumer_passthrough";
+    }
+    if (useDefaultBrokerAccount) {
+      interactiveRequest.prompt = "none";
+      msalLogger.verbose("Attempting broker authentication using the default broker account");
+    } else {
+      msalLogger.verbose("Attempting broker authentication without the default broker account");
+    }
+
+    if (options.proofOfPossessionOptions) {
+      interactiveRequest.shrNonce = options.proofOfPossessionOptions.nonce;
+      interactiveRequest.authenticationScheme = "pop";
+      interactiveRequest.resourceRequestMethod =
+        options.proofOfPossessionOptions.resourceRequestMethod;
+      interactiveRequest.resourceRequestUri = options.proofOfPossessionOptions.resourceRequestUrl;
+    }
+    try {
+      return await app.acquireTokenInteractive(interactiveRequest);
+    } catch (e: any) {
+      msalLogger.verbose(`Failed to authenticate through the broker: ${e.message}`);
+      if (options.disableAutomaticAuthentication) {
+        throw new AuthenticationRequiredError({
+          scopes,
+          getTokenOptions: options,
+          message: "Cannot silently authenticate with default broker account.",
+        });
+      }
+      // If we tried to use the default broker account and failed, fall back to interactive authentication
+      if (useDefaultBrokerAccount) {
+        return getBrokeredTokenInternal(scopes, false, options);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * A helper function that supports brokered authentication through the MSAL's public application.
+   *
+   * When useDefaultBrokerAccount is true, the method will attempt to authenticate using the default broker account.
+   * If the default broker account is not available, the method will fall back to interactive authentication.
+   */
+  async function getBrokeredToken(
+    scopes: string[],
+    useDefaultBrokerAccount: boolean,
+    options: GetTokenInteractiveOptions = {},
+  ): Promise<AccessToken> {
+    msalLogger.getToken.info(
+      `Attempting to acquire token using brokered authentication with useDefaultBrokerAccount: ${useDefaultBrokerAccount}`,
+    );
+    const response = await getBrokeredTokenInternal(scopes, useDefaultBrokerAccount, options);
+    ensureValidMsalToken(scopes, response, options);
+    ensureValidMsalToken(scopes, response, options);
+    state.cachedAccount = response?.account ?? null;
+
+    state.logger.getToken.info(formatSuccess(scopes));
+    return {
+      token: response.accessToken,
+      expiresOnTimestamp: response.expiresOn.getTime(),
+      refreshAfterTimestamp: response.refreshOn?.getTime(),
+      tokenType: response.tokenType,
+    } as AccessToken;
+  }
+
   async function getTokenByInteractiveRequest(
     scopes: string[],
     options: GetTokenInteractiveOptions = {},
@@ -755,80 +884,15 @@ export function createMsalClient(
 
     const app = await getPublicApp(options);
 
-    /**
-     * A helper function that supports brokered authentication through the MSAL's public application.
-     *
-     * When options.useDefaultBrokerAccount is true, the method will attempt to authenticate using the default broker account.
-     * If the default broker account is not available, the method will fall back to interactive authentication.
-     */
-    async function getBrokeredToken(
-      useDefaultBrokerAccount: boolean,
-    ): Promise<msal.AuthenticationResult> {
-      msalLogger.verbose("Authentication will resume through the broker");
-      const interactiveRequest = createBaseInteractiveRequest();
-      if (state.pluginConfiguration.broker.parentWindowHandle) {
-        interactiveRequest.windowHandle = Buffer.from(
-          state.pluginConfiguration.broker.parentWindowHandle,
-        );
-      } else {
-        // this is a bug, as the pluginConfiguration handler should validate this case.
-        msalLogger.warning(
-          "Parent window handle is not specified for the broker. This may cause unexpected behavior. Please provide the parentWindowHandle.",
-        );
-      }
-
-      if (state.pluginConfiguration.broker.enableMsaPassthrough) {
-        (interactiveRequest.tokenQueryParameters ??= {})["msal_request_type"] =
-          "consumer_passthrough";
-      }
-      if (useDefaultBrokerAccount) {
-        interactiveRequest.prompt = "none";
-        msalLogger.verbose("Attempting broker authentication using the default broker account");
-      } else {
-        msalLogger.verbose("Attempting broker authentication without the default broker account");
-      }
-
-      if (options.proofOfPossessionOptions) {
-        interactiveRequest.shrNonce = options.proofOfPossessionOptions.nonce;
-        interactiveRequest.authenticationScheme = "pop";
-        interactiveRequest.resourceRequestMethod =
-          options.proofOfPossessionOptions.resourceRequestMethod;
-        interactiveRequest.resourceRequestUri = options.proofOfPossessionOptions.resourceRequestUrl;
-      }
-      try {
-        return await app.acquireTokenInteractive(interactiveRequest);
-      } catch (e: any) {
-        msalLogger.verbose(`Failed to authenticate through the broker: ${e.message}`);
-        // If we tried to use the default broker account and failed, fall back to interactive authentication
-        if (useDefaultBrokerAccount) {
-          return getBrokeredToken(/* useDefaultBrokerAccount: */ false);
-        } else {
-          throw e;
-        }
-      }
-    }
-
-    function createBaseInteractiveRequest(): msal.InteractiveRequest {
-      return {
-        openBrowser: async (url) => {
-          const open = await import("open");
-          await open.default(url, { wait: true, newInstance: true });
-        },
-        scopes,
-        authority: calculateRequestAuthority(options),
-        claims: options?.claims,
-        loginHint: options?.loginHint,
-        errorTemplate: options?.browserCustomizationOptions?.errorMessage,
-        successTemplate: options?.browserCustomizationOptions?.successMessage,
-        prompt: options?.loginHint ? "login" : "select_account",
-      };
-    }
-
     return withSilentAuthentication(app, scopes, options, async () => {
-      const interactiveRequest = createBaseInteractiveRequest();
+      const interactiveRequest = createBaseInteractiveRequest(scopes, options);
 
       if (state.pluginConfiguration.broker.isEnabled) {
-        return getBrokeredToken(state.pluginConfiguration.broker.useDefaultBrokerAccount ?? false);
+        return getBrokeredTokenInternal(
+          scopes,
+          state.pluginConfiguration.broker.useDefaultBrokerAccount ?? false,
+          options,
+        );
       }
       if (options.proofOfPossessionOptions) {
         interactiveRequest.shrNonce = options.proofOfPossessionOptions.nonce;
@@ -843,6 +907,7 @@ export function createMsalClient(
 
   return {
     getActiveAccount,
+    getBrokeredToken,
     getTokenByClientSecret,
     getTokenByClientAssertion,
     getTokenByClientCertificate,

--- a/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalPlugins.ts
@@ -115,6 +115,7 @@ function generatePluginConfiguration(options: MsalClientOptions): PluginConfigur
   const config: PluginConfiguration = {
     cache: {},
     broker: {
+      ...options.brokerOptions,
       isEnabled: options.brokerOptions?.enabled ?? false,
       enableMsaPassthrough: options.brokerOptions?.legacyEnableMsaPassthrough ?? false,
       parentWindowHandle: options.brokerOptions?.parentWindowHandle,

--- a/sdk/identity/identity/test/internal/node/brokerCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/brokerCredential.spec.ts
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { BrokerCredential } from "../../../src/credentials/brokerCredential.js";
+import { DeveloperSignOnClientId } from "../../../src/constants.js";
+import { createMsalClient } from "../../../src/msal/nodeFlows/msalClient.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
+import {
+  resolveTenantId,
+  resolveAdditionallyAllowedTenantIds,
+  processMultiTenantRequest,
+} from "../../../src/util/tenantIdUtils.js";
+
+vi.mock("../../../src/msal/nodeFlows/msalClient.js", () => ({
+  createMsalClient: vi.fn(),
+}));
+
+vi.mock("../../../src/util/tenantIdUtils.js", () => ({
+  resolveTenantId: vi.fn(),
+  resolveAdditionallyAllowedTenantIds: vi.fn(),
+  processMultiTenantRequest: vi.fn(),
+}));
+
+describe("BrokerCredential (internal)", function () {
+  let mockMsalClient: any;
+  let createMsalClientSpy: MockInstance;
+
+  beforeEach(async function () {
+    vi.mocked(resolveTenantId).mockReturnValue("test-tenant-id");
+    vi.mocked(resolveAdditionallyAllowedTenantIds).mockReturnValue([]);
+    vi.mocked(processMultiTenantRequest).mockReturnValue("test-tenant-id");
+
+    mockMsalClient = {
+      getBrokeredToken: vi.fn(),
+    };
+
+    createMsalClientSpy = vi.mocked(createMsalClient).mockReturnValue(mockMsalClient);
+  });
+
+  afterEach(async function () {
+    vi.clearAllMocks();
+  });
+
+  const scope = "https://vault.azure.net/.default";
+
+  describe("constructor", function () {
+    it("should initialize with default options", function () {
+      new BrokerCredential({});
+      expect(createMsalClientSpy).toHaveBeenCalledWith(
+        DeveloperSignOnClientId,
+        "test-tenant-id",
+        expect.objectContaining({
+          logger: expect.anything(),
+          brokerOptions: {
+            enabled: true,
+            parentWindowHandle: expect.any(Uint8Array),
+            useDefaultBrokerAccount: true,
+          },
+        }),
+      );
+    });
+    it("should pass through token credential options", function () {
+      const options = {
+        tenantId: "test-tenant",
+        authorityHost: "https://custom.authority.com",
+        additionallyAllowedTenants: ["tenant1"],
+      };
+
+      new BrokerCredential(options);
+
+      expect(createMsalClientSpy).toHaveBeenCalledWith(
+        DeveloperSignOnClientId,
+        "test-tenant-id",
+        expect.objectContaining({
+          ...options,
+          tokenCredentialOptions: options,
+          logger: expect.anything(),
+          brokerOptions: {
+            enabled: true,
+            parentWindowHandle: expect.any(Uint8Array),
+            useDefaultBrokerAccount: true,
+          },
+        }),
+      );
+    });
+  });
+
+  describe("getToken", function () {
+    it("should get token with default options", async function () {
+      const expectedToken = {
+        token: "test-token",
+        expiresOnTimestamp: Date.now() + 3600 * 1000,
+        tokenType: "pop",
+        refreshAfterTimestamp: undefined,
+      };
+      mockMsalClient.getBrokeredToken.mockResolvedValue(expectedToken);
+
+      const credential = new BrokerCredential({});
+      const token = await credential.getToken(scope);
+
+      expect(token).toEqual(expectedToken);
+    });
+  });
+});

--- a/tsconfig.src.build.json
+++ b/tsconfig.src.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["DOM", "DOM.Iterable", "DOM.AsyncIterable", "ES2017"],
+    "jsx": "preserve"
+  }
+}


### PR DESCRIPTION
### Packages impacted by this PR
@azure/identity

### Issues associated with this PR


### Describe the problem that is addressed by this PR
- Add broker flow to DAC using a new broker credential

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
1. Separate out the `getBrokeredToken` function & add a separate check for `disableAutomaticAuthentication` to prevent falling back to interactive authentication. This won't break current IBC implementation since IBC has throw before `onAuthenticationRequired` callback is reached.

**Pros:**
- Codepath is clear to follow, decoupled `getBrokeredToken` from `getTokenByInteractiveRequest`
- Save the time that customers would fail from `getTokenSilent` and go directly to the method that we want
**Cons:**
- More significant code change
- `disableAutomaticAuthentication` property is now overloaded with new code path

3. Add another property called `silentBrokeredAuthenticationOnly` to signify what we want to do. This property will only be checked inside `getBrokeredToken` in the catch block to ensure we do not use interactive authentication. 
**Pros:**
- Less code change
- Clear meaning for each options
- Keep IBC and BrokerCredential code path similar with each other
**Cons:**
- Customers have to wait for `getTokenSilent` to fail before actually getting to `getBrokeredToken`
0 Convoluted code path

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
