### PR TITLE
[Core] bump `@azure/*` dependency versions to latest published

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6299,16 +6299,16 @@ importers:
   sdk/core/core-amqp:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-auth':
-        specifier: ^1.7.2
+        specifier: ^1.10.0
         version: link:../core-auth
       '@azure/core-util':
-        specifier: ^1.9.0
+        specifier: ^1.13.0
         version: link:../core-util
       '@azure/logger':
-        specifier: ^1.1.2
+        specifier: ^1.3.0
         version: link:../logger
       buffer:
         specifier: ^6.0.3
@@ -6381,10 +6381,10 @@ importers:
   sdk/core/core-auth:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-util':
-        specifier: ^1.11.0
+        specifier: ^1.13.0
         version: link:../core-util
       tslib:
         specifier: ^2.6.2
@@ -6421,29 +6421,29 @@ importers:
   sdk/core/core-client:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-auth':
-        specifier: ^1.4.0
+        specifier: ^1.10.0
         version: link:../core-auth
       '@azure/core-rest-pipeline':
-        specifier: ^1.20.0
+        specifier: ^1.22.0
         version: link:../core-rest-pipeline
       '@azure/core-tracing':
-        specifier: ^1.0.0
+        specifier: ^1.3.0
         version: link:../core-tracing
       '@azure/core-util':
-        specifier: ^1.6.1
+        specifier: ^1.13.0
         version: link:../core-util
       '@azure/logger':
-        specifier: ^1.0.0
+        specifier: ^1.3.0
         version: link:../logger
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
     devDependencies:
       '@azure/core-xml':
-        specifier: ^1.3.4
+        specifier: ^1.5.0
         version: link:../core-xml
       '@azure/dev-tool':
         specifier: workspace:^
@@ -6476,16 +6476,16 @@ importers:
   sdk/core/core-client-rest:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-auth':
-        specifier: ^1.9.0
+        specifier: ^1.10.0
         version: link:../core-auth
       '@azure/core-rest-pipeline':
-        specifier: ^1.5.0
+        specifier: ^1.22.0
         version: link:../core-rest-pipeline
       '@azure/core-tracing':
-        specifier: ^1.0.1
+        specifier: ^1.3.0
         version: link:../core-tracing
       '@typespec/ts-http-runtime':
         specifier: ^0.3.0
@@ -6525,13 +6525,13 @@ importers:
   sdk/core/core-http-compat:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-client':
-        specifier: ^1.3.0
+        specifier: ^1.10.0
         version: link:../core-client
       '@azure/core-rest-pipeline':
-        specifier: ^1.20.0
+        specifier: ^1.22.0
         version: link:../core-rest-pipeline
     devDependencies:
       '@azure/dev-tool':
@@ -6565,13 +6565,13 @@ importers:
   sdk/core/core-lro:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-util':
-        specifier: ^1.2.0
+        specifier: ^1.13.0
         version: link:../core-util
       '@azure/logger':
-        specifier: ^1.0.0
+        specifier: ^1.3.0
         version: link:../logger
       tslib:
         specifier: ^2.6.2
@@ -6648,19 +6648,19 @@ importers:
   sdk/core/core-rest-pipeline:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@azure/core-auth':
-        specifier: ^1.8.0
+        specifier: ^1.10.0
         version: link:../core-auth
       '@azure/core-tracing':
-        specifier: ^1.0.1
+        specifier: ^1.3.0
         version: link:../core-tracing
       '@azure/core-util':
-        specifier: ^1.11.0
+        specifier: ^1.13.0
         version: link:../core-util
       '@azure/logger':
-        specifier: ^1.0.0
+        specifier: ^1.3.0
         version: link:../logger
       '@typespec/ts-http-runtime':
         specifier: ^0.3.0
@@ -6706,10 +6706,10 @@ importers:
         specifier: ^1.0.0
         version: link:../../test-utils/perf
       '@azure/core-auth':
-        specifier: ^1.9.0
+        specifier: ^1.10.0
         version: link:../core-auth
       '@azure/core-rest-pipeline':
-        specifier: ^1.19.1
+        specifier: ^1.22.0
         version: link:../core-rest-pipeline
       dotenv:
         specifier: ^16.0.0
@@ -6817,7 +6817,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@azure/core-auth':
-        specifier: ^1.3.0
+        specifier: workspace:^
         version: link:../core-auth
       '@azure/dev-tool':
         specifier: workspace:^
@@ -6850,7 +6850,7 @@ importers:
   sdk/core/core-util:
     dependencies:
       '@azure/abort-controller':
