### PR TITLE
[EngSys] pin typescript version to v5.8 temporarily

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -17,7 +17,7 @@
      */
     // "some-library": "1.2.3"
     "pg-protocol": "1.8.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.2"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,7 +16,8 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "pg-protocol": "1.8.0"
+    "pg-protocol": "1.8.0",
+    "typescript": "~5.8.3"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1327,6 +1327,9 @@ importers:
       pg-protocol:
         specifier: 1.8.0
         version: 1.8.0
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -2601,7 +2604,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-agricultureplatform@file:projects/arm-agricultureplatform.tgz':
-    resolution: {integrity: sha512-CFrjaGk1q6ZvvRd1deone8zdKFichj27UPiGy6L3h5L3iTO3OWa1hi1QjaYwvT+CVB6ZS3EcSvodwH6S2y6tAQ==, tarball: file:projects/arm-agricultureplatform.tgz}
+    resolution: {integrity: sha512-6Ag6ai3ve4CtcMSwJCmeBZd10aXr8754f7PrMaYdOGZ2aqIGZaaJqOkI3l76usX/53RMAP5zzpitatv5nPgV6Q==, tarball: file:projects/arm-agricultureplatform.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-agrifood@file:projects/arm-agrifood.tgz':
@@ -2841,7 +2844,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-databasewatcher@file:projects/arm-databasewatcher.tgz':
-    resolution: {integrity: sha512-TH/bCC1NhiTO1JlpSo30GkbVPAHp2f42SsehMH8IBYMSCmQ9YWqTBSFh0QFZeOzNWVL3xFgmQthsvgvh9up2tQ==, tarball: file:projects/arm-databasewatcher.tgz}
+    resolution: {integrity: sha512-Q6y/ZneDMBrGvByWxQ+XqA9p0g+k3Dxy+qKKWgdQu7tflifW7VRFz4ql2EEuiUKYRSIl1roPkih1O17gf39cLg==, tarball: file:projects/arm-databasewatcher.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-databoundaries@file:projects/arm-databoundaries.tgz':
@@ -2921,7 +2924,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-deviceregistry@file:projects/arm-deviceregistry.tgz':
-    resolution: {integrity: sha512-d2eMfoY8eiyRI9rb3NshUw/+4WYnGqoGK/IHilH51UggEYHWseOuarOLIGBBtXwr8kGvJ2gcWXeIZIRqv9wByw==, tarball: file:projects/arm-deviceregistry.tgz}
+    resolution: {integrity: sha512-bT7qHbMwE4wFNEmQEHdmcCUlTniGLu5klqBImcoKqkJz7NzlNw8zmn2Z6aka56F2AbTeZ6sK6XCuUmLy3JDavA==, tarball: file:projects/arm-deviceregistry.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-deviceupdate@file:projects/arm-deviceupdate.tgz':
@@ -2993,7 +2996,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-eventhub@file:projects/arm-eventhub.tgz':
-    resolution: {integrity: sha512-Cs51mkc5x/iCFkjHOzFiRgxiRa+1YOuIKD8ldGysCxYVPSlEsIVbbDldAaSeciHVSJXJpNdWeWXfWwISn+7K0A==, tarball: file:projects/arm-eventhub.tgz}
+    resolution: {integrity: sha512-WfYJ2/1+U6fRdbWzIPIGMKykjhFBuZRYdh9fS97nFrrGD7o+AySEXIM/rsiAx4zushzZVFmW9LRyvsS8A+m3Nw==, tarball: file:projects/arm-eventhub.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-extendedlocation@file:projects/arm-extendedlocation.tgz':
@@ -3057,7 +3060,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-hybridconnectivity@file:projects/arm-hybridconnectivity.tgz':
-    resolution: {integrity: sha512-X25l723N08etSEe6QkSvNWdcjjsUQ4kajOZUesbImUlHMZNowcE7PHSRhtjej6TihnvTkztHQWLgsEmz/JgbCw==, tarball: file:projects/arm-hybridconnectivity.tgz}
+    resolution: {integrity: sha512-TAov/bLw3BKBATXKyG8vfZiex2xuyzRABl2NL7Be2PYKvZSvzsbvpwmpFZT1tFbdxp3jFJw/vAfAxLImjmDtNw==, tarball: file:projects/arm-hybridconnectivity.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-hybridcontainerservice@file:projects/arm-hybridcontainerservice.tgz':
@@ -3065,7 +3068,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-hybridkubernetes@file:projects/arm-hybridkubernetes.tgz':
-    resolution: {integrity: sha512-kqFDneacdEwaMe0uI7DdKjnhlJ/fAtJydU4PWgfc+gdtb+qaSbosAmYxRG6cLh6R+Mg4on7pVUFW9NxZ69fRjA==, tarball: file:projects/arm-hybridkubernetes.tgz}
+    resolution: {integrity: sha512-/a6XIPnzbrYh60DQmjuCXcivKmwluFSaDx8XFHbd0CLBGDHyhOChQT4LkUnZzKjjjcwRQvXkU+bSWcdX7tStBQ==, tarball: file:projects/arm-hybridkubernetes.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-hybridnetwork@file:projects/arm-hybridnetwork.tgz':
@@ -3077,7 +3080,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-impactreporting@file:projects/arm-impactreporting.tgz':
-    resolution: {integrity: sha512-0yF5cWy7FoKXcZVrXiR+7BIeen+JhYNiJlc9A+zAWBCG/Sy98Rs9DaawY6k+01DyhVxuR9UH32Bb/ONskPybBQ==, tarball: file:projects/arm-impactreporting.tgz}
+    resolution: {integrity: sha512-m6dT6/zHpA1GrLPsuteL7JDGMc4MhQudQsOw1ytinIBkVuF55UkX+ppAkKRfptCkCuC8eKBcPUSqwhHlmSdvOA==, tarball: file:projects/arm-impactreporting.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-informaticadatamanagement@file:projects/arm-informaticadatamanagement.tgz':
@@ -3133,7 +3136,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-kusto@file:projects/arm-kusto.tgz':
-    resolution: {integrity: sha512-kBzL1RsMC21xFPU49I3Wfb72L4Lx4Xftw6VMSwQBIgwl66Gq+9GUS1PtAF+Vgkc/UPlZSp1hgc3fv6FqEhmK+w==, tarball: file:projects/arm-kusto.tgz}
+    resolution: {integrity: sha512-mybg1QAbLDlnl2qylO+Go0HF32qkNZL8eT2FwSkREPUDRwCBa9b1OqV7Ckvg6M4VAKpo5Rt+1PSCfQujSsFzMg==, tarball: file:projects/arm-kusto.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-labservices@file:projects/arm-labservices.tgz':
@@ -3289,7 +3292,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-nginx@file:projects/arm-nginx.tgz':
-    resolution: {integrity: sha512-Qavh6cTpGoCmyBSD6md+G8vq8UU66qgdnTbNUIUo2BVJ7rOCfsbUwPHzRghtCqg1qdlqmJyM0YfOnF+Vd6lAYw==, tarball: file:projects/arm-nginx.tgz}
+    resolution: {integrity: sha512-SEgw1FEa+PTxMuj5VzU3o9jMzhak7BQk3eHwul2Qg9E6a6qTmuLRZPQaJKkVvFLCg4Q+A4QCpQfEvkccWgGS6Q==, tarball: file:projects/arm-nginx.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-notificationhubs@file:projects/arm-notificationhubs.tgz':
@@ -3329,7 +3332,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-pineconevectordb@file:projects/arm-pineconevectordb.tgz':
-    resolution: {integrity: sha512-Alv+1wJ/XUREDynNGiyVlyj7qtybzP7Z3R38XLvxICGdiS8J/ZDn4Y/Qm6xkh2QxN1BG0PbOOEB6NBnqheg92w==, tarball: file:projects/arm-pineconevectordb.tgz}
+    resolution: {integrity: sha512-PcdrnKkLKCHC9qvQbo3l3+ehkZeRNI33u07/So8Sy/BFXRYqE9FT1lxNKKEJiiXEWINXr/bQMx09t9t17IT8ng==, tarball: file:projects/arm-pineconevectordb.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-planetarycomputer@file:projects/arm-planetarycomputer.tgz':
@@ -3349,11 +3352,11 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-policy@file:projects/arm-policy.tgz':
-    resolution: {integrity: sha512-CtMYzQI5h/4qLNyHKEJt2cSqypMI51q953jVhsz9hAPDjRxkVMSw9QqveTW4fz6mq4rAclX3PZQ3/2sgvRkuOw==, tarball: file:projects/arm-policy.tgz}
+    resolution: {integrity: sha512-ZIsv72+tHOMMDMPVznYG9UZYkDohJJL1gqIm/72REoL9tYuvdArsmg6fYyNd3RnBU8wH3PNvZuis63P5Dlq2hQ==, tarball: file:projects/arm-policy.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-policyinsights@file:projects/arm-policyinsights.tgz':
-    resolution: {integrity: sha512-rPKPc4oISQ6bSAWz/jSa+wj8yaWzwrg4ey3hp20AJ7V5JeJTpAVK7T40UuDrF8CPZSU9c/jY8JGEVpbFt8rlXg==, tarball: file:projects/arm-policyinsights.tgz}
+    resolution: {integrity: sha512-WtGHOMaXNuBJT4crYoc6DR9L/MEaewBU2jmZjqRbWeryDoD24WtOrDypgWymvQi6CED+czJZWjUnnzGGyKFGJg==, tarball: file:projects/arm-policyinsights.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-portal@file:projects/arm-portal.tgz':
@@ -3405,7 +3408,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-quota@file:projects/arm-quota.tgz':
-    resolution: {integrity: sha512-+f70SExBM6paYW700JMPde1+mhcotfrTZm+QBrajlCxJagftf56k8qUgTbZgUYBHd1o2TlUDrGsTa/H4VcBaLQ==, tarball: file:projects/arm-quota.tgz}
+    resolution: {integrity: sha512-pmGhjSsDiUdKf3fbUUG9SjiyFdRgiSib3QxSan9lLV1tdH8dL14I7hsnOX/KK88ykQrV84vTyG5MBrI4oOSJpQ==, tarball: file:projects/arm-quota.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-recoveryservices-siterecovery@file:projects/arm-recoveryservices-siterecovery.tgz':
@@ -3429,7 +3432,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/arm-rediscache@file:projects/arm-rediscache.tgz':
-    resolution: {integrity: sha512-/fTkVvuTcqNOQOCoxK/zWlAh732wIGDDOTgWJspRo/iePvSgJNgprv0ERjs3jhomQKyvfqYGDcbqT0rwssa5gA==, tarball: file:projects/arm-rediscache.tgz}
+    resolution: {integrity: sha512-kUngi3+glg8uu8Mmg0UUCxJy9+VoRri4DsBurscfSHdux/dMpvFyXKbEEPWtU7SJRFoE+MY3pgZw6gfM+W9UEg==, tarball: file:projects/arm-rediscache.tgz}
     version: 0.0.0
 
   '@rush-temp/arm-redisenterprisecache@file:projects/arm-redisenterprisecache.tgz':
@@ -4173,7 +4176,7 @@ packages:
     version: 0.0.0
 
   '@rush-temp/storage-common@file:projects/storage-common.tgz':
-    resolution: {integrity: sha512-shnl9mCWAyAaDgEPvLlAg/mginc+CB12D0h9kr6dfYJv6M8sHLD1OvIAtEziWcMlNSEtlTUd4APv/I+4Gi55rg==, tarball: file:projects/storage-common.tgz}
+    resolution: {integrity: sha512-bxoz9jSOjLj06HPjn6Lcl8gUF62DlSddvnloRNV5slRI44mApiFNz8ZbGRnMYD+DbCj5KCeLUat5Azs1nIOnTA==, tarball: file:projects/storage-common.tgz}
     version: 0.0.0
 
   '@rush-temp/storage-file-datalake@file:projects/storage-file-datalake.tgz':
@@ -7090,16 +7093,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -9834,7 +9827,7 @@ snapshots:
       eslint: 9.32.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -11961,7 +11954,7 @@ snapshots:
       eslint: 9.32.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -12674,7 +12667,7 @@ snapshots:
       eslint: 9.32.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -13319,7 +13312,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -13890,7 +13883,7 @@ snapshots:
       eslint: 9.32.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -13962,7 +13955,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -14070,7 +14063,7 @@ snapshots:
       eslint: 9.32.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -14572,7 +14565,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -15963,7 +15956,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -16319,7 +16312,7 @@ snapshots:
       eslint: 9.32.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -16497,7 +16490,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -16533,7 +16526,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -16997,7 +16990,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -17215,7 +17208,7 @@ snapshots:
       dotenv: 16.6.1
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.6.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -23519,7 +23512,7 @@ snapshots:
       events: 3.3.0
       playwright: 1.54.1
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 5.8.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/browser@3.2.4)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -27389,10 +27382,6 @@ snapshots:
   typescript@4.2.4: {}
 
   typescript@5.6.1-rc: {}
-
-  typescript@5.6.3: {}
-
-  typescript@5.7.3: {}
 
   typescript@5.8.2: {}
 

--- a/sdk/agricultureplatform/arm-agricultureplatform/package.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/package.json
@@ -83,7 +83,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
     "playwright": "^1.51.1",
-    "typescript": "~5.7.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "scripts": {

--- a/sdk/databasewatcher/arm-databasewatcher/package.json
+++ b/sdk/databasewatcher/arm-databasewatcher/package.json
@@ -80,7 +80,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "scripts": {

--- a/sdk/deviceregistry/arm-deviceregistry/package.json
+++ b/sdk/deviceregistry/arm-deviceregistry/package.json
@@ -80,7 +80,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "scripts": {

--- a/sdk/eventhub/arm-eventhub/package.json
+++ b/sdk/eventhub/arm-eventhub/package.json
@@ -40,7 +40,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": {

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
@@ -89,7 +89,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
     "playwright": "^1.51.1",
-    "typescript": "~5.7.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "scripts": {

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
@@ -40,7 +40,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.7.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/impactreporting/arm-impactreporting/package.json
+++ b/sdk/impactreporting/arm-impactreporting/package.json
@@ -80,7 +80,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "scripts": {

--- a/sdk/kusto/arm-kusto/package.json
+++ b/sdk/kusto/arm-kusto/package.json
@@ -40,7 +40,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/nginx/arm-nginx/package.json
+++ b/sdk/nginx/arm-nginx/package.json
@@ -39,7 +39,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": {

--- a/sdk/pineconevectordb/arm-pineconevectordb/package.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/package.json
@@ -83,7 +83,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^9.9.0",
     "playwright": "^1.51.1",
-    "typescript": "~5.7.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "scripts": {

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -39,7 +39,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.7.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/policyinsights/arm-policyinsights/package.json
+++ b/sdk/policyinsights/arm-policyinsights/package.json
@@ -40,7 +40,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/quota/arm-quota/package.json
+++ b/sdk/quota/arm-quota/package.json
@@ -40,7 +40,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/redis/arm-rediscache/package.json
+++ b/sdk/redis/arm-rediscache/package.json
@@ -41,7 +41,7 @@
     "@vitest/coverage-istanbul": "^3.0.9",
     "dotenv": "^16.0.0",
     "playwright": "^1.50.1",
-    "typescript": "~5.6.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.9"
   },
   "repository": "github:Azure/azure-sdk-for-js",

--- a/sdk/storage/storage-common/package.json
+++ b/sdk/storage/storage-common/package.json
@@ -65,7 +65,7 @@
     "@vitest/coverage-istanbul": "^3.0.6",
     "eslint": "^9.9.0",
     "playwright": "^1.51.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.8.2",
     "vitest": "^3.0.6"
   },
   "type": "module",


### PR DESCRIPTION
until we fix the break introduced by v5.9

also bump older versions to ~5.8.2 for packages missed the upgrade likely due to in-flight PRs