### PR TITLE
[Monitor OpenTelemetry] Enable Instrumentations by Default

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 1.12.1 ()
 
+### Features Added
+
+- All instrumentations apart from bunyan and winston are now enabled by default.
+
 ### Bugs Fixed
 
 - Fix declaration of the preview customer statsbeat enablement environment variable.

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 1.12.1 ()
+### 1.13.0 ()
 
 ### Features Added
 

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -108,11 +108,12 @@ useAzureMonitor(options);
       <pre><code class="language-javascript">
 {
   http: { enabled: true },
-  azureSdk: { enabled: false },
-  mongoDb: { enabled: false },
-  mySql: { enabled: false },
-  postgreSql: { enabled: false },
-  redis: { enabled: false },
+  azureSdk: { enabled: true },
+  mongoDb: { enabled: true },
+  mySql: { enabled: true },
+  postgreSql: { enabled: true },
+  redis: { enabled: true },
+  redis4: { enabled: true },
   bunyan: { enabled: false }, 
   winston: { enabled: false } 
 }
@@ -195,6 +196,8 @@ process.env["APPLICATIONINSIGHTS_CONFIGURATION_FILE"] = "path/to/customConfig.js
 ## Instrumentation libraries
 
 The following OpenTelemetry Instrumentation libraries are included as part of Azure Monitor OpenTelemetry.
