### PR TITLE
Look for the correct property to skip dev feed publishing

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -107,7 +107,7 @@ steps:
         Copy-Item $packageFile $stagingArtifactDirectory
         Copy-Item sdk/$($artifactDetails.ServiceDirectory)/**/browser/$artifact-[0-9]*.[0-9]*.[0-9]*.zip $stagingArtifactDirectory
 
-        if ($env:SETDEVVERSION -eq 'true' -and $artifactDetails.ArtifactDetails.skipPublishDev -ne $true)
+        if ($env:SETDEVVERSION -eq 'true' -and $artifactDetails.ArtifactDetails.skipPublishDevFeed -ne $true)
         {
           $stagingDevArtifactDirectory = "$(Agent.TempDirectory)/packages-dev-publish/$artifact"
           New-Item -Type Directory $stagingDevArtifactDirectory -Force | Out-Null


### PR DESCRIPTION
Some packages like [test-utils](https://github.com/Azure/azure-sdk-for-js/blob/bfe9b4b6b22a90b216cb5943c0515c8310e28360/sdk/test-utils/ci.yml#L39) do not want to publish to the dev tag so we need to skip them. My earlier PR https://github.com/Azure/azure-sdk-for-js/pull/34850 had a but on the property, name so fixing that here. 