### PR TITLE
[EngSys] bump required pnpm version to latest 10.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "rimraf": "^6.0.1",
     "turbo": "^2.5.6"
   },
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.17.0",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=10.12.1"
+    "pnpm": ">=10.17.0"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,7 +866,7 @@ importers:
         version: link:../../core/abort-controller
       '@azure/ai-agents':
         specifier: 1.1.0
-        version: link:../ai-agents
+        version: 1.1.0
       '@azure/core-auth':
         specifier: ^1.6.0
         version: link:../../core/core-auth
@@ -28365,6 +28365,10 @@ packages:
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
 
+  '@azure/ai-agents@1.1.0':
+    resolution: {integrity: sha512-i8HFA7ql18t/otGrRfTWNOE5HgJf/RqedV3VNbFav5z9iTSexf8k4EeWOb/IWWaCsq0z/S7mihdGPAluPs+nXQ==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/app-configuration-provider@2.2.0':
     resolution: {integrity: sha512-bcLtlREDWS+3CrW6ZnwGxAU9M8wV7nkO+00TU1ceOOxGsV2fVQopwhd1SF5XnS6gz0ukPaUi2t9VzrF3KLl18g==}
 
@@ -28443,6 +28447,10 @@ packages:
   '@azure/core-lro@2.7.2':
     resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
     engines: {node: '>=18.0.0'}
+
+  '@azure/core-lro@3.3.1':
+    resolution: {integrity: sha512-bulm3klLqIAhzI3iQMYQ42i+V9EnevScsHdI9amFfjaw6OJqPBK1038cq5qachoKV3yt/iQQEDittHmZW2aSuA==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/core-paging@1.6.2':
     resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
@@ -33478,6 +33486,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@azure/ai-agents@1.1.0':
+    dependencies:
+      '@azure-rest/core-client': 2.5.1
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-lro': 3.3.1
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.22.1
+      '@azure/core-sse': 2.3.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/app-configuration-provider@2.2.0':
     dependencies:
       '@azure/app-configuration': 1.8.0
@@ -33716,6 +33740,15 @@ snapshots:
       - supports-color
 
   '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-lro@3.3.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-util': 1.13.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 linkWorkspacePackages: true
+minimumReleaseAge: 1440
 
 packages:
   - 'sdk/**'


### PR DESCRIPTION
this allows us to use the `minimumReleaseAge` feature introduced in v10.16 to
reduce supply-chain attack risk.

The delay is set to one day. Only packages released at least one day ago can be
installed.