### PR TITLE
use tsconfig.src.build.json in select libs

### DIFF
--- a/sdk/agricultureplatform/arm-agricultureplatform/package.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/package.json
@@ -25,7 +25,7 @@
       "react-native"
     ],
     "selfLink": false,
-    "project": "./tsconfig.src.json"
+    "project": "../../../tsconfig.src.build.json"
   },
   "type": "module",
   "keywords": [

--- a/sdk/agricultureplatform/arm-agricultureplatform/src/static-helpers/urlTemplate.ts
+++ b/sdk/agricultureplatform/arm-agricultureplatform/src/static-helpers/urlTemplate.ts
@@ -170,7 +170,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
@@ -82,7 +82,7 @@
       "commonjs"
     ],
     "selfLink": false,
-    "project": "./tsconfig.src.json"
+    "project": "./tsconfig.src.build.json"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.src.build.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/tsconfig.src.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.src.build.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
+  "exclude": ["./src/templates"]
+}

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -115,7 +115,7 @@
       "react-native"
     ],
     "selfLink": false,
-    "project": "./tsconfig.src.json"
+    "project": "../../../tsconfig.src.build.json"
   },
   "module": "./dist/esm/index.js"
 }

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -120,7 +120,7 @@
       "react-native"
     ],
     "selfLink": false,
-    "project": "./tsconfig.src.json"
+    "project": "../../../tsconfig.src.build.json"
   },
   "module": "./dist/esm/index.js"
 }

--- a/sdk/core/core-sse/review/core-sse-node.api.md
+++ b/sdk/core/core-sse/review/core-sse-node.api.md
@@ -24,8 +24,7 @@ export interface EventMessage {
 }
 
 // @public
-export interface EventMessageStream extends ReadableStream<EventMessage>, AsyncDisposable, AsyncIterable<EventMessage> {
-}
+export type EventMessageStream = ReadableStream<EventMessage> & AsyncDisposable & AsyncIterable<EventMessage>;
 
 // @public
 export interface NodeJSReadableStream extends NodeJS.ReadableStream {

--- a/sdk/core/core-sse/src/models.ts
+++ b/sdk/core/core-sse/src/models.ts
@@ -19,10 +19,9 @@ export interface EventMessage {
 /**
  * A stream of event messages
  */
-export interface EventMessageStream
-  extends ReadableStream<EventMessage>,
-    AsyncDisposable,
-    AsyncIterable<EventMessage> {}
+export type EventMessageStream = ReadableStream<EventMessage> &
+  AsyncDisposable &
+  AsyncIterable<EventMessage>;
 
 export type PartialSome<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 

--- a/tsconfig.src.build.json
+++ b/tsconfig.src.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["DOM", "DOM.Iterable", "DOM.AsyncIterable", "ES2017"],
+    "lib": ["DOM", "DOM.Iterable", "DOM.AsyncIterable", "ES2017", "ES2021.Promise"],
     "jsx": "preserve"
   }
 }


### PR DESCRIPTION
Updates a few packages to use `tsconfig.src.build.json` when it is not straightforward.
- **core-sse**: rewrite the stream type to an equivalent form to fix this failure: https://dev.azure.com/azure-sdk/public/_build/results?buildId=5109924&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=25f5bbca-262e-5e46-5cac-451228cdef01&l=7862
- **core-amqp**: adds `ES2021.Promise` to the list of libs in `tsconfig.src.build.json` to support `AggregateError` (it is already supported in nodejs 16+)
- **apimanagement**: enable skipLibCheck because of an error in lru-cache v10
- **arm-agricultureplatform**: fix format