### PR TITLE
[Monitor OpenTelemetry Exporter] Add Support for User Semantic Conventions

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/types.ts
@@ -181,6 +181,8 @@ export const legacySemanticValues = [
  */
 export enum experimentalOpenTelemetryValues {
   SYNTHETIC_TYPE = "user_agent.synthetic.type",
+  ATTR_ENDUSER_PSEUDO_ID = "enduser.pseudo.id",
+  ATTR_ENDUSER_ID = "enduser.id",
 }
 
 /**
@@ -210,6 +212,8 @@ export const httpSemanticValues = [
   ATTR_EXCEPTION_TYPE,
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
+  experimentalOpenTelemetryValues.ATTR_ENDUSER_ID,
+  experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID,
   experimentalOpenTelemetryValues.SYNTHETIC_TYPE,
 ];
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -24,6 +24,7 @@ import {
   ATTR_EXCEPTION_STACKTRACE,
   ATTR_EXCEPTION_TYPE,
 } from "@opentelemetry/semantic-conventions";
+import { experimentalOpenTelemetryValues } from "../../src/types.js";
 import type { Measurements, Properties, Tags } from "../types.js";
 import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "../types.js";
 import type { Attributes } from "@opentelemetry/api";
@@ -159,6 +160,23 @@ function createTagsFromLog(log: ReadableLogRecord): Tags {
   const microsoftClientIp = log.attributes?.[MicrosoftClientIp];
   if (microsoftClientIp) {
     tags[KnownContextTagKeys.AiLocationIp] = String(microsoftClientIp);
+  }
+
+  // Map user ID attributes
+  const attributes = log.attributes as Attributes;
+  if (attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]) {
+    const endUserId = String(attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]);
+    if (endUserId && endUserId.length > 0) {
+      tags[KnownContextTagKeys.AiUserAuthUserId] = endUserId;
+    }
+  }
+  if (attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID]) {
+    const endUserPseudoId = String(
+      attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID],
+    );
+    if (endUserPseudoId && endUserPseudoId.length > 0) {
+      tags[KnownContextTagKeys.AiUserId] = endUserPseudoId;
+    }
   }
 
   return tags;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -24,7 +24,7 @@ import {
   ATTR_EXCEPTION_STACKTRACE,
   ATTR_EXCEPTION_TYPE,
 } from "@opentelemetry/semantic-conventions";
-import { experimentalOpenTelemetryValues } from "../../src/types.js";
+import { experimentalOpenTelemetryValues } from "../types.js";
 import type { Measurements, Properties, Tags } from "../types.js";
 import { httpSemanticValues, legacySemanticValues, MaxPropertyLengths } from "../types.js";
 import type { Attributes } from "@opentelemetry/api";

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/spanUtils.ts
@@ -14,7 +14,6 @@ import {
   SEMATTRS_DB_OPERATION,
   SEMATTRS_DB_STATEMENT,
   SEMATTRS_DB_SYSTEM,
-  SEMATTRS_ENDUSER_ID,
   SEMATTRS_EXCEPTION_ESCAPED,
   SEMATTRS_EXCEPTION_MESSAGE,
   SEMATTRS_EXCEPTION_STACKTRACE,
@@ -62,6 +61,7 @@ import {
   internalMicrosoftAttributes,
   legacySemanticValues,
   MaxPropertyLengths,
+  experimentalOpenTelemetryValues,
 } from "../types.js";
 import { parseEventHubSpan } from "./eventhub.js";
 import {
@@ -88,10 +88,18 @@ function createTagsFromSpan(span: ReadableSpan): Tags {
   if (span.parentSpanContext?.spanId) {
     tags[KnownContextTagKeys.AiOperationParentId] = span.parentSpanContext.spanId;
   }
-  const endUserId = span.attributes[SEMATTRS_ENDUSER_ID];
+
+  // Map OpenTelemetry enduser attributes to Application Insights user attributes
+  const endUserId = span.attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID];
   if (endUserId) {
-    tags[KnownContextTagKeys.AiUserId] = String(endUserId);
+    tags[KnownContextTagKeys.AiUserAuthUserId] = String(endUserId);
   }
+
+  const endUserPseudoId = span.attributes[experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID];
+  if (endUserPseudoId) {
+    tags[KnownContextTagKeys.AiUserId] = String(endUserPseudoId);
+  }
+
   const httpUserAgent = getUserAgent(span.attributes);
   if (httpUserAgent) {
     // TODO: Not exposed in Swagger, need to update def

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -567,4 +567,68 @@ describe("logUtils.ts", () => {
       expectedServiceTagsBase,
     );
   });
+
+  it("should map ATTR_ENDUSER_ID to ai.user.authUserId in log tags", () => {
+    testLogRecord.body = "Test message";
+    testLogRecord.severityLevel = "Information";
+    testLogRecord.attributes = {
+      [experimentalOpenTelemetryValues.ATTR_ENDUSER_ID]: "test-auth-user-id",
+      "extra.attribute": "foo",
+      [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "",
+    };
+
+    const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+
+    // Verify the user auth ID is mapped to the correct tag
+    assert.deepStrictEqual(envelope?.tags, {
+      ...context.tags,
+      ...expectedServiceTagsBase,
+      [KnownContextTagKeys.AiUserAuthUserId]: "test-auth-user-id",
+    });
+
+    // Verify properties don't include the user ID (it should be filtered out)
+    assert.deepStrictEqual((envelope?.data?.baseData as any).properties, {
+      "extra.attribute": "foo",
+    });
+
+    // Verify that ATTR_ENDUSER_ID is not in properties
+    assert.ok(
+      envelope &&
+        !envelope.data?.baseData?.properties?.[experimentalOpenTelemetryValues.ATTR_ENDUSER_ID],
+      "ATTR_ENDUSER_ID should not be included in properties",
+    );
+  });
+
+  it("should map ATTR_ENDUSER_PSEUDO_ID to ai.user.id in log tags", () => {
+    testLogRecord.body = "Test message";
+    testLogRecord.severityLevel = "Information";
+    testLogRecord.attributes = {
+      [experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID]: "test-pseudo-user-id",
+      "extra.attribute": "foo",
+      [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "",
+    };
+
+    const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+
+    // Verify the pseudo user ID is mapped to the correct tag
+    assert.deepStrictEqual(envelope?.tags, {
+      ...context.tags,
+      ...expectedServiceTagsBase,
+      [KnownContextTagKeys.AiUserId]: "test-pseudo-user-id",
+    });
+
+    // Verify properties don't include the user ID (it should be filtered out)
+    assert.deepStrictEqual((envelope?.data?.baseData as any).properties, {
+      "extra.attribute": "foo",
+    });
+
+    // Verify that ATTR_ENDUSER_PSEUDO_ID is not in properties
+    assert.ok(
+      envelope &&
+        !envelope.data?.baseData?.properties?.[
+          experimentalOpenTelemetryValues.ATTR_ENDUSER_PSEUDO_ID
+        ],
+      "ATTR_ENDUSER_PSEUDO_ID should not be included in properties",
+    );
+  });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
https://msazure.visualstudio.com/One/_git/CommonSchema/pullrequest/13225763?path=/v4.0/Mappings/AzureMonitor-AI.md

This pull request updates how OpenTelemetry end user identifiers are mapped to Application Insights tags, ensuring more accurate user tracking and improved compatibility with semantic conventions. The main changes involve introducing support for new experimental OpenTelemetry attributes, updating mapping logic, and enhancing test coverage.

**End User Attribute Mapping:**

* Added support for `ATTR_ENDUSER_ID` and `ATTR_ENDUSER_PSEUDO_ID` in `experimentalOpenTelemetryValues`, and included them in `httpSemanticValues` for consistent attribute handling. [[1]](diffhunk://#diff-e3555707ab8d46333aa668332f4c26950f95975852c4f234c0f308f321ccd50bR184-R185) [[2]](diffhunk://#diff-e3555707ab8d46333aa668332f4c26950f95975852c4f234c0f308f321ccd50bR215-R216)
* Updated `createTagsFromSpan` and `createTagsFromLog` to map `ATTR_ENDUSER_ID` to `ai.user.authUserId` and `ATTR_ENDUSER_PSEUDO_ID` to `ai.user.id`, replacing the previous usage of `SEMATTRS_ENDUSER_ID`. [[1]](diffhunk://#diff-91578a36a9cd93bc063569087dd9e7421dd054203bbf445a117c780ad4192e4aL91-R102) [[2]](diffhunk://#diff-15bd578d481957b4453643ba93950786245a414b0249b0f656273d7955a8756cR165-R181)

**Codebase Cleanup:**

* Removed imports and references to `SEMATTRS_ENDUSER_ID` throughout the codebase, switching to the new experimental attributes for user identification. [[1]](diffhunk://#diff-91578a36a9cd93bc063569087dd9e7421dd054203bbf445a117c780ad4192e4aL17) [[2]](diffhunk://#diff-deac85b40c347e06f8b2060600343e31dd8fffe2d0fe1236798d165e122d6b7fL48) [[3]](diffhunk://#diff-91578a36a9cd93bc063569087dd9e7421dd054203bbf445a117c780ad4192e4aR64)

**Testing Improvements:**

* Added and updated unit tests to verify correct mapping of `ATTR_ENDUSER_ID` and `ATTR_ENDUSER_PSEUDO_ID` to Application Insights tags, and to ensure these attributes are not included in properties. [[1]](diffhunk://#diff-3da3e650a34abea29243940eec2d4051ac923e159015101e417a44f3592c5a1bR570-R633) [[2]](diffhunk://#diff-deac85b40c347e06f8b2060600343e31dd8fffe2d0fe1236798d165e122d6b7fL1539-R1544) [[3]](diffhunk://#diff-deac85b40c347e06f8b2060600343e31dd8fffe2d0fe1236798d165e122d6b7fL1555-R1554) [[4]](diffhunk://#diff-deac85b40c347e06f8b2060600343e31dd8fffe2d0fe1236798d165e122d6b7fL1585-R1642)

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
