### PR TITLE
[App Configuration] - Fix the racing problem when deleting a lock in the testcases

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -89,9 +89,8 @@ export async function deleteEverySetting(): Promise<void> {
     } catch (error) {
       if (isRestError(error) && error.statusCode === 404) {
         continue;
-      } else {
-        throw error;
       }
+      throw error;
     }
     await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }

--- a/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/utils/testHelpers.ts
@@ -17,7 +17,7 @@ import type {
 import type { RecorderStartOptions, VitestTestContext } from "@azure-tools/test-recorder";
 import { Recorder, isPlaybackMode, assertEnvironmentVariable } from "@azure-tools/test-recorder";
 import type { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
-import type { RestError } from "@azure/core-rest-pipeline";
+import { isRestError, type RestError } from "@azure/core-rest-pipeline";
 import type { TokenCredential } from "@azure/identity";
 import { createTestCredential } from "@azure-tools/test-credential";
 import { assert } from "vitest";
@@ -78,7 +78,21 @@ export async function deleteEverySetting(): Promise<void> {
   const settingsList = client.listConfigurationSettings({});
 
   for await (const setting of settingsList) {
-    await client.setReadOnly({ key: setting.key, label: setting.label }, false);
+    // Other parallel tests may delete a setting after it was listed, creating a racing problem in the live mode.
+    // Service behaviors:
+    //   - Deleting an unexisted setting returns 204.
+    //   - Attempting to remove the read-only (lock) on a unexisted setting returns 404.
+    // Ignore the 404 from setReadOnly.
+    // Reference: https://learn.microsoft.com/azure/azure-app-configuration/rest-api-locks#unlock-key-value
+    try {
+      await client.setReadOnly({ key: setting.key, label: setting.label }, false);
+    } catch (error) {
+      if (isRestError(error) && error.statusCode === 404) {
+        continue;
+      } else {
+        throw error;
+      }
+    }
     await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }


### PR DESCRIPTION
### Packages impacted by this PR

### Issues associated with this PR

#35887


### Describe the problem that is addressed by this PR

In the testsuite, we have `deleteEverySetting` function, it will list all configuration settings and delete each setting.

However, the ADO CI pipeline may [occasionally fail](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5375880&view=logs&j=93ae3283-646d-56f5-516e-76f2b1ad7aff&t=79cb0933-95ff-5f35-aa3e-6c46498861b6&s=e1cfda09-5da2-5701-1d18-8913ba179eab). The root cause is that：
Other parallel tests may delete a setting after it was listed, creating a racing problem.
Before deleting a setting, we will first call `client.setReadOnly({ key: setting.key, label: setting.label }, false);` which will delete the lock for the configuration settings which will return 404 if the configuration setting is not existed. (Deleting an unexisted setting will return 204). We should ignore the 404 from `setReadOnly`.


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
