### PR TITLE
Validate package version before publishing

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -205,7 +205,7 @@ function HasPackageSourceCodeChanges($package, $workingDirectory) {
   $packageBefore = Get-PackageJsonContentFromPackage -package $package -workingDirectory $workingDirectory
   $name = $packageBefore.name
 
-  if ($packageBefore.version -notcontains "-alpha") {
+  if (!$packageBefore.version.Contains("-alpha")) {
     Write-Error "The package $name with version $($packageBefore.version) is not a dev version (i.e. doesn't contain '-alpha') so not going to include in publishing."
     # Return false to indicate no changes so it doesn't get added to the publish set.
     return $false


### PR DESCRIPTION
Add check for package version to ensure it's a dev version before publishing.