### PR TITLE
[Monitor OpenTelemetry Exporter] Change Customer Statsbeat to Customer SDK Stats

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Track CLIENT_READONLY and CLIENT_TIMEOUT customer statsbeat.
+- Track CLIENT_READONLY and CLIENT_TIMEOUT customer SDK Stats.
 
 ### Bugs Fixed
 
@@ -18,7 +18,7 @@
 
 ### Features Added
 
-- Added customer-facing statsbeat preview.
+- Added customer-facing SDK Stats preview.
 
 ### Features Added
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
@@ -109,7 +109,7 @@ export const ENV_AZURE_MONITOR_PREFIX = "AZURE_MONITOR_PREFIX";
 export const ENV_AZURE_MONITOR_DISTRO_VERSION = "AZURE_MONITOR_DISTRO_VERSION";
 
 /**
- * Enables the preview version of customer-facing Statsbeat.
+ * Enables the preview version of customer-facing SDK Stats.
  * @internal
  */
 export const ENV_APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW =

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -58,10 +58,10 @@ export class NetworkStatsbeat {
 }
 
 /**
- * Statsbeat class for customer-visible telemetry.
+ * SDK Stats class for customer-visible telemetry.
  * @internal
  */
-export class CustomerStatsbeat {
+export class CustomerSDKStats {
   public totalItemSuccessCount: Map<TelemetryType, number>;
 
   // Nested Map structure: telemetry_type -> drop.code -> drop.reason -> count
@@ -79,6 +79,9 @@ export class CustomerStatsbeat {
     >();
   }
 }
+
+// Legacy alias for backward compatibility
+export const CustomerStatsbeat = CustomerSDKStats;
 
 export const STATSBEAT_LANGUAGE = "node";
 
@@ -112,11 +115,14 @@ export enum StatsbeatCounter {
   FEATURE = "Feature",
 }
 
-export enum CustomStatsbeatCounter {
+export enum CustomSDKStatsCounter {
   ITEM_SUCCESS_COUNT = "preview.item.success.count",
   ITEM_DROP_COUNT = "preview.item.dropped.count",
   ITEM_RETRY_COUNT = "preview.item.retry.count",
 }
+
+// Legacy alias for backward compatibility
+export const CustomStatsbeatCounter = CustomSDKStatsCounter;
 
 export const AIMS_URI = "http://169.254.169.254/metadata/instance/compute";
 export const AIMS_API_VERSION = "api-version=2017-12-01";
@@ -150,11 +156,14 @@ export interface CommonStatsbeatProperties {
   attach: string;
 }
 
-export interface CustomerStatsbeatProperties {
+export interface CustomerSDKStatsProperties {
   language: string;
   version: string;
   computeType: string;
 }
+
+// Legacy alias for backward compatibility
+export type CustomerStatsbeatProperties = CustomerSDKStatsProperties;
 
 export enum TelemetryType {
   AVAILABILITY = "AVAILABILITY",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -23,7 +23,7 @@ import {
   ENV_APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
   RetriableRestErrorTypes,
 } from "../../Declarations/Constants.js";
-import { CustomerStatsbeatMetrics } from "../../export/statsbeat/customerStatsbeat.js";
+import { CustomerSDKStatsMetrics } from "../../export/statsbeat/customerSDKStats.js";
 
 const DEFAULT_BATCH_SEND_RETRY_INTERVAL_MS = 60_000;
 
@@ -36,7 +36,7 @@ export abstract class BaseSender {
   private numConsecutiveRedirects: number;
   private retryTimer: NodeJS.Timeout | null;
   private networkStatsbeatMetrics: NetworkStatsbeatMetrics | undefined;
-  private customerStatsbeatMetrics: CustomerStatsbeatMetrics | undefined;
+  private customerSDKStatsMetrics: CustomerSDKStatsMetrics | undefined;
   private longIntervalStatsbeatMetrics;
   private statsbeatFailureCount: number = 0;
   private batchSendRetryIntervalMs: number = DEFAULT_BATCH_SEND_RETRY_INTERVAL_MS;
@@ -65,7 +65,7 @@ export abstract class BaseSender {
         disableOfflineStorage: this.disableOfflineStorage,
       });
       if (process.env[ENV_APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW]) {
-        this.customerStatsbeatMetrics = CustomerStatsbeatMetrics.getInstance({
+        this.customerSDKStatsMetrics = CustomerSDKStatsMetrics.getInstance({
           instrumentationKey: options.instrumentationKey,
           endpointUrl: options.endpointUrl,
           disableOfflineStorage: this.disableOfflineStorage,
@@ -75,7 +75,7 @@ export abstract class BaseSender {
     this.persister = new FileSystemPersist(
       options.instrumentationKey,
       options.exporterOptions,
-      this.customerStatsbeatMetrics,
+      this.customerSDKStatsMetrics,
     );
     this.retryTimer = null;
     this.isStatsbeatSender = options.isStatsbeatSender || false;
@@ -114,7 +114,7 @@ export abstract class BaseSender {
         // If we are not exporting statsbeat and statsbeat is not disabled -- count success
         if (!this.isStatsbeatSender) {
           this.networkStatsbeatMetrics?.countSuccess(duration);
-          this.customerStatsbeatMetrics?.countSuccessfulItems(envelopes);
+          this.customerSDKStatsMetrics?.countSuccessfulItems(envelopes);
         }
         return { code: ExportResultCode.SUCCESS };
       } else if (statusCode && isRetriable(statusCode)) {
@@ -122,7 +122,7 @@ export abstract class BaseSender {
         if (statusCode === 429 || statusCode === 439) {
           if (!this.isStatsbeatSender) {
             this.networkStatsbeatMetrics?.countThrottle(statusCode);
-            this.customerStatsbeatMetrics?.countRetryItems(envelopes, statusCode);
+            this.customerSDKStatsMetrics?.countRetryItems(envelopes, statusCode);
           }
           return {
             code: ExportResultCode.SUCCESS,
@@ -132,7 +132,7 @@ export abstract class BaseSender {
           diag.info(result);
           const breezeResponse = JSON.parse(result) as BreezeResponse;
           const filteredEnvelopes: Envelope[] = [];
-          // Create a list of successful envelopes by filtering out the failed ones for customer statsbeat
+          // Create a list of successful envelopes by filtering out the failed ones for customer SDK Stats
           const successfulEnvelopes: Envelope[] = [...envelopes];
 
           // If we have a partial success, count the succeeded envelopes
@@ -157,13 +157,13 @@ export abstract class BaseSender {
             // Count only the successful envelopes (non-undefined)
             if (!this.isStatsbeatSender) {
               this.networkStatsbeatMetrics?.countSuccess(duration);
-              this.customerStatsbeatMetrics?.countSuccessfulItems(envelopes);
+              this.customerSDKStatsMetrics?.countSuccessfulItems(envelopes);
             }
           }
           if (filteredEnvelopes.length > 0) {
             if (!this.isStatsbeatSender) {
               this.networkStatsbeatMetrics?.countRetry(statusCode);
-              this.customerStatsbeatMetrics?.countRetryItems(envelopes, statusCode);
+              this.customerSDKStatsMetrics?.countRetryItems(envelopes, statusCode);
             }
             // calls resultCallback(ExportResult) based on result of persister.push
             return await this.persist(filteredEnvelopes);
@@ -171,8 +171,8 @@ export abstract class BaseSender {
           // Failed -- not retriable
           if (!this.isStatsbeatSender) {
             this.networkStatsbeatMetrics?.countFailure(duration, statusCode);
-            // Count dropped items for customer statsbeat for non-retriable status codes
-            this.customerStatsbeatMetrics?.countDroppedItems(
+            // Count dropped items for customer SDK Stats for non-retriable status codes
+            this.customerSDKStatsMetrics?.countDroppedItems(
               successfulEnvelopes.filter(Boolean),
               statusCode,
             );
@@ -184,7 +184,7 @@ export abstract class BaseSender {
           // calls resultCallback(ExportResult) based on result of persister.push
           if (!this.isStatsbeatSender) {
             this.networkStatsbeatMetrics?.countRetry(statusCode);
-            this.customerStatsbeatMetrics?.countRetryItems(envelopes, statusCode);
+            this.customerSDKStatsMetrics?.countRetryItems(envelopes, statusCode);
           }
           return await this.persist(envelopes);
         }
@@ -193,12 +193,12 @@ export abstract class BaseSender {
         if (this.networkStatsbeatMetrics && !this.isStatsbeatSender) {
           if (statusCode) {
             this.networkStatsbeatMetrics.countFailure(duration, statusCode);
-            this.customerStatsbeatMetrics?.countDroppedItems(envelopes, statusCode);
+            this.customerSDKStatsMetrics?.countDroppedItems(envelopes, statusCode);
           }
         } else {
           // Handles all other status codes or client exceptions for Statsbeat
           this.incrementStatsbeatFailure();
-          this.customerStatsbeatMetrics?.countDroppedItems(envelopes, DropCode.CLIENT_EXCEPTION);
+          this.customerSDKStatsMetrics?.countDroppedItems(envelopes, DropCode.CLIENT_EXCEPTION);
         }
         return {
           code: ExportResultCode.FAILED,
@@ -228,7 +228,7 @@ export abstract class BaseSender {
           const redirectError = new Error("Circular redirect");
           if (!this.isStatsbeatSender) {
             this.networkStatsbeatMetrics?.countException(redirectError);
-            this.customerStatsbeatMetrics?.countDroppedItems(
+            this.customerSDKStatsMetrics?.countDroppedItems(
               envelopes,
               DropCode.CLIENT_EXCEPTION,
               redirectError.message,
@@ -242,7 +242,7 @@ export abstract class BaseSender {
         !this.isStatsbeatSender
       ) {
         this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
-        this.customerStatsbeatMetrics?.countRetryItems(envelopes, restError.statusCode);
+        this.customerSDKStatsMetrics?.countRetryItems(envelopes, restError.statusCode);
         return this.persist(envelopes);
       } else if (
         restError.statusCode === 400 &&
@@ -263,8 +263,8 @@ export abstract class BaseSender {
 
       // For retriable REST errors
       if (this.isRetriableRestError(restError) && !this.isStatsbeatSender) {
-        if (this.customerStatsbeatMetrics?.isTimeoutError(restError) && !this.isStatsbeatSender) {
-          this.customerStatsbeatMetrics?.countRetryItems(
+        if (this.customerSDKStatsMetrics?.isTimeoutError(restError) && !this.isStatsbeatSender) {
+          this.customerSDKStatsMetrics?.countRetryItems(
             envelopes,
             RetryCode.CLIENT_TIMEOUT,
             "timeout_exception",
@@ -272,7 +272,7 @@ export abstract class BaseSender {
           diag.error("Request timed out. Error message:", restError.message);
         } else if (restError.statusCode) {
           this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
-          this.customerStatsbeatMetrics?.countRetryItems(envelopes, restError.statusCode);
+          this.customerSDKStatsMetrics?.countRetryItems(envelopes, restError.statusCode);
         }
         diag.error(
           "Retrying due to transient client side error. Error message:",
@@ -308,7 +308,7 @@ export abstract class BaseSender {
       if (!this.isStatsbeatSender) {
         this.networkStatsbeatMetrics?.countWriteFailure();
         if (this.disableOfflineStorage && envelopes) {
-          this.customerStatsbeatMetrics?.countDroppedItems(
+          this.customerSDKStatsMetrics?.countDroppedItems(
             envelopes as Envelope[],
             DropCode.CLIENT_STORAGE_DISABLED,
           );
@@ -338,8 +338,8 @@ export abstract class BaseSender {
     if (this.longIntervalStatsbeatMetrics) {
       this.longIntervalStatsbeatMetrics?.shutdown();
     }
-    if (this.customerStatsbeatMetrics) {
-      this.customerStatsbeatMetrics.shutdown();
+    if (this.customerSDKStatsMetrics) {
+      this.customerSDKStatsMetrics.shutdown();
     }
     this.statsbeatFailureCount = 0;
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -92,7 +92,7 @@ vi.mock("../../src/export/statsbeat/longIntervalStatsbeatMetrics.js", () => {
   };
 });
 
-export const mockCustomerStatsbeatMetrics = {
+export const mockCustomerSDKStatsMetrics = {
   countSuccessfulItems: vi.fn(),
   countDroppedItems: vi.fn(),
   countRetryItems: vi.fn(),
@@ -100,11 +100,11 @@ export const mockCustomerStatsbeatMetrics = {
   shutdown: vi.fn(),
 };
 
-vi.mock("../../src/export/statsbeat/customerStatsbeat.js", () => {
+vi.mock("../../src/export/statsbeat/customerSDKStats.js", () => {
   return {
-    CustomerStatsbeatMetrics: {
+    CustomerSDKStatsMetrics: {
       getInstance: vi.fn().mockImplementation(() => {
-        return mockCustomerStatsbeatMetrics;
+        return mockCustomerSDKStatsMetrics;
       }),
       shutdown: vi.fn(),
     },
@@ -166,8 +166,8 @@ class TestBaseSender extends BaseSender {
       value: mockLongIntervalStats,
       writable: true,
     });
-    Object.defineProperty(this, "customerStatsbeatMetrics", {
-      value: mockCustomerStatsbeatMetrics,
+    Object.defineProperty(this, "customerSDKStatsMetrics", {
+      value: mockCustomerSDKStatsMetrics,
       writable: true,
     });
     Object.defineProperty(this, "persister", {
@@ -490,7 +490,7 @@ describe("BaseSender", () => {
       nonRetriableError.statusCode = 400;
 
       // Mock isTimeoutError to return false so timeout logic isn't triggered
-      mockCustomerStatsbeatMetrics.isTimeoutError.mockReturnValue(false);
+      mockCustomerSDKStatsMetrics.isTimeoutError.mockReturnValue(false);
 
       sender.sendMock.mockRejectedValue(nonRetriableError);
 
@@ -592,7 +592,7 @@ describe("BaseSender", () => {
 
       await sender.exportEnvelopes([performanceCounterEnvelope]);
 
-      expect(mockCustomerStatsbeatMetrics.countSuccessfulItems).toHaveBeenCalledWith([
+      expect(mockCustomerSDKStatsMetrics.countSuccessfulItems).toHaveBeenCalledWith([
         performanceCounterEnvelope,
       ]);
     });
@@ -631,7 +631,7 @@ describe("BaseSender", () => {
 
       await sender.exportEnvelopes([customMetricEnvelope]);
 
-      expect(mockCustomerStatsbeatMetrics.countSuccessfulItems).toHaveBeenCalledWith([
+      expect(mockCustomerSDKStatsMetrics.countSuccessfulItems).toHaveBeenCalledWith([
         customMetricEnvelope,
       ]);
     });
@@ -675,20 +675,20 @@ describe("BaseSender", () => {
       await sender.exportEnvelopes([mixedMetricEnvelope]);
 
       // Should be counted as performance counter since it contains at least one
-      expect(mockCustomerStatsbeatMetrics.countSuccessfulItems).toHaveBeenCalledWith([
+      expect(mockCustomerSDKStatsMetrics.countSuccessfulItems).toHaveBeenCalledWith([
         mixedMetricEnvelope,
       ]);
     });
   });
 
-  describe("Customer Statsbeat Exception Message Handling", () => {
+  describe("Customer SDK Stats Exception Message Handling", () => {
     let testSender: TestBaseSender;
     let originalEnv: string | undefined;
 
     beforeEach(() => {
       // Save original environment variable
       originalEnv = process.env[ENV_APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
-      // Set environment variable to enable customer statsbeat metrics
+      // Set environment variable to enable Customer SDK Stats metrics
       process.env[ENV_APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "true";
 
       testSender = new TestBaseSender({
@@ -737,7 +737,7 @@ describe("BaseSender", () => {
       const result = await testSender.exportEnvelopes(envelopes);
 
       expect(result.code).toBe(ExportResultCode.FAILED);
-      expect(mockCustomerStatsbeatMetrics.countDroppedItems).toHaveBeenCalledWith(
+      expect(mockCustomerSDKStatsMetrics.countDroppedItems).toHaveBeenCalledWith(
         envelopes,
         "CLIENT_EXCEPTION",
         "Circular redirect",
@@ -768,7 +768,7 @@ describe("BaseSender", () => {
       const result = await testSender.exportEnvelopes(envelopes);
 
       expect(result.code).toBe(ExportResultCode.FAILED);
-      expect(mockCustomerStatsbeatMetrics.countDroppedItems).toHaveBeenCalledWith(
+      expect(mockCustomerSDKStatsMetrics.countDroppedItems).toHaveBeenCalledWith(
         envelopes,
         "CLIENT_EXCEPTION",
       );
@@ -794,10 +794,10 @@ describe("BaseSender", () => {
       const result = await testSender.exportEnvelopes(envelopes);
 
       expect(result.code).toBe(ExportResultCode.FAILED);
-      expect(mockCustomerStatsbeatMetrics.countDroppedItems).toHaveBeenCalledWith(envelopes, 400);
+      expect(mockCustomerSDKStatsMetrics.countDroppedItems).toHaveBeenCalledWith(envelopes, 400);
 
       // Verify exception.message is not passed for non-client exceptions
-      const call = mockCustomerStatsbeatMetrics.countDroppedItems.mock.calls[0];
+      const call = mockCustomerSDKStatsMetrics.countDroppedItems.mock.calls[0];
       expect(call.length).toBe(2); // envelopes array and drop code, but no exception message
     });
 
@@ -821,9 +821,9 @@ describe("BaseSender", () => {
       const result = await testSender.exportEnvelopes(envelopes);
 
       expect(result.code).toBe(ExportResultCode.SUCCESS);
-      expect(mockCustomerStatsbeatMetrics.countSuccessfulItems).toHaveBeenCalled();
-      expect(mockCustomerStatsbeatMetrics.countDroppedItems).not.toHaveBeenCalled();
-      expect(mockCustomerStatsbeatMetrics.countRetryItems).not.toHaveBeenCalled();
+      expect(mockCustomerSDKStatsMetrics.countSuccessfulItems).toHaveBeenCalled();
+      expect(mockCustomerSDKStatsMetrics.countDroppedItems).not.toHaveBeenCalled();
+      expect(mockCustomerSDKStatsMetrics.countRetryItems).not.toHaveBeenCalled();
     });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/customerSDKStats.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/customerSDKStats.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CustomerStatsbeatMetrics } from "../../src/export/statsbeat/customerStatsbeat.js";
+import { CustomerSDKStatsMetrics } from "../../src/export/statsbeat/customerSDKStats.js";
 import { DropCode, RetryCode, TelemetryType } from "../../src/export/statsbeat/types.js";
 import type { TelemetryItem as Envelope } from "../../src/generated/index.js";
 
@@ -59,8 +59,8 @@ function createMockEnvelopes(count: number, telemetryType: TelemetryType): Envel
   return envelopes;
 }
 
-describe("CustomerStatsbeatMetrics", () => {
-  let customerStatsbeatMetrics: CustomerStatsbeatMetrics;
+describe("CustomerSDKStatsMetrics", () => {
+  let customerSDKStatsMetrics: CustomerSDKStatsMetrics;
   const mockOptions = {
     instrumentationKey: "00000000-0000-0000-0000-000000000000", // Valid GUID format
     endpointUrl: "https://test.endpoint.com",
@@ -68,25 +68,25 @@ describe("CustomerStatsbeatMetrics", () => {
 
   beforeEach(() => {
     // Use getInstance to get the singleton
-    customerStatsbeatMetrics = CustomerStatsbeatMetrics.getInstance(mockOptions);
+    customerSDKStatsMetrics = CustomerSDKStatsMetrics.getInstance(mockOptions);
   });
 
   afterEach(async () => {
     // Clean up singleton instance
-    await CustomerStatsbeatMetrics.shutdown();
+    await CustomerSDKStatsMetrics.shutdown();
   });
 
   describe("countDroppedItems", () => {
     it("should store drop.reason for CLIENT_EXCEPTION drop code", () => {
       const exceptionMessage = "Network connection timeout";
 
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(5, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         exceptionMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const dropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -101,12 +101,12 @@ describe("CustomerStatsbeatMetrics", () => {
     });
 
     it("should not store drop.reason for CLIENT_EXCEPTION when message not provided", () => {
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const dropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -123,13 +123,13 @@ describe("CustomerStatsbeatMetrics", () => {
     it("should store appropriate drop.reason for non-CLIENT_EXCEPTION drop codes", () => {
       const exceptionMessage = "Some error message";
 
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         DropCode.NON_RETRYABLE_STATUS_CODE,
         exceptionMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const dropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -146,18 +146,18 @@ describe("CustomerStatsbeatMetrics", () => {
     it("should aggregate counts for same drop code and exception message", () => {
       const exceptionMessage = "Repeated error";
 
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         exceptionMessage,
       );
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         exceptionMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const dropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -172,18 +172,18 @@ describe("CustomerStatsbeatMetrics", () => {
     });
 
     it("should create separate entries for different telemetry types", () => {
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         "Error A",
       );
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(3, TelemetryType.DEPENDENCY),
         DropCode.CLIENT_EXCEPTION,
         "Error B",
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(2);
 
       const traceDropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -210,13 +210,13 @@ describe("CustomerStatsbeatMetrics", () => {
     it("should store retry.reason for CLIENT_EXCEPTION retry code", () => {
       const exceptionMessage = "Retry due to connection error";
 
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         exceptionMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemRetryCount.size).toBe(1);
 
       const retryCodeMap = counter.totalItemRetryCount.get(TelemetryType.TRACE);
@@ -231,12 +231,12 @@ describe("CustomerStatsbeatMetrics", () => {
     });
 
     it("should not store retry.reason for CLIENT_EXCEPTION when message not provided", () => {
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemRetryCount.size).toBe(1);
 
       const retryCodeMap = counter.totalItemRetryCount.get(TelemetryType.TRACE);
@@ -253,13 +253,13 @@ describe("CustomerStatsbeatMetrics", () => {
     it("should not store retry.reason for non-CLIENT_EXCEPTION retry codes", () => {
       const exceptionMessage = "Some retry message";
 
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(4, TelemetryType.TRACE),
         RetryCode.RETRYABLE_STATUS_CODE,
         exceptionMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemRetryCount.size).toBe(1);
 
       const retryCodeMap = counter.totalItemRetryCount.get(TelemetryType.TRACE);
@@ -276,18 +276,18 @@ describe("CustomerStatsbeatMetrics", () => {
     it("should aggregate counts for same retry code and retry reason", () => {
       const exceptionMessage = "Connection timeout";
 
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         exceptionMessage,
       );
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         exceptionMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemRetryCount.size).toBe(1);
 
       const retryCodeMap = counter.totalItemRetryCount.get(TelemetryType.TRACE);
@@ -305,12 +305,12 @@ describe("CustomerStatsbeatMetrics", () => {
   describe("Observable Callbacks", () => {
     it("should include drop.reason in drop count metrics when present", () => {
       // Add entries with different scenarios
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         "Test error",
       );
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         DropCode.NON_RETRYABLE_STATUS_CODE,
       );
@@ -320,8 +320,8 @@ describe("CustomerStatsbeatMetrics", () => {
       };
 
       // Call the item drop callback
-      const callback = (customerStatsbeatMetrics as any).itemDropCallback.bind(
-        customerStatsbeatMetrics,
+      const callback = (customerSDKStatsMetrics as any).itemDropCallback.bind(
+        customerSDKStatsMetrics,
       );
       callback(mockObservableResult);
 
@@ -344,12 +344,12 @@ describe("CustomerStatsbeatMetrics", () => {
 
     it("should include retry.reason in retry count metrics when present", () => {
       // Add entries with different scenarios
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(4, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         "Retry error",
       );
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(1, TelemetryType.TRACE),
         RetryCode.RETRYABLE_STATUS_CODE,
       );
@@ -359,8 +359,8 @@ describe("CustomerStatsbeatMetrics", () => {
       };
 
       // Call the item retry callback
-      const callback = (customerStatsbeatMetrics as any).itemRetryCallback.bind(
-        customerStatsbeatMetrics,
+      const callback = (customerSDKStatsMetrics as any).itemRetryCallback.bind(
+        customerSDKStatsMetrics,
       );
       callback(mockObservableResult);
 
@@ -382,18 +382,18 @@ describe("CustomerStatsbeatMetrics", () => {
     });
 
     it("should reset counts to zero after observation", () => {
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(5, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         "Test error",
       );
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         "Retry error",
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
 
       const traceDropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
       const traceDropReasonMap = traceDropCodeMap.get(DropCode.CLIENT_EXCEPTION);
@@ -408,11 +408,11 @@ describe("CustomerStatsbeatMetrics", () => {
       };
 
       // Call the callbacks
-      const dropCallback = (customerStatsbeatMetrics as any).itemDropCallback.bind(
-        customerStatsbeatMetrics,
+      const dropCallback = (customerSDKStatsMetrics as any).itemDropCallback.bind(
+        customerSDKStatsMetrics,
       );
-      const retryCallback = (customerStatsbeatMetrics as any).itemRetryCallback.bind(
-        customerStatsbeatMetrics,
+      const retryCallback = (customerSDKStatsMetrics as any).itemRetryCallback.bind(
+        customerSDKStatsMetrics,
       );
 
       dropCallback(mockObservableResult);
@@ -433,14 +433,14 @@ describe("CustomerStatsbeatMetrics", () => {
       const testErrorMessage = "Network connection failed";
 
       // Count dropped items with CLIENT_EXCEPTION and exception message
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(5, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         testErrorMessage,
       );
 
       // Verify the internal counter stores the telemetry_type
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const integrationDropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -457,8 +457,8 @@ describe("CustomerStatsbeatMetrics", () => {
         observe: vi.fn(),
       };
 
-      const dropCallback = (customerStatsbeatMetrics as any).itemDropCallback.bind(
-        customerStatsbeatMetrics,
+      const dropCallback = (customerSDKStatsMetrics as any).itemDropCallback.bind(
+        customerSDKStatsMetrics,
       );
       dropCallback(mockObservableResult);
       // Should observe the metric with drop.reason attribute
@@ -479,14 +479,14 @@ describe("CustomerStatsbeatMetrics", () => {
       const testErrorMessage = "Connection timeout during retry";
 
       // Count retry items with CLIENT_EXCEPTION and exception message
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         testErrorMessage,
       );
 
       // Verify the internal counter stores the exception message in the nested Map structure
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemRetryCount.size).toBe(1);
 
       const retryCodeMap = counter.totalItemRetryCount.get(TelemetryType.TRACE);
@@ -503,8 +503,8 @@ describe("CustomerStatsbeatMetrics", () => {
         observe: vi.fn(),
       };
 
-      const retryCallback = (customerStatsbeatMetrics as any).itemRetryCallback.bind(
-        customerStatsbeatMetrics,
+      const retryCallback = (customerSDKStatsMetrics as any).itemRetryCallback.bind(
+        customerSDKStatsMetrics,
       );
       retryCallback(mockObservableResult);
       // Should observe the metric with retry.reason attribute
@@ -525,13 +525,13 @@ describe("CustomerStatsbeatMetrics", () => {
       const testErrorMessage = "Some error message";
 
       // Test dropped items with non-CLIENT_EXCEPTION code
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         DropCode.NON_RETRYABLE_STATUS_CODE,
         testErrorMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const nonClientExceptionDropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -550,8 +550,8 @@ describe("CustomerStatsbeatMetrics", () => {
         observe: vi.fn(),
       };
 
-      const dropCallback = (customerStatsbeatMetrics as any).itemDropCallback.bind(
-        customerStatsbeatMetrics,
+      const dropCallback = (customerSDKStatsMetrics as any).itemDropCallback.bind(
+        customerSDKStatsMetrics,
       );
       dropCallback(mockObservableResult);
       expect(mockObservableResult.observe).toHaveBeenCalledWith(
@@ -571,12 +571,12 @@ describe("CustomerStatsbeatMetrics", () => {
       const error2 = "Authentication failed";
 
       // Add two different CLIENT_EXCEPTION errors
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         error1,
       );
-      customerStatsbeatMetrics.countRetryItems(
+      customerSDKStatsMetrics.countRetryItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         RetryCode.CLIENT_EXCEPTION,
         error2,
@@ -587,11 +587,11 @@ describe("CustomerStatsbeatMetrics", () => {
       };
 
       // Call both callbacks
-      const dropCallback = (customerStatsbeatMetrics as any).itemDropCallback.bind(
-        customerStatsbeatMetrics,
+      const dropCallback = (customerSDKStatsMetrics as any).itemDropCallback.bind(
+        customerSDKStatsMetrics,
       );
-      const retryCallback = (customerStatsbeatMetrics as any).itemRetryCallback.bind(
-        customerStatsbeatMetrics,
+      const retryCallback = (customerSDKStatsMetrics as any).itemRetryCallback.bind(
+        customerSDKStatsMetrics,
       );
 
       dropCallback(mockObservableResult);
@@ -628,18 +628,18 @@ describe("CustomerStatsbeatMetrics", () => {
       const testErrorMessage = "Repeated connection error";
 
       // Add the same error twice
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(2, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         testErrorMessage,
       );
-      customerStatsbeatMetrics.countDroppedItems(
+      customerSDKStatsMetrics.countDroppedItems(
         createMockEnvelopes(3, TelemetryType.TRACE),
         DropCode.CLIENT_EXCEPTION,
         testErrorMessage,
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemDropCount.size).toBe(1);
 
       const aggregateDropCodeMap = counter.totalItemDropCount.get(TelemetryType.TRACE);
@@ -656,8 +656,8 @@ describe("CustomerStatsbeatMetrics", () => {
         observe: vi.fn(),
       };
 
-      const dropCallback = (customerStatsbeatMetrics as any).itemDropCallback.bind(
-        customerStatsbeatMetrics,
+      const dropCallback = (customerSDKStatsMetrics as any).itemDropCallback.bind(
+        customerSDKStatsMetrics,
       );
       dropCallback(mockObservableResult);
       expect(mockObservableResult.observe).toHaveBeenCalledWith(
@@ -676,20 +676,20 @@ describe("CustomerStatsbeatMetrics", () => {
 
   describe("countSuccessfulItems", () => {
     it("should track successful items correctly", () => {
-      customerStatsbeatMetrics.countSuccessfulItems(
+      customerSDKStatsMetrics.countSuccessfulItems(
         createMockEnvelopes(10, TelemetryType.CUSTOM_EVENT),
       );
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemSuccessCount.size).toBe(1);
       expect(counter.totalItemSuccessCount.get(TelemetryType.CUSTOM_EVENT)).toBe(10);
     });
 
     it("should aggregate counts for same telemetry type", () => {
-      customerStatsbeatMetrics.countSuccessfulItems(createMockEnvelopes(5, TelemetryType.TRACE));
-      customerStatsbeatMetrics.countSuccessfulItems(createMockEnvelopes(3, TelemetryType.TRACE));
+      customerSDKStatsMetrics.countSuccessfulItems(createMockEnvelopes(5, TelemetryType.TRACE));
+      customerSDKStatsMetrics.countSuccessfulItems(createMockEnvelopes(3, TelemetryType.TRACE));
 
-      const counter = (customerStatsbeatMetrics as any).customerStatsbeatCounter;
+      const counter = (customerSDKStatsMetrics as any).customerSDKStatsCounter;
       expect(counter.totalItemSuccessCount.size).toBe(1);
       expect(counter.totalItemSuccessCount.get(TelemetryType.TRACE)).toBe(8);
     });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.spec.ts
@@ -203,11 +203,11 @@ describe("FileSystemPersist", () => {
   });
 
   describe("#CLIENT_READONLY scenarios", () => {
-    let mockCustomerStatsbeat: any;
+    let mockCustomerSDKStats: any;
     let originalOSFileProtection: boolean;
 
     beforeEach(() => {
-      mockCustomerStatsbeat = {
+      mockCustomerSDKStats = {
         countDroppedItems: vi.fn(),
       };
 
@@ -223,12 +223,12 @@ describe("FileSystemPersist", () => {
     });
 
     it("should have CLIENT_READONLY logic implemented", () => {
-      const persister = new FileSystemPersist(instrumentationKey, {}, mockCustomerStatsbeat);
+      const persister = new FileSystemPersist(instrumentationKey, {}, mockCustomerSDKStats);
       expect(persister).toBeDefined();
       expect(DropCode.CLIENT_READONLY).toBeDefined();
 
       // Verify that our mock is properly set up
-      expect(mockCustomerStatsbeat.countDroppedItems).toBeDefined();
+      expect(mockCustomerSDKStats.countDroppedItems).toBeDefined();
     });
 
     it("should track CLIENT_READONLY when permission errors occur", async () => {
@@ -247,7 +247,7 @@ describe("FileSystemPersist", () => {
         .spyOn(helpersMod, "confirmDirExists")
         .mockRejectedValue(error);
 
-      const persister = new FileSystemPersist(instrumentationKey, {}, mockCustomerStatsbeat);
+      const persister = new FileSystemPersist(instrumentationKey, {}, mockCustomerSDKStats);
 
       const result = await persister.push([envelope]);
 
@@ -255,7 +255,7 @@ describe("FileSystemPersist", () => {
       expect(result).toBe(false);
 
       // Should have called countDroppedItems with CLIENT_READONLY
-      expect(mockCustomerStatsbeat.countDroppedItems).toHaveBeenCalledWith(
+      expect(mockCustomerSDKStats.countDroppedItems).toHaveBeenCalledWith(
         [envelope],
         DropCode.CLIENT_READONLY,
       );


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This pull request refactors the terminology and code related to customer-facing Statsbeat metrics in the Azure Monitor OpenTelemetry Exporter SDK. The main change is a comprehensive renaming from "customer statsbeat" to "customer SDK Stats" throughout the codebase, documentation, and configuration. This improves clarity and aligns with updated product terminology, while maintaining backward compatibility through legacy aliases.

**Terminology and Documentation Updates:**

- Updated all references from "customer statsbeat" to "customer SDK Stats" in documentation, comments, and changelogs to reflect the new naming convention. [[1]](diffhunk://#diff-994a7fbc4177f96448b6098ea5c95fc5872615b8537e18822a17817cd3d70870L7-R7) [[2]](diffhunk://#diff-994a7fbc4177f96448b6098ea5c95fc5872615b8537e18822a17817cd3d70870L21-R21) [[3]](diffhunk://#diff-64f44affbca0b21471654d970b64e3c777b068851a41eb8e86c3652521c72190L112-R112)

**Codebase Refactoring:**

- Renamed the main metrics class and related types from `CustomerStatsbeatMetrics` to `CustomerSDKStatsMetrics`, and updated all usages throughout the codebase, including imports, variable names, and method calls. [[1]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L11-R35) [[2]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L48-R93) [[3]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L103-R159) [[4]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L26-R26) [[5]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L39-R39) [[6]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L68-R68) [[7]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L78-R78) [[8]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L117-R125) [[9]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L135-R135)

- Renamed supporting classes and enums, such as `CustomerStatsbeat`, `CustomStatsbeatCounter`, and `CustomerStatsbeatProperties`, to `CustomerSDKStats`, `CustomSDKStatsCounter`, and `CustomerSDKStatsProperties` respectively, and updated all relevant references. [[1]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L173-R174) [[2]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L208-R209) [[3]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L249-R249) [[4]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L272-R272) [[5]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L428-R428) [[6]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL61-R64) [[7]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL115-R126) [[8]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL153-R167)

**Backward Compatibility:**

- Added legacy aliases for renamed types and enums to ensure backward compatibility for existing integrations. [[1]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dR83-R85) [[2]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL115-R126) [[3]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL153-R167)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
No, purely a refactor.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
