### PR TITLE
[identity] Avoid waiting for app to close

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Fixed deprecation warnings in `AzureCliCredential` and `AzureDeveloperCliCredential`. [#34878](https://github.com/Azure/azure-sdk-for-js/pull/34878)
+- Fixed an issue where `InteractiveBrowserCredential` did not resolve correctly on Mac OS. [#35406](https://github.com/Azure/azure-sdk-for-js/pull/35406)
 
 ### Other Changes
 

--- a/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
+++ b/sdk/identity/identity/src/msal/nodeFlows/msalClient.ts
@@ -779,7 +779,7 @@ export function createMsalClient(
     return {
       openBrowser: async (url) => {
         const open = await import("open");
-        await open.default(url, { wait: true, newInstance: true });
+        await open.default(url, { newInstance: true });
       },
       scopes,
       authority: calculateRequestAuthority(options),
@@ -868,7 +868,6 @@ export function createMsalClient(
       `Attempting to acquire token using brokered authentication with useDefaultBrokerAccount: ${useDefaultBrokerAccount}`,
     );
     const response = await getBrokeredTokenInternal(scopes, useDefaultBrokerAccount, options);
-    ensureValidMsalToken(scopes, response, options);
     ensureValidMsalToken(scopes, response, options);
     state.cachedAccount = response?.account ?? null;
 


### PR DESCRIPTION
When using InteractiveBrowserCredential we set `wait` to true, which forces the
promise to wait until the app is _closed_ before fulfilling the promise. This
isn't quite right, as we want to hand control back to MSAL as soon as the app
opens and MSAL will then listen to the auth code and resolve the promise with an
access token.

The reason we did not notice this was because according to the 
[open documentation](https://github.com/sindresorhus/open?tab=readme-ov-file#wait) you
have to explicitly specify an app for it to be able to wait which we do not do.

As a result, on Mac, IBC does not resolve correctly until the browser instance
is exited. 

This PR removes the `wait` override, ensuring that control is handed back to
MSAL as soon as the browser opens.

Manual validation:

|Platform|Browser|Tested|
|-----|-----|-----|
|Windows|Chromium|x|
|Windows|Safari||
|Windows|Firefox|x|
|OSX|Chromium|x|
|OSX|Safari|x|
|OSX|Firefox|x|


Fixes #33641