### PR TITLE
delete StreamingData.getStreamingKind(), include kind in parse response

### DIFF
--- a/sdk/communication/communication-call-automation/src/models/streaming.ts
+++ b/sdk/communication/communication-call-automation/src/models/streaming.ts
@@ -8,6 +8,7 @@ import type { TranscriptionResultState } from "../generated/src/index.js";
  * Audio streaming data.
  */
 export interface AudioData {
+  kind: 'AudioData',
   /** A unique identifier for the media subscription.*/
   data: string;
   /** The timestamp indicating when the media content was received by the bot,
@@ -24,6 +25,7 @@ export interface AudioData {
  * Audio streaming metadata.
  */
 export interface AudioMetadata {
+  kind: 'AudioMetadata',
   /** Audio streaming subscription id.*/
   subscriptionId: string;
   /** The format used to encode the audio. Currently, only "pcm" (Pulse Code Modulation) is supported.*/
@@ -59,6 +61,7 @@ export interface WordData {
  * Metadata for Transcription Streaming.
  */
 export interface TranscriptionMetadata {
+  kind: 'TranscriptionMetadata',
   /** Transcription Subscription Id.*/
   subscriptionId: string;
   /** The target locale in which the translated text needs to be.*/
@@ -75,6 +78,7 @@ export interface TranscriptionMetadata {
  * Streaming Transcription.
  */
 export interface TranscriptionData {
+  kind: 'TranscriptionData',
   /** The display form of the recognized word.*/
   text: string;
   /** The format of text.*/
@@ -97,6 +101,7 @@ export interface TranscriptionData {
  * Dtmf streaming data.
  */
 export interface DtmfData {
+  kind: 'DtmfData',
   /** A unique identifier for the media subscription.*/
   data: string;
 }

--- a/sdk/communication/communication-call-automation/src/streamingData.ts
+++ b/sdk/communication/communication-call-automation/src/streamingData.ts
@@ -14,18 +14,10 @@ import type {
 
 /** Class to handle the parsing of incoming streaming data. */
 export class StreamingData {
-  // Kind of the streaming data ex.AudioData, AudioMetadata, TranscriptionData, TranscriptionMetadata.
-  private static streamingKind: StreamingDataKind;
-
   /** Parses a encoded json string or buffer into a StreamingData object,
             which can be one of the following subtypes: AudioData, AudioMetadata, TranscriptionData, or TranscriptionMetadata. */
   static parse(data: string | ArrayBuffer): StreamingDataResult {
     return StreamingData.parseStreamingData(data);
-  }
-
-  // Get Streaming data Kind.
-  static getStreamingKind(): StreamingDataKind {
-    return StreamingData.streamingKind;
   }
 
   /** Parses a encoded json string or buffer into a StreamingData object,
@@ -46,6 +38,7 @@ export class StreamingData {
     switch (kind) {
       case "TranscriptionMetadata": {
         const transcriptionMetadata: TranscriptionMetadata = {
+          kind: 'TranscriptionMetadata',
           subscriptionId: jsonObject.transcriptionMetadata.subscriptionId,
           locale: jsonObject.transcriptionMetadata.locale,
           callConnectionId: jsonObject.transcriptionMetadata.callConnectionId,
@@ -53,11 +46,11 @@ export class StreamingData {
           speechRecognitionModelEndpointId:
             jsonObject.transcriptionMetadata.speechRecognitionModelEndpointId,
         };
-        StreamingData.streamingKind = kind;
         return transcriptionMetadata;
       }
       case "TranscriptionData": {
         const transcriptionData: TranscriptionData = {
+          kind: 'TranscriptionData',
           text: jsonObject.transcriptionData.text,
           format: jsonObject.transcriptionData.format,
           confidence: jsonObject.transcriptionData.confidence,
@@ -73,21 +66,21 @@ export class StreamingData {
           participant: createIdentifierFromRawId(jsonObject.transcriptionData.participantRawID),
           resultState: jsonObject.transcriptionData.resultStatus,
         };
-        StreamingData.streamingKind = kind;
         return transcriptionData;
       }
       case "AudioMetadata": {
         const audioMetadata: AudioMetadata = {
+          kind: 'AudioMetadata',
           subscriptionId: jsonObject.audioMetadata.subscriptionId,
           encoding: jsonObject.audioMetadata.encoding,
           sampleRate: jsonObject.audioMetadata.sampleRate,
           channels: jsonObject.audioMetadata.channels,
         };
-        StreamingData.streamingKind = kind;
         return audioMetadata;
       }
       case "AudioData": {
         const audioData: AudioData = {
+          kind: 'AudioData',
           data: jsonObject.audioData.data,
           timestamp: jsonObject.audioData.timestamp,
           isSilent: jsonObject.audioData.silent,
@@ -96,14 +89,13 @@ export class StreamingData {
               ? createIdentifierFromRawId(jsonObject.audioData.participantRawID)
               : undefined,
         };
-        StreamingData.streamingKind = kind;
         return audioData;
       }
       case "DtmfData": {
         const dtmfData: DtmfData = {
+          kind: 'DtmfData',
           data: jsonObject.dtmfData.data,
         };
-        StreamingData.streamingKind = kind;
         return dtmfData;
       }
       default:


### PR DESCRIPTION
### Packages impacted by this PR
@azure/communication-call-automation

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/35610

### Describe the problem that is addressed by this PR
I deleted the static method StreamingData.getStreamingKind() as it can return inconsistent result
the .parse method is now adding the kind in the response object

### Are there test cases added in this PR? _(If not, why?)_
I can add / fix test if this approach make sense

### Checklists
- [ x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
