### PR TITLE
[api extractor] Use runtime-specific tsconfig

### DIFF
--- a/api-extractor-base.json
+++ b/api-extractor-base.json
@@ -12,9 +12,6 @@
     "reportFolder": "<projectFolder>/review"
   },
   "newlineKind": "lf",
-  "compiler": {
-    "tsconfigFilePath": "<projectFolder>/tsconfig.src.json"
-  },
   "messages": {
     "tsdocMessageReporting": {
       "default": {


### PR DESCRIPTION
The API Extractor uses `tsconfig.src.json` as its TypeScript configuration when generating all API files. However, each generated API file must be compliant with its target runtime environment. This means that all publicly exposed types must be fully defined for that runtime. For example, Node.js-specific types should not appear in a browser API report unless they have been explicitly redefined for the browser context. If we were to generate the complete API for the browser for ts-http-runtime today, we will find many references to undefined types in the browser context such as the `NodeJS` namespace: 
<img width="1377" height="277" alt="image" src="https://github.com/user-attachments/assets/d0320e21-6bf8-440f-b6b2-9e12984ed4c3" />


This PR improves the API extractor logic to look for `tsocnfig.src.<runtime name>.json` to use when generating the API files and falls back to `tsconfig.src.json` if one doesn't exist. A library author can provide such a targeted tsconfig file to catch any such unresolvable type references in the target runtime.