### PR TITLE
Fix typo in Client Access URL explanation

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/README.md
+++ b/sdk/web-pubsub/web-pubsub-client/README.md
@@ -38,7 +38,7 @@ npm install @azure/web-pubsub-client
 
 ### 2. Connect with your Web PubSub resource
 
-A client uses a Client Access URL to connect and authenticate with the service, which follows a pattern of `wss://<service_name>.webpubsub.azure.com/client/hubs/<hub_name>?access_token=<token>`. A client can have a few ways to obtain the Client Access URL. For this quick start, you can copy and paste one from Azure Portal shown below. (For production, your clients usually get the Client Access URL genegrated on your application server. [See details below](#use-negotiation-server-to-generate-client-access-url) )
+A client uses a Client Access URL to connect and authenticate with the service, which follows a pattern of `wss://<service_name>.webpubsub.azure.com/client/hubs/<hub_name>?access_token=<token>`. A client can have a few ways to obtain the Client Access URL. For this quick start, you can copy and paste one from Azure Portal shown below. (For production, your clients usually get the Client Access URL generated on your application server. [See details below](#use-negotiation-server-to-generate-client-access-url) )
 
 ![get_client_url](https://learn.microsoft.com/azure/azure-web-pubsub/media/howto-websocket-connect/generate-client-url.png)
 


### PR DESCRIPTION
### Packages impacted by this PR

- web-pubsub-client

### Issues associated with this PR

None

### Describe the problem that is addressed by this PR

Fix the spelling of genegrated => generated, visible on the [npm package listing](https://www.npmjs.com/package/@azure/web-pubsub-client) too

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A

### Are there test cases added in this PR? _(If not, why?)_

Not relevant

### Provide a list of related PRs _(if any)_

None

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
