### PR TITLE
[EngSys] stop auto-incrementing package version after release

### DIFF
--- a/eng/tools/versioning/increment.js
+++ b/eng/tools/versioning/increment.js
@@ -71,11 +71,6 @@ async function main(argv) {
     return;
   }
 
-  const updatedPackageJson = {
-    ...packageJsonContents,
-    version: newVersion,
-  };
-  await writePackageJson(packageJsonLocation, updatedPackageJson);
   await updatePackageConstants(
     path.join(repoRoot, targetPackagePath),
     packageJsonContents,

--- a/eng/tools/versioning/package-lock.json
+++ b/eng/tools/versioning/package-lock.json
@@ -19,7 +19,9 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/yargs": "^17.0.33"
+        "@types/yargs": "^17.0.33",
+        "prettier": "^3.6.2",
+        "typescript": "~5.8.2"
       }
     },
     "../eng-package-utils": {
@@ -1380,6 +1382,22 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -1658,6 +1676,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/eng/tools/versioning/package.json
+++ b/eng/tools/versioning/package.json
@@ -5,6 +5,9 @@
   "main": "echo \"use increment.js or set-dev.js\"",
   "type": "module",
   "scripts": {
+    "build": "npm run format && npm run typecheck",
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore  \"./**/*.{js,json}\"",
+    "typecheck": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -28,6 +31,8 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.33",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "prettier": "^3.6.2",
+    "typescript": "~5.8.2"
   }
 }


### PR DESCRIPTION
We are moving to manually increment package version in package.json only when new changes are introduced. This allows us to use `"workspace:^"` version specifier for our `@azure*` dependencies without interrupting our publishing story. Otherwise, depending on the auto-incremented unpublished version of a dependency without any new code changes would still require that dependency to be published.

The code to update version constants and CHANGELOG files remain unchanged.

While at it also enable typecheck and format for the tool.
