### PR TITLE
[cosmos] use tsconfig.src.build.json

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -137,7 +137,7 @@
   },
   "type": "module",
   "tshy": {
-    "project": "./tsconfig.src.json",
+    "project": "./tsconfig.src.build.json",
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"

--- a/sdk/cosmosdb/cosmos/tsconfig.src.build.json
+++ b/sdk/cosmosdb/cosmos/tsconfig.src.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.src.build.json",
+  "compilerOptions": {
+    "stripInternal": true,
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "strict": false,
+    "noImplicitAny": true,
+    "noImplicitReturns": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}


### PR DESCRIPTION
Switching to use [`tsconfig.src.build.json`](https://github.com/Azure/azure-sdk-for-js/blob/main/tsconfig.src.build.json).