### PR TITLE
Create landing page for Monitor Query migration guides

### DIFF
--- a/sdk/monitor/MIGRATION_QUERY.md
+++ b/sdk/monitor/MIGRATION_QUERY.md
@@ -1,0 +1,17 @@
+# How to migrate away from @azure/monitor-query
+
+To migrate away from the deprecated [@azure/monitor-query](https://www.npmjs.com/package/@azure/monitor-query) package, see the table below.
+
+| Client name          | Replacement package            | Migration guidance |
+|----------------------|--------------------------------|--------------------|
+| `LogsQueryClient`    | [@azure/monitor-query-logs]    | [Guide][mg-lqc]    |
+| `MetricsClient`      | [@azure/monitor-query-metrics] | [Guide][mg-mc]     |
+| `MetricsQueryClient` | [@azure/arm-monitor]           | [Guide][mg-mqc]    |
+
+<!-- LINKS -->
+[@azure/arm-monitor]: https://www.npmjs.com/package/@azure/arm-monitor
+[@azure/monitor-query-logs]: https://www.npmjs.com/package/@azure/monitor-query-logs
+[@azure/monitor-query-metrics]: https://www.npmjs.com/package/@azure/monitor-query-metrics
+[mg-lqc]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query-logs/MIGRATION.md
+[mg-mc]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query-metrics/MIGRATION.md
+[mg-mqc]: https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/arm-monitor/MIGRATION_METRICSQUERYCLIENT_TO_ARM_MONITOR.md


### PR DESCRIPTION
Now that the [@azure/monitor-query](https://www.npmjs.com/package/@azure/monitor-query) package is deprecated, I need to update the [JS CSV file](https://github.com/Azure/azure-sdk/blob/main/_data/releases/latest/js-packages.csv) with this new status. The CSV expects a single migration guide link. This PR introduces a centralized guide we can point to in that CSV.