### PR TITLE
[EngSys] add a `azurelkg` catalog to pnpm workspace

### DIFF
--- a/eng/tools/pnpm-utils/README.md
+++ b/eng/tools/pnpm-utils/README.md
@@ -1,0 +1,124 @@
+# PNPM Utilities
+
+This directory contains utility scripts for managing the PNPM workspace configuration.
+
+## Scripts
+
+### update-azurelkg.js
+
+A Node.js script that automatically updates the `azurelkg` catalog in `pnpm-workspace.yaml` with the latest stable versions of Azure SDK core and identity packages from npm.
+
+#### Purpose
+
+The `azurelkg` catalog provides a centralized way to manage versions of Azure SDK core packages (`@azure/core-*`, `@azure/identity*`, etc.) across the entire monorepo. This ensures:
+
+- **Version consistency** across all packages that depend on Azure SDK core libraries
+- **Easier maintenance** - update versions in one place rather than in hundreds of package.json files
+- **Automatic updates** - packages using `catalog:azurelkg` automatically get the latest approved versions
+
+#### Usage
+
+```bash
+# Run from the repository root
+node eng/tools/pnpm-utils/update-azurelkg.js
+```
+
+followed by `pnpm install` if there are changes to `pnpm-workspace.yaml`.
+
+#### What it does
+
+1. **Reads the existing `azurelkg` catalog** from `pnpm-workspace.yaml`
+2. **Fetches latest stable versions** from npm for each package in the catalog
+3. **Updates the catalog** with the new versions using caret ranges (e.g., `^1.10.1`)
+4. **Preserves the package list** - only updates versions, doesn't add/remove packages
+
+#### Example Output
+
+```
+Getting Azure SDK Core and Identity packages from azurelkg catalog...
+Reading azurelkg catalog from pnpm-workspace.yaml...
+Found 19 packages in azurelkg catalog
+
+# Azure SDK Core and Identity packages with latest stable versions
+azurelkg:
+  Checking @azure/core-auth...
+    found 1.10.1
+  '@azure/core-auth': 1.10.1
+  ...
+
+Updating pnpm-workspace.yaml...
+Updated pnpm-workspace.yaml with latest versions
+
+Processed 19 packages successfully!
+```
+
+#### Packages Managed
+
+The script manages versions for these Azure SDK packages:
+
+**Core packages:**
+
+- `@azure/abort-controller`
+- `@azure/core-amqp`
+- `@azure/core-auth`
+- `@azure/core-client`
+- `@azure-rest/core-client`
+- `@azure/core-http-compat`
+- `@azure/core-lro`
+- `@azure/core-paging`
+- `@azure/core-rest-pipeline`
+- `@azure/core-sse`
+- `@azure/core-tracing`
+- `@azure/core-util`
+- `@azure/core-xml`
+- `@azure/logger`
+- `@typespec/ts-http-runtime`
+
+**Identity packages:**
+
+- `@azure/identity`
+- `@azure/identity-broker`
+- `@azure/identity-cache-persistence`
+- `@azure/identity-vscode`
+
+#### Using the azurelkg catalog
+
+In package.json files, reference the catalog like this:
+
+```json
+{
+  "dependencies": {
+    "@azure/core-auth": "catalog:azurelkg",
+    "@azure/core-client": "catalog:azurelkg",
+    "@azure/identity": "catalog:azurelkg"
+  }
+}
+```
+
+#### Requirements
+
+- Node.js (ES modules support)
+- `npm` command available in PATH
+- Access to npm registry to fetch package versions
+
+#### Implementation Details
+
+- Uses simple regex parsing instead of full YAML parser for better performance
+- Only fetches stable versions (not beta/preview)
+- Maintains alphabetical package order
+- Uses caret ranges (`^`) for semantic versioning compatibility
+- Error handling for network issues and missing packages
+
+#### Adding/Removing Packages
+
+To add or remove packages from the catalog, manually edit the `azurelkg` section in `pnpm-workspace.yaml`. The script will then manage versions for the updated package list.
+
+## Contributing
+
+When adding new utilities to this directory:
+
+1. Follow the existing code style and patterns
+2. Include comprehensive error handling
+3. Add appropriate documentation
+4. Use ES modules syntax
+5. Include debug output for troubleshooting

