### PR TITLE
Added spec-gen-sdk config for azsdk-cli tools

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -1,0 +1,41 @@
+{
+  "advancedOptions": {
+    "createSdkPullRequests": true,
+    "generationCallMode": "one-per-config",
+    "breakingChangeTracking": true
+  },
+  "initOptions": {
+    "initScript": {
+      "path": "sh .scripts/automation_init.sh",
+      "stderr": {
+        "showInComment": ".*ERROR.*",
+        "scriptError": "\\[ERROR\\]"
+      },
+      "stdout": {
+        "showInComment": ".*ERROR.*",
+        "scriptError": "\\[ERROR\\]"
+      }
+    }
+  },
+  "generateOptions": {
+    "generateScript": {
+      "path": "sh .scripts/automation_generate.sh",
+      "stderr": {
+        "showInComment": ".*ERROR.*",
+        "scriptError": "\\[ERROR\\]"
+      },
+      "stdout": {
+        "showInComment": ".*ERROR.*",
+        "scriptError": "\\[ERROR\\]"
+      }
+    },
+    "parseGenerateOutput": true
+  },
+  "packageOptions": {
+    "breakingChangeLabel": "CI-BreakingChange-JavaScript",
+    "breakingChangesLabel": "BreakingChange-JavaScript-Sdk",
+    "buildScript": {
+      "path": "./eng/scripts/build-sdk.ps1"
+    }
+  }
+}


### PR DESCRIPTION
Copied the current configuration file used by SDK validation pipeline and added `buildScript` option.