+
+**Note:** The Azure SDK, MongoDB, MySQL, PostgreSQL, Redis, and Redis-4 instrumentations are enabled by default for distributed tracing. The HTTP/HTTPS instrumentation is also enabled by default. All other instrumentations are disabled by default and can be enabled by setting `enabled: true` in the instrumentation options.
 
 > _Warning:_ Instrumentation libraries are based on experimental OpenTelemetry specifications. Microsoft's _preview_ support commitment is to ensure that the following libraries emit data to Azure Monitor Application Insights, but it's possible that breaking changes or experimental mapping will block some data elements.
 

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -78,12 +78,12 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
     this.metricExportIntervalMillis = this.calculateMetricExportInterval();
     this.instrumentationOptions = {
       http: { enabled: true },
-      azureSdk: { enabled: false },
-      mongoDb: { enabled: false },
-      mySql: { enabled: false },
-      postgreSql: { enabled: false },
-      redis: { enabled: false },
-      redis4: { enabled: false },
+      azureSdk: { enabled: true },
+      mongoDb: { enabled: true },
+      mySql: { enabled: true },
+      postgreSql: { enabled: true },
+      redis: { enabled: true },
+      redis4: { enabled: true },
     };
     this._setDefaultResource();
     this.browserSdkLoaderOptions = {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -174,11 +174,7 @@ describe("Library/Config", () => {
         true,
         "Wrong azureSdk",
       );
-      assert.deepStrictEqual(
-        config.instrumentationOptions.mongoDb?.enabled,
-        true,
-        "Wrong mongoDb",
-      );
+      assert.deepStrictEqual(config.instrumentationOptions.mongoDb?.enabled, true, "Wrong mongoDb");
       assert.deepStrictEqual(config.instrumentationOptions.mySql?.enabled, true, "Wrong mySql");
       assert.deepStrictEqual(
         config.instrumentationOptions.postgreSql?.enabled,
@@ -244,11 +240,7 @@ describe("Library/Config", () => {
         true,
         "Wrong azureSdk",
       );
-      assert.deepStrictEqual(
-        config.instrumentationOptions.mongoDb?.enabled,
-        true,
-        "Wrong mongoDb",
-      );
+      assert.deepStrictEqual(config.instrumentationOptions.mongoDb?.enabled, true, "Wrong mongoDb");
       assert.deepStrictEqual(config.instrumentationOptions.mySql?.enabled, true, "Wrong mySql");
       assert.deepStrictEqual(
         config.instrumentationOptions.postgreSql?.enabled,

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -204,7 +204,7 @@ describe("Library/Config", () => {
         },
         samplingRatio: 0.7,
         instrumentationOptions: {
-          redis4: { enabled: true },
+          redis4: { enabled: false },
         },
       };
       env["APPLICATIONINSIGHTS_CONFIGURATION_CONTENT"] = JSON.stringify(jsonOptions);
@@ -232,7 +232,7 @@ describe("Library/Config", () => {
         "Wrong connectionString",
       );
       assert.deepStrictEqual(config.instrumentationOptions.http?.enabled, false, "Wrong http");
-      assert.deepStrictEqual(config.instrumentationOptions.redis4?.enabled, true, "Wrong redis4");
+      assert.deepStrictEqual(config.instrumentationOptions.redis4?.enabled, false, "Wrong redis4");
 
       // Default values
       assert.deepStrictEqual(

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/config.test.ts
@@ -171,22 +171,22 @@ describe("Library/Config", () => {
       assert.deepStrictEqual(config.tracesPerSecond, undefined, "Wrong tracesPerSecond");
       assert.deepStrictEqual(
         config.instrumentationOptions.azureSdk?.enabled,
-        false,
+        true,
         "Wrong azureSdk",
       );
       assert.deepStrictEqual(
         config.instrumentationOptions.mongoDb?.enabled,
-        false,
+        true,
         "Wrong mongoDb",
       );
-      assert.deepStrictEqual(config.instrumentationOptions.mySql?.enabled, false, "Wrong mySql");
+      assert.deepStrictEqual(config.instrumentationOptions.mySql?.enabled, true, "Wrong mySql");
       assert.deepStrictEqual(
         config.instrumentationOptions.postgreSql?.enabled,
-        false,
+        true,
         "Wrong postgreSql",
       );
-      assert.deepStrictEqual(config.instrumentationOptions.redis?.enabled, false, "Wrong redis");
-      assert.deepStrictEqual(config.instrumentationOptions.redis4?.enabled, false, "Wrong redis4");
+      assert.deepStrictEqual(config.instrumentationOptions.redis?.enabled, true, "Wrong redis");
+      assert.deepStrictEqual(config.instrumentationOptions.redis4?.enabled, true, "Wrong redis4");
       assert.deepStrictEqual(
         config.azureMonitorExporterOptions?.disableOfflineStorage,
         undefined,
@@ -241,21 +241,21 @@ describe("Library/Config", () => {
       // Default values
       assert.deepStrictEqual(
         config.instrumentationOptions.azureSdk?.enabled,
-        false,
+        true,
         "Wrong azureSdk",
       );
       assert.deepStrictEqual(
         config.instrumentationOptions.mongoDb?.enabled,
-        false,
+        true,
         "Wrong mongoDb",
       );
-      assert.deepStrictEqual(config.instrumentationOptions.mySql?.enabled, false, "Wrong mySql");
+      assert.deepStrictEqual(config.instrumentationOptions.mySql?.enabled, true, "Wrong mySql");
       assert.deepStrictEqual(
         config.instrumentationOptions.postgreSql?.enabled,
-        false,
+        true,
         "Wrong postgreSql",
       );
-      assert.deepStrictEqual(config.instrumentationOptions.redis?.enabled, false, "Wrong redis");
+      assert.deepStrictEqual(config.instrumentationOptions.redis?.enabled, true, "Wrong redis");
     });
   });
 

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.ts
@@ -227,8 +227,19 @@ describe("Library/TraceHandler", () => {
     });
 
     it("http should not track if instrumentations are disabled", () => {
-      createHandler({ enabled: false });
-      // No HTTP instrumentation should be created
+      // Disable all instrumentations
+      _config.instrumentationOptions = {
+        http: { enabled: false },
+        azureSdk: { enabled: false },
+        mongoDb: { enabled: false },
+        mySql: { enabled: false },
+        postgreSql: { enabled: false },
+        redis: { enabled: false },
+        redis4: { enabled: false },
+      };
+      metricHandler = new MetricHandler(_config);
+      handler = new TraceHandler(_config, metricHandler);
+      // No instrumentations should be created
       expect(handler.getInstrumentations()).toHaveLength(0);
     });
   });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
This pull request updates the default configuration for OpenTelemetry instrumentations in the Azure Monitor SDK, making several instrumentations enabled by default and updating documentation and tests to reflect this change.

**Configuration changes:**

* The following instrumentations are now enabled by default: `azureSdk`, `mongoDb`, `mySql`, `postgreSql`, `redis`, and `redis4` in the `InternalConfig` class (`config.ts`). Previously, only `http` was enabled by default. (`[sdk/monitor/monitor-opentelemetry/src/shared/config.tsL81-R86](diffhunk://#diff-e87f512e0da7968d6421a844d909559a6b2963c947802ea359a7172e4e41d0c6L81-R86)`)

**Documentation updates:**

* The README and CHANGELOG have been updated to clarify that Azure SDK, MongoDB, MySQL, PostgreSQL, Redis, and Redis-4 instrumentations are enabled by default for distributed tracing. Bunyan and Winston remain disabled by default. (`[[1]](diffhunk://#diff-6bc8742d7c20db909a2aa294a72c1748e7f7f0d6b65e7ef985989070b5f5b09cL111-R116)`, `[[2]](diffhunk://#diff-6bc8742d7c20db909a2aa294a72c1748e7f7f0d6b65e7ef985989070b5f5b09cR200-R201)`, `[[3]](diffhunk://#diff-ac8e2149ba18d601cb7e70506ec0eae272490d5068ff91dd731651ac432633a0R5-R8)`)

**Test updates:**

* Unit tests in `config.test.ts` have been updated to expect the new default values for enabled instrumentations. (`[[1]](diffhunk://#diff-716c78a6b3caa3ff2df2fdc016071e643c06bb9ee849bcf25a21ae8fca958215L174-R185)`, `[[2]](diffhunk://#diff-716c78a6b3caa3ff2df2fdc016071e643c06bb9ee849bcf25a21ae8fca958215L244-R250)`)
* The test for disabling all instrumentations in `traceHandler.test.ts` has been updated to explicitly set all instrumentations to `enabled: false` before asserting that no instrumentations are created. (`[sdk/monitor/monitor-opentelemetry/test/internal/unit/traces/traceHandler.test.tsL230-R242](diffhunk://#diff-9f8c1deb63081785381bd0625c60eb4adab9dd59e02ca100ab4cba1a4558d995L230-R242)`)

### Are there test cases added in this PR? _(If not, why?)_
Tests are updated.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
