### PR TITLE
docs: add AGENTS.md repository guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,12 @@
 - Infra/cache in `eng/*`, docs in `documentation/*`, samples in `samples/*`.
 
 ## Build, Test, and Development Commands
-- `pnpm install` — install workspace deps (Node >= 20, pnpm >= 10.17).
+- `pnpm install` — install workspace deps (Node current LTS, pnpm v10).
 - Incremental builds: `pnpm turbo build -F {package name} --token 1` (build changed packages only; enables remote cache read).
-- Full build: `pnpm build` — builds all packages via Turborepo (avoid for small changes).
+- Full build: `pnpm build` — builds all packages via Turborepo (avoid).
 - Tests: `pnpm test`; or `pnpm test:node` / `pnpm test:browser`.
 - Lint/format: `pnpm lint`, `pnpm lint:fix`, `pnpm format`, `pnpm check-format`.
-- Type check/clean: `pnpm typecheck`, `pnpm clean`.
-- Filter examples: `pnpm test --filter @azure/web-pubsub...`, `pnpm turbo build --filter sdk/web-pubsub/web-pubsub`.
+- Filter examples: `pnpm test --filter @azure/web-pubsub`, `pnpm turbo build --filter sdk/web-pubsub/web-pubsub...`.
 
 ## Coding Style & Naming Conventions
 - TypeScript; 2-space indent; semicolons; printWidth 100; double quotes (see `.prettierrc.json`).
@@ -26,9 +25,6 @@
 - Node test config excludes browser/snippets; browser tests via `test:browser`.
 - Coverage with Istanbul; reports in `coverage/` (see `vitest.shared.config.ts`).
 
-## Commit & Pull Request Guidelines
-- Commits: imperative, scoped by package. Example: `sdk/web-pubsub/web-pubsub: fix reconnect logic`.
-- PRs: clear description, linked issues, affected package path, test evidence (logs or `test-results.xml`), and doc updates when needed.
 
 ## Security & Configuration Tips
 - `preinstall` enforces `pnpm`; Turborepo remote cache configured in `turbo.json`.


### PR DESCRIPTION
(created by copilot)

Add AGENTS.md at repo root as a concise contributor and agent guide tailored to this monorepo.

Why
- Complements CONTRIBUTING.md with short, actionable guidance for agents and humans.

Reference
- AGENTS.md convention used by agentic tooling (e.g., Codex CLI). See https://github.com/openai/codex-cli for context.

Scope
- Documentation only; no code changes.