### PR TITLE
[Monitor OpenTelemetry] Change Customer Statsbeat to Customer SDK Stats

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.12.1 ()
+
+### Other Changes
+
+- Change customer statsbeat feature name to customer SDK Stats.
+
 ## 1.12.0 (2025-08-04)
 
 ### Features Added

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -13,7 +13,7 @@ import type { StatsbeatFeatures, StatsbeatInstrumentations } from "./types.js";
 import {
   AZURE_MONITOR_OPENTELEMETRY_VERSION,
   AzureMonitorOpenTelemetryOptions,
-  APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
+  APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW,
   InstrumentationOptions,
   BrowserSdkLoaderOptions,
 } from "./types.js";
@@ -54,7 +54,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
     diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
     rateLimitedSampler: !!config.tracesPerSecond,
-    customerStatsbeat: process.env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] === "True",
+    customerSdkStats: process.env[APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW] === "True",
   };
   getInstance().setStatsbeatFeatures(statsbeatInstrumentations, statsbeatFeatures);
 

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -71,7 +71,7 @@ export interface StatsbeatFeatures {
   distro?: boolean;
   liveMetrics?: boolean;
   shim?: boolean;
-  customerStatsbeat?: boolean;
+  customerSdkStats?: boolean;
   multiIkey?: boolean;
   rateLimitedSampler?: boolean;
 }
@@ -87,7 +87,7 @@ export const StatsbeatFeaturesMap = new Map<string, number>([
   ["distro", 8],
   ["liveMetrics", 16],
   ["shim", 32],
-  ["customerStatsbeat", 64],
+  ["customerSdkStats", 64],
   ["multiIkey", 128],
   ["rateLimitedSampler", 256],
 ]);
@@ -193,8 +193,8 @@ export const AzureMonitorSampleRate = "microsoft.sample_rate";
  * Enables the preview version of customer-facing Statsbeat.
  * @internal
  */
-export declare const APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW =
-  "APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW";
+export declare const APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW =
+  "APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW";
 
 export enum StatsbeatFeature {
   NONE = 0,
@@ -204,7 +204,7 @@ export enum StatsbeatFeature {
   DISTRO = 8,
   LIVE_METRICS = 16,
   SHIM = 32,
-  CUSTOMER_STATSBEAT = 64,
+  CUSTOMER_SDKSTATS = 64,
   MULTI_IKEY = 128,
 }
 

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -10,7 +10,7 @@ import type { MeterProvider } from "@opentelemetry/sdk-metrics";
 import type { StatsbeatEnvironmentConfig } from "../../../src/types.js";
 import {
   AZURE_MONITOR_STATSBEAT_FEATURES,
-  APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW,
+  APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW,
   StatsbeatFeature,
   StatsbeatInstrumentation,
   StatsbeatInstrumentationMap,
@@ -434,9 +434,9 @@ describe("Main functions", () => {
     void shutdownAzureMonitor();
   });
 
-  it("should detect CUSTOMER_STATSBEAT feature when APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW is 'True'", () => {
+  it("should detect CUSTOMER_SDKSTATS feature when APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW is 'True'", () => {
     const env = <{ [id: string]: string }>{};
-    env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "True";
+    env[APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW] = "True";
     process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
@@ -449,16 +449,16 @@ describe("Main functions", () => {
     };
     const features = Number(output["feature"] || 0);
     assert.ok(
-      features & StatsbeatFeature.CUSTOMER_STATSBEAT,
+      features & StatsbeatFeature.CUSTOMER_SDKSTATS,
       "CUSTOMER_STATSBEAT feature should be detected when env var is 'True'",
     );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should also be set");
     void shutdownAzureMonitor();
   });
 
-  it("should not detect CUSTOMER_STATSBEAT feature when APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW is not 'True'", () => {
+  it("should not detect CUSTOMER_SDKSTATS feature when APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW is not 'True'", () => {
     const env = <{ [id: string]: string }>{};
-    env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW] = "false";
+    env[APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW] = "false";
     process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
@@ -471,16 +471,16 @@ describe("Main functions", () => {
     };
     const features = Number(output["feature"] || 0);
     assert.ok(
-      !(features & StatsbeatFeature.CUSTOMER_STATSBEAT),
+      !(features & StatsbeatFeature.CUSTOMER_SDKSTATS),
       "CUSTOMER_STATSBEAT feature should not be detected when env var is not 'True'",
     );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
     void shutdownAzureMonitor();
   });
 
-  it("should not detect CUSTOMER_STATSBEAT feature when APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW is not set", () => {
+  it("should not detect CUSTOMER_SDKSTATS feature when APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW is not set", () => {
     const env = <{ [id: string]: string }>{};
-    delete env[APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW];
+    delete env[APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW];
     process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
       azureMonitorExporterOptions: {
@@ -493,8 +493,8 @@ describe("Main functions", () => {
     };
     const features = Number(output["feature"] || 0);
     assert.ok(
-      !(features & StatsbeatFeature.CUSTOMER_STATSBEAT),
-      "CUSTOMER_STATSBEAT feature should not be detected when env var is undefined",
+      !(features & StatsbeatFeature.CUSTOMER_SDKSTATS),
+      "CUSTOMER_SDKSTATS feature should not be detected when env var is undefined",
     );
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO feature should still be set");
     void shutdownAzureMonitor();


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
This pull request updates the naming of the "customer statsbeat" feature to "customer SDK Stats" throughout the Azure Monitor OpenTelemetry SDK. This change affects environment variables, code identifiers, feature flags, and related tests to ensure consistency and clarity.

**Feature renaming and environment variable updates:**

* Renamed the feature flag from `customerStatsbeat` to `customerSdkStats` in the `StatsbeatFeatures` interface and updated its usage throughout the codebase. [[1]](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028L74-R74) [[2]](diffhunk://#diff-e7e1dcf8f0ac5c3aea3811994ab032c757ad020b9ca8855dec69d18bb5343ef3L57-R57)
* Changed the environment variable from `APPLICATIONINSIGHTS_STATSBEAT_ENABLED_PREVIEW` to `APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW` and updated all relevant imports and references. [[1]](diffhunk://#diff-e7e1dcf8f0ac5c3aea3811994ab032c757ad020b9ca8855dec69d18bb5343ef3L16-R16) [[2]](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028L196-R197) [[3]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7L13-R13)

**Enum and mapping adjustments:**

* Updated the `StatsbeatFeature` enum value from `CUSTOMER_STATSBEAT` to `CUSTOMER_SDKSTATS`, and made corresponding changes in the `StatsbeatFeaturesMap`. [[1]](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028L207-R207) [[2]](diffhunk://#diff-48c64776365220d515750e313877e3ff6c92347670e2e5892c0df15179561028L90-R90)

**Test updates:**

* Modified all affected test cases to use the new feature and environment variable names, ensuring that detection logic and assertions reflect the renamed identifiers. [[1]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7L437-R439) [[2]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7L452-R461) [[3]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7L474-R483) [[4]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7L496-R497)

**Documentation:**

* Updated the changelog to note the renaming of the customer statsbeat feature to customer SDK Stats.

### Are there test cases added in this PR? _(If not, why?)_
Test cases are modified to work with 

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
