### PR TITLE
Remove redundant "prebuild" scripts

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -69,7 +69,6 @@
     "lint": "eslint src tests/rules",
     "lint:fix": "eslint src tests/rules --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
-    "prebuild": "npm run clean",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
     "test:node": "vitest",

--- a/sdk/containerregistry/container-registry-perf-tests/package.json
+++ b/sdk/containerregistry/container-registry-perf-tests/package.json
@@ -65,7 +65,6 @@
     "lint:fix": "dev-tool run vendored eslint -c ../../../common/tools/eslint-plugin-azure-sdk/eslint.perftests.config.mjs src --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
     "perf-test:node": "npm run build && node dist/esm/index.js",
-    "prebuild": "npm run clean",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "echo skipped",
     "test:node": "echo skipped",


### PR DESCRIPTION
The two packages already include "npm run clean" in their "build" script