### PR TITLE
[notfication-hubs] Remove the need for BodilessMatcher in the tests with sanitizers

### DIFF
--- a/sdk/notificationhubs/notification-hubs/assets.json
+++ b/sdk/notificationhubs/notification-hubs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/notificationhubs/notification-hubs",
-  "Tag": "js/notificationhubs/notification-hubs_9b371a54ae"
+  "Tag": "js/notificationhubs/notification-hubs_40f2abdea1"
 }

--- a/sdk/notificationhubs/notification-hubs/test/public/createOrUpdateRegistration.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/createOrUpdateRegistration.spec.ts
@@ -21,7 +21,6 @@ describe("createRegistrationId()", () => {
 
   beforeEach(async (ctx) => {
     recorder = new Recorder(ctx);
-    await recorder.setMatcher("BodilessMatcher");
     context = await createRecordedClientContext(recorder);
 
     registrationId = await createRegistrationId(context);

--- a/sdk/notificationhubs/notification-hubs/test/public/getRegistration.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/getRegistration.spec.ts
@@ -17,7 +17,6 @@ describe("getRegistration", () => {
 
   beforeEach(async (ctx) => {
     recorder = new Recorder(ctx);
-    await recorder.setMatcher("BodilessMatcher");
     context = await createRecordedClientContext(recorder);
 
     let registration = createAppleRegistrationDescription({

--- a/sdk/notificationhubs/notification-hubs/test/public/listRegistrations.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/listRegistrations.spec.ts
@@ -17,7 +17,6 @@ describe("listRegistrations()", () => {
 
   beforeEach(async (ctx) => {
     recorder = new Recorder(ctx);
-    await recorder.setMatcher("BodilessMatcher");
     context = await createRecordedClientContext(recorder);
 
     for (let i = 0; i < 3; i++) {

--- a/sdk/notificationhubs/notification-hubs/test/public/listRegistrationsByTag.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/listRegistrationsByTag.spec.ts
@@ -21,7 +21,6 @@ describe("listRegistrationsByTag()", () => {
 
   beforeEach(async (ctx) => {
     recorder = new Recorder(ctx);
-    await recorder.setMatcher("BodilessMatcher");
     context = await createRecordedClientContext(recorder);
 
     for (let i = 0; i < 3; i++) {

--- a/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
@@ -32,6 +32,10 @@ const recorderOptions: RecorderStartOptions = {
 export async function createRecordedClientContext(
   recorder: Recorder,
 ): Promise<NotificationHubsClientContext> {
+  // The following hardcoded timestamps are used to ensure deterministic playback in tests.
+  // [0]: "2024-04-16T22:06:17.401Z" is used for API responses that include milliseconds in the timestamp.
+  // [1]: "2024-04-16T22:06:17Z" is used for API responses that omit milliseconds.
+  // These values were chosen arbitrarily and do not correspond to any specific event; they simply provide a fixed reference time for playback mode.
   const dummyTimeForPlayback = ["2024-04-16T22:06:17.401Z", "2024-04-16T22:06:17Z"];
   if (isPlaybackMode()) {
     // In playback mode, we need to set the system time to a fixed value to ensure consistent results

--- a/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
+++ b/sdk/notificationhubs/notification-hubs/test/public/utils/recordedClient.ts
@@ -39,7 +39,7 @@ export async function createRecordedClientContext(
   const dummyTimeForPlayback = ["2024-04-16T22:06:17.401Z", "2024-04-16T22:06:17Z"];
   if (isPlaybackMode()) {
     // In playback mode, we need to set the system time to a fixed value to ensure consistent results
-    // This is because the server might return different timestamps based on the current time
+    // This is because the src code uses new Date().toISOString(), to set current time
     vi.useFakeTimers();
     vi.setSystemTime(new Date(dummyTimeForPlayback[0])); // for the first request that is made in the test
   }


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/notification-hubs`
### Bodiless Matcher is flaky
Bodiless Matcher doesn't always get activated even though registered as part of the test, leading to test failures in the pipeline for some jobs, not all.
I couldn't reproduce the issue locally, but there are several instances of evidence from the pipeline.
1. Pipeline/job complaining mismatch in req body - https://dev.azure.com/azure-sdk/public/_build/results?buildId=5175819&view=logs&j=3b001400-51a2-579b-5880-362a5b0a112a&t=4fd227ba-0f36-57a1-8fce-5a18caa54ed9&l=1759
2. Corresponding test recording - [azure-sdk-assets/js/sdk/notificationhubs/notification-hubs/recordings/node/listregistrationsbytag/recording_should_list_all_registrations.json at js/notificationhubs/notification-hubs_9b371a54ae · Azure/azure-sdk-assets](https://github.com/Azure/azure-sdk-assets/blob/js/notificationhubs/notification-hubs_9b371a54ae/js/sdk/notificationhubs/notification-hubs/recordings/node/listregistrationsbytag/recording_should_list_all_registrations.json)
3. corresponding test that sets BodiliessMatcher - https://github.com/Azure/azure-sdk-for-js/blob/e7399dcd46e686dfa22f9a3399f9148c906e1679/sdk/notificationhubs/notification-hubs/test/public/listRegistrationsByTag.spec.ts#L24
Noticed by @jeremymeng  in the notification-hubs pipeline in JS.
Being addressed by @scbedd at https://github.com/Azure/azure-sdk-tools/pull/11515
### Fix for `@azure/notification-hubs`
1. Remove bodiless matcher in the tests
2. Add new sanitizers to make the timestamps constant and predictable with dummy timestamps
3. Update recordings to have the dummy timestamps from the sanitizers