### PR TITLE
Remove azure-monitor-query from CI artifact list

### DIFF
--- a/sdk/monitor/ci.yml
+++ b/sdk/monitor/ci.yml
@@ -39,8 +39,6 @@ extends:
         safeName: azuremonitoropentelemetry
       - name: azure-monitor-opentelemetry-exporter
         safeName: azuremonitoropentelemetryexporter
-      - name: azure-monitor-query
-        safeName: azuremonitorquery
       - name: azure-monitor-ingestion
         safeName: azuremonitoringestion
       - name: azure-monitor-query-logs


### PR DESCRIPTION
as the package `azure/monitor-query` has been deleted.
