### PR TITLE
Update DAC docs

### DIFF
--- a/sdk/identity/identity/src/credentials/brokerCredential.ts
+++ b/sdk/identity/identity/src/credentials/brokerCredential.ts
@@ -22,7 +22,7 @@ const logger = credentialLogger("BrokerCredential");
 
 /**
  * Enables authentication to Microsoft Entra ID using WAM (Web Account Manager) broker.
- * This credential extends InteractiveBrowserCredential and provides additional broker-specific functionality.
+ * This credential uses the default account logged into the OS via a broker.
  */
 export class BrokerCredential implements TokenCredential {
   private brokerMsalClient: MsalClient;

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -65,7 +65,7 @@ export class UnavailableDefaultCredential implements TokenCredential {
  * - {@link AzureCliCredential}
  * - {@link AzurePowerShellCredential}
  * - {@link AzureDeveloperCliCredential}
- * - {@link BrokerCredential} - A broker-enabled instance of {@link InteractiveBrowserCredential}
+ * - {@link BrokerCredential}
  *
  * Consult the documentation of these credential types for more information
  * on how they attempt authentication.

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -65,20 +65,10 @@ export class UnavailableDefaultCredential implements TokenCredential {
  * - {@link AzureCliCredential}
  * - {@link AzurePowerShellCredential}
  * - {@link AzureDeveloperCliCredential}
+ * - {@link BrokerCredential} - A broker-enabled instance of {@link InteractiveBrowserCredential}
  *
  * Consult the documentation of these credential types for more information
  * on how they attempt authentication.
- *
- * Selecting credentials
- *
- * Set environment variable AZURE_TOKEN_CREDENTIALS to select a subset of the credential chain.
- * DefaultAzureCredential will try only the specified credential(s), but its other behavior remains the same.
- * Valid values for AZURE_TOKEN_CREDENTIALS are the name of any single type in the above chain, for example
- * "EnvironmentCredential" or "AzureCliCredential", and these special values:
- *
- *   - "dev": try [VisualStudioCodeCredential], [AzureCliCredential], [AzurePowerShellCredential] and [AzureDeveloperCliCredential], in that order
- *   - "prod": try [EnvironmentCredential], [WorkloadIdentityCredential], and [ManagedIdentityCredential], in that order
- *
  */
 export class DefaultAzureCredential extends ChainedTokenCredential {
   /**


### PR DESCRIPTION
Add BrokerCredential to the list of credentials used by DAC. Also remove the AZURE_TOKEN_CREDENTIALS detail, as we want the credential chains doc to be the source of truth for that info.