### PR TITLE
[identity] Mac OS Broker support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12719,7 +12719,7 @@ importers:
         specifier: ^3.2.2
         version: 3.7.2
       '@azure/msal-node-extensions':
-        specifier: ^1.3.0
+        specifier: ^1.5.20
         version: 1.5.21
       tslib:
         specifier: ^2.2.0
@@ -12780,7 +12780,7 @@ importers:
         specifier: ^3.2.2
         version: 3.7.2
       '@azure/msal-node-extensions':
-        specifier: ^1.5.0
+        specifier: ^1.5.20
         version: 1.5.21
       keytar:
         specifier: ^7.6.0
@@ -12875,7 +12875,7 @@ importers:
         specifier: ^3.2.2
         version: 3.7.2
       '@azure/msal-node-extensions':
-        specifier: ^1.3.0
+        specifier: ^1.5.20
         version: 1.5.21
       tslib:
         specifier: ^2.8.1

--- a/sdk/identity/identity-broker/CHANGELOG.md
+++ b/sdk/identity/identity-broker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.1 (Unreleased)
+## 1.3.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/identity/identity-broker/CHANGELOG.md
+++ b/sdk/identity/identity-broker/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for Mac OS broker authentication. [#35683](https://github.com/Azure/azure-sdk-for-js/pull/35683)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/identity-broker",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "sdk-type": "client",
   "description": "A native plugin for Azure Identity credentials to enable broker authentication such as WAM",
   "main": "./dist/commonjs/index.js",

--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -51,7 +51,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/identity": "^4.7.0",
     "@azure/msal-node": "^3.2.2",
-    "@azure/msal-node-extensions": "^1.3.0",
+    "@azure/msal-node-extensions": "^1.5.20",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -52,7 +52,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/identity": "^4.7.0",
     "@azure/msal-node": "^3.2.2",
-    "@azure/msal-node-extensions": "^1.5.0",
+    "@azure/msal-node-extensions": "^1.5.20",
     "keytar": "^7.6.0",
     "tslib": "^2.8.1"
   },

--- a/sdk/identity/identity-vscode/CHANGELOG.md
+++ b/sdk/identity/identity-vscode/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for Mac OS broker authentication via VSCode. [#35683](https://github.com/Azure/azure-sdk-for-js/pull/35683)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/identity/identity-vscode/CHANGELOG.md
+++ b/sdk/identity/identity-vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (Unreleased)
+## 2.1.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@azure/identity": "^4.11.0",
     "@azure/msal-node": "^3.2.2",
-    "@azure/msal-node-extensions": "^1.3.0",
+    "@azure/msal-node-extensions": "^1.5.20",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/identity-vscode",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "sdk-type": "client",
   "description": "Use the Azure Account extension for Visual Studio Code to authenticate with Azure Identity",
   "main": "./dist/commonjs/index.js",

--- a/sdk/identity/identity/TROUBLESHOOTING.md
+++ b/sdk/identity/identity/TROUBLESHOOTING.md
@@ -466,7 +466,8 @@ Broker authentication is used by `DefaultAzureCredential` to enable secure sign-
 | `CredentialUnavailableException: Failed to acquire token using broker authentication` | An unexpected error occurred while getting token with the broker authentication flow. | Check the inner exception for more details. Ensure your environment meets all requirements for broker authentication (Windows OS, correct dependencies, and configuration). |
 
 > [!NOTE] 
-> Brokered authentication is currently only supported on Windows. macOS and Linux are not yet supported.
+> Brokered authentication is currently only supported on Windows and macOS. Linux is not yet supported.
+> macOS support requires `@azure/identity-broker` version 1.3.0 and higher.
 
 ### Unable to log in with Microsoft account (MSA) on Windows
 

--- a/sdk/identity/identity/TROUBLESHOOTING.md
+++ b/sdk/identity/identity/TROUBLESHOOTING.md
@@ -468,6 +468,7 @@ Broker authentication is used by `DefaultAzureCredential` to enable secure sign-
 > [!NOTE] 
 > Brokered authentication is currently only supported on Windows and macOS. Linux is not yet supported.
 > macOS support requires `@azure/identity-broker` version 1.3.0 and higher.
+> Linux is not yet supported.
 
 ### Unable to log in with Microsoft account (MSA) on Windows
 


### PR DESCRIPTION
Updates the min-version of `@azure/msal-node-extensions` to one that supports Mac OS broker. In addition, update identity-broker and identity-vscode to the next minor.