### PR TITLE
Update Codeowners rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -331,13 +331,9 @@
 # ServiceLabel: %Azure Load Testing
 /sdk/loadtesting/ @azure/testing-services
 
-
 ####################
 # Management Libraries
 ####################
-
-# Managment API review files
-/sdk/**/review/arm-*.api.md @qiaozha @MaryGao @Azure/azure-sdk-for-js-core
 
 # PRLabel: %Mgmt
 /sdk/advisor/arm-advisor/ @qiaozha @MaryGao


### PR DESCRIPTION
Remove API review rule from the Codeowners file to unblock service team. Copying's Maor's text before resolving conversation to merge the PR:

> Context:
> 
> - GA package shipping is blocked pending APIView approval
> - As of 2024, _all_ CODEOWNERS (per group) must sign off on a PR to allow merging
>   - Prior to that, _any_ CODEOWNER group can sign off on a PR
> - While it is helpful for me to review api.md files in smaller diffs (give a developer 10 lines to review and they'll find 10 problems, give them 100 lines and they'll say "looks good" 😄 ) , I think with APIView Copilot improvements and standardization of our client libraries using codegen we can probably view the APIView changes
> - Speaking of standardization, we're moving more and more towards codegen first with minimal hand-authored changes, so that's probably another reason to relax this restriction
> - When a package is first prepped for release we still need to approve the name which acts as a forcing function to giving the public API a review as well
> 