### PR TITLE
[ai-document-translator-rest] upgrade recorder to v4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9452,8 +9452,8 @@ importers:
         specifier: ^2.3.1
         version: link:../../core/core-client-rest
       '@azure-tools/test-recorder':
-        specifier: ^3.0.0
-        version: 3.5.2
+        specifier: ^4.1.0
+        version: link:../../test-utils/recorder
       '@azure/abort-controller':
         specifier: ^2.1.2
         version: link:../../core/abort-controller
@@ -28105,10 +28105,6 @@ packages:
     resolution: {integrity: sha512-KMVIPxG6ygcQ1M2hKHahF7eddKejYsWTjoLIfTWiqnaj42dBkYzj4+S8rK9xxmlOaEHKZHcMrRbm0NfN4kgwHw==}
     engines: {node: '>=20.0.0'}
 
-  '@azure-tools/test-recorder@3.5.2':
-    resolution: {integrity: sha512-81vTGIiF7enEu4ekVrcLPlDPP9oQHL725pX87EIaVhmh1C3Sky4GE19adBiTcGXoahwB70xtHQ7i4HuFXDlhGg==}
-    engines: {node: '>=18.0.0'}
-
   '@azure/abort-controller@1.1.0':
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
     engines: {node: '>=12.0.0'}
@@ -33166,15 +33162,6 @@ snapshots:
       '@azure/core-tracing': 1.3.0
       '@typespec/ts-http-runtime': 0.3.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure-tools/test-recorder@3.5.2':
-    dependencies:
-      '@azure/core-auth': 1.10.0
-      '@azure/core-rest-pipeline': 1.22.0
-      '@azure/core-util': 1.13.0
-      '@azure/logger': 1.3.0
     transitivePeerDependencies:
       - supports-color
 

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -76,7 +76,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure-rest/core-client": "^2.3.1",
-    "@azure-tools/test-recorder": "^3.0.0",
+    "@azure-tools/test-recorder": "^4.1.0",
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-lro": "^3.0.0",


### PR DESCRIPTION
This pull request updates the `@azure-tools/test-recorder` dependency in the `ai-document-translator-rest` package to a newer version.

* Updated the `@azure-tools/test-recorder` dependency version from `^3.0.0` to `^4.1.0` in `package.json`.
* updated `pnpm-lock.yaml`

This PR removes the last reference of recorder 3.5.2 in the repository, all the SDKs now depend on v4 recorder