### PR TITLE
Install azsdk mcp server in copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,3 +28,9 @@ jobs:
 
       - name: Install library dependencies
         run: rush update
+
+      - name: Install azsdk mcp server
+        shell: pwsh
+        run: |
+          ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin
+


### PR DESCRIPTION
Install azsdk mcp server in copilot setup steps.

This pairs with the coding agent config in the repo settings:

```
{
  "mcpServers": {
    "azure-sdk-mcp": {
      "type": "local",
      "command": "/home/runner/bin/azsdk",
      "tools": [
        "AnalyzePipeline",
        "GetFailedTestCaseData",
        "CheckPackageReleaseReadiness"
      ],
      "args": [
        "start"
      ]
    }
  }
}
```