### PR TITLE
[Monitor OpenTelemetry] Silence Useless/Unactionable OpenTelemetry Logs

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add customer statsbeat feature to feature statsbeat.
 - Add multi-ikey feature to feature statsbeat.
+- Silence noisy warnings about expected async attributes not being populated.
 
 ## 1.11.1 (2025-06-09)
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Add customer statsbeat feature to feature statsbeat.
 - Add multi-ikey feature to feature statsbeat.
-- Silence noisy warnings about expected async attributes not being populated.
+- Silence noisy warnings about expected async attributes and the @azure/core-tracing load order not being populated.
 
 ## 1.11.1 (2025-06-09)
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -194,14 +194,33 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
     });
     this._resource = resource.merge(azureResource);
 
+    // Handle VM resource detection asynchronously to avoid warnings
+    // about accessing resource attributes before async attributes are settled
+    this._initializeVmResourceAsync();
+  }
+
+  /**
+   * Initialize VM resource detection asynchronously to avoid warnings
+   * about accessing resource attributes before async attributes settle
+   */
+  private _initializeVmResourceAsync(): void {
     const vmResource = detectResources({
       detectors: [azureVmDetector],
     });
+    
+    // Don't wait for VM resource detection to complete during initialization
+    // This prevents warnings about accessing resource attributes before async attributes are settled
     if (vmResource.asyncAttributesPending) {
       void vmResource.waitForAsyncAttributes?.().then(() => {
         this._resource = this._resource.merge(vmResource);
         return;
+      }).catch(() => {
+        // Silently ignore VM detection errors to avoid unnecessary warnings
+        // VM detection is optional and failures shouldn't impact core functionality
       });
+    } else {
+      // If VM detection completed synchronously, merge immediately
+      this._resource = this._resource.merge(vmResource);
     }
   }
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -207,17 +207,20 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
     const vmResource = detectResources({
       detectors: [azureVmDetector],
     });
