### PR TITLE
chore(vscode): set Prettier as default formatter and disable formatOnSave for Markdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,12 @@
 {
   "editor.autoIndent": "full",
   "editor.detectIndentation": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
+  "[markdown]": {
+    "editor.formatOnSave": false
+  },
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "eslint.workingDirectories": [

--- a/dataplane.code-workspace
+++ b/dataplane.code-workspace
@@ -286,8 +286,12 @@
     }
   ],
   "settings": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.detectIndentation": false,
     "editor.formatOnSave": true,
+    "[markdown]": {
+      "editor.formatOnSave": false
+    },
     "editor.insertSpaces": true,
     "editor.tabSize": 2,
     "files.insertFinalNewline": true,


### PR DESCRIPTION
This PR updates VS Code workspace settings to use Prettier as the default formatter and disables format-on-save specifically for Markdown files as we don't enforce a specific formatting style for them so auto-formatting can cause unwanted changes.

- Add editor.defaultFormatter: esbenp.prettier-vscode
- Add [markdown] override to disable format on save
- Mirror settings in dataplane.code-workspace for consistency