### PR TITLE
[engSys] emit ES2023 syntax

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2882,7 +2882,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-dell-storage@file:projects/arm-dell-storage.tgz':
-    resolution: {integrity: sha512-HIKw9Ee8igQFVaqv5J+FFcx9axsWi1bUH7wrOqojiPRgxPu6/Tzb0zZnF/UZU3Ane3DlnyezDanONyvxKEs0GA==, tarball: file:projects/arm-dell-storage.tgz}
+    resolution: {integrity: sha512-F8ugaeL44+MWGEqZ3U++IwgNgdF4BEkQJbRn+lz3DW/dag+hRbjD1y4DoSXQZQXZiy+YExT/WcH1ZrJr5Fl8jA==, tarball: file:projects/arm-dell-storage.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-dependencymap@file:projects/arm-dependencymap.tgz':
@@ -4388,9 +4388,6 @@ packages:
 
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
-
-  '@types/node@18.19.120':
-    resolution: {integrity: sha512-WtCGHFXnVI8WHLxDAt5TbnCM4eSE+nI0QN2NJtwzcgMhht2eNz6V9evJrk+lwC8bCY8OWV5Ym8Jz7ZEyGnKnMA==}
 
   '@types/node@20.19.1':
     resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
@@ -7116,9 +7113,6 @@ packages:
 
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -12407,7 +12401,7 @@ snapshots:
   '@rush-temp/arm-dell-storage@file:projects/arm-dell-storage.tgz(@types/debug@4.1.12)(tsx@4.20.3)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0)':
     dependencies:
       '@azure/identity': 4.10.2
-      '@types/node': 18.19.120
+      '@types/node': 20.19.1
       '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-istanbul': 3.2.4(vitest@3.2.4)
       dotenv: 16.5.0
@@ -12415,7 +12409,7 @@ snapshots:
       playwright: 1.53.1
       tslib: 2.8.1
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.120)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/debug'
@@ -24404,10 +24398,6 @@ snapshots:
     dependencies:
       '@types/node': 22.7.9
 
-  '@types/node@18.19.120':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.19.1':
     dependencies:
       undici-types: 6.21.0
@@ -27325,8 +27315,6 @@ snapshots:
 
   underscore@1.13.7: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
@@ -27385,27 +27373,6 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
-
-  vite-node@3.2.4(@types/node@18.19.120)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@18.19.120)(tsx@4.20.3)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vite-node@3.2.4(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
@@ -27470,20 +27437,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@18.19.120)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.6
-      rollup: 4.44.0
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 18.19.120
-      fsevents: 2.3.3
-      tsx: 4.20.3
-      yaml: 2.8.0
-
   vite@6.3.5(@types/node@20.19.1)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