-    
+
     // Don't wait for VM resource detection to complete during initialization
     // This prevents warnings about accessing resource attributes before async attributes are settled
     if (vmResource.asyncAttributesPending) {
-      void vmResource.waitForAsyncAttributes?.().then(() => {
-        this._resource = this._resource.merge(vmResource);
-        return;
-      }).catch(() => {
-        // Silently ignore VM detection errors to avoid unnecessary warnings
-        // VM detection is optional and failures shouldn't impact core functionality
-      });
+      void vmResource
+        .waitForAsyncAttributes?.()
+        .then(() => {
+          this._resource = this._resource.merge(vmResource);
+          return;
+        })
+        .catch(() => {
+          // Silently ignore VM detection errors to avoid unnecessary warnings
+          // VM detection is optional and failures shouldn't impact core functionality
+        });
     } else {
       // If VM detection completed synchronously, merge immediately
       this._resource = this._resource.merge(vmResource);

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -202,8 +202,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       console.log("Failed to generate backup log file", err);
     } finally {
       // Store logs
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      writeFileAsync(this._fileFullPath, data);
+      await writeFileAsync(this._fileFullPath, data);
     }
   }
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -108,10 +108,6 @@ export class DiagFileConsoleLogger implements DiagLogger {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public async logMessage(message?: any, ...optionalParams: any[]): Promise<void> {
-    // Filter out warnings about accessing resource attributes before async attributes are settled
-    if (this._shouldFilterResourceAttributeWarning(message, optionalParams)) {
-      return;
-    }
     try {
       const args = message ? [message, ...optionalParams] : optionalParams;
       if (this._logToFile) {

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -129,15 +129,15 @@ export class DiagFileConsoleLogger implements DiagLogger {
    */
   private _shouldFilterResourceAttributeWarning(message?: any, args?: any[]): boolean {
     const messagesToFilter = [
-      "Accessing resource attributes before async attributes settled",
-      "Resource attributes being accessed before async attributes finished",
+      "accessing resource attributes before async attributes settled",
+      "resource attributes being accessed before async attributes finished",
       "async attributes settled",
-      "Resource attributes accessed before async detection completed",
-      "Module @azure/core-tracing has been loaded before @azure/opentelemetry-instrumentation-azure-sdk",
+      "resource attributes accessed before async detection completed",
+      "module @azure/core-tracing has been loaded before @azure/opentelemetry-instrumentation-azure-sdk",
     ];
 
     if (typeof message === "string") {
-      if (messagesToFilter.some((filterText) => message.includes(filterText))) {
+      if (messagesToFilter.some((filterText) => message.toLowerCase().includes(filterText))) {
         return true;
       }
     }
@@ -146,7 +146,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
     if (args && Array.isArray(args)) {
       for (const arg of args) {
         if (typeof arg === "string") {
-          if (messagesToFilter.some((filterText) => arg.includes(filterText))) {
+          if (messagesToFilter.some((filterText) => arg.toLowerCase().includes(filterText))) {
             return true;
           }
         }

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -150,11 +150,11 @@ export class DiagFileConsoleLogger implements DiagLogger {
     // Also check if message starts with the warning text (in case it's formatted differently)
     if (typeof message === "string") {
       const messageParts = message.split(" ");
-      if (messageParts.length >= 3) {
-        const messageStart = `${messageParts[0]} ${messageParts[1]} ${messageParts[2]}`;
-        if (messageStart === "Accessing resource attributes") {
-          return true;
-        }
+      if (messageParts.length >= 3 &&
+          messageParts[0].toLowerCase() === "accessing" &&
+          messageParts[1].toLowerCase() === "resource" &&
+          messageParts[2].toLowerCase() === "attributes") {
+        return true;
       }
     }
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -149,9 +149,12 @@ export class DiagFileConsoleLogger implements DiagLogger {
     
     // Also check if message starts with the warning text (in case it's formatted differently)
     if (typeof message === 'string') {
-      const messageStart = message.split(' ')[0] + ' ' + message.split(' ')[1] + ' ' + message.split(' ')[2];
-      if (messageStart === 'Accessing resource attributes') {
-        return true;
+      const messageParts = message.split(' ');
+      if (messageParts.length >= 3) {
+        const messageStart = `${messageParts[0]} ${messageParts[1]} ${messageParts[2]}`;
+        if (messageStart === 'Accessing resource attributes') {
+          return true;
+        }
       }
     }
     

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -156,10 +156,12 @@ export class DiagFileConsoleLogger implements DiagLogger {
     // Also check if message starts with the warning text (in case it's formatted differently)
     if (typeof message === "string") {
       const messageParts = message.split(" ");
-      if (messageParts.length >= 3 &&
-          messageParts[0].toLowerCase() === "accessing" &&
-          messageParts[1].toLowerCase() === "resource" &&
-          messageParts[2].toLowerCase() === "attributes") {
+      if (
+        messageParts.length >= 3 &&
+        messageParts[0].toLowerCase() === "accessing" &&
+        messageParts[1].toLowerCase() === "resource" &&
+        messageParts[2].toLowerCase() === "attributes"
+      ) {
         return true;
       }
     }

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -125,39 +125,39 @@ export class DiagFileConsoleLogger implements DiagLogger {
    */
   private _shouldFilterResourceAttributeWarning(message?: any, args?: any[]): boolean {
     const messagesToFilter = [
-      'Accessing resource attributes before async attributes settled',
-      'Resource attributes being accessed before async attributes finished',
-      'async attributes settled',
-      'Resource attributes accessed before async detection completed'
+      "Accessing resource attributes before async attributes settled",
+      "Resource attributes being accessed before async attributes finished",
+      "async attributes settled",
+      "Resource attributes accessed before async detection completed",
     ];
 
-    if (typeof message === 'string') {
+    if (typeof message === "string") {
       // Filter out warnings about accessing resource attributes before async attributes are settled
-      return messagesToFilter.some(filterText => message.includes(filterText));
+      return messagesToFilter.some((filterText) => message.includes(filterText));
     }
-    
+
     // Check if the message is in the args array
     if (args && Array.isArray(args)) {
       for (const arg of args) {
-        if (typeof arg === 'string') {
-          if (messagesToFilter.some(filterText => arg.includes(filterText))) {
+        if (typeof arg === "string") {
+          if (messagesToFilter.some((filterText) => arg.includes(filterText))) {
             return true;
           }
         }
       }
     }
-    
+
     // Also check if message starts with the warning text (in case it's formatted differently)
-    if (typeof message === 'string') {
-      const messageParts = message.split(' ');
+    if (typeof message === "string") {
+      const messageParts = message.split(" ");
       if (messageParts.length >= 3) {
         const messageStart = `${messageParts[0]} ${messageParts[1]} ${messageParts[2]}`;
-        if (messageStart === 'Accessing resource attributes') {
+        if (messageStart === "Accessing resource attributes") {
           return true;
         }
       }
     }
-    
+
     return false;
   }
 

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -13,7 +13,7 @@ describe("DiagFileConsoleLogger filtering", () => {
     logger = new DiagFileConsoleLogger();
     originalConsoleLog = console.log;
     loggedMessages = [];
-    
+
     // Mock console.log to capture what gets logged
     console.log = vi.fn((...args: any[]) => {
       loggedMessages.push(args);
@@ -33,24 +33,24 @@ describe("DiagFileConsoleLogger filtering", () => {
       "Resource attributes accessed before async detection completed",
       "async attributes settled",
     ];
-    
+
     // Test messages that should NOT be filtered
     const notFilteredMessages = [
       "Some other warning message",
       "Normal log message",
       "Resource information is available",
-      "Attributes have been set"
+      "Attributes have been set",
     ];
 
     // Test filtering of messages that should be filtered in ERROR method
-    filteredMessages.forEach(message => {
+    filteredMessages.forEach((message) => {
       loggedMessages = []; // Reset
       logger.error(message);
       expect(loggedMessages).toHaveLength(0); // Should be filtered (no logs)
     });
 
     // Test filtering of messages that should NOT be filtered in ERROR method
-    notFilteredMessages.forEach(message => {
+    notFilteredMessages.forEach((message) => {
       loggedMessages = []; // Reset
       logger.error(message);
       expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered (has logs)
@@ -59,22 +59,22 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   it("should NOT filter resource attribute warnings in other log methods", () => {
     const warningMessage = "Accessing resource attributes before async attributes settled";
-    
+
     // Test warn method - should NOT filter
     loggedMessages = [];
     logger.warn(warningMessage);
     expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
-    
+
     // Test info method - should NOT filter
     loggedMessages = [];
     logger.info(warningMessage);
     expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
-    
+
     // Test debug method - should NOT filter
     loggedMessages = [];
     logger.debug(warningMessage);
     expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
-    
+
     // Test verbose method - should NOT filter
     loggedMessages = [];
     logger.verbose(warningMessage);
@@ -83,11 +83,11 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   it("should NOT filter resource attribute warnings in logMessage method", async () => {
     const warningMessage = "Accessing resource attributes before async attributes settled";
-    
+
     loggedMessages = []; // Reset
     await logger.logMessage(warningMessage, []);
     expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
-    
+
     // Test normal message should also not be filtered
     loggedMessages = []; // Reset
     await logger.logMessage("Normal message", []);
@@ -99,7 +99,7 @@ describe("DiagFileConsoleLogger filtering", () => {
     loggedMessages = []; // Reset
     logger.error("Accessing resource attributes before async attributes settled", []);
     expect(loggedMessages).toHaveLength(0); // Should be filtered even with args
-    
+
     // Test warn method with args - should NOT filter
     loggedMessages = []; // Reset
     logger.warn("Accessing resource attributes before async attributes settled", []);

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -1,14 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, expect } from "vitest";
-import { DiagFileConsoleLogger } from "../../../../src/shared/logging/index.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DiagFileConsoleLogger } from "../../../../../src/shared/logging/diagFileConsoleLogger.js";
 
 describe("DiagFileConsoleLogger filtering", () => {
-  it("should filter resource attribute warnings", () => {
-    const logger = new DiagFileConsoleLogger();
+  let logger: DiagFileConsoleLogger;
+  let originalConsoleLog: typeof console.log;
+  let loggedMessages: any[];
+
+  beforeEach(() => {
+    logger = new DiagFileConsoleLogger();
+    originalConsoleLog = console.log;
+    loggedMessages = [];
     
-    // Test messages that should be filtered
+    // Mock console.log to capture what gets logged
+    console.log = vi.fn((...args: any[]) => {
+      loggedMessages.push(args);
+    });
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    vi.restoreAllMocks();
+  });
+
+  it("should filter resource attribute warnings in error method only", () => {
+    // Test messages that should be filtered in error method
     const filteredMessages = [
       "Accessing resource attributes before async attributes settled",
       "Resource attributes being accessed before async attributes finished",
@@ -24,36 +42,67 @@ describe("DiagFileConsoleLogger filtering", () => {
       "Attributes have been set"
     ];
 
-    // Test filtering of messages that should be filtered
+    // Test filtering of messages that should be filtered in ERROR method
     filteredMessages.forEach(message => {
-      const result = logger._shouldFilterResourceAttributeWarning(message, []);
-      expect(result).toBe(true);
+      loggedMessages = []; // Reset
+      logger.error(message);
+      expect(loggedMessages).toHaveLength(0); // Should be filtered (no logs)
     });
 
-    // Test filtering of messages that should NOT be filtered
+    // Test filtering of messages that should NOT be filtered in ERROR method
     notFilteredMessages.forEach(message => {
-      const result = logger._shouldFilterResourceAttributeWarning(message, []);
-      expect(result).toBe(false);
+      loggedMessages = []; // Reset
+      logger.error(message);
+      expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered (has logs)
     });
   });
 
-  it("should filter resource attribute warnings in args array", () => {
-    const logger = new DiagFileConsoleLogger();
+  it("should NOT filter resource attribute warnings in other log methods", () => {
+    const warningMessage = "Accessing resource attributes before async attributes settled";
     
-    // Test with warning in args array
-    const result1 = logger._shouldFilterResourceAttributeWarning(null, [
-      "Some message",
-      "Accessing resource attributes before async attributes settled",
-      "Another message"
-    ]);
-    expect(result1).toBe(true);
+    // Test warn method - should NOT filter
+    loggedMessages = [];
+    logger.warn(warningMessage);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+    
+    // Test info method - should NOT filter
+    loggedMessages = [];
+    logger.info(warningMessage);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+    
+    // Test debug method - should NOT filter
+    loggedMessages = [];
+    logger.debug(warningMessage);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+    
+    // Test verbose method - should NOT filter
+    loggedMessages = [];
+    logger.verbose(warningMessage);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+  });
 
-    // Test with no warning in args array
-    const result2 = logger._shouldFilterResourceAttributeWarning(null, [
-      "Some message",
-      "Normal message",
-      "Another message"
-    ]);
-    expect(result2).toBe(false);
+  it("should NOT filter resource attribute warnings in logMessage method", async () => {
+    const warningMessage = "Accessing resource attributes before async attributes settled";
+    
+    loggedMessages = []; // Reset
+    await logger.logMessage(warningMessage, []);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+    
+    // Test normal message should also not be filtered
+    loggedMessages = []; // Reset
+    await logger.logMessage("Normal message", []);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+  });
+
+  it("should filter warnings with additional arguments in error method only", () => {
+    // Test error method with args - should filter
+    loggedMessages = []; // Reset
+    logger.error("Accessing resource attributes before async attributes settled", []);
+    expect(loggedMessages).toHaveLength(0); // Should be filtered even with args
+    
+    // Test warn method with args - should NOT filter
+    loggedMessages = []; // Reset
+    logger.warn("Accessing resource attributes before async attributes settled", []);
+    expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from "vitest";
+import { DiagFileConsoleLogger } from "../../../../src/shared/logging/index.js";
+
+describe("DiagFileConsoleLogger filtering", () => {
+  it("should filter resource attribute warnings", () => {
+    const logger = new DiagFileConsoleLogger();
+    
+    // Test messages that should be filtered
+    const filteredMessages = [
+      "Accessing resource attributes before async attributes settled",
+      "Resource attributes being accessed before async attributes finished",
+      "Resource attributes accessed before async detection completed",
+      "async attributes settled",
+    ];
+    
+    // Test messages that should NOT be filtered
+    const notFilteredMessages = [
+      "Some other warning message",
+      "Normal log message",
+      "Resource information is available",
+      "Attributes have been set"
+    ];
+
+    // Test filtering of messages that should be filtered
+    filteredMessages.forEach(message => {
+      const result = logger._shouldFilterResourceAttributeWarning(message, []);
+      expect(result).toBe(true);
+    });
+
+    // Test filtering of messages that should NOT be filtered
+    notFilteredMessages.forEach(message => {
+      const result = logger._shouldFilterResourceAttributeWarning(message, []);
+      expect(result).toBe(false);
+    });
+  });
+
+  it("should filter resource attribute warnings in args array", () => {
+    const logger = new DiagFileConsoleLogger();
+    
+    // Test with warning in args array
+    const result1 = logger._shouldFilterResourceAttributeWarning(null, [
+      "Some message",
+      "Accessing resource attributes before async attributes settled",
+      "Another message"
+    ]);
+    expect(result1).toBe(true);
+
+    // Test with no warning in args array
+    const result2 = logger._shouldFilterResourceAttributeWarning(null, [
+      "Some message",
+      "Normal message",
+      "Another message"
+    ]);
+    expect(result2).toBe(false);
+  });
+});

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -26,13 +26,17 @@ describe("DiagFileConsoleLogger filtering", () => {
   });
 
   it("should filter resource attribute warnings in error and warn methods", () => {
-    // Test messages that should be filtered in error and warn methods
+    // Test messages that should be filtered in error and warn methods (case insensitive)
     const filteredMessages = [
-      "Accessing resource attributes before async attributes settled",
-      "Resource attributes being accessed before async attributes finished",
-      "Resource attributes accessed before async detection completed",
+      "accessing resource attributes before async attributes settled",
+      "resource attributes being accessed before async attributes finished",
+      "resource attributes accessed before async detection completed",
       "async attributes settled",
-      "Module @azure/core-tracing has been loaded before @azure/opentelemetry-instrumentation-azure-sdk",
+      "module @azure/core-tracing has been loaded before @azure/opentelemetry-instrumentation-azure-sdk",
+      // Test case variations to verify case-insensitive matching
+      "Accessing Resource Attributes Before Async Attributes Settled",
+      "RESOURCE ATTRIBUTES BEING ACCESSED BEFORE ASYNC ATTRIBUTES FINISHED",
+      "Module @azure/core-tracing Has Been Loaded Before @azure/opentelemetry-instrumentation-azure-sdk",
     ];
 
     // Test messages that should NOT be filtered
@@ -119,5 +123,40 @@ describe("DiagFileConsoleLogger filtering", () => {
     loggedMessages = []; // Reset
     logger.info("Accessing resource attributes before async attributes settled", []);
     expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+  });
+
+  it("should filter messages in a case-insensitive manner", () => {
+    const testCases = [
+      // Different case variations of the same message
+      "accessing resource attributes before async attributes settled",
+      "ACCESSING RESOURCE ATTRIBUTES BEFORE ASYNC ATTRIBUTES SETTLED",
+      "Accessing Resource Attributes Before Async Attributes Settled",
+      "aCcEsSiNg ReS0uRcE AtTrIbUtEs BeFoRe AsYnC AtTrIbUtEs SeTtLeD",
+      // Mixed case for the core-tracing message
+      "MODULE @azure/core-tracing HAS BEEN LOADED BEFORE @azure/opentelemetry-instrumentation-azure-sdk",
+      "Module @Azure/Core-Tracing Has Been Loaded Before @Azure/Opentelemetry-Instrumentation-Azure-Sdk",
+    ];
+
+    // All these should be filtered in error and warn methods
+    testCases.forEach((message) => {
+      loggedMessages = []; // Reset
+      logger.error(message);
+      expect(loggedMessages).toHaveLength(0); // Should be filtered
+
+      loggedMessages = []; // Reset
+      logger.warn(message);
+      expect(loggedMessages).toHaveLength(0); // Should be filtered
+    });
+
+    // But should NOT be filtered in other methods
+    testCases.forEach((message) => {
+      loggedMessages = []; // Reset
+      logger.info(message);
+      expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+
+      loggedMessages = []; // Reset
+      logger.debug(message);
+      expect(loggedMessages.length).toBeGreaterThan(0); // Should NOT be filtered
+    });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
@@ -79,9 +79,12 @@ describe("Library/DiagFileConsoleLogger", () => {
       );
       logger["_maxSizeBytes"] = 122;
 
-      const writeStub = vi.spyOn(fileHelper, "writeFileAsync");
-      const appendStub = vi.spyOn(fileHelper, "appendFileAsync");
-      const readStub = vi.spyOn(fileHelper, "readFileAsync");
+      const writeStub = vi.spyOn(fileHelper, "writeFileAsync").mockImplementation(async () => {});
+      const appendStub = vi.spyOn(fileHelper, "appendFileAsync").mockImplementation(async () => {});
+      const readStub = vi.spyOn(fileHelper, "readFileAsync").mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async () => Buffer.from("existing content")
+      );
       logger["_logToFile"] = true;
 
       await logger["logMessage"]("backupTestMessage");
@@ -106,8 +109,11 @@ describe("Library/DiagFileConsoleLogger", () => {
           // Fake file size check
           123,
       );
-      const writeStub = vi.spyOn(fileHelper, "writeFileAsync");
-      const readStub = vi.spyOn(fileHelper, "readFileAsync");
+      const writeStub = vi.spyOn(fileHelper, "writeFileAsync").mockImplementation(async () => {});
+      const readStub = vi.spyOn(fileHelper, "readFileAsync").mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async () => Buffer.from("existing content")
+      );
       logger["_maxSizeBytes"] = 122;
       logger["_logToFile"] = true;
       await logger["logMessage"]("backupTestMessage");
@@ -139,7 +145,7 @@ describe("Library/DiagFileConsoleLogger", () => {
           ] as any,
       );
       logger["_maxHistory"] = 0;
-      const unlinkStub = vi.spyOn(fileHelper, "unlinkAsync");
+      const unlinkStub = vi.spyOn(fileHelper, "unlinkAsync").mockImplementation(async () => {});
       await logger["_fileCleanupTask"]();
       expect(unlinkStub).toHaveBeenCalledTimes(2);
     });
@@ -156,7 +162,7 @@ describe("Library/DiagFileConsoleLogger", () => {
           ] as any,
       );
       logger["_maxHistory"] = 1;
-      const unlinkStub = vi.spyOn(fileHelper, "unlinkAsync");
+      const unlinkStub = vi.spyOn(fileHelper, "unlinkAsync").mockImplementation(async () => {});
       await logger["_fileCleanupTask"]();
       expect(unlinkStub).toHaveBeenCalledTimes(1);
       assert.ok(

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
@@ -83,7 +83,7 @@ describe("Library/DiagFileConsoleLogger", () => {
       const appendStub = vi.spyOn(fileHelper, "appendFileAsync").mockImplementation(async () => {});
       const readStub = vi.spyOn(fileHelper, "readFileAsync").mockImplementation(
         // eslint-disable-next-line @typescript-eslint/require-await
-        async () => Buffer.from("existing content")
+        async () => Buffer.from("existing content"),
       );
       logger["_logToFile"] = true;
 
@@ -112,7 +112,7 @@ describe("Library/DiagFileConsoleLogger", () => {
       const writeStub = vi.spyOn(fileHelper, "writeFileAsync").mockImplementation(async () => {});
       const readStub = vi.spyOn(fileHelper, "readFileAsync").mockImplementation(
         // eslint-disable-next-line @typescript-eslint/require-await
-        async () => Buffer.from("existing content")
+        async () => Buffer.from("existing content"),
       );
       logger["_maxSizeBytes"] = 122;
       logger["_logToFile"] = true;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/35066

### Describe the problem that is addressed by this PR
This pull request focuses on silencing noisy warnings related to async resource attributes and improving test coverage and logging behavior in the OpenTelemetry monitoring SDK. The main changes include adding filtering for specific warnings, handling VM resource detection asynchronously, and enhancing test cases to verify the new behavior.

### Improvements to warning handling:

* **Silencing noisy warnings**: Updated `DiagFileConsoleLogger` to filter out warnings about accessing resource attributes before async attributes are settled and improper module load order. This prevents unnecessary warnings from being displayed to users. (`sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts`, [[1]](diffhunk://#diff-3208c9278df3aedc6f410f18f714935209bd2cc908f2ffc000a4ce680aff5681R73-R86) [[2]](diffhunk://#diff-3208c9278df3aedc6f410f18f714935209bd2cc908f2ffc000a4ce680aff5681R126-R171)
* **Asynchronous VM resource detection**: Added `_initializeVmResourceAsync` method in `InternalConfig` to handle VM resource detection asynchronously, avoiding warnings about accessing resource attributes before they are fully resolved. (`sdk/monitor/monitor-opentelemetry/src/shared/config.ts`, [sdk/monitor/monitor-opentelemetry/src/shared/config.tsR197-R226](diffhunk://#diff-e87f512e0da7968d6421a844d909559a6b2963c947802ea359a7172e4e41d0c6R197-R226))

### Enhancements to testing:

* **New unit tests for warning filtering**: Added a dedicated test file, `diagFileConsoleLogger.filter.test.ts`, to validate that specific warnings are filtered out in `error` and `warn` methods, while ensuring other log levels are unaffected. (`sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts`, [sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.tsR1-R123](diffhunk://#diff-40188977e08dc90c984b4c9e35896eda9a981cf4dfd95948b9fb72ba67fbfffcR1-R123))
* **Mock implementations in existing tests**: Updated existing tests in `diagFileConsoleLogger.test.ts` to use mock implementations for file operations like `writeFileAsync`, `appendFileAsync`, and `unlinkAsync`, improving test reliability and isolation. (`sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts`, [[1]](diffhunk://#diff-db8da722f9e0ae7cd375308687845d4391e9c88c0360ee2737b37d9e8ede380dL82-R87) [[2]](diffhunk://#diff-db8da722f9e0ae7cd375308687845d4391e9c88c0360ee2737b37d9e8ede380dL109-R116) [[3]](diffhunk://#diff-db8da722f9e0ae7cd375308687845d4391e9c88c0360ee2737b37d9e8ede380dL142-R148) [[4]](diffhunk://#diff-db8da722f9e0ae7cd375308687845d4391e9c88c0360ee2737b37d9e8ede380dL159-R165)

### Documentation updates:

* **Changelog update**: Documented the change to silence noisy warnings in the `CHANGELOG.md` file for better visibility to users. (`sdk/monitor/monitor-opentelemetry/CHANGELOG.md`, [sdk/monitor/monitor-opentelemetry/CHANGELOG.mdR13](diffhunk://#diff-ac8e2149ba18d601cb7e70506ec0eae272490d5068ff91dd731651ac432633a0R13))
### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
