### PR TITLE
Silence 1ESPT non-blocking error

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -13,7 +13,7 @@ parameters:
 stages:
   - ${{if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
       - ${{ each artifact in parameters.Artifacts }}:
-          - stage:
+          - stage: 'Release_${{artifact.safename}}'
             variables:
               - template: /eng/pipelines/templates/variables/globals.yml
               - template: /eng/pipelines/templates/variables/image.yml


### PR DESCRIPTION
Changes within 1ESPT are throwing out a new error output:

<img width="1471" height="206" alt="image" src="https://github.com/user-attachments/assets/d7d07273-f52c-4ddb-bc86-1c1c8c9b848d" />

- [Before my change](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5497774&view=results)
- [After my change](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5497775&view=results)