### PR TITLE
[EngSys] add a pipeline that builds all packages

### DIFF
--- a/eng/pipelines/build-all-packages.yml
+++ b/eng/pipelines/build-all-packages.yml
@@ -1,0 +1,70 @@
+trigger:
+  branches:
+    include:
+      - main
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - api-extractor-base.json
+      - package.json
+      - turbo.json
+      - pnpm-*.yaml
+      - tsconfig.json
+      - tsconfig.src.build.json
+
+pr: none
+
+stages:
+  - stage:
+    displayName: Building All Packages
+
+    pool:
+      name: azsdk-pool
+      demands: ImageOverride -equals ubuntu-24.04
+
+    jobs:
+      - job: BuildAllPackages
+        timeoutInMinutes: 180
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            fetchTags: false
+
+          - template: /eng/pipelines/templates/steps/use-node-version.yml
+            parameters:
+              NodeVersion: $(NODE_VERSION_LTS_ACTIVE)
+
+          - script: |
+              git log -m --abbrev-commit --pretty=format:'%h  %s (%cr) %an <%ae>' -50
+            displayName: git log
+
+          - script: |
+              npm install -g pnpm
+            displayName: "Install Pnpm"
+
+          - script: |
+              pnpm install
+            displayName: "Install library dependencies"
+
+          - script: |
+              pnpm build
+            env:
+              TURBO_TEAM: azsdkjs
+              TURBO_TEAMID: azsdkjs
+              TURBO_TOKEN: $(js-turborepo-cache-token)
+              TURBO_CACHE: local:rw,remote:rw
+            condition: not(eq(variables['dataPlaneOnly'], 'true'))
+            displayName: "Build All Packages"
+
+          - script: |
+              pnpm exec turbo build --filter='!@azure/arm-*' --filter='!@azure-rest/arm-*'
+            env:
+              TURBO_TEAM: azsdkjs
+              TURBO_TEAMID: azsdkjs
+              TURBO_TOKEN: $(js-turborepo-cache-token)
+              TURBO_CACHE: local:rw,remote:rw
+            condition: eq(variables['dataPlaneOnly'], 'true')
+            displayName: "Build All Data-plane Packages"

--- a/eng/pipelines/build-all-packages.yml
+++ b/eng/pipelines/build-all-packages.yml
@@ -49,22 +49,23 @@ stages:
               pnpm install
             displayName: "Install library dependencies"
 
-          - script: |
-              pnpm build
-            env:
-              TURBO_TEAM: azsdkjs
-              TURBO_TEAMID: azsdkjs
-              TURBO_TOKEN: $(js-turborepo-cache-token)
-              TURBO_CACHE: local:rw,remote:rw
-            condition: not(eq(variables['dataPlaneOnly'], 'true'))
-            displayName: "Build All Packages"
+          - ${{ if and(eq(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')) }}:
+            - script: |
+                pnpm build
+              env:
+                TURBO_TEAM: azsdkjs
+                TURBO_TEAMID: azsdkjs
+                TURBO_TOKEN: $(js-turborepo-cache-token)
+                TURBO_CACHE: local:rw,remote:rw
+              condition: not(eq(variables['skipMgmt'], 'true'))
+              displayName: "Build All Packages"
 
-          - script: |
-              pnpm exec turbo build --filter='!@azure/arm-*' --filter='!@azure-rest/arm-*'
-            env:
-              TURBO_TEAM: azsdkjs
-              TURBO_TEAMID: azsdkjs
-              TURBO_TOKEN: $(js-turborepo-cache-token)
-              TURBO_CACHE: local:rw,remote:rw
-            condition: eq(variables['dataPlaneOnly'], 'true')
-            displayName: "Build All Data-plane Packages"
+            - script: |
+                pnpm exec turbo build --filter='!@azure/arm-*' --filter='!@azure-rest/arm-*'
+              env:
+                TURBO_TEAM: azsdkjs
+                TURBO_TEAMID: azsdkjs
+                TURBO_TOKEN: $(js-turborepo-cache-token)
+                TURBO_CACHE: local:rw,remote:rw
+              condition: eq(variables['skipMgmt'], 'true')
+              displayName: "Build Non-Mgmt Packages"


### PR DESCRIPTION
Currently changes to global configuration files trigger `js - core` CI build
after they are merged. However, `js - core` CI only builds core packages then
cache their build output. Other packages are not built thus their remote cache
are not updated even though global inputs are changed.

This PR adds a pipeline that builds all packages and writes to remote cache when
global configuration files are changed.