--- a/eng/tools/pnpm-utils/eslint.config.mjs
+++ b/eng/tools/pnpm-utils/eslint.config.mjs
@@ -1,0 +1,14 @@
+import eslint from "@eslint/js";
+import globals from "globals";
+
+export default [
+  {
+    files: ["./update-azurelkg.js"],
+    rules: eslint.configs.recommended.rules,
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+];

--- a/eng/tools/pnpm-utils/package.json
+++ b/eng/tools/pnpm-utils/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@azure-tools/pnpm-utils",
+  "type": "module",
+  "prettier": "../../../common/tools/eslint-plugin-azure-sdk/prettier.json",
+  "scripts": {
+    "build": "npm run format && npm run lint && npm run typecheck && npm run test",
+    "format": "prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore update-azurelkg.js",
+    "typecheck": "tsc",
+    "lint": "eslint update-azurelkg.js",
+    "test": "echo skipped for now"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.9.0",
+    "@types/node": "^20.0.0",
+    "eslint": "^9.9.0",
+    "globals": "^16.4.0",
+    "prettier": "^3.6.2",
+    "typescript": "~5.8.2",
+    "vitest": "^3.1.1"
+  }
+}

--- a/eng/tools/pnpm-utils/tsconfig.json
+++ b/eng/tools/pnpm-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "target": "ES2023",
+    "skipLibCheck": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "types": ["node"]
+  },
+  "include": ["./update-azurelkg.js"]
+}

