### PR TITLE
[core] upgrade dev dep typescript to v5.9 for ts-http-runtime

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,3 +55,5 @@ catalogs:
     vitest: ^3.2.3
   internal:
     '@azure/identity': 4.11.1
+  adventurous:
+    typescript: 5.9.3

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -153,7 +153,7 @@
     "eslint": "catalog:",
     "playwright": "catalog:testing",
     "tsx": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:adventurous",
     "vitest": "catalog:testing"
   },
   "tshy": {


### PR DESCRIPTION
- add typescript 5.9.2 to `adventurous` catalog so we can upgrade packages incrementally

- change internal `BuildRequestBodyResponse.body` to optional and of type `BodyInit` which is expected by `fetch()` api.

- fix compilation error introduced by targeting ES 2024.  `ArrayBuffer` and `SharedArrayBuffer` type definitions diverged and no longer compatible.  This PR adds a helper to convert ArrayBufferView to ArrayBuffer.
