### PR TITLE
[EngSys] fix dependency testing

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,6 @@ packages:
   - '!sdk/batch/batch'
   - '!sdk/cosmosdb/cosmos/MultiRegionWriteSample'
   - '!sdk/identity/identity/integration/**'
-  - '!sdk/identity/identity/test/**'
-  - '!sdk/servicebus/service-bus/test/**'
-  - '!sdk/eventhub/event-hubs/test/**'
-
+  - '!sdk/identity/identity/test/manual*/**'
+  - '!sdk/servicebus/service-bus/test/stress/**'
+  - '!sdk/eventhub/event-hubs/test/stress/**'


### PR DESCRIPTION
The exclusion of identity test directory prevents `pnpm install` from finding
the newly added package under test/public thus its dependencies are not
installed.

This PR exclues more specific sub directory under test/ so that new package
test/public is included in the workspace.