### PR TITLE
Update CODEOWNERS for Monitor Query Metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1080,6 +1080,7 @@
 /sdk/monitor/monitor-opentelemetry-exporter @hectorhdzg @rads-1996 @Karlie-777 @MSNev @JacksonWeber @lzchen @jeremydvoss
 
 /sdk/monitor/monitor-query/ @srnagar @lmolkova @Azure/azure-sdk-write-monitor-data-plane
+/sdk/monitor/monitor-query-metrics/ @Azure/azure-sdk-write-monitor-query-metrics
 /sdk/monitor/perf-tests/ @srnagar @Azure/azure-sdk-write-monitor-data-plane
 
 # PRLabel: %Mgmt


### PR DESCRIPTION
Adds a new entry for the Monitor Query Metrics SDK, which is owned by the service team. A new team is assigned to it, and that team contains the service team engineers.