### PR TITLE
[ai-agents] Fix rendering of AgentEventMessage

### DIFF
--- a/sdk/ai/ai-agents/src/models/streamingModels.ts
+++ b/sdk/ai/ai-agents/src/models/streamingModels.ts
@@ -15,7 +15,7 @@ import type {
  * Each event in a server-sent events stream has an `event` and `data` property:
  *
  * @example
- * ```ts
+ * ```ts snippet:ignore
  *  event: thread.created
  *  data: {"id": "thread_123", "object": "thread", ...}
  * ```


### PR DESCRIPTION
The rendered docs for `AgentEventMessage` render incorrectly due to formatting
issues. While we should find a way to flag these in the future (or display them
properly via error-correction) this PR updates the docs to render cleanly.

## Before

<img width="1063" height="732" alt="image" src="https://github.com/user-attachments/assets/439ad931-704f-4c34-a1da-bb330ddfa2a1" />

## After 

<img width="1019" height="554" alt="image" src="https://github.com/user-attachments/assets/614db256-437a-4b8d-b614-c669d87144e8" />

