### PR TITLE
[dev-tool] report error when browser tests fail to build

### DIFF
--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -127,7 +127,7 @@ export default leafCommand(commandInfo, async (options) => {
 
     log.info(`Building for browser testing...`);
     const esmMap = overrides.has("esm") ? overrides.get("esm")!.map : new Map<string, string>();
-    return await compileForEnvironment("browser", browserConfig, importMap, esmMap);
+    return compileForEnvironment("browser", browserConfig, importMap, esmMap);
   }
 
   return true;


### PR DESCRIPTION
Currently the result of `compileForEnvironment("browser", ...)` is ignored.  This PR changes to return its result so that compilation errors are reported as failure.
