### PR TITLE
[notification-hubs] fix TypeError when parsing AppleTemplateRegistrationDescription

### DIFF
--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - Properly handle single-element headers of template registrations [PR #36114](https://github.com/Azure/azure-sdk-for-js/pull/36114).
 
-### Other Changes
-
 ## 2.0.0 (2024-10-14)
 
 ### Features Added

--- a/sdk/notificationhubs/notification-hubs/CHANGELOG.md
+++ b/sdk/notificationhubs/notification-hubs/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Release History
 
-## 2.0.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 2.0.2 (2025-10-07)
 
 ### Bugs Fixed
+
+- Properly handle single-element headers of template registrations [PR #36114](https://github.com/Azure/azure-sdk-for-js/pull/36114).
 
 ### Other Changes
 

--- a/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
+++ b/sdk/notificationhubs/notification-hubs/src/serializers/registrationSerializer.ts
@@ -502,14 +502,14 @@ export const registrationDescriptionParser: RegistrationDescriptionParser = {
 };
 
 function getHeadersOrUndefined(
-  value?: { Header: string; Value: string }[],
+  value?: { Header: string; Value: string }[] | { Header: string; Value: string },
 ): Record<string, string> | undefined {
   if (!isDefined(value)) {
     return undefined;
   }
 
   const headerObj: Record<string, string> = {};
-  for (const { Header, Value } of value) {
+  for (const { Header, Value } of Array.isArray(value) ? value : [value]) {
     headerObj[Header] = Value;
   }
 

--- a/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
+++ b/sdk/notificationhubs/notification-hubs/test/internal/unit/registrationSerializer.spec.ts
@@ -101,6 +101,24 @@ const APPLE_TEMPLATE_REGISTRATION = `<?xml version="1.0" encoding="utf-8"?>
     </content>
 </entry>`;
 
+const APPLE_TEMPLATE_REGISTRATION_SINGLE_APNSHEADER = `<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom">
+    <content type="application/xml">
+        <AppleTemplateRegistrationDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+            <Tags>myTag,myOtherTag</Tags>
+            <RegistrationId>{Registration Id}</RegistrationId> 
+            <DeviceToken>{DeviceToken}</DeviceToken> 
+            <BodyTemplate><![CDATA[{Template for the body}]]></BodyTemplate>
+            <ApnsHeaders>
+                <ApnsHeader>
+                    <Header>apns-priority</Header>
+                    <Value>10</Value>
+                </ApnsHeader>
+            </ApnsHeaders>
+        </AppleTemplateRegistrationDescription>
+    </content>
+</entry>`;
+
 const BAIDU_REGISTRATION = `<?xml version="1.0" encoding="utf-8"?>
 <entry xmlns="http://www.w3.org/2005/Atom">
     <content type="application/xml">
@@ -335,6 +353,19 @@ describe("parseRegistrationEntry", () => {
     assert.equal(registration.bodyTemplate, "{Template for the body}");
     assert.equal(registration.apnsHeaders!["apns-priority"], "10");
     assert.equal(registration.apnsHeaders!["apns-expiration"], "0");
+  });
+
+  it("should parse an apple template registration description with single apns header", async () => {
+    const registration = (await registrationDescriptionParser.parseRegistrationEntry(
+      APPLE_TEMPLATE_REGISTRATION_SINGLE_APNSHEADER,
+    )) as AppleTemplateRegistrationDescription;
+
+    assert.equal(registration.kind, "AppleTemplate");
+    assert.equal(registration.registrationId, "{Registration Id}");
+    assert.equal(registration.deviceToken, "{DeviceToken}");
+    assert.deepEqual(registration.tags, ["myTag", "myOtherTag"]);
+    assert.equal(registration.bodyTemplate, "{Template for the body}");
+    assert.equal(registration.apnsHeaders!["apns-priority"], "10");
   });
 
   it("should parse an Baidu registration description", async () => {


### PR DESCRIPTION
Currently `getHeadersOrUndefined` incorrectly assumes that the `ApnsHeaders` parsed from XML is always an array. However, for single XML element the XML parser gives back an object instead. This change ensures we are iterating over an array.

One alternative approach is to add an option to `core-xml` specifying whether to treat certain single xml elements as an object or the single item of an array.  Our underlying XML parser `fast-xml-parser` allows passing in a `isArray: (name, jpath, isLeafNode, isAttribute) => boolean` predicate but it is specific to `fast-xml-parser` and needs more discussion on how to properly expose it in `core-xml`.  For this targeted scenario, it is good enough to check whether the parsed result is an array.  This package uses same pattern in other places too, for example, https://github.com/Azure/azure-sdk-for-js/blob/953fcf9f84b/sdk/notificationhubs/notification-hubs/src/serializers/notificationHubJobSerializer.ts#L61