### PR TITLE
[core-xml] fix TypeScript compilation error for browser

### DIFF
--- a/sdk/core/core-xml/tsconfig.browser.config.json
+++ b/sdk/core/core-xml/tsconfig.browser.config.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.browser.base.json",
   "compilerOptions": {
+    "types": ["trusted-types"],
     "paths": {
       "@azure/core-xml": ["./dist/browser/index.d.ts"],
       "@azure/core-xml/*": ["./dist/browser/*"],


### PR DESCRIPTION
The browser version needs types from `@types/trusted-types`. This PR adds an
entry for `trusted-types` in core-xml's `types` compiler options in its
tsconfig.browser.config.json.