### PR TITLE
[EngSys] fix aggregate-reports pipeline

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -41,8 +41,12 @@ stages:
               Condition: succeededOrFailed()
 
           - script: 'npm ci'
+            workingDirectory: '$(Build.SourcesDirectory)/eng/tools/eng-package-utils'
+            displayName: 'Install eng-package-utils dependencies'
+
+          - script: 'npm ci'
             workingDirectory: '$(Build.SourcesDirectory)/eng/tools/analyze-deps'
-            displayName: 'Install tool dependencies'
+            displayName: 'Install analyze-deps dependencies'
 
           - script: |
               node index.js --verbose --out "$(Build.ArtifactStagingDirectory)/dependencies.html" --dump "$(Build.ArtifactStagingDirectory)"


### PR DESCRIPTION
After pnpm migration, `analyze-deps` too's dependency `eng-package-utils`
package has external dependencies thus needs to have them installed first.

It is possible that some other step was doing the installation so that this
pipeline was passing but things changed.