### PR TITLE
Added validation for range headers when it undefined.

### DIFF
--- a/sdk/communication/communication-call-automation/src/contentDownloader.ts
+++ b/sdk/communication/communication-call-automation/src/contentDownloader.ts
@@ -113,8 +113,7 @@ export class ContentDownloaderImpl {
     opt.headers?.set("OriginalUrl", sourceLocationUrl);
     opt.headers?.set("x-ms-host", endpoint.host);
     opt.headers?.set("accept", "application/json");
-
-    if (rangeHeader !== "bytes=" + undefined) {
+    if (options.offset) {
       opt.headers?.set("Range", rangeHeader);
     }
 

--- a/sdk/communication/communication-call-automation/src/contentDownloader.ts
+++ b/sdk/communication/communication-call-automation/src/contentDownloader.ts
@@ -113,7 +113,10 @@ export class ContentDownloaderImpl {
     opt.headers?.set("OriginalUrl", sourceLocationUrl);
     opt.headers?.set("x-ms-host", endpoint.host);
     opt.headers?.set("accept", "application/json");
-    opt.headers?.set("Range", rangeHeader);
+
+    if (rangeHeader !== "bytes=" + undefined) {
+      opt.headers?.set("Range", rangeHeader);
+    }
 
     const req = createPipelineRequest(opt);
 


### PR DESCRIPTION
Added validation with offset for download recording file and metadata file

[Task 4142881](https://skype.visualstudio.com/SPOOL/_workitems/edit/4142881): Verify the two download methods in all SDKs with the updated AMS endpoint.

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
