### PR TITLE
[ai-agents ] Fix issue with agent response format serialization

### DIFF
--- a/sdk/ai/ai-agents/src/models/models.ts
+++ b/sdk/ai/ai-agents/src/models/models.ts
@@ -1592,10 +1592,26 @@ export type AgentsResponseFormatOption =
   | ResponseFormatJsonSchemaType;
 
 export function agentsResponseFormatOptionSerializer(item: AgentsResponseFormatOption): any {
-  return item;
+  if (typeof item === "string") {
+    return item;
+  }
+
+  if (item.type === "json_schema") {
+    return responseFormatJsonSchemaTypeSerializer(item);
+  }
+
+  return item
 }
 
 export function agentsResponseFormatOptionDeserializer(item: any): AgentsResponseFormatOption {
+  if (typeof item === "string") {
+    return item;
+  }
+
+  if (item.type === "json_schema") {
+    return responseFormatJsonSchemaTypeDeserializer(item);
+  }
+
   return item;
 }
 

--- a/sdk/ai/ai-agents/test/public/agents/models.spec.ts
+++ b/sdk/ai/ai-agents/test/public/agents/models.spec.ts
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import {
+  agentsResponseFormatOptionSerializer,
+  agentsResponseFormatOptionDeserializer,
+  type AgentsResponseFormat,
+  type ResponseFormatJsonSchemaType,
+  type ResponseFormatJsonSchema,
+  type AgentsResponseFormatMode,
+} from "../../../src/models/models.js";
+
+describe("AgentsResponseFormatOption Serialization", () => {
+  describe("agentsResponseFormatOptionSerializer", () => {
+    it("should serialize string values directly", () => {
+      const input = "text";
+      const result = agentsResponseFormatOptionSerializer(input);
+      assert.strictEqual(result, "text");
+    });
+
+    it("should serialize AgentsResponseFormatMode values directly", () => {
+      const autoMode: AgentsResponseFormatMode = "auto";
+      const noneMode: AgentsResponseFormatMode = "none";
+
+      assert.strictEqual(agentsResponseFormatOptionSerializer(autoMode), "auto");
+      assert.strictEqual(agentsResponseFormatOptionSerializer(noneMode), "none");
+    });
+
+    it("should serialize AgentsResponseFormat objects directly", () => {
+      const format: AgentsResponseFormat = {
+        type: "text"
+      };
+
+      const result = agentsResponseFormatOptionSerializer(format);
+      assert.deepStrictEqual(result, { type: "text" });
+    });
+
+    it("should serialize AgentsResponseFormat with json_object type", () => {
+      const format: AgentsResponseFormat = {
+        type: "json_object"
+      };
+
+      const result = agentsResponseFormatOptionSerializer(format);
+      assert.deepStrictEqual(result, { type: "json_object" });
+    });
+
+    it("should serialize ResponseFormatJsonSchemaType using responseFormatJsonSchemaTypeSerializer", () => {
+      const jsonSchema: ResponseFormatJsonSchema = {
+        name: "test_schema",
+        description: "A test schema",
+        schema: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            age: { type: "number" }
+          },
+          required: ["name"]
+        }
+      };
+
+      const format: ResponseFormatJsonSchemaType = {
+        type: "json_schema",
+        jsonSchema
+      };
+
+      const result = agentsResponseFormatOptionSerializer(format);
+      assert.deepStrictEqual(result, {
+        type: "json_schema",
+        json_schema: {
+          name: "test_schema",
+          description: "A test schema",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              age: { type: "number" }
+            },
+            required: ["name"]
+          }
+        }
+      });
+    });
+  });
+
+  describe("agentsResponseFormatOptionDeserializer", () => {
+    it("should deserialize string values directly", () => {
+      const input = "text";
+      const result = agentsResponseFormatOptionDeserializer(input);
+      assert.strictEqual(result, "text");
+    });
+
+    it("should deserialize AgentsResponseFormatMode strings directly", () => {
+      assert.strictEqual(agentsResponseFormatOptionDeserializer("auto"), "auto");
+      assert.strictEqual(agentsResponseFormatOptionDeserializer("none"), "none");
+    });
+
+    it("should deserialize objects without json_schema type directly", () => {
+      const input = { type: "text" };
+      const result = agentsResponseFormatOptionDeserializer(input);
+      assert.deepStrictEqual(result, { type: "text" });
+    });
+
+    it("should deserialize objects with json_object type directly", () => {
+      const input = { type: "json_object" };
+      const result = agentsResponseFormatOptionDeserializer(input);
+      assert.deepStrictEqual(result, { type: "json_object" });
+    });
+
+    it("should deserialize json_schema type using responseFormatJsonSchemaTypeDeserializer", () => {
+      const input = {
+        type: "json_schema",
+        json_schema: {
+          name: "test_schema",
+          description: "A test schema",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              age: { type: "number" }
+            },
+            required: ["name"]
+          }
+        }
+      };
+
+      const result = agentsResponseFormatOptionDeserializer(input);
+      assert.deepStrictEqual(result, {
+        type: "json_schema",
+        jsonSchema: {
+          name: "test_schema",
+          description: "A test schema",
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              age: { type: "number" }
+            },
+            required: ["name"]
+          }
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

@azure/ai-agents


### Describe the problem that is addressed by this PR

The payload send to ai-agents REST api is not correctly transformed before being sen. The `responseFormat.jsonSchema` property is not accepted by the REST API and has to be transformed to `responseFormat.json_schema`

Sample code:
```
this.client.agents.runs.createAndPoll(
        thread.id,
        config.agentId,
        {
          responseFormat: {
            type: "json_schema",
            jsonSchema: {
              name: "AgentResponse",
              schema: AgentResponseSchema,
            },
          },
        },
      );
```

Error logged
```
RestError: Missing required parameter: 'response_format.json_schema'. You provided 'jsonSchema', did you mean to provide 'json_schema'? 
 {
  "name": "RestError",
  "code": "missing_required_parameter",
  "statusCode": 400,
  "details": {
    "error": {
      "message": "Missing required parameter: 'response_format.json_schema'. You provided 'jsonSchema', did you mean to provide 'json_schema'?",
      "type": "invalid_request_error",
      "param": "response_format.json_schema",
      "code": "missing_required_parameter"
    }
  },
  "request": {
    "url": "",
    "headers": {
      "accept": "application/json",
      "content-type": "application/json",
      "accept-encoding": "gzip,deflate",
      "user-agent": "azsdk-js-client azsdk-js-api azsdk-js-ai-projects/1.0.0-beta.8 azsdk-js-client azsdk-js-api azsdk-js-ai-agents/1.0.0 core-rest-pipeline/1.22.0 Node/20.12.2 OS/(x64-Windows_NT-10.0.22621)",
      "x-ms-client-request-id": "0060f4b0-1673-469e-aa06-114b8c2282ac",
      "authorization": "REDACTED",
      "content-length": "775"
    },
    "method": "POST",
    "timeout": 0,
    "disableKeepAlive": false,
    "withCredentials": false,
    "requestId": "0060f4b0-1673-469e-aa06-114b8c2282ac",
    "allowInsecureConnection": false,
    "enableBrowserStreams": true
  }
}
[ResponseProcessor] Error processing response: RestError: Missing required parameter: 'response_format.json_schema'. You provided 'jsonSchema', did you mean to provide 'json_schema'?


```
### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

Yes 

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