--- a/eng/tools/pnpm-utils/update-azurelkg.js
+++ b/eng/tools/pnpm-utils/update-azurelkg.js
@@ -74,7 +74,7 @@ async function updatePnpmWorkspaceYaml(packages) {
   // Build the azurelkg catalog section
   let azurelkgSection = "";
   for (const [packageName, version] of Object.entries(packages)) {
-    azurelkgSection += `    '${packageName}': ${version}\n`;
+    azurelkgSection += `    '${packageName}': ^${version}\n`;
   }
 
   // Replace the azurelkg section - find from "  azurelkg:" to the next section at the same indentation level

--- a/eng/tools/pnpm-utils/update-azurelkg.js
+++ b/eng/tools/pnpm-utils/update-azurelkg.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+// created by copilot agent Claude Sonnet 4
+
+// @ts-check
+
+import { readFileSync, writeFileSync } from "fs";
+import { resolve, dirname, join as pathJoin, normalize } from "path";
+import { fileURLToPath } from "url";
+import { execSync } from "child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function getLatestStableVersion(packageName) {
+  try {
+    console.error(`  Checking ${packageName}...`);
+    const output = execSync(`npm view "${packageName}" version`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    const version = output.trim();
+    console.error(`    found ${version}`);
+    return version;
+  } catch {
+    console.error(`    not found on npm`);
+    return null;
+  }
+}
+
+async function getAzureLkgPackagesFromWorkspace() {
+  console.error("Reading azurelkg catalog from pnpm-workspace.yaml...");
+
+  try {
+    const workspaceYamlPath = resolve(__dirname, "../../../pnpm-workspace.yaml");
+    const normalized = normalize(pathJoin(__dirname, "../../../pnpm-workspace.yaml"));
+    console.dir({ workspaceYamlPath, normalized });
+    const content = readFileSync(workspaceYamlPath, "utf8");
+
+    // Find the azurelkg section and extract package names
+    const azurelkgRegex = /azurelkg:\s*\n([\s\S]*?)(?:\n {2}\w+:|$)/;
+    const match = content.match(azurelkgRegex);
+
+    if (!match) {
+      throw new Error("azurelkg catalog not found in pnpm-workspace.yaml");
+    }
+
+    const azurelkgSection = match[1];
+
+    // Extract package names from lines like "    '@azure/package-name': version"
+    const packageRegex = /^\s{4,}'([^']+)':\s*.+$/gm;
+    const packages = [];
+    let packageMatch;
+
+    while ((packageMatch = packageRegex.exec(azurelkgSection)) !== null) {
+      packages.push(packageMatch[1]);
+    }
+
+    packages.sort();
+    console.error(`Found ${packages.length} packages in azurelkg catalog`);
+
+    return packages;
+  } catch (error) {
+    console.error("Error reading pnpm-workspace.yaml:", error.message);
+    throw error;
+  }
+}
+async function updatePnpmWorkspaceYaml(packages) {
+  const workspaceYamlPath = resolve(__dirname, "../../../pnpm-workspace.yaml");
+  const normalized = normalize(pathJoin(__dirname, "../../../pnpm-workspace.yaml"));
+  console.dir({ workspaceYamlPath, normalized });
+  let content = readFileSync(workspaceYamlPath, "utf8");
+
+  // Build the azurelkg catalog section
+  let azurelkgSection = "";
+  for (const [packageName, version] of Object.entries(packages)) {
+    azurelkgSection += `    '${packageName}': ${version}\n`;
+  }
+
+  // Replace the azurelkg section - find from "  azurelkg:" to the next section at the same indentation level
+  const azurelkgRegex = /( {2}azurelkg:\s*\n)([\s\S]*?)(\n {2}\w+:|$)/;
+  const match = content.match(azurelkgRegex);
+
+  if (match) {
+    const beforeSection = content.substring(0, match.index + match[1].length);
+    const afterMatch = match.index + match[1].length + match[2].length;
+    const afterSection = content.substring(afterMatch);
+    content = beforeSection + azurelkgSection + afterSection;
+  } else {
+    console.error("Could not find azurelkg section in pnpm-workspace.yaml");
+    console.error("Looking for pattern:", azurelkgRegex);
+    return;
+  }
+
+  writeFileSync(workspaceYamlPath, content, "utf8");
+  console.log("Updated pnpm-workspace.yaml with latest versions");
+}
+
+async function main() {
+  try {
+    console.error("Getting Azure SDK Core and Identity packages from azurelkg catalog...");
+    const packageNames = await getAzureLkgPackagesFromWorkspace();
+
+    console.log("# Azure SDK Core and Identity packages with latest stable versions");
+    console.log("azurelkg:");
+
+    const packages = {};
+
+    for (const packageName of packageNames) {
+      const version = await getLatestStableVersion(packageName);
+      if (version) {
+        packages[packageName] = version;
+        console.log(`  '${packageName}': ${version}`);
+      }
+    }
+
+    console.error("\nUpdating pnpm-workspace.yaml...");
+    await updatePnpmWorkspaceYaml(packages);
+
+    console.error(`\nProcessed ${Object.keys(packages).length} packages successfully!`);
+  } catch (error) {
+    console.error("Error:", error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,31 @@ catalogs:
     '@azure/arm-webpubsub':
       specifier: 1.2.0
       version: 1.2.0
+  azurelkg:
+    '@azure/core-auth':
+      specifier: ^1.10.1
+      version: 1.10.1
+    '@azure/core-client':
+      specifier: ^1.10.1
+      version: 1.10.1
+    '@azure/core-paging':
+      specifier: ^1.6.2
+      version: 1.6.3
+    '@azure/core-rest-pipeline':
+      specifier: ^1.22.1
+      version: 1.22.1
+    '@azure/core-tracing':
+      specifier: ^1.3.1
+      version: 1.3.1
+    '@azure/core-util':
+      specifier: ^1.13.1
+      version: 1.13.1
+    '@azure/core-xml':
+      specifier: ^1.5.0
+      version: 1.5.1
+    '@azure/logger':
+      specifier: ^1.3.0
+      version: 1.3.1
   default:
     '@types/node':
       specifier: ^20.19.0
@@ -26497,31 +26522,31 @@ importers:
   sdk/tables/data-tables:
     dependencies:
       '@azure/core-auth':
-        specifier: ^1.9.0
+        specifier: catalog:azurelkg
         version: link:../../core/core-auth
       '@azure/core-client':
-        specifier: ^1.9.2
+        specifier: catalog:azurelkg
         version: link:../../core/core-client
       '@azure/core-paging':
-        specifier: ^1.6.2
+        specifier: catalog:azurelkg
         version: link:../../core/core-paging
       '@azure/core-rest-pipeline':
-        specifier: ^1.19.0
+        specifier: catalog:azurelkg
         version: link:../../core/core-rest-pipeline
       '@azure/core-tracing':
-        specifier: ^1.2.0
+        specifier: catalog:azurelkg
         version: link:../../core/core-tracing
       '@azure/core-util':
-        specifier: ^1.11.0
+        specifier: catalog:azurelkg
         version: link:../../core/core-util
       '@azure/core-xml':
-        specifier: ^1.4.4
+        specifier: catalog:azurelkg
         version: link:../../core/core-xml
       '@azure/logger':
-        specifier: ^1.1.4
+        specifier: catalog:azurelkg
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29929,56 +29954,67 @@ packages:
     resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.0':
     resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.0':
     resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.0':
     resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.0':
     resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.0':
     resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.0':
     resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.0':
     resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.0':
     resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.0':
     resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.0':
     resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.0':
     resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,25 +36,25 @@ catalogs:
     '@azure/arm-cognitiveservices': 7.6.0
     '@azure/arm-webpubsub': 1.2.0
   azurelkg:
-    '@azure-rest/core-client': 2.5.1
-    '@azure/abort-controller': 2.1.2
-    '@azure/core-amqp': 4.4.1
-    '@azure/core-auth': 1.10.1
-    '@azure/core-client': 1.10.1
-    '@azure/core-http-compat': 2.3.1
-    '@azure/core-lro': 3.3.1
-    '@azure/core-paging': 1.6.2
-    '@azure/core-rest-pipeline': 1.22.1
-    '@azure/core-sse': 2.3.0
-    '@azure/core-tracing': 1.3.1
-    '@azure/core-util': 1.13.1
-    '@azure/core-xml': 1.5.0
-    '@azure/identity': 4.12.0
-    '@azure/identity-broker': 1.2.0
-    '@azure/identity-cache-persistence': 1.2.0
-    '@azure/identity-vscode': 2.0.0
-    '@azure/logger': 1.3.0
-    '@typespec/ts-http-runtime': 0.3.1
+    '@azure-rest/core-client': ^2.5.1
+    '@azure/abort-controller': ^2.1.2
+    '@azure/core-amqp': ^4.4.1
+    '@azure/core-auth': ^1.10.1
+    '@azure/core-client': ^1.10.1
+    '@azure/core-http-compat': ^2.3.1
+    '@azure/core-lro': ^3.3.1
+    '@azure/core-paging': ^1.6.2
+    '@azure/core-rest-pipeline': ^1.22.1
+    '@azure/core-sse': ^2.3.0
+    '@azure/core-tracing': ^1.3.1
+    '@azure/core-util': ^1.13.1
+    '@azure/core-xml': ^1.5.0
+    '@azure/identity': ^4.12.0
+    '@azure/identity-broker': ^1.2.0
+    '@azure/identity-cache-persistence': ^1.2.0
+    '@azure/identity-vscode': ^2.0.0
+    '@azure/logger': ^1.3.0
+    '@typespec/ts-http-runtime': ^0.3.1
 
   testing:
     '@rollup/plugin-inject': ^5.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,26 @@ catalogs:
     '@azure/arm-storage': 18.5.0
     '@azure/arm-cognitiveservices': 7.6.0
     '@azure/arm-webpubsub': 1.2.0
+  azurelkg:
+    '@azure/abort-controller': 2.1.2
+    '@azure/core-amqp': 4.4.1
+    '@azure/core-auth': 1.10.1
+    '@azure/core-client': 1.10.1
+    '@azure-rest/core-client': 2.5.1
+    '@azure/core-http-compat': 2.3.1
+    '@azure/core-lro': 3.3.1
+    '@azure/core-paging': 1.6.2
+    '@azure/core-rest-pipeline': 1.22.1
+    '@azure/core-sse': 2.3.0
+    '@azure/core-tracing': 1.3.1
+    '@azure/core-util': 1.13.1
+    '@azure/core-xml': 1.5.0
+    '@azure/identity': 4.12.0
+    '@azure/identity-broker': 1.2.0
+    '@azure/identity-cache-persistence': 1.2.0
+    '@azure/identity-vscode': 2.0.0
+    '@azure/logger': 1.3.0
+    '@typespec/ts-http-runtime': 0.3.1
   testing:
     '@rollup/plugin-inject': ^5.0.5
     '@types/chai': ^5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,11 +36,11 @@ catalogs:
     '@azure/arm-cognitiveservices': 7.6.0
     '@azure/arm-webpubsub': 1.2.0
   azurelkg:
+    '@azure-rest/core-client': 2.5.1
     '@azure/abort-controller': 2.1.2
     '@azure/core-amqp': 4.4.1
     '@azure/core-auth': 1.10.1
     '@azure/core-client': 1.10.1
-    '@azure-rest/core-client': 2.5.1
     '@azure/core-http-compat': 2.3.1
     '@azure/core-lro': 3.3.1
     '@azure/core-paging': 1.6.2
@@ -55,6 +55,7 @@ catalogs:
     '@azure/identity-vscode': 2.0.0
     '@azure/logger': 1.3.0
     '@typespec/ts-http-runtime': 0.3.1
+
   testing:
     '@rollup/plugin-inject': ^5.0.5
     '@types/chai': ^5.2.1

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -46,15 +46,15 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-auth": "^1.9.0",
-    "@azure/core-client": "^1.9.2",
-    "@azure/core-paging": "^1.6.2",
-    "@azure/core-rest-pipeline": "^1.19.0",
-    "@azure/core-tracing": "^1.2.0",
-    "@azure/core-util": "^1.11.0",
-    "@azure/core-xml": "^1.4.4",
-    "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "@azure/core-auth": "catalog:azurelkg",
+    "@azure/core-client": "catalog:azurelkg",
+    "@azure/core-paging": "catalog:azurelkg",
+    "@azure/core-rest-pipeline": "catalog:azurelkg",
+    "@azure/core-tracing": "catalog:azurelkg",
+    "@azure/core-util": "catalog:azurelkg",
+    "@azure/core-xml": "catalog:azurelkg",
+    "@azure/logger": "catalog:azurelkg",
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",


### PR DESCRIPTION
which includes Last-Known-Good versions of Azure core packages. Non-core package
versions may also be added in the future too when needed.

A tool is added to update the `azurelkg` catalog with latest published stable
versions.

As an example, the `@azure/data-tables` has been updated to use catalog versions
for its runtime dependencies.