### PR TITLE
[CODEOWNERS] Messaging ownership transfer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -149,11 +149,10 @@
 # ServiceOwners: @shankarsama @rajeshka
 
 # PRLabel: %Event Hubs
-/sdk/eventhub/ @xirzec
+/sdk/eventhub/ @axisc @sjkwak @hmlam
 
 # ServiceLabel: %Event Hubs
-# AzureSdkOwners: @xirzec
-# ServiceOwners: @axisc
+# ServiceOwners: @axisc @sjkwak @hmlam
 
 # ServiceLabel: %Cognitive - Health Insights
 # PRLabel: %Cognitive - Health Insights
@@ -182,11 +181,10 @@
 # AzureSdkOwners: @maorleger
 
 # PRLabel: %Service Bus
-/sdk/servicebus/ @xirzec
+/sdk/servicebus/ @skarri-microsoft @EldertGrootenboer
 
 # ServiceLabel: %Service Bus
-# AzureSdkOwners: @xirzec
-# ServiceOwners: @EldertGrootenboer
+# ServiceOwners: @skarri-microsoft @EldertGrootenboer
 
 # PRLabel: %Storage
 # ServiceLabel: %Storage
@@ -287,11 +285,10 @@
 /sdk/vision/ai-vision-image-analysis-rest/ @rhurey @dargilco
 
 # PRLabel: %Schema Registry
-/sdk/schemaregistry/ @xirzec
+/sdk/schemaregistry/ @axisc @sjkwak @hmlam
 
 # ServiceLabel: %Schema Registry
-# AzureSdkOwners: @xirzec
-# ServiceOwners: @axisc
+# ServiceOwners: @axisc @sjkwak @hmlam
 
 # PRLabel: %Cognitive - Form Recognizer
 /sdk/formrecognizer/ @HarshaNalluru @jeremymeng
@@ -1327,9 +1324,6 @@
 # ServiceLabel: %Digital Twins %Service Attention
 # ServiceOwners:          @sourabhguha @inesk-vt
 
-# ServiceLabel: %Event Hubs %Service Attention
-# ServiceOwners:          @kasun04
-
 # ServiceLabel: %Functions %Service Attention
 # ServiceOwners:          @ahmedelnably @fabiocav
 
@@ -1480,14 +1474,8 @@
 # ServiceLabel: %Security %Service Attention
 # ServiceOwners:          @chlahav
 
-# ServiceLabel: %Service Attention %Service Bus
-# ServiceOwners:          @EldertGrootenboer
-
 # ServiceLabel: %Service Attention %Service Fabric
 # ServiceOwners:          @QingChenmsft @vaishnavk @juhacket
-
-# ServiceLabel: %Schema Registry %Service Attention
-# ServiceOwners:          @arerlend
 
 # ServiceLabel: %Service Attention %SignalR
 # ServiceOwners:          @sffamily @chenkennt


### PR DESCRIPTION
# Summary

The focus of these changes is to transfer ownership of the Azure messaging services to the associated service teams.