### PR TITLE
[storage]: Expose blobDeleteType in client

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.30.0 (Unreleased)
+
+### Features Added
+
+- Added support for blobDeleteType in BlobClient.delete() to permanently delete blobs in storage accounts with soft delete enabled.
+
 ## 12.29.1 (2025-10-16)
 
 ### Features Added

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -347,6 +347,12 @@ export interface BlobDeleteOptions extends CommonOptions {
    */
   deleteSnapshots?: DeleteSnapshotsOptionType;
   /**
+   * Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled.
+   * When not specified, the blob follows the configured soft delete policy.
+   * Has no effect if soft delete is not enabled on the storage account.
+   */
+  blobDeleteType?: "permanent";
+  /**
    * Customer Provided Key Info.
    */
   customerProvidedKey?: CpkInfo;
@@ -1436,6 +1442,7 @@ export class BlobClient extends StorageClient {
           abortSignal: options.abortSignal,
           deleteSnapshots: options.deleteSnapshots,
           leaseAccessConditions: options.conditions,
+          blobDeleteType: options.blobDeleteType,
           modifiedAccessConditions: {
             ...options.conditions,
             ifTags: options.conditions?.tagConditions,

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -1624,7 +1624,7 @@ describe("BlobClient - ImmutabilityPolicy", () => {
         await deleteBlobClient.setLegalHold(false);
 
         await deleteBlobClient.deleteImmutabilityPolicy();
-        await deleteBlobClient.delete({ deleteSnapshots: "include" });
+        await deleteBlobClient.delete({ deleteSnapshots: "include", blobDeleteType: "permanent" });
       }
       if (recorder) {
         await recorder.stop();
@@ -1809,7 +1809,7 @@ describe("BlobClient - ImmutabilityPolicy", () => {
     assert.equal(setLegalHoldResult.legalHold, false);
 
     await blobSnapshotClient.deleteImmutabilityPolicy();
-    await blobClient.delete({ deleteSnapshots: "include" });
+    await blobClient.delete({ deleteSnapshots: "include", blobDeleteType: "permanent" });
   });
 
   it("Set immutability policy and set legalhold and delete immutability policy on blob with version", async () => {


### PR DESCRIPTION
It is already implemented in the blob operation, but was not made available in the client.


### Packages impacted by this PR
storage-blob

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The SDK doesn't expose a way to permanently delete a blob.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Tested only for typescript availability, not the real functionality.

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [X] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [X] Added a changelog (if necessary)
