### PR TITLE
Update CODEOWNERS for Monitor Query Logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1079,7 +1079,7 @@
 /sdk/monitor/monitor-opentelemetry @hectorhdzg @rads-1996 @Karlie-777 @MSNev @JacksonWeber @lzchen @jeremydvoss
 /sdk/monitor/monitor-opentelemetry-exporter @hectorhdzg @rads-1996 @Karlie-777 @MSNev @JacksonWeber @lzchen @jeremydvoss
 
-/sdk/monitor/monitor-query/ @srnagar @Azure/azure-sdk-write-monitor-data-plane
+/sdk/monitor/monitor-query-logs/ @Azure/azure-sdk-write-monitor-query-logs
 /sdk/monitor/monitor-query-metrics/ @Azure/azure-sdk-write-monitor-query-metrics
 /sdk/monitor/perf-tests/ @srnagar @Azure/azure-sdk-write-monitor-data-plane
 


### PR DESCRIPTION
**Summary of changes**
- Add an entry for the new Monitor Query Logs library that's owned by the service team.
- Remove the entry for the deprecated Monitor Query library that was deleted in https://github.com/Azure/azure-sdk-for-js/pull/35561.