### PR TITLE
[Monitor OpenTelemetry Exporter] Fix Dynamic Import

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/customerSDKStats.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/export/statsbeat/customerSDKStats.ts
@@ -5,9 +5,9 @@ import type { BatchObservableResult, Meter, ObservableGauge } from "@opentelemet
 import { diag } from "@opentelemetry/api";
 import type { PeriodicExportingMetricReaderOptions } from "@opentelemetry/sdk-metrics";
 import { MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
-import type { AzureMonitorExporterOptions } from "../../index.js";
 import * as ai from "../../utils/constants/applicationinsights.js";
 import { StatsbeatMetrics } from "./statsbeatMetrics.js";
+import type { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
 import type { CustomerSDKStatsProperties, StatsbeatOptions } from "./types.js";
 import {
   CustomerSDKStats,
@@ -19,7 +19,6 @@ import {
 } from "./types.js";
 import { CustomSDKStatsCounter, STATSBEAT_LANGUAGE, TelemetryType } from "./types.js";
 import { getAttachType } from "../../utils/metricUtils.js";
-import { AzureMonitorStatsbeatExporter } from "./statsbeatExporter.js";
 import { BreezePerformanceCounterNames } from "../../types.js";
 import type { MetricsData, RemoteDependencyData, RequestData } from "../../generated/index.js";
 import type { TelemetryItem as Envelope } from "../../generated/index.js";
@@ -55,13 +54,12 @@ export class CustomerSDKStatsMetrics extends StatsbeatMetrics {
   // Customer SDK Stats properties
   private customerProperties: CustomerSDKStatsProperties;
 
-  private constructor(options: StatsbeatOptions) {
+  private constructor(
+    options: StatsbeatOptions, 
+    exporter: AzureMonitorStatsbeatExporter
+  ) {
     super();
-    const exporterConfig: AzureMonitorExporterOptions = {
-      connectionString: `InstrumentationKey=${options.instrumentationKey};IngestionEndpoint=${options.endpointUrl}`,
-    };
-
-    this.customerSDKStatsExporter = new AzureMonitorStatsbeatExporter(exporterConfig);
+    this.customerSDKStatsExporter = exporter;
     // Exports Customer SDK Stats every 15 minutes
     const customerMetricReaderOptions: PeriodicExportingMetricReaderOptions = {
       exporter: this.customerSDKStatsExporter,
@@ -109,11 +107,17 @@ export class CustomerSDKStatsMetrics extends StatsbeatMetrics {
   /**
    * Get singleton instance of CustomerSDKStatsMetrics
    * @param options - Configuration options for customer SDK Stats metrics
-   * @returns The singleton instance
+   * @returns Promise of the singleton instance
    */
-  public static getInstance(options: StatsbeatOptions): CustomerSDKStatsMetrics {
+  public static async getInstance(options: StatsbeatOptions): Promise<CustomerSDKStatsMetrics> {
     if (!CustomerSDKStatsMetrics._instance) {
-      CustomerSDKStatsMetrics._instance = new CustomerSDKStatsMetrics(options);
+      // Use dynamic import to break circular dependency
+      const { AzureMonitorStatsbeatExporter } = await import("./statsbeatExporter.js");
+      const customerStatsExporterConfig = {
+        connectionString: `InstrumentationKey=${options.instrumentationKey};IngestionEndpoint=${options.endpointUrl}`,
+      };
+      const exporter = new AzureMonitorStatsbeatExporter(customerStatsExporterConfig);
+      CustomerSDKStatsMetrics._instance = new CustomerSDKStatsMetrics(options, exporter);
     }
     return CustomerSDKStatsMetrics._instance;
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -106,7 +106,7 @@ vi.mock("../../src/export/statsbeat/customerSDKStats.js", () => {
   return {
     CustomerSDKStatsMetrics: {
       getInstance: vi.fn().mockImplementation(() => {
-        return mockCustomerSDKStatsMetrics;
+        return Promise.resolve(mockCustomerSDKStatsMetrics);
       }),
       shutdown: vi.fn(),
     },

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/customerSDKStats.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/customerSDKStats.spec.ts
@@ -77,9 +77,9 @@ describe("CustomerSDKStatsMetrics", () => {
     endpointUrl: "https://test.endpoint.com",
   };
 
-  beforeEach(() => {
-    // Use getInstance to get the singleton
-    customerSDKStatsMetrics = CustomerSDKStatsMetrics.getInstance(mockOptions);
+  beforeEach(async () => {
+    // Use getInstance to get the singleton (now async)
+    customerSDKStatsMetrics = await CustomerSDKStatsMetrics.getInstance(mockOptions);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/36066

### Describe the problem that is addressed by this PR
This pull request refactors the initialization of the customer SDK stats metrics and the statsbeat exporter to resolve circular dependency issues and improve asynchronous handling. The main changes involve switching to dynamic imports and lazy initialization, updating the singleton pattern to be asynchronous, and adjusting related tests and usages to accommodate these changes.

**Circular dependency resolution and async initialization:**

* Refactored `CustomerSDKStatsMetrics` to use an async singleton pattern with dynamic import of `AzureMonitorStatsbeatExporter`, allowing for asynchronous and circular-dependency-safe initialization. (`customerSDKStats.ts`, [[1]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L58-R62) [[2]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L112-R120)
* Updated `BaseSender` to asynchronously import and initialize `CustomerSDKStatsMetrics`, ensuring it only initializes if not already set and logging warnings if initialization fails. (`baseSender.ts`, [[1]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L41-R40) [[2]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L82-R99)

**Statsbeat exporter improvements:**

* Modified `AzureMonitorStatsbeatExporter` to lazily initialize the HTTP sender using dynamic import, storing sender options for later use, and updating export/shutdown logic to handle async sender initialization. (`statsbeatExporter.ts`, [[1]](diffhunk://#diff-cf9651a5fcd1ee85b2eb97d676fc6eafec5c506e6d8f26e2a8e21aabb4dc7057L24-R50) [[2]](diffhunk://#diff-cf9651a5fcd1ee85b2eb97d676fc6eafec5c506e6d8f26e2a8e21aabb4dc7057L82-R95) [[3]](diffhunk://#diff-cf9651a5fcd1ee85b2eb97d676fc6eafec5c506e6d8f26e2a8e21aabb4dc7057R104-R107)

**Test updates for async changes:**

* Updated mocks and tests to handle the now-async `getInstance` method for `CustomerSDKStatsMetrics`, ensuring proper setup and teardown in test environments. (`baseSender.spec.ts`, [[1]](diffhunk://#diff-e92bd4b395d01c03dd800ccdfb0053a70100c18c216dcde1d6789be817018427L109-R109); `customerSDKStats.spec.ts`, [[2]](diffhunk://#diff-d1341d0902c02c5da1fa738a22afc4b7f186367d0e29fff1db008c4ec9c05e68L80-R82)

**Code cleanup:**

* Removed unused imports and updated type annotations to use `any` where necessary to accommodate dynamic imports and async initialization. (`customerSDKStats.ts`, [[1]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L8-R10) [[2]](diffhunk://#diff-2f4066f1034ba4adc1b1010a2db050dd609f6b2f1d5935ac9e0574d293c148f1L22); `statsbeatExporter.ts`, [[3]](diffhunk://#diff-cf9651a5fcd1ee85b2eb97d676fc6eafec5c506e6d8f26e2a8e21aabb4dc7057L11); `baseSender.ts`, [[4]](diffhunk://#diff-3614c3b3d4cc1da2e731ad02fe179b1a84a8d0dcfd9be0baaa5140063aa91305L28)

These changes collectively improve the reliability and maintainability of statsbeat metrics and exporter initialization, especially in environments where circular dependencies previously caused issues.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
