### PR TITLE
Update pnpm commands in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,8 @@ Generally speaking, the following commands are roughly equivalent:
 | `npm build`                          | `pnpm [re]build`                              | Build all projects in the pnpm workspace                         |
 |                                      | `pnpm [re]build --filter=<package>...`        | Build named project and any projects it depends on               |
 |                                      | `pnpm build`                                  | Build the current project only                                   |
+|                                      | `pnpm -F {./}... build`                       | (Run inside a project) Build the project and its dependencies    |
+|                                      | `pnpm --filter=<package>... build`            | (Run inside a project) Build the project and its dependencies    |
 | `npm test`                           | `pnpm test`                                   | Run dev tests in all projects in the pnpm workspace              |
 |                                      | `pnpm test --filter=<packagename>...`         | Run dev tests in named project and any projects it depends on    |
 |                                      | `pnpm test`                                   | Run dev tests in the current project only                        |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,8 +210,8 @@ Generally speaking, the following commands are roughly equivalent:
 | ------------------------------------ | --------------------------------------------- | ---------------------------------------------------------------- |
 | `npm install`                        | `pnpm install`                                | Install dependencies for all projects in the pnpm workspace      |
 | `npm install --save[-dev] <package>` | `pnpm add -p <package> [-D]`                  | Add or update a dependency in the current project                |
-| `npm build`                          | `pnpm [re]build`                              | Build all projects in the pnpm workspace                         |
-|                                      | `pnpm [re]build --filter=<package>...`        | Build named project and any projects it depends on               |
+| `npm build`                          | `pnpm build`                                  | Build all projects in the pnpm workspace                         |
+|                                      | `pnpm build --filter=<package>...`            | Build named project and any projects it depends on               |
 |                                      | `pnpm build`                                  | Build the current project only                                   |
 |                                      | `pnpm -F {./}... build`                       | (Run inside a project) Build the project and its dependencies    |
 |                                      | `pnpm --filter=<package>... build`            | (Run inside a project) Build the project and its dependencies    |


### PR DESCRIPTION
This pull request adds clarification to the build command documentation in `CONTRIBUTING.md`, specifically regarding how to build a project and its dependencies using pnpm when inside a project.

Documentation updates:

* Added examples for `pnpm -F {./}... build` and `pnpm --filter=<package>... build` to show how to build a project and its dependencies from within the project directory.