### PR TITLE
[PPAF] Override enablePartitionLevelFailover flag from getDatabaseAccount call

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
@@ -637,6 +637,7 @@ export const Constants: {
     ENABLE_MULTIPLE_WRITABLE_LOCATIONS: string;
     ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR: string;
     DefaultUnavailableLocationExpirationTimeMS: number;
+    PPAFDynamicEnablementRefreshTimeMS: number;
     ThrottleRetryCount: string;
     ThrottleRetryWaitTimeInMs: string;
     CurrentVersion: string;

--- a/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
@@ -637,7 +637,7 @@ export const Constants: {
     ENABLE_MULTIPLE_WRITABLE_LOCATIONS: string;
     ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR: string;
     DefaultUnavailableLocationExpirationTimeMS: number;
-    PPAFDynamicEnablementRefreshTimeMS: number;
+    DynamicEnablementRefreshTimeMS: number;
     ThrottleRetryCount: string;
     ThrottleRetryWaitTimeInMs: string;
     CurrentVersion: string;

--- a/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
@@ -635,6 +635,7 @@ export const Constants: {
     WriteRequestFailureCountThreshold: number;
     ConsecutiveFailureCountResetIntervalInMS: number;
     ENABLE_MULTIPLE_WRITABLE_LOCATIONS: string;
+    ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR: string;
     DefaultUnavailableLocationExpirationTimeMS: number;
     ThrottleRetryCount: string;
     ThrottleRetryWaitTimeInMs: string;
@@ -928,6 +929,8 @@ export class DatabaseAccount {
     readonly databasesLink: string;
     // (undocumented)
     readonly enableMultipleWritableLocations: boolean;
+    // (undocumented)
+    readonly enablePerPartitionFailoverBehavior: boolean;
     // @deprecated
     get MaxMediaStorageUsageInMB(): number;
     readonly maxMediaStorageUsageInMB: number;

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -168,7 +168,6 @@ export class CosmosClient {
           "enableEndpointDiscovery must be set to true to use partition level failover or circuit breaker.",
         );
       }
-      
     }
 
     this.globalPartitionEndpointManager = new GlobalPartitionEndpointManager(
@@ -195,7 +194,7 @@ export class CosmosClient {
       this.backgroundRefreshEndpointList(
         globalEndpointManager,
         optionsOrConnectionString.connectionPolicy.endpointRefreshRateInMs ||
-        defaultConnectionPolicy.endpointRefreshRateInMs,
+          defaultConnectionPolicy.endpointRefreshRateInMs,
       );
     }
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -168,13 +168,15 @@ export class CosmosClient {
           "enableEndpointDiscovery must be set to true to use partition level failover or circuit breaker.",
         );
       }
-      this.globalPartitionEndpointManager = new GlobalPartitionEndpointManager(
-        optionsOrConnectionString,
-        globalEndpointManager,
-        async (diagnosticNode: DiagnosticNodeInternal, opts: RequestOptions) =>
-          this.getDatabaseAccountInternal(diagnosticNode, opts),
-      );
+      
     }
+
+    this.globalPartitionEndpointManager = new GlobalPartitionEndpointManager(
+      optionsOrConnectionString,
+      globalEndpointManager,
+      async (diagnosticNode: DiagnosticNodeInternal, opts: RequestOptions) =>
+        this.getDatabaseAccountInternal(diagnosticNode, opts),
+    );
 
     this.clientContext = new ClientContext(
       optionsOrConnectionString,

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -23,6 +23,7 @@ import { ResourceResponse } from "./request/index.js";
 import { checkURL } from "./utils/checkURL.js";
 import { getEmptyCosmosDiagnostics, withDiagnostics } from "./utils/diagnostics.js";
 import { GlobalPartitionEndpointManager } from "./globalPartitionEndpointManager.js";
+import { startBackgroundTask } from "./utils/time.js";
 
 /**
  * Provides a client-side logical representation of the Azure Cosmos DB database account.
@@ -77,6 +78,7 @@ export class CosmosClient {
   public readonly offers: Offers;
   private clientContext: ClientContext;
   private endpointRefresher: NodeJS.Timeout;
+  private dynamicEnablementRefresher: NodeJS.Timeout;
   /**
    * @internal
    */
@@ -169,6 +171,8 @@ export class CosmosClient {
       this.globalPartitionEndpointManager = new GlobalPartitionEndpointManager(
         optionsOrConnectionString,
         globalEndpointManager,
+        async (diagnosticNode: DiagnosticNodeInternal, opts: RequestOptions) =>
+          this.getDatabaseAccountInternal(diagnosticNode, opts),
       );
     }
 
@@ -189,12 +193,17 @@ export class CosmosClient {
       this.backgroundRefreshEndpointList(
         globalEndpointManager,
         optionsOrConnectionString.connectionPolicy.endpointRefreshRateInMs ||
-          defaultConnectionPolicy.endpointRefreshRateInMs,
+        defaultConnectionPolicy.endpointRefreshRateInMs,
       );
     }
 
     this.databases = new Databases(this, this.clientContext, this.encryptionManager);
     this.offers = new Offers(this, this.clientContext);
+
+    this.dynamicallyEnablePPAFAndPPCBFlags(
+      this.globalPartitionEndpointManager,
+      60000, // 5 minutes
+    );
   }
 
   private initializeClientConfigDiagnostic(
@@ -336,6 +345,7 @@ export class CosmosClient {
     if (this.globalPartitionEndpointManager) {
       this.globalPartitionEndpointManager.dispose();
     }
+    clearTimeout(this.dynamicEnablementRefresher);
   }
 
   private async backgroundRefreshEndpointList(
@@ -367,5 +377,31 @@ export class CosmosClient {
    */
   public async updateHostFramework(hostFramework: string): Promise<void> {
     this.clientContext.refreshUserAgent(hostFramework);
+  }
+
+  /**
+   * Dynamically enable/disable the Per Partition Level Failover (PPAF) and Per Partition Level Circuit Breaker (PPCB) flags
+   * based on the value from database account.
+   * @param globalPartitionEndpointManager - Instance of GlobalPartitionEndpointManager
+   * @param refreshRate - Rate in milliseconds at which the client will refresh the PPAF and PPCB flags in the background
+   * @internal
+   */
+  private async dynamicallyEnablePPAFAndPPCBFlags(
+    globalPartitionEndpointManager: GlobalPartitionEndpointManager,
+    refreshRate: number,
+  ) {
+    const task = async () => {
+      try {
+        return withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
+          return globalPartitionEndpointManager.refreshPPAFAndPPCBFlags(diagnosticNode);
+        }, this.clientContext);
+      } catch (e: any) {
+        console.warn("Failed to dynamically enable or disable ppaf & ppcb flags", e);
+      }
+    };
+    // Running once immediately
+    await task();
+    // Scheduling it in the background
+    this.dynamicEnablementRefresher = startBackgroundTask(task, refreshRate);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -193,7 +193,7 @@ export class CosmosClient {
       this.backgroundRefreshEndpointList(
         globalEndpointManager,
         optionsOrConnectionString.connectionPolicy.endpointRefreshRateInMs ||
-          defaultConnectionPolicy.endpointRefreshRateInMs,
+        defaultConnectionPolicy.endpointRefreshRateInMs,
       );
     }
 
@@ -202,7 +202,7 @@ export class CosmosClient {
 
     this.dynamicallyEnablePPAFAndPPCBFlags(
       this.globalPartitionEndpointManager,
-      Constants.PPAFDynamicEnablementRefreshTimeMS,
+      Constants.DynamicEnablementRefreshTimeMS,
     );
   }
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -193,7 +193,7 @@ export class CosmosClient {
       this.backgroundRefreshEndpointList(
         globalEndpointManager,
         optionsOrConnectionString.connectionPolicy.endpointRefreshRateInMs ||
-        defaultConnectionPolicy.endpointRefreshRateInMs,
+          defaultConnectionPolicy.endpointRefreshRateInMs,
       );
     }
 

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -78,7 +78,7 @@ export class CosmosClient {
   public readonly offers: Offers;
   private clientContext: ClientContext;
   private endpointRefresher: NodeJS.Timeout;
-  private dynamicEnablementRefresher: NodeJS.Timeout;
+  private ppafDynamicEnablementRefresher: NodeJS.Timeout;
   /**
    * @internal
    */
@@ -202,7 +202,7 @@ export class CosmosClient {
 
     this.dynamicallyEnablePPAFAndPPCBFlags(
       this.globalPartitionEndpointManager,
-      60000, // 5 minutes
+      Constants.PPAFDynamicEnablementRefreshTimeMS,
     );
   }
 
@@ -345,7 +345,7 @@ export class CosmosClient {
     if (this.globalPartitionEndpointManager) {
       this.globalPartitionEndpointManager.dispose();
     }
-    clearTimeout(this.dynamicEnablementRefresher);
+    clearTimeout(this.ppafDynamicEnablementRefresher);
   }
 
   private async backgroundRefreshEndpointList(
@@ -402,6 +402,6 @@ export class CosmosClient {
     // Running once immediately
     await task();
     // Scheduling it in the background
-    this.dynamicEnablementRefresher = startBackgroundTask(task, refreshRate);
+    this.ppafDynamicEnablementRefresher = startBackgroundTask(task, refreshRate);
   }
 }

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -214,6 +214,7 @@ export const Constants = {
 
   // Background refresh time
   DefaultUnavailableLocationExpirationTimeMS: 5 * 60 * 1000,
+  PPAFDynamicEnablementRefreshTimeMS: 5* 60 * 1000,
 
   // Client generated retry count response header
   ThrottleRetryCount: "x-ms-throttle-retry-count",

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -210,6 +210,7 @@ export const Constants = {
 
   // ServiceDocument Resource
   ENABLE_MULTIPLE_WRITABLE_LOCATIONS: "enableMultipleWriteLocations",
+  ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR: "enablePerPartitionFailoverBehavior",
 
   // Background refresh time
   DefaultUnavailableLocationExpirationTimeMS: 5 * 60 * 1000,

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -214,7 +214,7 @@ export const Constants = {
 
   // Background refresh time
   DefaultUnavailableLocationExpirationTimeMS: 5 * 60 * 1000,
-  PPAFDynamicEnablementRefreshTimeMS: 5* 60 * 1000,
+  PPAFDynamicEnablementRefreshTimeMS: 5 * 60 * 1000,
 
   // Client generated retry count response header
   ThrottleRetryCount: "x-ms-throttle-retry-count",

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -400,26 +400,26 @@ export enum PermissionScopeValues {
 
   ScopeAccountReadAllAccessValue = 0xffff,
   ScopeDatabaseReadAllAccessValue = PermissionScopeValues.ScopeDatabaseReadValue |
-  PermissionScopeValues.ScopeDatabaseReadOfferValue |
-  PermissionScopeValues.ScopeDatabaseListContainerValue |
-  PermissionScopeValues.ScopeContainerReadValue |
-  PermissionScopeValues.ScopeContainerReadOfferValue,
+    PermissionScopeValues.ScopeDatabaseReadOfferValue |
+    PermissionScopeValues.ScopeDatabaseListContainerValue |
+    PermissionScopeValues.ScopeContainerReadValue |
+    PermissionScopeValues.ScopeContainerReadOfferValue,
 
   ScopeContainersReadAllAccessValue = PermissionScopeValues.ScopeContainerReadValue |
-  PermissionScopeValues.ScopeContainerReadOfferValue,
+    PermissionScopeValues.ScopeContainerReadOfferValue,
 
   ScopeAccountWriteAllAccessValue = 0xffff,
   ScopeDatabaseWriteAllAccessValue = PermissionScopeValues.ScopeDatabaseDeleteValue |
-  PermissionScopeValues.ScopeDatabaseReplaceOfferValue |
-  PermissionScopeValues.ScopeDatabaseCreateContainerValue |
-  PermissionScopeValues.ScopeDatabaseDeleteContainerValue |
-  PermissionScopeValues.ScopeContainerReplaceValue |
-  PermissionScopeValues.ScopeContainerDeleteValue |
-  PermissionScopeValues.ScopeContainerReplaceOfferValue,
+    PermissionScopeValues.ScopeDatabaseReplaceOfferValue |
+    PermissionScopeValues.ScopeDatabaseCreateContainerValue |
+    PermissionScopeValues.ScopeDatabaseDeleteContainerValue |
+    PermissionScopeValues.ScopeContainerReplaceValue |
+    PermissionScopeValues.ScopeContainerDeleteValue |
+    PermissionScopeValues.ScopeContainerReplaceOfferValue,
 
   ScopeContainersWriteAllAccessValue = PermissionScopeValues.ScopeContainerReplaceValue |
-  PermissionScopeValues.ScopeContainerDeleteValue |
-  PermissionScopeValues.ScopeContainerReplaceOfferValue,
+    PermissionScopeValues.ScopeContainerDeleteValue |
+    PermissionScopeValues.ScopeContainerReplaceOfferValue,
 
   /**
    * Values which set permission Scope applicable to data plane related operations.
@@ -463,15 +463,15 @@ export enum PermissionScopeValues {
 
   ScopeContainerReadAllAccessValue = 0xffffffff,
   ScopeItemReadAllAccessValue = PermissionScopeValues.ScopeContainerExecuteQueriesValue |
-  PermissionScopeValues.ScopeItemReadValue,
+    PermissionScopeValues.ScopeItemReadValue,
   ScopeContainerWriteAllAccessValue = 0xffffffff,
   ScopeItemWriteAllAccessValue = PermissionScopeValues.ScopeContainerCreateItemsValue |
-  PermissionScopeValues.ScopeContainerReplaceItemsValue |
-  PermissionScopeValues.ScopeContainerUpsertItemsValue |
-  PermissionScopeValues.ScopeContainerDeleteItemsValue |
-  PermissionScopeValues.ScopeItemReplaceValue |
-  PermissionScopeValues.ScopeItemUpsertValue |
-  PermissionScopeValues.ScopeItemDeleteValue,
+    PermissionScopeValues.ScopeContainerReplaceItemsValue |
+    PermissionScopeValues.ScopeContainerUpsertItemsValue |
+    PermissionScopeValues.ScopeContainerDeleteItemsValue |
+    PermissionScopeValues.ScopeItemReplaceValue |
+    PermissionScopeValues.ScopeItemUpsertValue |
+    PermissionScopeValues.ScopeItemDeleteValue,
 
   NoneValue = 0,
 }

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -214,7 +214,7 @@ export const Constants = {
 
   // Background refresh time
   DefaultUnavailableLocationExpirationTimeMS: 5 * 60 * 1000,
-  PPAFDynamicEnablementRefreshTimeMS: 5 * 60 * 1000,
+  DynamicEnablementRefreshTimeMS: 5 * 60 * 1000,
 
   // Client generated retry count response header
   ThrottleRetryCount: "x-ms-throttle-retry-count",
@@ -400,26 +400,26 @@ export enum PermissionScopeValues {
 
   ScopeAccountReadAllAccessValue = 0xffff,
   ScopeDatabaseReadAllAccessValue = PermissionScopeValues.ScopeDatabaseReadValue |
-    PermissionScopeValues.ScopeDatabaseReadOfferValue |
-    PermissionScopeValues.ScopeDatabaseListContainerValue |
-    PermissionScopeValues.ScopeContainerReadValue |
-    PermissionScopeValues.ScopeContainerReadOfferValue,
+  PermissionScopeValues.ScopeDatabaseReadOfferValue |
+  PermissionScopeValues.ScopeDatabaseListContainerValue |
+  PermissionScopeValues.ScopeContainerReadValue |
+  PermissionScopeValues.ScopeContainerReadOfferValue,
 
   ScopeContainersReadAllAccessValue = PermissionScopeValues.ScopeContainerReadValue |
-    PermissionScopeValues.ScopeContainerReadOfferValue,
+  PermissionScopeValues.ScopeContainerReadOfferValue,
 
   ScopeAccountWriteAllAccessValue = 0xffff,
   ScopeDatabaseWriteAllAccessValue = PermissionScopeValues.ScopeDatabaseDeleteValue |
-    PermissionScopeValues.ScopeDatabaseReplaceOfferValue |
-    PermissionScopeValues.ScopeDatabaseCreateContainerValue |
-    PermissionScopeValues.ScopeDatabaseDeleteContainerValue |
-    PermissionScopeValues.ScopeContainerReplaceValue |
-    PermissionScopeValues.ScopeContainerDeleteValue |
-    PermissionScopeValues.ScopeContainerReplaceOfferValue,
+  PermissionScopeValues.ScopeDatabaseReplaceOfferValue |
+  PermissionScopeValues.ScopeDatabaseCreateContainerValue |
+  PermissionScopeValues.ScopeDatabaseDeleteContainerValue |
+  PermissionScopeValues.ScopeContainerReplaceValue |
+  PermissionScopeValues.ScopeContainerDeleteValue |
+  PermissionScopeValues.ScopeContainerReplaceOfferValue,
 
   ScopeContainersWriteAllAccessValue = PermissionScopeValues.ScopeContainerReplaceValue |
-    PermissionScopeValues.ScopeContainerDeleteValue |
-    PermissionScopeValues.ScopeContainerReplaceOfferValue,
+  PermissionScopeValues.ScopeContainerDeleteValue |
+  PermissionScopeValues.ScopeContainerReplaceOfferValue,
 
   /**
    * Values which set permission Scope applicable to data plane related operations.
@@ -463,15 +463,15 @@ export enum PermissionScopeValues {
 
   ScopeContainerReadAllAccessValue = 0xffffffff,
   ScopeItemReadAllAccessValue = PermissionScopeValues.ScopeContainerExecuteQueriesValue |
-    PermissionScopeValues.ScopeItemReadValue,
+  PermissionScopeValues.ScopeItemReadValue,
   ScopeContainerWriteAllAccessValue = 0xffffffff,
   ScopeItemWriteAllAccessValue = PermissionScopeValues.ScopeContainerCreateItemsValue |
-    PermissionScopeValues.ScopeContainerReplaceItemsValue |
-    PermissionScopeValues.ScopeContainerUpsertItemsValue |
-    PermissionScopeValues.ScopeContainerDeleteItemsValue |
-    PermissionScopeValues.ScopeItemReplaceValue |
-    PermissionScopeValues.ScopeItemUpsertValue |
-    PermissionScopeValues.ScopeItemDeleteValue,
+  PermissionScopeValues.ScopeContainerReplaceItemsValue |
+  PermissionScopeValues.ScopeContainerUpsertItemsValue |
+  PermissionScopeValues.ScopeContainerDeleteItemsValue |
+  PermissionScopeValues.ScopeItemReplaceValue |
+  PermissionScopeValues.ScopeItemUpsertValue |
+  PermissionScopeValues.ScopeItemDeleteValue,
 
   NoneValue = 0,
 }

--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionPolicy.ts
@@ -54,6 +54,6 @@ export const defaultConnectionPolicy: ConnectionPolicy = Object.freeze({
   useMultipleWriteLocations: true,
   endpointRefreshRateInMs: 300000,
   enableBackgroundEndpointRefreshing: true,
-  enablePartitionLevelFailover: false,
-  enablePartitionLevelCircuitBreaker: false,
+  enablePartitionLevelFailover: true,
+  enablePartitionLevelCircuitBreaker: true,
 });

--- a/sdk/cosmosdb/cosmos/src/documents/DatabaseAccount.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/DatabaseAccount.ts
@@ -67,6 +67,7 @@ export class DatabaseAccount {
   /** Gets the UserConsistencyPolicy settings. */
   public readonly consistencyPolicy: ConsistencyLevel;
   public readonly enableMultipleWritableLocations: boolean;
+  public readonly enablePerPartitionFailoverBehavior: boolean = false;
 
   // TODO: body - any
   public constructor(body: { [key: string]: any }, headers: CosmosHeaders) {
@@ -89,6 +90,11 @@ export class DatabaseAccount {
         body[Constants.ENABLE_MULTIPLE_WRITABLE_LOCATIONS] === "true";
     } else {
       this.enableMultipleWritableLocations = false;
+    }
+    if (body[Constants.ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR]) {
+      this.enablePerPartitionFailoverBehavior =
+        body[Constants.ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR] === true ||
+        body[Constants.ENABLE_PER_PARTITION_FAILOVER_BEHAVIOR] === "true";
     }
   }
 }

--- a/sdk/cosmosdb/cosmos/src/globalPartitionEndpointManager.ts
+++ b/sdk/cosmosdb/cosmos/src/globalPartitionEndpointManager.ts
@@ -178,9 +178,7 @@ export class GlobalPartitionEndpointManager {
         if (enablePerPartitionFailoverBehavior === false) {
           this.enablePartitionLevelFailover = enablePerPartitionFailoverBehavior;
           this.enablePartitionLevelCircuitBreaker = enablePerPartitionFailoverBehavior;
-          if (this.enablePartitionLevelCircuitBreaker === false) {
-            this.dispose();
-          }
+          this.dispose();
         }
       }
       this.isRefreshing = false;

--- a/sdk/cosmosdb/cosmos/test/public/functional/excludedLocationsRequestPPAF.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/excludedLocationsRequestPPAF.spec.ts
@@ -44,6 +44,7 @@ const databaseAccountResponse = {
       },
     ],
     enableMultipleWriteLocations: true,
+    enablePerPartitionFailoverBehavior: true,
     userReplicationPolicy: {
       asyncReplication: false,
       minReplicaSetSize: 3,
@@ -180,6 +181,7 @@ describe("Excluded Regions with Per Partition Automatic Failover(PPAF)", { timeo
     let lastEndpointCalled = "";
 
     const responses = [
+      databaseAccountResponse,
       databaseAccountResponse,
       collectionResponse,
       readPartitionKeyRangesResponse,

--- a/sdk/cosmosdb/cosmos/test/public/functional/excludedLocationsRequestPPCB.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/excludedLocationsRequestPPCB.spec.ts
@@ -52,6 +52,7 @@ const databaseAccountResponse = {
       },
     ],
     enableMultipleWriteLocations: true,
+    enablePerPartitionFailoverBehavior: true,
     userReplicationPolicy: {
       asyncReplication: false,
       minReplicaSetSize: 3,
@@ -180,6 +181,7 @@ describe("Excluded Regions with PPCB", { timeout: 30000 }, () => {
     let lastEndpointCalled = "";
 
     const responses = [
+      databaseAccountResponse,
       databaseAccountResponse,
       collectionResponse,
       readPartitionKeyRangesResponse,

--- a/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
@@ -148,7 +148,7 @@ describe("Plugin", () => {
 
     const client = new CosmosClient({ ...options, plugins } as any);
     const response = await client.database("foo").read();
-    assert.equal(requestCount, 3); // Get Database Account twice+ Get Database
+    assert.equal(requestCount, 3); // Get Database Account twice + Get Database
     assert.equal(responseCount, 3); // Get Database Account twice + Get Database
     assert.equal(innerRequestCount, 3); // Get Database Account twice + Get Database
     assert.notEqual(response, undefined);

--- a/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/plugin.spec.ts
@@ -49,7 +49,7 @@ describe("Plugin", () => {
 
     const client = new CosmosClient({ ...options, plugins } as any);
     const response = await client.database("foo").read();
-    assert.equal(requestCount, FAILCOUNT + 1); // Get Database Account + FAILED GET Database + Get Database
+    assert.equal(requestCount, FAILCOUNT + 2); // Get Database Account twice + FAILED GET Database + Get Database
     assert.notEqual(response, undefined);
     assert.equal(response.statusCode, successResponse.code);
     assert.deepEqual(
@@ -95,7 +95,7 @@ describe("Plugin", () => {
 
     const client = new CosmosClient({ ...options, plugins } as any);
     const response = await client.database("foo").read();
-    assert.equal(requestCount, 2); // Get Database Account + Get Database
+    assert.equal(requestCount, 3); // Get Database Account twice + Get Database
     assert.notEqual(response, undefined);
     assert.equal(response.statusCode, successResponse.code);
     assert.deepEqual(
@@ -148,9 +148,9 @@ describe("Plugin", () => {
 
     const client = new CosmosClient({ ...options, plugins } as any);
     const response = await client.database("foo").read();
-    assert.equal(requestCount, 2); // Get Database Account + Get Database
-    assert.equal(responseCount, 2); // Get Database Account + Get Database
-    assert.equal(innerRequestCount, 2); // Get Database Account + Get Database
+    assert.equal(requestCount, 3); // Get Database Account twice+ Get Database
+    assert.equal(responseCount, 3); // Get Database Account twice + Get Database
+    assert.equal(innerRequestCount, 3); // Get Database Account twice + Get Database
     assert.notEqual(response, undefined);
     assert.equal(response.statusCode, successResponse.code);
     assert.deepEqual(

--- a/sdk/cosmosdb/cosmos/test/public/integration/client.retry.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/client.retry.spec.ts
@@ -116,6 +116,7 @@ describe("RetryPolicy", () => {
       const lastEndpointCalled: string[] = [];
       const responses = [
         databaseAccountResponse,
+        databaseAccountResponse,
         collectionResponse,
         { code: 503, result: {}, headers: {}, diagnostics: getEmptyCosmosDiagnostics() },
         { code: 200, result: {}, headers: {}, diagnostics: getEmptyCosmosDiagnostics() },
@@ -143,6 +144,7 @@ describe("RetryPolicy", () => {
       const lastEndpointCalled: string[] = [];
       const responses = [
         databaseAccountResponse,
+        databaseAccountResponse,
         collectionResponse,
         { code: 503, result: {}, headers: {}, diagnostics: getEmptyCosmosDiagnostics() },
         { code: 503, result: {}, headers: {}, diagnostics: getEmptyCosmosDiagnostics() },
@@ -163,6 +165,7 @@ describe("RetryPolicy", () => {
 
     it("when both regions Timeout with retrial window", async () => {
       const responses = [
+        databaseAccountResponse,
         databaseAccountResponse,
         collectionResponse,
         {
@@ -232,6 +235,7 @@ describe("RetryPolicy", () => {
     it("timeout error thrown when retry count exceeds 120", async () => {
       const lastEndpointCalled: string[] = [];
       const responses = [
+        databaseAccountResponse,
         databaseAccountResponse,
         collectionResponse,
         {

--- a/sdk/cosmosdb/cosmos/test/public/integration/failover.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/failover.spec.ts
@@ -45,6 +45,7 @@ const databaseAccountResponse = () => ({
       },
     ],
     enableMultipleWriteLocations: true,
+    enablePerPartitionFailoverBehavior: false,
     userReplicationPolicy: {
       asyncReplication: false,
       minReplicaSetSize: 3,
@@ -139,6 +140,46 @@ const WriteForbiddenResponse = {
   headers: {},
 };
 
+const readPartitionKeyRangesResponse = {
+  code: 200,
+  result: {
+    PartitionKeyRanges: [
+      {
+        _rid: "JAY0AJIzFhACAAAAAAAAUA==",
+        id: "0",
+        _etag: '"0100f742-0000-4d00-0000-680875d90000"',
+        minInclusive: "",
+        maxExclusive: "05C1DFFFFFFFFC",
+        ridPrefix: 0,
+        _self: "dbs/JAY0AA==/colls/JAY0AJIzFhA=/pkranges/JAY0AJIzFhACAAAAAAAAUA==/",
+        throughputFraction: 0.5,
+        status: "online",
+        parents: [] as unknown[],
+        ownedArchivalPKRangeIds: [] as unknown[],
+        _ts: 1745384921,
+        lsn: 5330,
+      },
+      {
+        _rid: "JAY0AJIzFhADAAAAAAAAUA==",
+        id: "1",
+        _etag: '"0100f842-0000-4d00-0000-680875d90000"',
+        minInclusive: "05C1DFFFFFFFFC",
+        maxExclusive: "FF",
+        ridPrefix: 1,
+        _self: "dbs/JAY0AA==/colls/JAY0AJIzFhA=/pkranges/JAY0AJIzFhADAAAAAAAAUA==/",
+        throughputFraction: 0.5,
+        status: "online",
+        parents: [] as unknown[],
+        ownedArchivalPKRangeIds: [] as unknown[],
+        _ts: 1745384921,
+        lsn: 5330,
+      },
+    ],
+  },
+  headers: {},
+  diagnostics: getEmptyCosmosDiagnostics(),
+};
+
 describe("Region Failover", () => {
   let responses: any[];
 
@@ -147,13 +188,16 @@ describe("Region Failover", () => {
     let lastEndpointCalled = "";
     responses = [
       databaseAccountResponse(),
+      databaseAccountResponse(),
       collectionResponse,
       readResponse,
       WriteForbiddenResponse,
       databaseAccountResponse(),
       readResponse,
     ];
-    const options: CosmosClientOptions = { endpoint, key: masterKey };
+    const options: CosmosClientOptions = { endpoint, key: masterKey,
+      connectionPolicy: { enablePartitionLevelFailover: false, enablePartitionLevelCircuitBreaker: false }
+     };
     const plugins: PluginConfig[] = [
       {
         on: PluginOn.request,
@@ -189,13 +233,17 @@ describe("Region Failover", () => {
     let lastEndpointCalled = "";
     responses = [
       databaseAccountResponse(),
+      databaseAccountResponse(),
       collectionResponse,
       readResponse,
       DatabaseAccountNotFoundResponse,
       databaseAccountResponse(),
       readResponse,
     ];
-    const options: CosmosClientOptions = { endpoint, key: masterKey };
+    const options: CosmosClientOptions = {
+      endpoint, key: masterKey,
+      connectionPolicy: { enablePartitionLevelFailover: false, enablePartitionLevelCircuitBreaker: false }
+    };
     const plugins: PluginConfig[] = [
       {
         on: PluginOn.request,
@@ -231,6 +279,7 @@ describe("Region Failover", () => {
     let lastEndpointCalled = "";
     responses = [
       databaseAccountResponse(),
+      databaseAccountResponse(),
       collectionResponse,
       readResponse,
       DatabaseAccountNotFoundResponse,
@@ -239,7 +288,10 @@ describe("Region Failover", () => {
       databaseAccountResponse(),
       readResponse,
     ];
-    const options: CosmosClientOptions = { endpoint, key: masterKey };
+    const options: CosmosClientOptions = {
+      endpoint, key: masterKey,
+      connectionPolicy: { enablePartitionLevelFailover: false, enablePartitionLevelCircuitBreaker: false }
+    };
     const plugins: PluginConfig[] = [
       {
         on: PluginOn.request,

--- a/sdk/cosmosdb/cosmos/test/public/integration/failover.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/failover.spec.ts
@@ -195,9 +195,14 @@ describe("Region Failover", () => {
       databaseAccountResponse(),
       readResponse,
     ];
-    const options: CosmosClientOptions = { endpoint, key: masterKey,
-      connectionPolicy: { enablePartitionLevelFailover: false, enablePartitionLevelCircuitBreaker: false }
-     };
+    const options: CosmosClientOptions = {
+      endpoint,
+      key: masterKey,
+      connectionPolicy: {
+        enablePartitionLevelFailover: false,
+        enablePartitionLevelCircuitBreaker: false,
+      },
+    };
     const plugins: PluginConfig[] = [
       {
         on: PluginOn.request,
@@ -241,8 +246,12 @@ describe("Region Failover", () => {
       readResponse,
     ];
     const options: CosmosClientOptions = {
-      endpoint, key: masterKey,
-      connectionPolicy: { enablePartitionLevelFailover: false, enablePartitionLevelCircuitBreaker: false }
+      endpoint,
+      key: masterKey,
+      connectionPolicy: {
+        enablePartitionLevelFailover: false,
+        enablePartitionLevelCircuitBreaker: false,
+      },
     };
     const plugins: PluginConfig[] = [
       {
@@ -289,8 +298,12 @@ describe("Region Failover", () => {
       readResponse,
     ];
     const options: CosmosClientOptions = {
-      endpoint, key: masterKey,
-      connectionPolicy: { enablePartitionLevelFailover: false, enablePartitionLevelCircuitBreaker: false }
+      endpoint,
+      key: masterKey,
+      connectionPolicy: {
+        enablePartitionLevelFailover: false,
+        enablePartitionLevelCircuitBreaker: false,
+      },
     };
     const plugins: PluginConfig[] = [
       {

--- a/sdk/cosmosdb/cosmos/test/public/integration/multiregion.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/multiregion.spec.ts
@@ -111,13 +111,55 @@ const collectionResponse = {
   diagnostics: getEmptyCosmosDiagnostics(),
 };
 
+const readPartitionKeyRangesResponse = {
+  code: 200,
+  result: {
+    PartitionKeyRanges: [
+      {
+        _rid: "JAY0AJIzFhACAAAAAAAAUA==",
+        id: "0",
+        _etag: '"0100f742-0000-4d00-0000-680875d90000"',
+        minInclusive: "",
+        maxExclusive: "05C1DFFFFFFFFC",
+        ridPrefix: 0,
+        _self: "dbs/JAY0AA==/colls/JAY0AJIzFhA=/pkranges/JAY0AJIzFhACAAAAAAAAUA==/",
+        throughputFraction: 0.5,
+        status: "online",
+        parents: [] as unknown[],
+        ownedArchivalPKRangeIds: [] as unknown[],
+        _ts: 1745384921,
+        lsn: 5330,
+      },
+      {
+        _rid: "JAY0AJIzFhADAAAAAAAAUA==",
+        id: "1",
+        _etag: '"0100f842-0000-4d00-0000-680875d90000"',
+        minInclusive: "05C1DFFFFFFFFC",
+        maxExclusive: "FF",
+        ridPrefix: 1,
+        _self: "dbs/JAY0AA==/colls/JAY0AJIzFhA=/pkranges/JAY0AJIzFhADAAAAAAAAUA==/",
+        throughputFraction: 0.5,
+        status: "online",
+        parents: [] as unknown[],
+        ownedArchivalPKRangeIds: [] as unknown[],
+        _ts: 1745384921,
+        lsn: 5330,
+      },
+    ],
+  },
+  headers: {},
+  diagnostics: getEmptyCosmosDiagnostics(),
+};
+
 describe("Multi-region tests", { timeout: 30000 }, () => {
   it("Preferred locations should be honored for readEndpoint", async () => {
     let requestIndex = 0;
     let lastEndpointCalled = "";
     const responses = [
       databaseAccountResponse,
+      databaseAccountResponse,
       collectionResponse,
+      readPartitionKeyRangesResponse,
       { code: 200, result: {}, headers: {}, diagnostics: getEmptyCosmosDiagnostics() },
     ];
     const options: CosmosClientOptions = {
@@ -160,6 +202,7 @@ describe("Multi-region tests", { timeout: 30000 }, () => {
     let requestIndex = 0;
     let lastEndpointCalled = "";
     const responses = [
+      databaseAccountResponse,
       databaseAccountResponse,
       collectionResponse,
       {

--- a/sdk/cosmosdb/cosmos/test/public/integration/ppaf.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/ppaf.spec.ts
@@ -44,6 +44,7 @@ const databaseAccountResponse = {
       },
     ],
     enableMultipleWriteLocations: true,
+    enablePerPartitionFailoverBehavior: true,
     userReplicationPolicy: {
       asyncReplication: false,
       minReplicaSetSize: 3,

--- a/sdk/cosmosdb/cosmos/test/public/integration/ppaf.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/ppaf.spec.ts
@@ -182,6 +182,7 @@ describe("Per Partition Automatic Failover", { timeout: 30000 }, () => {
 
     const responses = [
       databaseAccountResponse,
+      databaseAccountResponse,
       collectionResponse,
       readPartitionKeyRangesResponse,
       SuccessResponse,

--- a/sdk/cosmosdb/cosmos/test/public/integration/ppcb.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/ppcb.spec.ts
@@ -52,6 +52,7 @@ const databaseAccountResponse = {
       },
     ],
     enableMultipleWriteLocations: true,
+    enablePerPartitionFailoverBehavior: true,
     userReplicationPolicy: {
       asyncReplication: false,
       minReplicaSetSize: 3,

--- a/sdk/cosmosdb/cosmos/test/public/integration/ppcb.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/ppcb.spec.ts
@@ -182,6 +182,7 @@ describe("Per Partition Circuit Breaker", { timeout: 30000 }, () => {
 
     const responses = [
       databaseAccountResponse,
+      databaseAccountResponse,
       collectionResponse,
       readPartitionKeyRangesResponse,
       ...Array.from({ length: 11 }).flatMap(() => [ServiceUnavailableResponse, SuccessResponse]),


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR


### Describe the problem that is addressed by this PR

This PR implements override functionality for the enablePartitionLevelFailover flag from getDatabaseAccount calls. The changes enable dynamic control of Per Partition Automatic Failover (PPAF) and Per Partition Circuit Breaker (PPCB) features based on database account settings.

1. Adds enablePerPartitionFailoverBehavior property to DatabaseAccount class
2. Implements background refresh mechanism to dynamically enable/disable PPAF and PPCB flags
3. Updates test files to account for additional database account calls

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
