### PR TITLE
[dev-tool] Accept semver ranges in npm version specifier validation

### DIFF
--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -84,7 +84,9 @@ function isValidNpmVersionSpecifier(specifier: string) {
   return (
     semver.valid(
       specifier.startsWith("^") || specifier.startsWith("~") ? specifier.substring(1) : specifier,
-    ) || ["latest", "dev", "next"].includes(specifier)
+    ) ||
+    semver.validRange(specifier) ||
+    ["latest", "dev", "next"].includes(specifier)
   );
 }
 


### PR DESCRIPTION
Allow `semver.validRange(...)` in `isValidNpmVersionSpecifier` so range specifiers (e.g. ">=1.2.0 <2.0.0") are treated as valid versions.

Our nightly builds set Azure SDK package versions to dev versions (for example, "1.2.0-alpha.20251020.1") and use a range that is satisfied (for example, ">=1.2.0-alpha <1.2.0-alphb") in dependents. This range format should be considered valid and kept. Otherwise, it is passed to Pnpm catalog resolution and causes error.