### PR TITLE
[EngSys] add several dev dependency to default catalog

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,6 @@ catalog:
   tslib: ^2.8.1
   tsx: ^4.20.4
   typescript: ~5.8.3
-  turbo: ^2.5.6
 
 # Named catalogs
 catalogs:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,10 +24,15 @@ packages:
 catalog:
   '@types/node': ^20.19.0
   autorest: latest
+  cross-env: ^7.0.3
   eslint: ^9.33.0
+  mkdirp: ^3.0.1
+  prettier: ^3.6.2
+  rimraf: ^6.0.1
   tslib: ^2.8.1
   tsx: ^4.20.4
   typescript: ~5.8.3
+  turbo: ^2.5.6
 
 # Named catalogs
 catalogs:


### PR DESCRIPTION
This PR prepares for the removal of the dev-tool run vendored call on these
tools. Per Pnpm recommendation, dependencies needed by individual packages
should be included in their package.json instead of global package.json.

These dev dependencies will be added to individual packages later with their
"catalog:` specifier.