### PR TITLE
chore(loadtesting): removed useCloudHostedBrowsers

### DIFF
--- a/sdk/loadtesting/playwright/review/playwright-node.api.md
+++ b/sdk/loadtesting/playwright/review/playwright-node.api.md
@@ -38,7 +38,6 @@ export type PlaywrightServiceAdditionalOptions = {
     timeout?: number;
     slowMo?: number;
     exposeNetwork?: string;
-    useCloudHostedBrowsers?: boolean;
     credential?: TokenCredential;
     runName?: string;
     apiVersion?: "2025-07-01-preview";

--- a/sdk/loadtesting/playwright/samples/v1/javascript/customising-service-parameters/README.md
+++ b/sdk/loadtesting/playwright/samples/v1/javascript/customising-service-parameters/README.md
@@ -17,7 +17,6 @@ export default defineConfig(
   getServiceConfig(config, {
     os: ServiceOS.WINDOWS, // Select the operating system where you want to run tests.
     credential: new AzureCliCredential(), // Select the authentication method you want to use with Entra.
-    useCloudHostedBrowsers: true, //Select if you want to use cloud-hosted browsers to run your Playwright tests.
   })
 );
 
@@ -41,13 +40,6 @@ export default defineConfig(
     - **Example**:
       ```typescript
       credential: new AzureCliCredential()
-      ```
-
-3. **`useCloudHostedBrowsers`**
-    - **Description**: This setting allows you to select whether to use cloud-hosted browsers to run your Playwright tests. Reporting features remain available even if you disable this setting.
-    - **Example**:
-      ```typescript
-      useCloudHostedBrowsers: true
       ```
 
 4. **`runName`**:

--- a/sdk/loadtesting/playwright/samples/v1/javascript/customising-service-parameters/playwright.service.config.js
+++ b/sdk/loadtesting/playwright/samples/v1/javascript/customising-service-parameters/playwright.service.config.js
@@ -14,7 +14,6 @@ const playwrightServiceAdditionalOptions = {
   timeout: 30000, // Maximum time in milliseconds to wait for the connection to be established
   slowMo: 0, // Slows down Playwright operations by the specified amount of milliseconds
   exposeNetwork: "<loopback>", // Exposes network available on the connecting client to the browser being connected to
-  useCloudHostedBrowsers: true, // Use cloud hosted browsers
   credential: azureCredential, // Custom token credential for Entra ID authentication
   runName: "JavaScript V1 - Sample Run", // Run name for the test run
 };

--- a/sdk/loadtesting/playwright/samples/v1/javascript/manually-connecting-to-browsers/tests/sample.spec.js
+++ b/sdk/loadtesting/playwright/samples/v1/javascript/manually-connecting-to-browsers/tests/sample.spec.js
@@ -30,7 +30,6 @@ test("get started link", async ({ browserName }) => {
     timeout: 30000, // Maximum time in milliseconds to wait for the connection to be established
     slowMo: 0, // Slows down Playwright operations by the specified amount of milliseconds
     exposeNetwork: "<loopback>", // Exposes network available on the connecting client to the browser being connected to
-    useCloudHostedBrowsers: true, // Use cloud hosted browsers
     credential: azureCredential, // Custom token credential for Entra ID authentication
     runName: "JavaScript V1 - Sample Run", // Run name for the test run
   };

--- a/sdk/loadtesting/playwright/samples/v1/typescript/customising-service-parameters/README.md
+++ b/sdk/loadtesting/playwright/samples/v1/typescript/customising-service-parameters/README.md
@@ -17,7 +17,6 @@ export default defineConfig(
   getServiceConfig(config, {
     os: ServiceOS.WINDOWS, // Select the operating system where you want to run tests.
     credential: new AzureCliCredential(), // Select the authentication method you want to use with Entra.
-    useCloudHostedBrowsers: true, //Select if you want to use cloud-hosted browsers to run your Playwright tests.
   })
 );
 
@@ -41,13 +40,6 @@ export default defineConfig(
     - **Example**:
       ```typescript
       credential: new AzureCliCredential()
-      ```
-
-3. **`useCloudHostedBrowsers`**
-    - **Description**: This setting allows you to select whether to use cloud-hosted browsers to run your Playwright tests. Reporting features remain available even if you disable this setting.
-    - **Example**:
-      ```typescript
-      useCloudHostedBrowsers: true
       ```
 
 4. **`runName`**:

--- a/sdk/loadtesting/playwright/samples/v1/typescript/customising-service-parameters/playwright.service.config.ts
+++ b/sdk/loadtesting/playwright/samples/v1/typescript/customising-service-parameters/playwright.service.config.ts
@@ -21,7 +21,6 @@ const playwrightServiceAdditionalOptions: PlaywrightServiceAdditionalOptions = {
   timeout: 30000, // Maximum time in milliseconds to wait for the connection to be established
   slowMo: 0, // Slows down Playwright operations by the specified amount of milliseconds
   exposeNetwork: "<loopback>", // Exposes network available on the connecting client to the browser being connected to
-  useCloudHostedBrowsers: true, // Use cloud hosted browsers
   credential: azureCredential, // Custom token credential for Entra ID authentication
   runName: "Typescript V1 - Sample Run", // Run name for the test run
 };

--- a/sdk/loadtesting/playwright/samples/v1/typescript/manually-connecting-to-browsers/playwright.service.config.ts
+++ b/sdk/loadtesting/playwright/samples/v1/typescript/manually-connecting-to-browsers/playwright.service.config.ts
@@ -6,6 +6,7 @@ import config from "./playwright.config.js";
 export default defineConfig(
   config,
   getServiceConfig(config, {
+    serviceAuthType: "ACCESS_TOKEN",
     credential: new DefaultAzureCredential(),
   }),
 );

--- a/sdk/loadtesting/playwright/samples/v1/typescript/manually-connecting-to-browsers/playwright.service.config.ts
+++ b/sdk/loadtesting/playwright/samples/v1/typescript/manually-connecting-to-browsers/playwright.service.config.ts
@@ -6,7 +6,6 @@ import config from "./playwright.config.js";
 export default defineConfig(
   config,
   getServiceConfig(config, {
-    serviceAuthType: "ACCESS_TOKEN",
     credential: new DefaultAzureCredential(),
   }),
 );

--- a/sdk/loadtesting/playwright/samples/v1/typescript/manually-connecting-to-browsers/tests/sample.spec.ts
+++ b/sdk/loadtesting/playwright/samples/v1/typescript/manually-connecting-to-browsers/tests/sample.spec.ts
@@ -33,7 +33,6 @@ test("get started link", async ({ browserName }) => {
     timeout: 30000, // Maximum time in milliseconds to wait for the connection to be established
     slowMo: 0, // Slows down Playwright operations by the specified amount of milliseconds
     exposeNetwork: "<loopback>", // Exposes network available on the connecting client to the browser being connected to
-    useCloudHostedBrowsers: true, // Use cloud hosted browsers
     credential: azureCredential, // Custom token credential for Entra ID authentication
     runName: "Typescript V1 - Sample Run", // Run name for the test run
   };

--- a/sdk/loadtesting/playwright/src/common/types.ts
+++ b/sdk/loadtesting/playwright/src/common/types.ts
@@ -114,15 +114,6 @@ export type PlaywrightServiceAdditionalOptions = {
   /**
    * @public
    *
-   * Use cloud hosted browsers.
-   *
-   * @defaultValue `false`
-   */
-  useCloudHostedBrowsers?: boolean;
-
-  /**
-   * @public
-   *
    * Custom token credential for Entra ID authentication. Learn more at {@link https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/using-azure-identity.md | Using Azure Identity}.
    *
    * @defaultValue `DefaultAzureCredential`

--- a/sdk/loadtesting/playwright/src/core/playwrightService.ts
+++ b/sdk/loadtesting/playwright/src/core/playwrightService.ts
@@ -151,12 +151,9 @@ const getServiceConfig = (
     globalFunctions.globalSetup = globalPaths.setup;
     globalFunctions.globalTeardown = globalPaths.teardown;
   }
+
   performOneTimeOperation(options);
-  if (options?.useCloudHostedBrowsers === false) {
-    return {
-      ...globalFunctions,
-    };
-  }
+
   if (!process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED]) {
     process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED] = "true";
     console.log("\nRunning tests using Azure Playwright service.");

--- a/sdk/loadtesting/playwright/test/core/playwrightService.spec.ts
+++ b/sdk/loadtesting/playwright/test/core/playwrightService.spec.ts
@@ -364,22 +364,6 @@ describe("getServiceConfig", () => {
     });
   });
 
-  it("should not set connect options if disable scalable execution is true", async () => {
-    vi.stubEnv(ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN, "token");
-    const { getServiceConfig: localGetServiceConfig } = await import(
-      "../../src/core/playwrightService.js"
-    );
-
-    const config = localGetServiceConfig(samplePlaywrightConfigInput, {
-      useCloudHostedBrowsers: false,
-    });
-
-    expect(config).to.deep.equal({
-      globalSetup: globalSetupPath,
-      globalTeardown: globalTeardownPath,
-    });
-  });
-
   it("should set token credentials if passed on playwright service entra singleton object", async () => {
     const accessToken = "token";
     vi.stubEnv(ServiceEnvironmentVariable.PLAYWRIGHT_SERVICE_ACCESS_TOKEN, accessToken);


### PR DESCRIPTION
### Packages impacted by this PR

@azure/create-playwright
@azure/playwright


### Issues associated with this PR

The useCloudHostedBrowsers option previously allowed users to choose whether they wanted to use cloud-hosted browsers or not. This is no longer necessary because if customers do not want to use cloud-hosted browsers, they can simply run the tests using their local configuration. Therefore, we are removing this option.

### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
