### PR TITLE
[monitor-query-logs] tsp-location update with full hash

### DIFF
--- a/sdk/monitor/monitor-query-logs/tsp-location.yaml
+++ b/sdk/monitor/monitor-query-logs/tsp-location.yaml
@@ -1,3 +1,3 @@
 directory: specification/monitor/Monitor.Query.Logs
-commit: fe3a4c5
+commit: fe3a4c5e55bff5ef805503fa9260a5cd3118cbf2
 repo: azure/azure-rest-api-specs


### PR DESCRIPTION
Needed to fix the validation check https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5157329&view=logs&j=76698a2a-d14c-5c6b-54c9-86ac83b9ff72&t=77075814-4745-5051-6a72-475c72cab76c