### PR TITLE
[EngSys] remove unnecessary `npm install` for ci-runner

### DIFF
--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -76,7 +76,6 @@ steps:
       Artifacts: ${{ parameters.Artifacts }}
 
   - pwsh: |
-      npm install ./eng/tools/ci-runner
       node eng/tools/ci-runner/index.js build "$(ChangedServices)" -packages "$(ArtifactPackageNames)"
     env:
       TURBO_TEAM: azsdkjs


### PR DESCRIPTION
as ci-runner does not have any runtime dependencies.