-        specifier: ^2.0.0
+        specifier: ^2.1.2
         version: link:../abort-controller
       '@typespec/ts-http-runtime':
         specifier: ^0.3.0
@@ -6860,7 +6860,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@azure-tools/vite-plugin-browser-test-map':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../../common/tools/vite-plugin-browser-test-map
       '@azure/dev-tool':
         specifier: workspace:^

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 4.4.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -68,10 +68,10 @@
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.7.2",
-    "@azure/core-util": "^1.9.0",
-    "@azure/logger": "^1.1.2",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-auth": "^1.10.0",
+    "@azure/core-util": "^1.13.0",
+    "@azure/logger": "^1.3.0",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "process": "^0.11.10",

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 1.10.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -68,8 +68,8 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-util": "^1.11.0",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-util": "^1.13.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 2.5.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -68,10 +68,10 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.9.0",
-    "@azure/core-rest-pipeline": "^1.5.0",
-    "@azure/core-tracing": "^1.0.1",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-auth": "^1.10.0",
+    "@azure/core-rest-pipeline": "^1.22.0",
+    "@azure/core-tracing": "^1.3.0",
     "@typespec/ts-http-runtime": "^0.3.0",
     "tslib": "^2.6.2"
   },

--- a/sdk/core/core-client/CHANGELOG.md
+++ b/sdk/core/core-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 1.10.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -68,16 +68,16 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.4.0",
-    "@azure/core-rest-pipeline": "^1.20.0",
-    "@azure/core-tracing": "^1.0.0",
-    "@azure/core-util": "^1.6.1",
-    "@azure/logger": "^1.0.0",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-auth": "^1.10.0",
+    "@azure/core-rest-pipeline": "^1.22.0",
+    "@azure/core-tracing": "^1.3.0",
+    "@azure/core-util": "^1.13.0",
+    "@azure/logger": "^1.3.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@azure/core-xml": "^1.3.4",
+    "@azure/core-xml": "^1.5.0",
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@types/node": "catalog:",

--- a/sdk/core/core-http-compat/CHANGELOG.md
+++ b/sdk/core/core-http-compat/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 2.3.0 (2025-05-01)
 
 ### Features Added

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -68,9 +68,9 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-client": "^1.3.0",
-    "@azure/core-rest-pipeline": "^1.20.0"
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-client": "^1.10.0",
+    "@azure/core-rest-pipeline": "^1.22.0"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 3.3.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -83,9 +83,9 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-util": "^1.2.0",
-    "@azure/logger": "^1.0.0",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-util": "^1.13.0",
+    "@azure/logger": "^1.3.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/sdk/core/core-rest-pipeline-perf-tests/package.json
+++ b/sdk/core/core-rest-pipeline-perf-tests/package.json
@@ -44,8 +44,8 @@
   "private": true,
   "dependencies": {
     "@azure-tools/test-perf": "^1.0.0",
-    "@azure/core-auth": "^1.9.0",
-    "@azure/core-rest-pipeline": "^1.19.1",
+    "@azure/core-auth": "^1.10.0",
+    "@azure/core-rest-pipeline": "^1.22.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1",
     "undici": "^7.1.0"

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 1.22.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -85,11 +85,11 @@
     "migrationDate": "2023-03-08T18:36:03.000Z"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
-    "@azure/core-auth": "^1.8.0",
-    "@azure/core-tracing": "^1.0.1",
-    "@azure/core-util": "^1.11.0",
-    "@azure/logger": "^1.0.0",
+    "@azure/abort-controller": "^2.1.2",
+    "@azure/core-auth": "^1.10.0",
+    "@azure/core-tracing": "^1.3.0",
+    "@azure/core-util": "^1.13.0",
+    "@azure/logger": "^1.3.0",
     "@typespec/ts-http-runtime": "^0.3.0",
     "tslib": "^2.6.2"
   },

--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 1.3.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -71,7 +71,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@azure/core-auth": "^1.3.0",
+    "@azure/core-auth": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@types/node": "catalog:",

--- a/sdk/core/core-util/CHANGELOG.md
+++ b/sdk/core/core-util/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Upgrade `@azure/*` dependencies to latest versions.
+
 ## 1.13.0 (2025-07-10)
 
 ### Other Changes

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -68,12 +68,12 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "@azure/abort-controller": "^2.0.0",
+    "@azure/abort-controller": "^2.1.2",
     "@typespec/ts-http-runtime": "^0.3.0",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@azure-tools/vite-plugin-browser-test-map": "^1.0.0",
+    "@azure-tools/vite-plugin-browser-test-map": "workspace:^",
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@types/node": "catalog:",


### PR DESCRIPTION
This should help reduce incompatible version issues that appeared recently.