### PR TITLE
[identity] Skip IBC sample execution

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -13,6 +13,9 @@
       "entra",
       "entra-id"
     ],
+    "skip": [
+      "interactiveBrowserCredential.js"
+    ],
     "requiredResources": {
       "Register an app with the Microsoft identity platform": "https://learn.microsoft.com/entra/identity-platform/quickstart-register-app",
       "Set and retrieve a secret from Azure Key Vault": "https://learn.microsoft.com/azure/key-vault/secrets/quick-create-portal"


### PR DESCRIPTION
It never worked, and having now given back control to MSAL before the browser is closed the sample will hang unfortunately. Disabling it makes sense given that it doesn't work on CI