### PR TITLE
[EngSys] add `tshy` to default catalog and to core packages' dev deps

### DIFF
--- a/common/tools/dev-tool/src/commands/run/build-package.ts
+++ b/common/tools/dev-tool/src/commands/run/build-package.ts
@@ -17,7 +17,7 @@ const TSHY_BIN_PATH = path.resolve(__dirname, "..", "..", "..", "node_modules", 
 export default leafCommand(commandInfo, async () => {
   const centralCommandPath = isWindows() ? `${TSHY_BIN_PATH}.CMD` : TSHY_BIN_PATH;
   const localBinPath = path.resolve(process.cwd(), "node_modules", ".bin", "tshy");
-  const localCommandPath = isWindows()? `${localBinPath}.CMD` : localBinPath;
+  const localCommandPath = isWindows() ? `${localBinPath}.CMD` : localBinPath;
   const commandPath = existsSync(localCommandPath) ? localCommandPath : centralCommandPath;
 
   log.info(`Building package with tshy from ${commandPath}`);

--- a/common/tools/dev-tool/src/commands/run/build-package.ts
+++ b/common/tools/dev-tool/src/commands/run/build-package.ts
@@ -6,6 +6,7 @@ import { createPrinter } from "../../util/printer";
 import path from "node:path";
 import { spawnSync, StdioOptions } from "node:child_process";
 import { isWindows } from "../../util/platform";
+import { existsSync } from "node:fs";
 
 const log = createPrinter("build-package");
 
@@ -14,7 +15,11 @@ export const commandInfo = makeCommandInfo("build-package", "build a package for
 const TSHY_BIN_PATH = path.resolve(__dirname, "..", "..", "..", "node_modules", ".bin", "tshy");
 
 export default leafCommand(commandInfo, async () => {
-  const commandPath = isWindows() ? `${TSHY_BIN_PATH}.CMD` : TSHY_BIN_PATH;
+  const centralCommandPath = isWindows() ? `${TSHY_BIN_PATH}.CMD` : TSHY_BIN_PATH;
+  const localBinPath = path.resolve(process.cwd(), "node_modules", ".bin", "tshy");
+  const localCommandPath = isWindows()? `${localBinPath}.CMD` : localBinPath;
+  const commandPath = existsSync(localCommandPath) ? localCommandPath : centralCommandPath;
+
   log.info(`Building package with tshy from ${commandPath}`);
 
   const proc = spawnSync(commandPath, { stdio: "pipe" as StdioOptions, shell: isWindows() });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ catalogs:
     eslint:
       specifier: ^9.33.0
       version: 9.37.0
+    tshy:
+      specifier: ^3.0.0
+      version: 3.0.3
     tslib:
       specifier: ^2.8.1
       version: 2.8.1
@@ -6411,6 +6414,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6490,6 +6496,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6533,6 +6542,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6588,6 +6600,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6637,6 +6652,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6677,6 +6695,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6726,6 +6747,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6760,6 +6784,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6815,6 +6842,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6864,6 +6894,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -6922,6 +6955,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       tsx:
         specifier: 'catalog:'
         version: 4.20.6
@@ -6962,6 +6998,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -7005,6 +7044,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -7045,6 +7087,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -7085,6 +7130,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -7128,6 +7176,9 @@ importers:
       playwright:
         specifier: catalog:testing
         version: 1.55.1
+      tshy:
+        specifier: 'catalog:'
+        version: 3.0.3
       tsx:
         specifier: 'catalog:'
         version: 4.20.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ catalog:
   rimraf: ^6.0.1
   tslib: ^2.8.1
   tsx: ^4.20.4
+  tshy: ^3.0.0
   typescript: ~5.8.3
 
 # Named catalogs

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -84,6 +84,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -93,6 +93,7 @@
     "debug": "^4.3.4",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing",
     "ws": "^8.17.0"

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -80,6 +80,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -83,6 +83,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -85,6 +85,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -80,6 +80,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -99,6 +99,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -84,6 +84,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-rest-pipeline-perf-tests/package.json
+++ b/sdk/core/core-rest-pipeline-perf-tests/package.json
@@ -58,6 +58,7 @@
     "concurrently": "^9.2.1",
     "eslint": "catalog:",
     "express": "^5.1.0",
+    "tshy": "catalog:",
     "typescript": "catalog:"
   },
   "scripts": {

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -102,6 +102,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -89,6 +89,7 @@
     "eslint": "catalog:",
     "express": "^5.1.0",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -79,6 +79,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -81,6 +81,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -80,6 +80,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -86,6 +86,7 @@
     "dotenv": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -152,6 +152,7 @@
     "@vitest/coverage-istanbul": "catalog:testing",
     "eslint": "catalog:",
     "playwright": "catalog:testing",
+    "tshy": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:testing"


### PR DESCRIPTION
per Pnpm recommendation, dependencies needed for individual packages should be
included in their package.json while the global package.json lists tools for mono
repo maintenance.

This PR adds `tshy` to the default catalog and includes it in core packages'
package.json files. Changes to rest of packages and code generator will be in
separate pull requests.