### PR TITLE
[App Configuration] - Make list label test deterministic

### DIFF
--- a/sdk/appconfiguration/app-configuration/assets.json
+++ b/sdk/appconfiguration/app-configuration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/appconfiguration/app-configuration",
-  "Tag": "js/appconfiguration/app-configuration_d666a5f99b"
+  "Tag": "js/appconfiguration/app-configuration_bdaf29d71a"
 }

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -608,7 +608,12 @@ describe("AppConfigurationClient", () => {
     });
 
     it("basic list labels", async () => {
-      const labelsIterator = client.listLabels();
+      // Use nameFilter to make the test deterministic in live mode.
+      // Without this, parallel CI jobs (or other tests) that introduce an unlabeled setting
+      // can cause an additional { name: null } label to appear between successive enumerations
+      // in `toSortedLabelsArray`, leading to a mismatch. Filtering ensures we only retrieve
+      // the label created for this test.
+      const labelsIterator = client.listLabels({ nameFilter: uniqueLabel });
       const byLabelSettings = await toSortedLabelsArray(labelsIterator);
       assert.deepEqual(
         [
@@ -648,7 +653,10 @@ describe("AppConfigurationClient", () => {
     });
 
     it("Using `select` via `fields`", async () => {
+      // Add nameFilter to eliminate interference from concurrently added labels (null or others)
+      // in live CI runs. This keeps the test focused on field selection behavior.
       const labelsIterator = client.listLabels({
+        nameFilter: uniqueLabel,
         fields: ["name"],
       });
 


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/app-configuration`

### Issues associated with this PR

#35887

### Describe the problem that is addressed by this PR
parallel CI jobs (or other tests) that introduce an unlabeled setting can cause an additional { name: null } label to appear between successive enumerations in `toSortedLabelsArray`, leading to a mismatch.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_

Yes.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
