### PR TITLE
[engsys] [devtool] tweak api-extractor and runtime diff report to always use unix newlines

### DIFF
--- a/api-extractor-base.json
+++ b/api-extractor-base.json
@@ -11,6 +11,7 @@
     "enabled": true,
     "reportFolder": "<projectFolder>/review"
   },
+  "newlineKind": "lf",
   "compiler": {
     "tsconfigFilePath": "<projectFolder>/tsconfig.src.json"
   },

--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -133,7 +133,7 @@ function createApiDiff(
   runtimeContent: string,
   runtime: string,
 ): string | undefined {
-  const diff = createTwoFilesPatch("NodeJS", runtime, nodeContent, runtimeContent);
+  const diff = createTwoFilesPatch("NodeJS", runtime, nodeContent, runtimeContent, undefined, undefined, {stripTrailingCr: true, ignoreWhitespace: true});
   const parsed = parsePatch(diff);
   const hasRealChanges = parsed.some((file) =>
     file.hunks.some((hunk) =>

--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -133,7 +133,15 @@ function createApiDiff(
   runtimeContent: string,
   runtime: string,
 ): string | undefined {
-  const diff = createTwoFilesPatch("NodeJS", runtime, nodeContent, runtimeContent, undefined, undefined, {stripTrailingCr: true, ignoreWhitespace: true});
+  const diff = createTwoFilesPatch(
+    "NodeJS",
+    runtime,
+    nodeContent,
+    runtimeContent,
+    undefined,
+    undefined,
+    { stripTrailingCr: true, ignoreWhitespace: true },
+  );
   const parsed = parsePatch(diff);
   const hasRealChanges = parsed.some((file) =>
     file.hunks.some((hunk) =>


### PR DESCRIPTION
### Packages impacted by this PR

`dev-tool`

### Describe the problem that is addressed by this PR

When running `api-extractor` locally it will introduce CRLF as the eol for api reports which is different from what is checked into git. Similarly, the `diff` package that we use to look at deltas between runtimes by default will preference towards introducing them as well.