### PR TITLE
fix typo: ISO 8061 -> ISO 8601

### DIFF
--- a/sdk/servicebus/arm-servicebus/src/models/index.ts
+++ b/sdk/servicebus/arm-servicebus/src/models/index.ts
@@ -699,7 +699,7 @@ export interface SBQueue extends ProxyResource {
   status?: EntityStatus;
   /** Value that indicates whether server-side batched operations are enabled. */
   enableBatchedOperations?: boolean;
-  /** ISO 8061 timeSpan idle interval after which the queue is automatically deleted. The minimum duration is 5 minutes. */
+  /** ISO 8601 timeSpan idle interval after which the queue is automatically deleted. The minimum duration is 5 minutes. */
   autoDeleteOnIdle?: string;
   /** A value that indicates whether the queue is to be partitioned across multiple message brokers. */
   enablePartitioning?: boolean;
@@ -821,11 +821,11 @@ export interface SBSubscription extends ProxyResource {
    * NOTE: This property will not be serialized. It can only be populated by the server.
    */
   readonly countDetails?: MessageCountDetails;
-  /** ISO 8061 lock duration timespan for the subscription. The default value is 1 minute. */
+  /** ISO 8601 lock duration timespan for the subscription. The default value is 1 minute. */
   lockDuration?: string;
   /** Value indicating if a subscription supports the concept of sessions. */
   requiresSession?: boolean;
-  /** ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself. */
+  /** ISO 8601 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself. */
   defaultMessageTimeToLive?: string;
   /** Value that indicates whether a subscription has dead letter support on filter evaluation exceptions. */
   deadLetteringOnFilterEvaluationExceptions?: boolean;
@@ -839,7 +839,7 @@ export interface SBSubscription extends ProxyResource {
   status?: EntityStatus;
   /** Value that indicates whether server-side batched operations are enabled. */
   enableBatchedOperations?: boolean;
-  /** ISO 8061 timeSpan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes. */
+  /** ISO 8601 timeSpan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes. */
   autoDeleteOnIdle?: string;
   /** Queue/Topic name to forward the messages */
   forwardTo?: string;

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -42,7 +42,7 @@ import {
 import { StorageSharedKeyCredential } from "./credentials/StorageSharedKeyCredential.js";
 import { AnonymousCredential } from "./credentials/AnonymousCredential.js";
 import type { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
-import { truncatedISO8061Date, assertResponse } from "./utils/utils.common.js";
+import { truncatedISO8601Date, assertResponse } from "./utils/utils.common.js";
 import { tracingClient } from "./utils/tracing.js";
 import { BlobBatchClient } from "./BlobBatchClient.js";
 import type { CommonOptions } from "./StorageClient.js";
@@ -1145,8 +1145,8 @@ export class BlobServiceClient extends StorageClient {
         >(
           await this.serviceContext.getUserDelegationKey(
             {
-              startsOn: truncatedISO8061Date(startsOn, false),
-              expiresOn: truncatedISO8061Date(expiresOn, false),
+              startsOn: truncatedISO8601Date(startsOn, false),
+              expiresOn: truncatedISO8601Date(expiresOn, false),
             },
             {
               abortSignal: options.abortSignal,

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -62,7 +62,7 @@ import {
   isIpEndpointStyle,
   parseObjectReplicationRecord,
   toTags,
-  truncatedISO8061Date,
+  truncatedISO8601Date,
 } from "./utils/utils.common.js";
 import type { ContainerSASPermissions } from "./sas/ContainerSASPermissions.js";
 import {
@@ -1133,11 +1133,11 @@ export class ContainerClient extends StorageClient {
           acl.push({
             accessPolicy: {
               expiresOn: identifier.accessPolicy.expiresOn
-                ? truncatedISO8061Date(identifier.accessPolicy.expiresOn)
+                ? truncatedISO8601Date(identifier.accessPolicy.expiresOn)
                 : "",
               permissions: identifier.accessPolicy.permissions,
               startsOn: identifier.accessPolicy.startsOn
-                ? truncatedISO8061Date(identifier.accessPolicy.startsOn)
+                ? truncatedISO8601Date(identifier.accessPolicy.startsOn)
                 : "",
             },
             id: identifier.id,

--- a/sdk/storage/storage-blob/src/sas/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/sas/AccountSASSignatureValues.ts
@@ -10,7 +10,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "../utils/constants.js";
-import { truncatedISO8061Date } from "../utils/utils.common.js";
+import { truncatedISO8601Date } from "../utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -165,9 +165,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,
@@ -181,9 +181,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,

--- a/sdk/storage/storage-blob/src/sas/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/sas/BlobSASSignatureValues.ts
@@ -10,7 +10,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "../utils/constants.js";
-import { truncatedISO8061Date } from "../utils/utils.common.js";
+import { truncatedISO8601Date } from "../utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -456,10 +456,10 @@ function generateBlobSASQueryParameters20150405(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -563,10 +563,10 @@ function generateBlobSASQueryParameters20181109(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -672,10 +672,10 @@ function generateBlobSASQueryParameters20201206(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -782,10 +782,10 @@ function generateBlobSASQueryParametersUDK20181109(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -795,10 +795,10 @@ function generateBlobSASQueryParametersUDK20181109(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -896,10 +896,10 @@ function generateBlobSASQueryParametersUDK20200210(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -909,10 +909,10 @@ function generateBlobSASQueryParametersUDK20200210(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -1015,10 +1015,10 @@ function generateBlobSASQueryParametersUDK20201206(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -1028,10 +1028,10 @@ function generateBlobSASQueryParametersUDK20201206(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -1136,10 +1136,10 @@ function generateBlobSASQueryParametersUDK20250705(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     blobSASSignatureValues.startsOn
-      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.startsOn, false)
       : "",
     blobSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -1149,10 +1149,10 @@ function generateBlobSASQueryParametersUDK20250705(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,

--- a/sdk/storage/storage-blob/src/sas/SASQueryParameters.ts
+++ b/sdk/storage/storage-blob/src/sas/SASQueryParameters.ts
@@ -3,7 +3,7 @@
 
 import type { SasIPRange } from "./SasIPRange.js";
 import { ipRangeToString } from "./SasIPRange.js";
-import { truncatedISO8061Date } from "../utils/utils.common.js";
+import { truncatedISO8601Date } from "../utils/utils.common.js";
 import type { UserDelegationKey } from "../BlobServiceClient.js";
 
 /**
@@ -471,14 +471,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined,
+            this.startsOn ? truncatedISO8601Date(this.startsOn, false) : undefined,
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined,
+            this.expiresOn ? truncatedISO8601Date(this.expiresOn, false) : undefined,
           );
           break;
         case "sip":
@@ -504,14 +504,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedStartsOn ? truncatedISO8061Date(this.signedStartsOn, false) : undefined,
+            this.signedStartsOn ? truncatedISO8601Date(this.signedStartsOn, false) : undefined,
           );
           break;
         case "ske": // Signed key expiry time
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedExpiresOn ? truncatedISO8061Date(this.signedExpiresOn, false) : undefined,
+            this.signedExpiresOn ? truncatedISO8601Date(this.signedExpiresOn, false) : undefined,
           );
           break;
         case "sks": // Signed key service

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -445,9 +445,9 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8601 format, with or without 7 milliseconds component
  */
-export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
+export function truncatedISO8601Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
   const dateString = date.toISOString();
 

--- a/sdk/storage/storage-common/src/utils/utils.common.ts
+++ b/sdk/storage/storage-common/src/utils/utils.common.ts
@@ -432,9 +432,9 @@ export function appendToURLQuery(url: string, queryParts: string): string {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8601 format, with or without 7 milliseconds component
  */
-export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
+export function truncatedISO8601Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
   const dateString = date.toISOString();
 

--- a/sdk/storage/storage-file-datalake/src/sas/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/AccountSASSignatureValues.ts
@@ -10,7 +10,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "../utils/constants.js";
-import { truncatedISO8061Date } from "../utils/utils.common.js";
+import { truncatedISO8601Date } from "../utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -121,9 +121,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,
@@ -137,9 +137,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,

--- a/sdk/storage/storage-file-datalake/src/sas/DataLakeSASSignatureValues.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/DataLakeSASSignatureValues.ts
@@ -11,7 +11,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "../utils/constants.js";
-import { truncatedISO8061Date } from "../utils/utils.common.js";
+import { truncatedISO8601Date } from "../utils/utils.common.js";
 import { DirectorySASPermissions } from "./DirectorySASPermissions.js";
 
 /**
@@ -397,10 +397,10 @@ function generateBlobSASQueryParameters20150405(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -519,10 +519,10 @@ function generateBlobSASQueryParameters20181109(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -639,10 +639,10 @@ function generateBlobSASQueryParametersUDK20181109(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -652,10 +652,10 @@ function generateBlobSASQueryParametersUDK20181109(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -769,10 +769,10 @@ function generateBlobSASQueryParametersUDK20200210(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -782,10 +782,10 @@ function generateBlobSASQueryParametersUDK20200210(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -908,10 +908,10 @@ function generateBlobSASQueryParameters20201206(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -1033,10 +1033,10 @@ function generateBlobSASQueryParametersUDK20201206(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -1046,10 +1046,10 @@ function generateBlobSASQueryParametersUDK20201206(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -1168,10 +1168,10 @@ function generateBlobSASQueryParametersUDK20250705(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     dataLakeSASSignatureValues.startsOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.startsOn, false)
       : "",
     dataLakeSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(dataLakeSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(dataLakeSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -1181,10 +1181,10 @@ function generateBlobSASQueryParametersUDK20250705(
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
     userDelegationKeyCredential.userDelegationKey.signedStartsOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedExpiresOn
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
+      ? truncatedISO8601Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,

--- a/sdk/storage/storage-file-datalake/src/sas/SASQueryParameters.ts
+++ b/sdk/storage/storage-file-datalake/src/sas/SASQueryParameters.ts
@@ -4,7 +4,7 @@
 import type { UserDelegationKey } from "../models.js";
 import type { SasIPRange } from "./SasIPRange.js";
 import { ipRangeToString } from "./SasIPRange.js";
-import { truncatedISO8061Date } from "../utils/utils.common.js";
+import { truncatedISO8601Date } from "../utils/utils.common.js";
 
 /**
  * Protocols for generated SAS.
@@ -506,14 +506,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined,
+            this.startsOn ? truncatedISO8601Date(this.startsOn, false) : undefined,
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined,
+            this.expiresOn ? truncatedISO8601Date(this.expiresOn, false) : undefined,
           );
           break;
         case "sip":
@@ -539,14 +539,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedStartsOn ? truncatedISO8061Date(this.signedStartsOn, false) : undefined,
+            this.signedStartsOn ? truncatedISO8601Date(this.signedStartsOn, false) : undefined,
           );
           break;
         case "ske": // Signed key expiry time
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedExpiresOn ? truncatedISO8061Date(this.signedExpiresOn, false) : undefined,
+            this.signedExpiresOn ? truncatedISO8601Date(this.signedExpiresOn, false) : undefined,
           );
           break;
         case "sks": // Signed key service

--- a/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.common.ts
@@ -442,9 +442,9 @@ export function setURLQueries(url: string, queryString: string): string {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8601 format, with or without 7 milliseconds component
  */
-export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
+export function truncatedISO8601Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
   const dateString = date.toISOString();
 

--- a/sdk/storage/storage-file-share/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-file-share/src/AccountSASSignatureValues.ts
@@ -10,7 +10,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "./utils/constants.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -115,9 +115,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,
@@ -131,9 +131,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,

--- a/sdk/storage/storage-file-share/src/Clients.ts
+++ b/sdk/storage/storage-file-share/src/Clients.ts
@@ -121,7 +121,7 @@ import type { WithResponse } from "./utils/utils.common.js";
 import {
   appendToURLPath,
   setURLParameter,
-  truncatedISO8061Date,
+  truncatedISO8601Date,
   extractConnectionStringParts,
   getShareNameAndPathFromUrl,
   appendToURLQuery,
@@ -1200,11 +1200,11 @@ export class ShareClient extends StorageClient {
           acl.push({
             accessPolicy: {
               expiresOn: identifier.accessPolicy?.expiresOn
-                ? truncatedISO8061Date(identifier.accessPolicy.expiresOn)
+                ? truncatedISO8601Date(identifier.accessPolicy.expiresOn)
                 : undefined,
               permissions: identifier.accessPolicy?.permissions,
               startsOn: identifier.accessPolicy?.startsOn
-                ? truncatedISO8061Date(identifier.accessPolicy.startsOn)
+                ? truncatedISO8601Date(identifier.accessPolicy.startsOn)
                 : undefined,
             },
             id: identifier.id,

--- a/sdk/storage/storage-file-share/src/FileSASSignatureValues.ts
+++ b/sdk/storage/storage-file-share/src/FileSASSignatureValues.ts
@@ -9,7 +9,7 @@ import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { ShareSASPermissions } from "./ShareSASPermissions.js";
 import { SERVICE_VERSION } from "./utils/constants.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -154,10 +154,10 @@ export function generateFileSASQueryParametersInternal(
   const stringToSign = [
     verifiedPermissions,
     fileSASSignatureValues.startsOn
-      ? truncatedISO8061Date(fileSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(fileSASSignatureValues.startsOn, false)
       : "",
     fileSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(fileSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(fileSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,

--- a/sdk/storage/storage-file-share/src/SASQueryParameters.ts
+++ b/sdk/storage/storage-file-share/src/SASQueryParameters.ts
@@ -3,7 +3,7 @@
 
 import type { SasIPRange } from "./SasIPRange.js";
 import { ipRangeToString } from "./SasIPRange.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 
 /**
  * Protocols for generated SAS.
@@ -230,14 +230,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined,
+            this.startsOn ? truncatedISO8601Date(this.startsOn, false) : undefined,
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined,
+            this.expiresOn ? truncatedISO8601Date(this.expiresOn, false) : undefined,
           );
           break;
         case "sip":

--- a/sdk/storage/storage-file-share/src/models.ts
+++ b/sdk/storage/storage-file-share/src/models.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { FileSystemAttributes } from "./FileSystemAttributes.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 import { logger } from "./log.js";
 import type { FilePermissionFormat, NfsFileType, ShareTokenIntent } from "./generatedModels.js";
 import type { StoragePipelineOptions } from "./Pipeline.js";
@@ -456,19 +456,19 @@ export function fileAttributesToString(
 export function fileCreationTimeToString(
   time: Date | TimeNowType | TimePreserveType | undefined,
 ): string | undefined {
-  return time instanceof Date ? truncatedISO8061Date(time) : time;
+  return time instanceof Date ? truncatedISO8601Date(time) : time;
 }
 
 export function fileLastWriteTimeToString(
   time: Date | TimeNowType | TimePreserveType | undefined,
 ): string | undefined {
-  return time instanceof Date ? truncatedISO8061Date(time) : time;
+  return time instanceof Date ? truncatedISO8601Date(time) : time;
 }
 
 export function fileChangeTimeToString(
   time: Date | TimeNowType | TimePreserveType | undefined,
 ): string | undefined {
-  return time instanceof Date ? truncatedISO8061Date(time) : time;
+  return time instanceof Date ? truncatedISO8601Date(time) : time;
 }
 
 /**

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -356,9 +356,9 @@ export function getURLQueries(url: string): { [key: string]: string } {
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8601 format, with or without 7 milliseconds component
  */
-export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
+export function truncatedISO8601Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
   const dateString = date.toISOString();
 

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -13,7 +13,7 @@ import type { FilePosixProperties, ShareClient, ShareServiceClient } from "../sr
 import { ShareDirectoryClient, FileSystemAttributes } from "../src/index.js";
 import { Recorder, isLiveMode } from "@azure-tools/test-recorder";
 import type { DirectoryCreateResponse } from "../src/generatedModels.js";
-import { truncatedISO8061Date } from "../src/utils/utils.common.js";
+import { truncatedISO8601Date } from "../src/utils/utils.common.js";
 import { getYieldedValue } from "@azure-tools/test-utils-vitest";
 import { isBrowser } from "@azure/core-util";
 import { describe, it, assert, beforeEach, afterEach, expect } from "vitest";
@@ -163,9 +163,9 @@ describe("DirectoryClient", () => {
     assert.ok(respFileAttributes.offline);
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileChangeOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileChangeOn!), truncatedISO8601Date(now));
     assert.equal(result.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -202,8 +202,8 @@ describe("DirectoryClient", () => {
     assert.ok(respFileAttributes.offline);
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
     assert.ok(result.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -244,8 +244,8 @@ describe("DirectoryClient", () => {
     assert.ok(respFileAttributes.offline);
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
     assert.ok(result.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -324,12 +324,12 @@ describe("DirectoryClient", () => {
     assert.equal(result.errorCode, undefined);
     assert.equal(result.fileAttributes!, defaultDirCreateResp.fileAttributes!);
     assert.equal(
-      truncatedISO8061Date(result.fileCreatedOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileCreatedOn!),
+      truncatedISO8601Date(result.fileCreatedOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileCreatedOn!),
     );
     assert.equal(
-      truncatedISO8061Date(result.fileLastWriteOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileLastWriteOn!),
+      truncatedISO8601Date(result.fileLastWriteOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileLastWriteOn!),
     );
     assert.equal(result.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
@@ -363,9 +363,9 @@ describe("DirectoryClient", () => {
     assert.ok(respFileAttributes.offline);
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileChangeOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileChangeOn!), truncatedISO8601Date(now));
     assert.ok(result.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -1461,9 +1461,9 @@ describe("DirectoryClient", () => {
 
     const copyFileSMBInfo = {
       fileAttributes: fileAttributesInstance.toString(),
-      fileCreationTime: truncatedISO8061Date(creationDate),
-      fileLastWriteTime: truncatedISO8061Date(lastwriteTime),
-      fileChangeTime: truncatedISO8061Date(changedTime),
+      fileCreationTime: truncatedISO8601Date(creationDate),
+      fileLastWriteTime: truncatedISO8601Date(lastwriteTime),
+      fileChangeTime: truncatedISO8601Date(changedTime),
     };
 
     const sourceDirName = recorder.variable("sourcedir", getUniqueName("sourcedir"));
@@ -1483,15 +1483,15 @@ describe("DirectoryClient", () => {
     const properties = await result.destinationDirectoryClient.getProperties();
     assert.ok(properties.filePermissionKey, "File permission should have been set to destination");
     assert.ok(
-      truncatedISO8061Date(properties.fileCreatedOn!) === truncatedISO8061Date(creationDate),
+      truncatedISO8601Date(properties.fileCreatedOn!) === truncatedISO8601Date(creationDate),
       "Creation time should be expected",
     );
     assert.ok(
-      truncatedISO8061Date(properties.fileLastWriteOn!) === truncatedISO8061Date(lastwriteTime),
+      truncatedISO8601Date(properties.fileLastWriteOn!) === truncatedISO8601Date(lastwriteTime),
       "Last write time should be expected",
     );
     assert.ok(
-      truncatedISO8061Date(properties.fileChangeOn!) === truncatedISO8061Date(changedTime),
+      truncatedISO8601Date(properties.fileChangeOn!) === truncatedISO8601Date(changedTime),
       "Changed time should be expected",
     );
     const fileSystemAttributes = FileSystemAttributes.parse(properties.fileAttributes!);
@@ -1709,12 +1709,12 @@ describe("DirectoryClient - OAuth", () => {
     assert.equal(result.errorCode, undefined);
     assert.equal(result.fileAttributes!, defaultDirCreateResp.fileAttributes!);
     assert.equal(
-      truncatedISO8061Date(result.fileCreatedOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileCreatedOn!),
+      truncatedISO8601Date(result.fileCreatedOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileCreatedOn!),
     );
     assert.equal(
-      truncatedISO8061Date(result.fileLastWriteOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileLastWriteOn!),
+      truncatedISO8601Date(result.fileLastWriteOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileLastWriteOn!),
     );
     assert.equal(result.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
@@ -1748,9 +1748,9 @@ describe("DirectoryClient - OAuth", () => {
     assert.ok(respFileAttributes.offline);
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileChangeOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileChangeOn!), truncatedISO8601Date(now));
     assert.ok(result.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -1981,12 +1981,12 @@ describe("DirectoryClient - AllowingTrailingDots - True", () => {
     assert.equal(result.errorCode, undefined);
     assert.equal(result.fileAttributes!, defaultDirCreateResp.fileAttributes!);
     assert.equal(
-      truncatedISO8061Date(result.fileCreatedOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileCreatedOn!),
+      truncatedISO8601Date(result.fileCreatedOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileCreatedOn!),
     );
     assert.equal(
-      truncatedISO8061Date(result.fileLastWriteOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileLastWriteOn!),
+      truncatedISO8601Date(result.fileLastWriteOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileLastWriteOn!),
     );
     assert.equal(result.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
@@ -2224,12 +2224,12 @@ describe("DirectoryClient - AllowingTrailingDots - False", () => {
     assert.equal(result.errorCode, undefined);
     assert.equal(result.fileAttributes!, defaultDirCreateResp.fileAttributes!);
     assert.equal(
-      truncatedISO8061Date(result.fileCreatedOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileCreatedOn!),
+      truncatedISO8601Date(result.fileCreatedOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileCreatedOn!),
     );
     assert.equal(
-      truncatedISO8061Date(result.fileLastWriteOn!),
-      truncatedISO8061Date(defaultDirCreateResp.fileLastWriteOn!),
+      truncatedISO8601Date(result.fileLastWriteOn!),
+      truncatedISO8601Date(defaultDirCreateResp.fileLastWriteOn!),
     );
     assert.equal(result.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(result.fileChangeOn!);

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -21,7 +21,7 @@ import {
   toOctalFileMode,
   toSymbolicFileMode,
 } from "../src/index.js";
-import { truncatedISO8061Date } from "../src/utils/utils.common.js";
+import { truncatedISO8601Date } from "../src/utils/utils.common.js";
 import {
   bodyToString,
   compareBodyWithUint8Array,
@@ -149,9 +149,9 @@ describe("FileClient", () => {
     assert.ok(respFileAttributesFromDownload.notContentIndexed);
     assert.ok(respFileAttributesFromDownload.noScrubData);
     assert.ok(respFileAttributesFromDownload.temporary);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileChangeOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileChangeOn!), truncatedISO8601Date(now));
     assert.equal(result.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -175,9 +175,9 @@ describe("FileClient", () => {
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
     assert.ok(respFileAttributes.temporary);
-    assert.equal(truncatedISO8061Date(properties.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(properties.fileLastWriteOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileChangeOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(properties.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(properties.fileLastWriteOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileChangeOn!), truncatedISO8601Date(now));
     assert.equal(properties.filePermissionKey!, defaultDirCreateResp.filePermissionKey!);
     assert.ok(properties.fileChangeOn!);
     assert.ok(properties.fileId!);
@@ -377,9 +377,9 @@ describe("FileClient", () => {
     assert.ok(respFileAttributes.notContentIndexed);
     assert.ok(respFileAttributes.noScrubData);
     assert.ok(respFileAttributes.temporary);
-    assert.equal(truncatedISO8061Date(result.fileCreatedOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileLastWriteOn!), truncatedISO8061Date(now));
-    assert.equal(truncatedISO8061Date(result.fileChangeOn!), truncatedISO8061Date(now));
+    assert.equal(truncatedISO8601Date(result.fileCreatedOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileLastWriteOn!), truncatedISO8601Date(now));
+    assert.equal(truncatedISO8601Date(result.fileChangeOn!), truncatedISO8601Date(now));
     assert.ok(result.filePermissionKey!);
     assert.ok(result.fileChangeOn!);
     assert.ok(result.fileId!);
@@ -642,9 +642,9 @@ describe("FileClient", () => {
     const fileAttributes = fileAttributesInstance.toString();
 
     const fileCreationDate = new Date("05 October 2011 14:48 UTC");
-    const fileCreationTime = truncatedISO8061Date(fileCreationDate);
+    const fileCreationTime = truncatedISO8601Date(fileCreationDate);
     const fileChangeDate = new Date("05 October 2011 14:48 UTC");
-    const fileChangeTime = truncatedISO8061Date(fileChangeDate);
+    const fileChangeTime = truncatedISO8601Date(fileChangeDate);
     const options: FileStartCopyOptions = {
       filePermission: filePermissionInSDDL,
       copyFileSmbInfo: {
@@ -685,7 +685,7 @@ describe("FileClient", () => {
     const fileAttributes = fileAttributesInstance.toString();
 
     const fileCreationDate = new Date("05 October 2011 14:48 UTC");
-    const fileCreationTime = truncatedISO8061Date(fileCreationDate);
+    const fileCreationTime = truncatedISO8601Date(fileCreationDate);
     const options: FileStartCopyOptions = {
       filePermissionKey: createPermResp.filePermissionKey,
       copyFileSmbInfo: {
@@ -770,16 +770,16 @@ describe("FileClient", () => {
     assert.ok(respFileAttributes.noScrubData);
     assert.ok(respFileAttributes.temporary);
     assert.equal(
-      truncatedISO8061Date(updatedProperties.fileCreatedOn!),
-      truncatedISO8061Date(creationDate),
+      truncatedISO8601Date(updatedProperties.fileCreatedOn!),
+      truncatedISO8601Date(creationDate),
     );
     assert.equal(
-      truncatedISO8061Date(updatedProperties.fileLastWriteOn!),
-      truncatedISO8061Date(lastwriteTime),
+      truncatedISO8601Date(updatedProperties.fileLastWriteOn!),
+      truncatedISO8601Date(lastwriteTime),
     );
     assert.equal(
-      truncatedISO8061Date(updatedProperties.fileChangeOn!),
-      truncatedISO8061Date(changedTime),
+      truncatedISO8601Date(updatedProperties.fileChangeOn!),
+      truncatedISO8601Date(changedTime),
     );
   });
 
@@ -1665,9 +1665,9 @@ describe("FileClient", () => {
 
     const copyFileSMBInfo = {
       fileAttributes: fileAttributesInstance.toString(),
-      fileCreationTime: truncatedISO8061Date(creationDate),
-      fileLastWriteTime: truncatedISO8061Date(lastwriteTime),
-      fileChangeTime: truncatedISO8061Date(changeTime),
+      fileCreationTime: truncatedISO8601Date(creationDate),
+      fileLastWriteTime: truncatedISO8601Date(lastwriteTime),
+      fileChangeTime: truncatedISO8601Date(changeTime),
     };
 
     const sourceFileName = recorder.variable("sourcefile", getUniqueName("sourcefile"));
@@ -1687,15 +1687,15 @@ describe("FileClient", () => {
     const properties = await result.destinationFileClient.getProperties();
     assert.ok(properties.filePermissionKey, "File permission should have been set to destination");
     assert.ok(
-      truncatedISO8061Date(properties.fileCreatedOn!) === truncatedISO8061Date(creationDate),
+      truncatedISO8601Date(properties.fileCreatedOn!) === truncatedISO8601Date(creationDate),
       "Creation time should be expected",
     );
     assert.ok(
-      truncatedISO8061Date(properties.fileLastWriteOn!) === truncatedISO8061Date(lastwriteTime),
+      truncatedISO8601Date(properties.fileLastWriteOn!) === truncatedISO8601Date(lastwriteTime),
       "Last write time should be expected",
     );
     assert.ok(
-      truncatedISO8061Date(properties.fileChangeOn!) === truncatedISO8061Date(changeTime),
+      truncatedISO8601Date(properties.fileChangeOn!) === truncatedISO8601Date(changeTime),
       "File changed time should be expected",
     );
     const fileSystemAttributes = FileSystemAttributes.parse(properties.fileAttributes!);

--- a/sdk/storage/storage-queue/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-queue/src/AccountSASSignatureValues.ts
@@ -10,7 +10,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "./utils/constants.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -116,9 +116,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,
@@ -132,9 +132,9 @@ export function generateAccountSASQueryParametersInternal(
       parsedServices,
       parsedResourceTypes,
       accountSASSignatureValues.startsOn
-        ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
+        ? truncatedISO8601Date(accountSASSignatureValues.startsOn, false)
         : "",
-      truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
+      truncatedISO8601Date(accountSASSignatureValues.expiresOn, false),
       accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
       accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
       version,

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -41,7 +41,7 @@ import {
   appendToURLPath,
   extractConnectionStringParts,
   isIpEndpointStyle,
-  truncatedISO8061Date,
+  truncatedISO8601Date,
   appendToURLQuery,
   assertResponse,
 } from "./utils/utils.common.js";
@@ -886,11 +886,11 @@ export class QueueClient extends StorageClient {
           acl.push({
             accessPolicy: {
               expiresOn: identifier.accessPolicy.expiresOn
-                ? truncatedISO8061Date(identifier.accessPolicy.expiresOn)
+                ? truncatedISO8601Date(identifier.accessPolicy.expiresOn)
                 : undefined,
               permissions: identifier.accessPolicy.permissions,
               startsOn: identifier.accessPolicy.startsOn
-                ? truncatedISO8061Date(identifier.accessPolicy.startsOn)
+                ? truncatedISO8601Date(identifier.accessPolicy.startsOn)
                 : undefined,
             },
             id: identifier.id,

--- a/sdk/storage/storage-queue/src/QueueSASSignatureValues.ts
+++ b/sdk/storage/storage-queue/src/QueueSASSignatureValues.ts
@@ -8,7 +8,7 @@ import { ipRangeToString } from "./SasIPRange.js";
 import type { SASProtocol } from "./SASQueryParameters.js";
 import { SASQueryParameters } from "./SASQueryParameters.js";
 import { SERVICE_VERSION } from "./utils/constants.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -114,10 +114,10 @@ export function generateQueueSASQueryParametersInternal(
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
     queueSASSignatureValues.startsOn
-      ? truncatedISO8061Date(queueSASSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(queueSASSignatureValues.startsOn, false)
       : "",
     queueSASSignatureValues.expiresOn
-      ? truncatedISO8061Date(queueSASSignatureValues.expiresOn, false)
+      ? truncatedISO8601Date(queueSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(sharedKeyCredential.accountName, queueSASSignatureValues.queueName),
     queueSASSignatureValues.identifier,

--- a/sdk/storage/storage-queue/src/SASQueryParameters.ts
+++ b/sdk/storage/storage-queue/src/SASQueryParameters.ts
@@ -3,7 +3,7 @@
 
 import type { SasIPRange } from "./SasIPRange.js";
 import { ipRangeToString } from "./SasIPRange.js";
-import { truncatedISO8061Date } from "./utils/utils.common.js";
+import { truncatedISO8601Date } from "./utils/utils.common.js";
 
 /**
  * Protocols for generated SAS.
@@ -172,14 +172,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined,
+            this.startsOn ? truncatedISO8601Date(this.startsOn, false) : undefined,
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined,
+            this.expiresOn ? truncatedISO8601Date(this.expiresOn, false) : undefined,
           );
           break;
         case "sip":

--- a/sdk/storage/storage-queue/src/utils/utils.common.ts
+++ b/sdk/storage/storage-queue/src/utils/utils.common.ts
@@ -281,9 +281,9 @@ export function extractConnectionStringParts(connectionString: string): Connecti
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8601 format, with or without 7 milliseconds component
  */
-export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
+export function truncatedISO8601Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
   const dateString = date.toISOString();
 

--- a/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/accountSasSignatureValues.ts
@@ -15,7 +15,7 @@ import { accountSasServicesFromString, accountSasServicesToString } from "./acco
 import type { NamedKeyCredential } from "@azure/core-auth";
 import { SERVICE_VERSION } from "../utils/constants.js";
 import { computeHMACSHA256 } from "../utils/computeHMACSHA256.js";
-import { truncatedISO8061Date } from "../utils/truncateISO8061Date.js";
+import { truncatedISO8601Date } from "../utils/truncateISO8601Date.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -111,9 +111,9 @@ export function generateAccountSasQueryParameters(
     parsedServices,
     parsedResourceTypes,
     accountSasSignatureValues.startsOn
-      ? truncatedISO8061Date(accountSasSignatureValues.startsOn, false)
+      ? truncatedISO8601Date(accountSasSignatureValues.startsOn, false)
       : "",
-    truncatedISO8061Date(accountSasSignatureValues.expiresOn, false),
+    truncatedISO8601Date(accountSasSignatureValues.expiresOn, false),
     accountSasSignatureValues.ipRange ? ipRangeToString(accountSasSignatureValues.ipRange) : "",
     accountSasSignatureValues.protocol ? accountSasSignatureValues.protocol : "",
     version,

--- a/sdk/tables/data-tables/src/sas/sasQueryParameters.ts
+++ b/sdk/tables/data-tables/src/sas/sasQueryParameters.ts
@@ -4,7 +4,7 @@
 import type { SasIPRange } from "./sasIPRange.js";
 import { ipRangeToString } from "./sasIPRange.js";
 import type { UserDelegationKey } from "./models.js";
-import { truncatedISO8061Date } from "../utils/truncateISO8061Date.js";
+import { truncatedISO8601Date } from "../utils/truncateISO8601Date.js";
 
 /**
  * Protocols for generated SAS.
@@ -265,14 +265,14 @@ export class SasQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined,
+            this.startsOn ? truncatedISO8601Date(this.startsOn, false) : undefined,
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined,
+            this.expiresOn ? truncatedISO8601Date(this.expiresOn, false) : undefined,
           );
           break;
         case "sip":
@@ -295,14 +295,14 @@ export class SasQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedStartsOn ? truncatedISO8061Date(this.signedStartsOn, false) : undefined,
+            this.signedStartsOn ? truncatedISO8601Date(this.signedStartsOn, false) : undefined,
           );
           break;
         case "ske": // Signed key expiry time
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedExpiresOn ? truncatedISO8061Date(this.signedExpiresOn, false) : undefined,
+            this.signedExpiresOn ? truncatedISO8601Date(this.signedExpiresOn, false) : undefined,
           );
           break;
         case "sks": // Signed key service

--- a/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
+++ b/sdk/tables/data-tables/src/sas/tableSasSignatureValues.ts
@@ -16,7 +16,7 @@ import { tableSasPermissionsToString } from "./tableSasPermisions.js";
 import type { NamedKeyCredential } from "@azure/core-auth";
 import { SERVICE_VERSION } from "../utils/constants.js";
 import { computeHMACSHA256 } from "../utils/computeHMACSHA256.js";
-import { truncatedISO8061Date } from "../utils/truncateISO8061Date.js";
+import { truncatedISO8601Date } from "../utils/truncateISO8601Date.js";
 
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
@@ -118,10 +118,10 @@ export function generateTableSasQueryParameters(
 
   const signedPermissions = tableSasPermissionsToString(tableSasSignatureValues.permissions);
   const signedStart = tableSasSignatureValues.startsOn
-    ? truncatedISO8061Date(tableSasSignatureValues.startsOn, false /** withMilliseconds */)
+    ? truncatedISO8601Date(tableSasSignatureValues.startsOn, false /** withMilliseconds */)
     : "";
   const signedExpiry = tableSasSignatureValues.expiresOn
-    ? truncatedISO8061Date(tableSasSignatureValues.expiresOn, false /** withMilliseconds */)
+    ? truncatedISO8601Date(tableSasSignatureValues.expiresOn, false /** withMilliseconds */)
     : "";
   const canonicalizedResource = getCanonicalName(credential.name, tableName);
   const signedIdentifier = tableSasSignatureValues.identifier ?? "";

--- a/sdk/tables/data-tables/src/serialization.ts
+++ b/sdk/tables/data-tables/src/serialization.ts
@@ -7,7 +7,7 @@ import type {
   SignedIdentifier as GeneratedSignedIdentifier,
 } from "./generated/models/index.js";
 import { base64Decode, base64Encode } from "./utils/bufferSerializer.js";
-import { truncatedISO8061Date } from "./utils/truncateISO8061Date.js";
+import { truncatedISO8601Date } from "./utils/truncateISO8601Date.js";
 
 const propertyCaseMap: Map<string, string> = new Map<string, string>([
   ["PartitionKey", "partitionKey"],
@@ -219,10 +219,10 @@ export function serializeSignedIdentifiers(
     const { id, accessPolicy } = acl;
     const { start, expiry, ...rest } = accessPolicy ?? {};
     const serializedStart = start
-      ? truncatedISO8061Date(start, false /** withMilliseconds */)
+      ? truncatedISO8601Date(start, false /** withMilliseconds */)
       : undefined;
     const serializedExpiry = expiry
-      ? truncatedISO8061Date(expiry, false /** withMilliseconds */)
+      ? truncatedISO8601Date(expiry, false /** withMilliseconds */)
       : undefined;
 
     return {

--- a/sdk/tables/data-tables/src/utils/truncateISO8601Date.ts
+++ b/sdk/tables/data-tables/src/utils/truncateISO8601Date.ts
@@ -7,9 +7,9 @@
  * @param date -
  * @param withMilliseconds - If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
  *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
- * @returns Date string in ISO8061 format, with or without 7 milliseconds component
+ * @returns Date string in ISO8601 format, with or without 7 milliseconds component
  */
-export function truncatedISO8061Date(date: Date, withMilliseconds: boolean = true): string {
+export function truncatedISO8601Date(date: Date, withMilliseconds: boolean = true): string {
   // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
   const dateString = date.toISOString();
 


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/data-tables`, `@azure/storage-blob`, `@azure/storage-file-datalake`, `@azure/storage-file-share`, `@azure/storage-queue` and its dependents

### Issues associated with this PR

_(none)_

### Describe the problem that is addressed by this PR

The typo made me look up what ISO 8061 is

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

_(none)_

### Are there test cases added in this PR? _(If not, why?)_

No test cases added, because it's trivial

### Provide a list of related PRs _(if any)_

_(none)_

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)

---

### Potential problems

If some external packages use `truncatedISO8061Date`, it will be broken.
