### PR TITLE
[dev-tool] extract `sortPackageJson` helper

### DIFF
--- a/common/tools/dev-tool/src/commands/admin/migrate-tests.ts
+++ b/common/tools/dev-tool/src/commands/admin/migrate-tests.ts
@@ -8,6 +8,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { vendoredWithOptions } from "../run/vendored";
 import { getRushJson, RushJsonProject } from "../../util/synthesizedRushJson";
+import { sortPackageJson } from "../../util/sortPackageJson";
 
 const log = createPrinter("migrate-tests");
 
@@ -133,7 +134,7 @@ async function updatePackageJson(projectFolder: string): Promise<boolean> {
     packageJson.scripts["test"] = "npm run test:node && npm run test:browser";
 
     // Clean it up
-    sortPackage(packageJson);
+    sortPackageJson(packageJson);
 
     await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
@@ -144,27 +145,6 @@ async function updatePackageJson(projectFolder: string): Promise<boolean> {
   }
 
   return true;
-}
-
-function sortObjectByKeys(unsortedObj: { [key: string]: string }): { [key: string]: string } {
-  const sortedEntries = Object.entries(unsortedObj).sort((a, b) => a[0].localeCompare(b[0]));
-  return Object.fromEntries(sortedEntries);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function sortPackage(packageJson: any): void {
-  if (packageJson.dependencies) {
-    packageJson.dependencies = sortObjectByKeys(packageJson.dependencies);
-  }
-  if (packageJson.devDependencies) {
-    packageJson.devDependencies = sortObjectByKeys(packageJson.devDependencies);
-  }
-  if (packageJson.peerDependencies) {
-    packageJson.peerDependencies = sortObjectByKeys(packageJson.peerDependencies);
-  }
-  if (packageJson.scripts) {
-    packageJson.scripts = sortObjectByKeys(packageJson.scripts);
-  }
 }
 
 async function runCleanup(projectFolder: string): Promise<boolean> {

--- a/common/tools/dev-tool/src/util/sortPackageJson.ts
+++ b/common/tools/dev-tool/src/util/sortPackageJson.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+function sortObjectByKeys(unsortedObj: { [key: string]: string }): { [key: string]: string } {
+  const sortedEntries = Object.entries(unsortedObj).sort((a, b) => a[0].localeCompare(b[0]));
+  return Object.fromEntries(sortedEntries);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function sortPackageJson(packageJson: any): void {
+  if (packageJson.dependencies) {
+    packageJson.dependencies = sortObjectByKeys(packageJson.dependencies);
+  }
+  if (packageJson.devDependencies) {
+    packageJson.devDependencies = sortObjectByKeys(packageJson.devDependencies);
+  }
+  if (packageJson.peerDependencies) {
+    packageJson.peerDependencies = sortObjectByKeys(packageJson.peerDependencies);
+  }
+  if (packageJson.scripts) {
+    packageJson.scripts = sortObjectByKeys(packageJson.scripts);
+  }
+}


### PR DESCRIPTION
as it is useful outside of migrate-test command, which could be removed in the future.