### PR TITLE
[EngSys] disable turbo daemon

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "ui": "tui",
+  "ui": "stream",
+  "daemon": false,
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
as it seems to lock files on Windows, preventing tshy from deleting .tshy-builds temporary folders.

Also change the default turbo UI to stream mode. Passing `--ui=tui` at the end of turbo commands to get the previous behavior.

Resovles https://github.com/Azure/azure-sdk-for-js/issues/35537