### PR TITLE
[web-pubsub-client] Fix the logic handling reconnection and handle closure

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -920,9 +920,9 @@ export class WebPubSubClient {
     // Try recover connection
     let recovered = false;
     this._state = WebPubSubClientState.Recovering;
-    const abortSignal = AbortSignal.timeout(30 * 1000);
     try {
-      while (!abortSignal.aborted || this._isStopping) {
+      const abortSignal = AbortSignal.timeout(30 * 1000);
+      while (!abortSignal.aborted && !this._isStopping) {
         try {
           await this._connectCore.call(this, recoveryUri);
           recovered = true;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/web-pubsub-client

### Issues associated with this PR
Fix a logic issue that may cause reconnection hung in a loop

### Describe the problem that is addressed by this PR
The condition of ` ||is_stopping` is wrong here which may cause it hung in reconnecting. Actually we want it to be break if is_stopping

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