@@ -27525,49 +27478,6 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.20.3
       yaml: 2.8.0
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.120)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.0
-      debug: 4.4.1
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@18.19.120)(tsx@4.20.3)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@18.19.120)(tsx@4.20.3)(yaml@2.8.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 18.19.120
-      '@vitest/browser': 3.2.4(playwright@1.53.1)(vite@6.3.5(@types/node@22.7.9)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(@vitest/browser@3.2.4)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:

--- a/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.ts
+++ b/sdk/cosmosdb/cosmos/src/encryption/EncryptionKey/ProtectedDataEncryptionKey.ts
@@ -15,8 +15,6 @@ export class ProtectedDataEncryptionKey extends DataEncryptionKey {
 
   public encryptedValue: Buffer;
 
-  public name: string;
-
   public constructor(
     name: string,
     keyEncryptionKey: KeyEncryptionKey,

--- a/sdk/dell/arm-dell-storage/package.json
+++ b/sdk/dell/arm-dell-storage/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta.1",
   "description": "A generated SDK for StorageClient.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -77,7 +77,7 @@
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.9.1",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "@vitest/browser": "^3.0.9",
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",

--- a/sdk/eventhub/mock-hub/src/storage/messageStore.ts
+++ b/sdk/eventhub/mock-hub/src/storage/messageStore.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/// <reference lib="ES2018.AsyncIterable" />
-
 import type { EventPosition } from "../utils/eventPosition.js";
 import type { Message } from "rhea";
 import { Queue } from "./queue.js";

--- a/sdk/identity/identity/src/errors.ts
+++ b/sdk/identity/identity/src/errors.ts
@@ -76,7 +76,6 @@ export const CredentialUnavailableErrorName = "CredentialUnavailableError";
  */
 export class CredentialUnavailableError extends Error {
   constructor(message?: string, options?: { cause?: unknown }) {
-    // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
     super(message, options);
     this.name = CredentialUnavailableErrorName;
   }
@@ -143,7 +142,6 @@ export class AuthenticationError extends Error {
 
     super(
       `${errorResponse.error} Status code: ${statusCode}\nMore details:\n${errorResponse.errorDescription},`,
-      // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
       options,
     );
     this.statusCode = statusCode;
@@ -232,11 +230,7 @@ export class AuthenticationRequiredError extends Error {
      */
     options: AuthenticationRequiredErrorOptions,
   ) {
-    super(
-      options.message,
-      // @ts-expect-error - TypeScript does not recognize this until we use ES2022 as the target; however, all our major runtimes do support the `cause` property
-      options.cause ? { cause: options.cause } : undefined,
-    );
+    super(options.message, options.cause ? { cause: options.cause } : undefined);
     this.scopes = options.scopes;
     this.getTokenOptions = options.getTokenOptions;
     this.name = "AuthenticationRequiredError";

--- a/sdk/identity/identity/tsconfig.src.json
+++ b/sdk/identity/identity/tsconfig.src.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../tsconfig.lib.json",
   "compilerOptions": {
-    "lib": ["DOM"]
+    "lib": ["DOM", "ES2023"]
   }
 }

--- a/sdk/openai/openai/tsconfig.json
+++ b/sdk/openai/openai/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2023",
     "moduleResolution": "nodenext",
     "module": "NodeNext"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2023",
     "module": "es6",
     "lib": [],
     "declaration": true,

--- a/tsconfig.src.build.json
+++ b/tsconfig.src.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["DOM", "DOM.Iterable", "DOM.AsyncIterable", "ES2017", "ES2021.Promise"],
+    "lib": ["DOM", "DOM.Iterable", "DOM.AsyncIterable", "ES2023"],
     "jsx": "preserve"
   }
 }


### PR DESCRIPTION
This pull request updates dependencies, compiler configurations, and code to align with the latest Node.js and TypeScript standards. The main changes include upgrading the Node.js version requirement, updating TypeScript configurations to target ES2023, and modifying dependencies and references in multiple files.

### Dependency and Version Updates:
* Updated Node.js version requirement from `>=18.0.0` to `>=20.0.0` in `sdk/dell/arm-dell-storage/package.json` and updated `@types/node` dependency to version `^20.0.0`. [[1]](diffhunk://#diff-b66411a58e1970d53c5e4fbf0027894a3a998d7673d48c1a8deab24ac0b72383L6-R6) [[2]](diffhunk://#diff-b66411a58e1970d53c5e4fbf0027894a3a998d7673d48c1a8deab24ac0b72383L80-R80)
* Removed references to older `@types/node` (v18.19.120) and `undici-types` (v5.26.5) dependencies in `common/config/rush/pnpm-lock.yaml` and replaced them with newer versions (`@types/node@20.19.1` and `undici-types@6.21.0`). [[1]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL4392-L4394) [[2]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL24407-L24410)

### TypeScript Configuration Updates:
* Updated TypeScript target to `ES2023` in `sdk/identity/identity/tsconfig.src.json`, `sdk/openai/openai/tsconfig.json`, and `tsconfig.src.build.json`. [[1]](diffhunk://#diff-9f664a53e12c458b58cb5ea0a906c73ac166aa49a1025fb0205996bacb78a2d7L4-R4) [[2]](diffhunk://#diff-fe4508463c948dcb191c55f802d77520cde0d2bbae78719372149a68c126204fL17-R17) [[3]](diffhunk://#diff-6741f24a7855ed1aad3102b235fbe5c2efecc6fefa010336eb64cef6f26b3161L6-R6)
* Added `ES2023` to the `lib` property in TypeScript configurations to support new language features. [[1]](diffhunk://#diff-9f664a53e12c458b58cb5ea0a906c73ac166aa49a1025fb0205996bacb78a2d7L4-R4) [[2]](diffhunk://#diff-6741f24a7855ed1aad3102b235fbe5c2efecc6fefa010336eb64cef6f26b3161L6-R6)

### Code Simplifications and Cleanup:
* Removed unnecessary `@ts-expect-error` comments related to the `cause` property in error classes (`CredentialUnavailableError`, `AuthenticationError`, and `AuthenticationRequiredError`) as they are now supported with the ES2023 target. [[1]](diffhunk://#diff-56a2e14b602ed9208f2df510876cbd76ba582e7a2e7e27053e66a60cd09bfc8cL79) [[2]](diffhunk://#diff-56a2e14b602ed9208f2df510876cbd76ba582e7a2e7e27053e66a60cd09bfc8cL146) [[3]](diffhunk://#diff-56a2e14b602ed9208f2df510876cbd76ba582e7a2e7e27053e66a60cd09bfc8cL235-R233)
* Removed an unused TypeScript reference directive (`/// <reference lib="ES2018.AsyncIterable" />`) in `sdk/eventhub/mock-hub/src/storage/messageStore.ts`.

### Dependency Lockfile Updates:
* Updated integrity hashes and dependency versions in `common/config/rush/pnpm-lock.yaml` to reflect the changes in Node.js and TypeScript dependencies. This includes updates to `vite`, `vitest`, and related transitive dependencies. [[1]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL12410-R12412) [[2]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL27328-L27329) [[3]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL27389-L27409) [[4]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL27473-L27486) [[5]](diffhunk://#diff-5029779360a5dab7df00ff76c5693ce33b68f76d2f433b44a28b333bf33f674aL27529-L27571)

These changes ensure compatibility with the latest Node.js and TypeScript features, improve maintainability, and remove outdated configurations.