### PR TITLE
[EngSys] Revert previous formatting changes

### DIFF
--- a/sdk/agricultureplatform/arm-agricultureplatform/src/static-helpers/urlTemplate.ts
+++ b/sdk/agricultureplatform/arm-agricultureplatform/src/static-helpers/urlTemplate.ts
@@ -170,7 +170,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/ai/ai-agents/src/static-helpers/urlTemplate.ts
+++ b/sdk/ai/ai-agents/src/static-helpers/urlTemplate.ts
@@ -174,7 +174,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/ai/ai-projects/src/static-helpers/urlTemplate.ts
+++ b/sdk/ai/ai-projects/src/static-helpers/urlTemplate.ts
@@ -174,7 +174,7 @@ export function expandUrlTemplate(
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
       // eslint-disable-next-line no-unused-expressions
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/avs/arm-avs/src/static-helpers/urlTemplate.ts
+++ b/sdk/avs/arm-avs/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/carbonoptimization/arm-carbonoptimization/src/static-helpers/urlTemplate.ts
+++ b/sdk/carbonoptimization/arm-carbonoptimization/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/chaos/arm-chaos/src/static-helpers/urlTemplate.ts
+++ b/sdk/chaos/arm-chaos/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/cloudhealth/arm-cloudhealth/src/static-helpers/urlTemplate.ts
+++ b/sdk/cloudhealth/arm-cloudhealth/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/computeschedule/arm-computeschedule/src/static-helpers/urlTemplate.ts
+++ b/sdk/computeschedule/arm-computeschedule/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/containerservice/arm-containerservicefleet/src/static-helpers/urlTemplate.ts
+++ b/sdk/containerservice/arm-containerservicefleet/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/dashboard/arm-dashboard/src/static-helpers/urlTemplate.ts
+++ b/sdk/dashboard/arm-dashboard/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/dell/arm-dell-storage/src/static-helpers/urlTemplate.ts
+++ b/sdk/dell/arm-dell-storage/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/dependencymap/arm-dependencymap/src/static-helpers/urlTemplate.ts
+++ b/sdk/dependencymap/arm-dependencymap/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/durabletask/arm-durabletask/src/static-helpers/urlTemplate.ts
+++ b/sdk/durabletask/arm-durabletask/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/src/static-helpers/urlTemplate.ts
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/src/static-helpers/urlTemplate.ts
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/src/static-helpers/urlTemplate.ts
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/src/static-helpers/urlTemplate.ts
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/src/static-helpers/urlTemplate.ts
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/mongocluster/arm-mongocluster/src/static-helpers/urlTemplate.ts
+++ b/sdk/mongocluster/arm-mongocluster/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/mongodbatlas/arm-mongodbatlas/src/static-helpers/urlTemplate.ts
+++ b/sdk/mongodbatlas/arm-mongodbatlas/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/neonpostgres/arm-neonpostgres/src/static-helpers/urlTemplate.ts
+++ b/sdk/neonpostgres/arm-neonpostgres/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/src/static-helpers/urlTemplate.ts
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/oracledatabase/arm-oracledatabase/src/static-helpers/urlTemplate.ts
+++ b/sdk/oracledatabase/arm-oracledatabase/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/pineconevectordb/arm-pineconevectordb/src/static-helpers/urlTemplate.ts
+++ b/sdk/pineconevectordb/arm-pineconevectordb/src/static-helpers/urlTemplate.ts
@@ -170,7 +170,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/planetarycomputer/arm-planetarycomputer/src/static-helpers/urlTemplate.ts
+++ b/sdk/planetarycomputer/arm-planetarycomputer/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/playwright/arm-playwright/src/static-helpers/urlTemplate.ts
+++ b/sdk/playwright/arm-playwright/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/portalservices/arm-portalservicescopilot/src/static-helpers/urlTemplate.ts
+++ b/sdk/portalservices/arm-portalservicescopilot/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/src/static-helpers/urlTemplate.ts
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/purestorageblock/arm-purestorageblock/src/static-helpers/urlTemplate.ts
+++ b/sdk/purestorageblock/arm-purestorageblock/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/src/static-helpers/urlTemplate.ts
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/resources/arm-resourcesbicep/src/static-helpers/urlTemplate.ts
+++ b/sdk/resources/arm-resourcesbicep/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/src/static-helpers/urlTemplate.ts
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/servicenetworking/arm-servicenetworking/src/static-helpers/urlTemplate.ts
+++ b/sdk/servicenetworking/arm-servicenetworking/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/sitemanager/arm-sitemanager/src/static-helpers/urlTemplate.ts
+++ b/sdk/sitemanager/arm-sitemanager/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/standbypool/arm-standbypool/src/static-helpers/urlTemplate.ts
+++ b/sdk/standbypool/arm-standbypool/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/storageactions/arm-storageactions/src/static-helpers/urlTemplate.ts
+++ b/sdk/storageactions/arm-storageactions/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/storagediscovery/arm-storagediscovery/src/static-helpers/urlTemplate.ts
+++ b/sdk/storagediscovery/arm-storagediscovery/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];

--- a/sdk/workloads/arm-workloadssapvirtualinstance/src/static-helpers/urlTemplate.ts
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/src/static-helpers/urlTemplate.ts
@@ -171,7 +171,7 @@ export function expandUrlTemplate(
     }
     let op;
     if (["+", "#", ".", "/", ";", "?", "&"].includes(expr[0])) {
-      (op = expr[0]), (expr = expr.slice(1));
+      ((op = expr[0]), (expr = expr.slice(1)));
     }
     const varList = expr.split(/,/g);
     const result = [];


### PR DESCRIPTION
Likely due to different version of prettier, current main is reporting incorrect formatting for changes introduced in PR #35504.

Revert "[EngSys] fix formatting for some management packages (#35504)"

This reverts commit 0ac6cff60bf3fae702d35d790da17de4eacb207e.