### PR TITLE
fix(playwright-service): override `{platform}` arg in `config.snapshotPathTemplate`

### DIFF
--- a/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
+++ b/sdk/playwrighttesting/microsoft-playwright-testing/src/core/playwrightService.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { InternalEnvironmentVariables, ServiceAuth } from "../common/constants.js";
+import { InternalEnvironmentVariables, ServiceAuth, ServiceOS } from "../common/constants.js";
 import customerConfig from "../common/customerConfig.js";
 import { PlaywrightServiceConfig } from "../common/playwrightServiceConfig.js";
 import playwrightServiceEntra from "./playwrightServiceEntra.js";
-import type { PlaywrightServiceAdditionalOptions, BrowserConnectOptions } from "../common/types.js";
+import type {
+  PlaywrightServiceAdditionalOptions,
+  BrowserConnectOptions,
+  OsType,
+} from "../common/types.js";
 import {
   emitReportingUrl,
   fetchOrValidateAccessToken,
@@ -21,7 +25,10 @@ import {
   getVersionInfo,
 } from "../utils/utils.js";
 import { ServiceErrorMessageConstants } from "../common/messages.js";
-import type { PlaywrightTestConfig } from "@playwright/test";
+import type {
+  PlaywrightTestConfig,
+  Project as PlaywrightTestConfigProject,
+} from "@playwright/test";
 import { globalSetupPath, globalTeardownPath } from "./playwrightServiceUtils.js";
 
 const performOneTimeOperation = (options?: PlaywrightServiceAdditionalOptions): void => {
@@ -33,6 +40,61 @@ const performOneTimeOperation = (options?: PlaywrightServiceAdditionalOptions): 
     warnIfAccessTokenCloseToExpiry();
   }
 };
+
+/**
+ * @override replace the `{platform}` token used by {@link PlaywrightTestConfig.snapshotPathTemplate}.
+ * Playwright resolves it to the value of the host's {@link process.platform} which is wrong in this context.
+ * Replace it with the value corresponding to {@link PlaywrightServiceAdditionalOptions.os}.
+ */
+const replaceSnapshotPathTemplates = (
+  baseConfig: PlaywrightTestConfig,
+  playwrightServiceConfig: PlaywrightServiceConfig,
+) => {
+  const platformTokenRegex = /\{(.?)platform\}/g;
+  const PLATFORM: Record<OsType, NodeJS.Platform> = {
+    [ServiceOS.WINDOWS]: "win32",
+    [ServiceOS.LINUX]: "linux",
+  };
+  const platform = PLATFORM[playwrightServiceConfig.serviceOs];
+  const replacePlatformToken = (pathTemplate: string) =>
+    pathTemplate.replace(platformTokenRegex, `$1${platform}`);
+
+  const replaceTemplates = (config: PlaywrightTestConfig | PlaywrightTestConfigProject) => {
+    const overrides: Pick<PlaywrightTestConfig, "snapshotPathTemplate" | "expect"> = {};
+    if (config.snapshotPathTemplate) {
+      overrides.snapshotPathTemplate = replacePlatformToken(config.snapshotPathTemplate);
+    }
+    if (config.expect) {
+      overrides.expect = Object.fromEntries(
+        Object.entries(config.expect).map(([key, value]) => [
+          key,
+          typeof value === "object" && "pathTemplate" in value && !!value.pathTemplate
+            ? {
+                ...value,
+                pathTemplate: replacePlatformToken(value.pathTemplate),
+              }
+            : value,
+        ]),
+      );
+    }
+    return overrides;
+  };
+
+  const overrides: Pick<PlaywrightTestConfig, "snapshotPathTemplate" | "projects" | "expect"> = {
+    ...replaceTemplates(baseConfig),
+    ...(baseConfig.projects
+      ? {
+          projects: baseConfig.projects.map((project) => ({
+            ...project,
+            ...replaceTemplates(project),
+          })),
+        }
+      : {}),
+  };
+
+  return overrides;
+};
+
 /**
  * @public
  *
@@ -173,6 +235,7 @@ const getServiceConfig = (
       },
     },
     ...globalFunctions,
+    ...replaceSnapshotPathTemplates(config, playwrightServiceConfig),
   };
 };
 


### PR DESCRIPTION

### Packages impacted by this PR

`sdk/playwrighttesting/microsoft-playwright-testing`
`sdk/loadtesting/playwright`



### Issues associated with this PR

https://github.com/microsoft/playwright/issues/33098 can suppress this PR entirely or simplify and future proof it.

### Describe the problem that is addressed by this PR

Using [`snapshotPathTemplate`](https://playwright.dev/docs/api/class-testconfig#test-config-snapshot-path-template) is prone to a gotcha when using with playwright service.
`snapshotPathTemplate` exposes a `platform` token that is resolved to `process.platform` in runtime.
In the context of snapshots the platform token is meant to be the browser's platform.
When using the remote browsers service, this will wrongly resolve to the host's platform and **prodcue snapshots that do NOT match the expected platform, causing false positive failing tests**.

This fix supports the use of the platform token seamlessly in both running contexts, local and remote.

Using 


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The mentioned [issue](https://github.com/microsoft/playwright/issues/33098) and [PR](https://github.com/microsoft/playwright/pull/34127) are a better solution IMO. Exposing a function the allows runtime path resolution will be a better and more robust solution than overriding each usage of the template in a config that might change in the future.
If something like that is exposed by playwright it will be straightforward to override it.

I have chosen this approach because the PR in playwright was closed. It was considered a feature request and was unfortunately dismissed, but here it is a bug fix.




### Are there test cases added in this PR? _(If not, why?)_

Yes, 100% coverage

### Provide a list of related PRs _(if any)_

https://github.com/microsoft/playwright/pull/34127


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
