### PR TITLE
[EngSys] update script to check for external dependency upgrades 

### DIFF
--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -18,7 +18,8 @@ $deprecatedDependency = "Deprecated-Dependency"
 $RepoRoot = Resolve-Path -Path "${PSScriptRoot}/../.."
 Write-Host "Repo root: $RepoRoot"
 
-. $RepoRoot/eng/common/scripts/common.ps1
+$EngCommonScriptsPath = Join-Path (Resolve-Path "${PSScriptRoot}/..") "common" "scripts"
+. (Join-Path $EngCommonScriptsPath common.ps1)
 
 $ghIssues = Get-GitHubIssues -RepoOwner $RepoOwner -RepoName $RepoName -CreatedBy "azure-sdk" -Labels "dependency-upgrade-required" -AuthToken $AuthToken
 # Check and return if an issue already exists to upgrade the package


### PR DESCRIPTION
This PR re-enables reporting of available major upgrades for our external dependencies using `pnpm outdated` command.