### PR TITLE
[Monitor OpenTelemetry Exporter] Customer SDK Stats Fixes

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Renamed Customer Statsbeat feature to customer SDK Stats.
 - Update drop.reason values for customer SDK Stats.
 - Update logic setting ai.location.ip to use the microsoft.client.ip value by default.
+- Add further drop reason for disk persistence disablement.
 
 ## 1.0.0-beta.33 (2025-08-04)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/customerSDKStats.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/customerSDKStats.ts
@@ -9,7 +9,14 @@ import type { AzureMonitorExporterOptions } from "../../index.js";
 import * as ai from "../../utils/constants/applicationinsights.js";
 import { StatsbeatMetrics } from "./statsbeatMetrics.js";
 import type { CustomerSDKStatsProperties, StatsbeatOptions } from "./types.js";
-import { CustomerSDKStats, DropCode, RetryCode, ExceptionType, DropReason } from "./types.js";
+import {
+  CustomerSDKStats,
+  DropCode,
+  RetryCode,
+  ExceptionType,
+  DropReason,
+  RetryReason,
+} from "./types.js";
 import { CustomSDKStatsCounter, STATSBEAT_LANGUAGE, TelemetryType } from "./types.js";
 import { getAttachType } from "../../utils/metricUtils.js";
 import { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
@@ -368,6 +375,8 @@ export class CustomerSDKStatsMetrics extends StatsbeatMetrics {
         return DropReason.CLIENT_READONLY;
       case DropCode.CLIENT_PERSISTENCE_CAPACITY:
         return DropReason.CLIENT_PERSISTENCE_CAPACITY;
+      case DropCode.CLIENT_STORAGE_DISABLED:
+        return DropReason.CLIENT_STORAGE_DISABLED;
       case DropCode.UNKNOWN:
       default:
         return DropReason.UNKNOWN;
@@ -523,10 +532,10 @@ export class CustomerSDKStatsMetrics extends StatsbeatMetrics {
     // Handle other enum retry codes
     switch (retryCode) {
       case RetryCode.CLIENT_TIMEOUT:
-        return "Client timeout";
+        return RetryReason.CLIENT_TIMEOUT;
       case RetryCode.UNKNOWN:
       default:
-        return "Unknown reason";
+        return RetryReason.UNKNOWN;
     }
   }
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/types.ts
@@ -245,7 +245,16 @@ export enum ExceptionType {
 export enum DropReason {
   CLIENT_READONLY = "Client readonly",
   CLIENT_PERSISTENCE_CAPACITY = "Client persistence capacity",
-  UNKNOWN = "Unknown",
+  CLIENT_STORAGE_DISABLED = "Client storage disabled",
+  UNKNOWN = "Unknown reason",
+}
+
+/**
+ * Reasons for retrying telemetry
+ */
+export enum RetryReason {
+  CLIENT_TIMEOUT = "Client timeout",
+  UNKNOWN = "Unknown reason",
 }
 
 /**


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This pull request introduces a new drop reason for disk persistence disablement in the customer SDK Stats, refines the handling of drop and retry reasons, and updates related enums and logic for improved clarity and consistency.

**Customer SDK Stats:**
* Added a new drop reason, `CLIENT_STORAGE_DISABLED`, to track when disk persistence is disabled for telemetry. [[1]](diffhunk://#diff-994a7fbc4177f96448b6098ea5c95fc5872615b8537e18822a17817cd3d70870R16) [[2]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1R378-R379) [[3]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL248-R257)

**Enums and Reason Handling:**
* Updated the `DropReason` enum to include `CLIENT_STORAGE_DISABLED` and changed the default unknown value to "Unknown reason" for clarity.
* Introduced a new `RetryReason` enum to standardize retry reason strings, replacing hardcoded values in the code. [[1]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L12-R19) [[2]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L526-R538) [[3]](diffhunk://#diff-88b62eef1c76c2db9a03f6c670881c41bab6de71bbb9c3fceeb1c33f0c9a455dL248-R257)
* Refactored logic in `CustomerSDKStatsMetrics` to use the new `RetryReason` enum for retry reason descriptions.

These changes improve the accuracy of telemetry drop and retry reporting and make the codebase easier to maintain.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
