### PR TITLE
docs(playwrighttesting):  README Update with deprecation notice for J…

### DIFF
--- a/sdk/playwrighttesting/arm-playwrighttesting/README.md
+++ b/sdk/playwrighttesting/arm-playwrighttesting/README.md
@@ -1,5 +1,9 @@
 # AzurePlaywrightService client library for JavaScript
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **@azure/arm-playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 This package contains an isomorphic SDK (runs both in Node.js and in browsers) for AzurePlaywrightService client.
 
 Microsoft.AzurePlaywrightService Resource Provider Management API.

--- a/sdk/playwrighttesting/create-microsoft-playwright-testing/README.md
+++ b/sdk/playwrighttesting/create-microsoft-playwright-testing/README.md
@@ -1,5 +1,9 @@
 # Microsoft Playwright Testing preview
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **@azure/create-playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 Microsoft Playwright Testing is a fully managed service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 
 ## Usage

--- a/sdk/playwrighttesting/microsoft-playwright-testing/README.md
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/README.md
@@ -1,5 +1,9 @@
 # Microsoft Playwright Testing preview
 
+**Deprecation message**
+ 
+This package has been deprecated and will no longer be maintained after **February 9, 2026**. Upgrade to the replacement package, **@azure/playwright**, to continue receiving updates. Refer to the [migration guide](https://aka.ms/mpt/migration-guide) for guidance on upgrading. Refer to our [deprecation policy](https://azure.github.io/azure-sdk/policies_support.html) for more details.
+
 Microsoft Playwright Testing is a fully managed Azure service that uses the cloud to enable you to run Playwright tests with much higher parallelization across different operating system-browser combinations simultaneously. This means faster test runs with broader scenario coverage, which helps speed up delivery of features without sacrificing quality. The service also enables you to publish test results and related artifacts to the service and view them in the service portal enabling faster and easier troubleshooting. With Microsoft Playwright Testing service, you can release features faster and more confidently.
 
 Ready to get started? Jump into our [quickstart guide](#get-started)!


### PR DESCRIPTION
…S control plane and data plane SDKs


### Packages impacted by this PR
@azure/arm-playwrighttesting
@azure/create-microsoft-playwrighttesting
@azure/microsoft-playwright-testing

**NOTE: This PR should not be merged before September 8th.**
As part of the retirement of Microsoft Playwright Testing (MPT) and its merger into Azure App Testing, we plan to deprecate the SDK packages associated with this service. This aligns with Azure’s service retirement policy and the ARM API Deprecation guidelines.

MPT’s core web testing capabilities are being integrated into Azure App Testing to provide a unified experience for both Load Testing and Playwright-based web testing. The standalone MPT service will be retired, and customers will need to migrate to Azure App Testing.
