### PR TITLE
[Monitor OpenTelemetry Exporter] Add support for configuring customer SDK Stats export interval

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.34 ()
 
+### Features Added
+
+- Added support for configuring customer SDK Stats export interval using the `APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL` environment variable (specified in seconds).
+
 ### Other Changes
 
 - Renamed Customer Statsbeat feature to customer SDK Stats.

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
@@ -116,6 +116,13 @@ export const ENV_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW =
   "APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW";
 
 /**
+ * Sets the export interval for customer-facing SDK Stats in seconds.
+ * @internal
+ */
+export const ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL =
+  "APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL";
+
+/**
  * QuickPulse metric counter names.
  * @internal
  */

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -7,8 +7,10 @@ import { ExportResultCode } from "@opentelemetry/core";
 import {
   RetriableRestErrorTypes,
   ENV_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW,
+  ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
 } from "../../src/Declarations/Constants.js";
 import type { SenderResult } from "../../src/types.js";
+import { CustomerSDKStatsMetrics } from "../../src/export/statsbeat/customerSDKStats.js";
 
 // Mock dependencies
 vi.mock("@opentelemetry/api", () => {
@@ -824,6 +826,115 @@ describe("BaseSender", () => {
       expect(mockCustomerSDKStatsMetrics.countSuccessfulItems).toHaveBeenCalled();
       expect(mockCustomerSDKStatsMetrics.countDroppedItems).not.toHaveBeenCalled();
       expect(mockCustomerSDKStatsMetrics.countRetryItems).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Customer SDK Stats Export Interval Configuration", () => {
+    let originalEnvEnabled: string | undefined;
+    let originalEnvInterval: string | undefined;
+
+    beforeEach(() => {
+      // Save original environment variables
+      originalEnvEnabled = process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW];
+      originalEnvInterval = process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL];
+
+      // Enable Customer SDK Stats for all tests in this section
+      process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW] = "true";
+
+      // Clear all mock calls from previous tests
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      // Restore original environment variables
+      if (originalEnvEnabled === undefined) {
+        delete process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW];
+      } else {
+        process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW] = originalEnvEnabled;
+      }
+
+      if (originalEnvInterval === undefined) {
+        delete process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL];
+      } else {
+        process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL] = originalEnvInterval;
+      }
+    });
+
+    it("should use custom export interval when valid environment variable is set", () => {
+      // Set a valid export interval (30 seconds)
+      process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL] = "30";
+
+      const testSender = new TestBaseSender({
+        endpointUrl: "https://example.com",
+        instrumentationKey: "test-key",
+        trackStatsbeat: true,
+        exporterOptions: {},
+        isStatsbeatSender: false,
+      });
+
+      // Verify sender was created successfully
+      expect(testSender).toBeDefined();
+
+      // Verify that CustomerSDKStatsMetrics.getInstance was called with the converted interval
+      expect(CustomerSDKStatsMetrics.getInstance).toHaveBeenCalledWith({
+        instrumentationKey: "test-key",
+        endpointUrl: "https://example.com",
+        disableOfflineStorage: false,
+        networkCollectionInterval: 30000, // 30 seconds * 1000 = 30000 milliseconds
+      });
+    });
+
+    it("should use default export interval when environment variable is not set", () => {
+      // Ensure the export interval env var is not set
+      delete process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL];
+
+      const testSender = new TestBaseSender({
+        endpointUrl: "https://example.com",
+        instrumentationKey: "test-key",
+        trackStatsbeat: true,
+        exporterOptions: {},
+        isStatsbeatSender: false,
+      });
+
+      // Verify sender was created successfully
+      expect(testSender).toBeDefined();
+
+      // Verify that CustomerSDKStatsMetrics.getInstance was called without networkCollectionInterval
+      expect(CustomerSDKStatsMetrics.getInstance).toHaveBeenCalledWith({
+        instrumentationKey: "test-key",
+        endpointUrl: "https://example.com",
+        disableOfflineStorage: false,
+        networkCollectionInterval: undefined,
+      });
+    });
+
+    it("should log warning and use default interval for non-numeric values", () => {
+      // Set an invalid export interval (non-numeric)
+      process.env[ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL] = "invalid";
+
+      const testSender = new TestBaseSender({
+        endpointUrl: "https://example.com",
+        instrumentationKey: "test-key",
+        trackStatsbeat: true,
+        exporterOptions: {},
+        isStatsbeatSender: false,
+      });
+
+      // Verify sender was created successfully
+      expect(testSender).toBeDefined();
+
+      // Verify warning was logged
+      expect(diag.warn).toHaveBeenCalledWith(
+        "Invalid value for APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL environment variable: 'invalid'. Expected a positive number (seconds). Using default export interval.",
+      );
+
+      // Verify that CustomerSDKStatsMetrics.getInstance was called without networkCollectionInterval
+      expect(CustomerSDKStatsMetrics.getInstance).toHaveBeenCalledWith({
+        instrumentationKey: "test-key",
+        endpointUrl: "https://example.com",
+        disableOfflineStorage: false,
+        networkCollectionInterval: undefined,
+      });
     });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This pull request adds support for configuring the export interval for customer SDK Stats using the `APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL` environment variable, allowing users to control how frequently stats are exported. It also introduces related tests to ensure correct behavior and updates documentation to reflect this new feature.

**SDK Stats Export Interval Configuration**

* Added support for setting the customer SDK Stats export interval via the `APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL` environment variable (specified in seconds), with validation and fallback to default if the value is invalid. (`baseSender.ts`, `Constants.ts`, `CHANGELOG.md`) [[1]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305R69-R85) [[2]](diffhunk://#diff-64f44affbca0b21471654d970b64e3c777b068851a41eb8e86c3652521c72190R118-R124) [[3]](diffhunk://#diff-994a7fbc4177f96448b6098ea5c95fc5872615b8537e18822a17817cd3d70870R5-R8)
* Updated the `CustomerSDKStatsMetrics.getInstance` invocation to accept the custom interval, converting seconds to milliseconds. (`baseSender.ts`)

**Testing and Validation**

* Added tests to verify correct handling of the export interval environment variable, including valid, missing, and invalid values, and ensuring warnings are logged for invalid input. (`baseSender.spec.ts`)
* Mocked and imported necessary constants and modules for the new tests. (`baseSender.spec.ts`)

**Documentation**

* Updated the changelog to document the new export interval configuration feature. (`CHANGELOG.md`)

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
