### PR TITLE
Lossen doc publishing restriction

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -48,16 +48,16 @@ steps:
       Artifacts: ${{ parameters.Artifacts }}
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: 'Azure SDK Artifacts'
-        scriptType: 'bash'
-        scriptLocation: 'inlineScript'
-        inlineScript: |
-          az account show
-          expiry=`date -u -d "45 minutes" '+%Y-%m-%dT%H:%MZ'`
-          sasToken=$(az storage container generate-sas --account-name azuresdkartifacts --name azure-sdk-for-js-rush-cache --permissions dlrw --auth-mode login --as-user --expiry $expiry --https-only -o tsv)
-          echo "##vso[task.setvariable variable=rushBuildCacheCred;issecret=true;]$sasToken"
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: "Azure SDK Artifacts"
+          scriptType: "bash"
+          scriptLocation: "inlineScript"
+          inlineScript: |
+            az account show
+            expiry=`date -u -d "45 minutes" '+%Y-%m-%dT%H:%MZ'`
+            sasToken=$(az storage container generate-sas --account-name azuresdkartifacts --name azure-sdk-for-js-rush-cache --permissions dlrw --auth-mode login --as-user --expiry $expiry --https-only -o tsv)
+            echo "##vso[task.setvariable variable=rushBuildCacheCred;issecret=true;]$sasToken"
 
   - pwsh: |
       node eng/tools/rush-runner/index.js build "$(ChangedServices)" -packages "$(ArtifactPackageNames)" --verbose -p max
@@ -123,8 +123,7 @@ steps:
           Get-ChildItem $stagingDevArtifactDirectory -Recurse -Name
         }
 
-        if ($${{ parameters.IncludeRelease }} -eq $true -and $artifactDetails.ArtifactDetails.skipPublishDocMs -ne $true `
-          -and (Get-Content $packageJson -Raw | ConvertFrom-Json).private -ne $true)
+        if ($${{ parameters.IncludeRelease }} -eq $true -and (Get-Content $packageJson -Raw | ConvertFrom-Json).private -ne $true)
         {
           New-Item -Type Directory $stagingArtifactDirectory/documentation -Force | Out-Null
           Copy-Item $(Build.SourcesDirectory)/docGen/$artifact.zip $stagingArtifactDirectory/documentation
@@ -135,11 +134,11 @@ steps:
 
         Get-ChildItem $stagingArtifactDirectory -Recurse -Name
       }
-    displayName: 'Copy Packages'
+    displayName: "Copy Packages"
 
   - pwsh: |
       eng/scripts/stage-api-review-file.ps1 -PackageInfoPath $(Build.ArtifactStagingDirectory)/PackageInfo -StagingDirectory $(Build.ArtifactStagingDirectory)
-    displayName: 'Copy API extracted files'
+    displayName: "Copy API extracted files"
 
   - task: Powershell@2
     inputs:
@@ -152,13 +151,13 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'packages'
+      ArtifactPath: "$(Build.ArtifactStagingDirectory)"
+      ArtifactName: "packages"
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
-      ArtifactPath: '$(Agent.TempDirectory)/packages-dev-publish'
-      ArtifactName: 'packages-dev-publish'
+      ArtifactPath: "$(Agent.TempDirectory)/packages-dev-publish"
+      ArtifactName: "packages-dev-publish"
       CustomCondition: eq(variables['SetDevVersion'], 'true')
 
   - template: /eng/common/pipelines/templates/steps/create-apireview.yml


### PR DESCRIPTION
### Packages impacted by this PR
azure-identity-vscode

### Issues associated with this PR
Failure at https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5104412&view=logs&j=fd4602b3-f8ce-5804-85c1-0ad7d8f5d5ab

### Describe the problem that is addressed by this PR
The doc publishing check is too restrictive. This PR allows generated docs to be copied over and published as a pipeline artifact.
The release jobs for the Docs have their own checks to ensure its only published when necessary.
https://github.com/Azure/azure-sdk-for-js/blob/5426b48f11184a99e1b9566399ce29b6fc0d542d/eng/pipelines/templates/stages/archetype-js-release.yml#L103
https://github.com/Azure/azure-sdk-for-js/blob/5426b48f11184a99e1b9566399ce29b6fc0d542d/eng/pipelines/templates/stages/archetype-js-release.yml#L71

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
NA

### Are there test cases added in this PR? _(If not, why?)_
No. Pipeline change

### Provide a list of related PRs _(if any)_
None

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
NA