### PR TITLE
Fix TypeScript compilation error in Device Provisioning Services samples

### DIFF
--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples-dev/dpsCertificateCreateOrUpdateSample.ts
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples-dev/dpsCertificateCreateOrUpdateSample.ts
@@ -22,7 +22,7 @@ async function dpsCreateOrUpdateCertificate(): Promise<void> {
   const provisioningServiceName = "myFirstProvisioningService";
   const certificateName = "cert";
   const certificateDescription: CertificateResponse = {
-    properties: { certificate: Buffer.from("MA==") },
+    properties: { certificate: Buffer.from("MA==") as Uint8Array },
   };
   const credential = new DefaultAzureCredential();
   const client = new IotDpsClient(credential, subscriptionId);

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v5/typescript/src/dpsCertificateCreateOrUpdateSample.ts
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v5/typescript/src/dpsCertificateCreateOrUpdateSample.ts
@@ -29,7 +29,7 @@ async function dpsCreateOrUpdateCertificate(): Promise<void> {
   const certificateName = "cert";
   const certificateDescription: CertificateResponse = {
     properties: {
-      certificate: Buffer.from("############################################")
+      certificate: Buffer.from("############################################") as Uint8Array
     }
   };
   const credential = new DefaultAzureCredential();

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v6-beta/typescript/src/dpsCertificateCreateOrUpdateSample.ts
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v6-beta/typescript/src/dpsCertificateCreateOrUpdateSample.ts
@@ -28,7 +28,7 @@ async function dpsCreateOrUpdateCertificate(): Promise<void> {
   const provisioningServiceName = "myFirstProvisioningService";
   const certificateName = "cert";
   const certificateDescription: CertificateResponse = {
-    properties: { certificate: Buffer.from("MA==") }
+    properties: { certificate: Buffer.from("MA==") as Uint8Array }
   };
   const credential = new DefaultAzureCredential();
   const client = new IotDpsClient(credential, subscriptionId);


### PR DESCRIPTION
### Packages impacted by this PR
azure-resourcemanager-deviceprovisioningservices


### Issues associated with this PR
https://github.com/Azure/azure-rest-api-specs/issues/37922

```
error TS2322: Type 'string' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
The generation process failed for specification-deviceprovisioningservices-resource-manager-Microsoft.Devices-DeviceProvisioningServices-tspconfig.yaml. Refer to the full log for details.
```

### Describe the problem that is addressed by this PR
* The error occurred because the sample code was using Buffer.from() to create certificate data, but the TypeScript compiler was not recognizing the implicit conversion from Buffer to Uint8Array.

* Recent TypeScript compiler versions have become more strict about implicit Buffer to Uint8Array conversions

Failed to generate javascript SDK:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5419379&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=1631

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
