### PR TITLE
Add support for float16 data type in vector embedding

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
@@ -2775,6 +2775,7 @@ export interface VectorEmbedding {
 
 // @public
 export enum VectorEmbeddingDataType {
+    Float16 = "float16",
     Float32 = "float32",
     Int8 = "int8",
     UInt8 = "uint8"

--- a/sdk/cosmosdb/cosmos/src/documents/VectorEmbeddingPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/VectorEmbeddingPolicy.ts
@@ -37,6 +37,10 @@ export interface VectorEmbedding {
  */
 export enum VectorEmbeddingDataType {
   /**
+   * 16-bit floating point number.
+   */
+  Float16 = "float16",
+  /**
    * 32-bit floating point number.
    */
   Float32 = "float32",

--- a/sdk/cosmosdb/cosmos/test/public/functional/NonStreamingQueryPolicy.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/NonStreamingQueryPolicy.spec.ts
@@ -12,7 +12,6 @@ import type { Database } from "../../../src/client/Database/Database.js";
 import type { Container } from "../../../src/client/index.js";
 import { describe, it, assert, beforeAll, afterAll } from "vitest";
 
-// Skipping these tests as they are not supported by public emulator
 describe("Vector search feature", async () => {
   describe("VectorEmbeddingPolicy", async () => {
     let database: Database;
@@ -70,8 +69,7 @@ describe("Vector search feature", async () => {
       }
     });
 
-    // skipping the test case for now. Will enable it once the changes are live on backend
-    it.skip("validate VectorEmbeddingPolicy", async () => {
+    it("validate VectorEmbeddingPolicy", async () => {
       const indexingPolicy: IndexingPolicy = {
         vectorIndexes: [
           { path: "/vector1", type: VectorIndexType.Flat },
@@ -126,7 +124,6 @@ describe("Vector search feature", async () => {
       assert(containerdef.vectorEmbeddingPolicy.vectorEmbeddings[0].path === "/vector1");
       assert(containerdef.vectorEmbeddingPolicy.vectorEmbeddings[1].path === "/vector2");
       assert(containerdef.vectorEmbeddingPolicy.vectorEmbeddings[2].path === "/vector3");
-
       assert(containerdef.indexingPolicy.vectorIndexes.length === 3);
       assert(containerdef.indexingPolicy.vectorIndexes[0].path === "/vector1");
       assert(containerdef.indexingPolicy.vectorIndexes[1].path === "/vector2");
@@ -142,7 +139,44 @@ describe("Vector search feature", async () => {
       assert(containerdef.indexingPolicy.vectorIndexes[1].vectorIndexShardKey[0] === "/Country");
       assert(containerdef.indexingPolicy.vectorIndexes[2].vectorIndexShardKey[0] === "/ZipCode");
     });
+    it.skip("validate VectorEmbeddingPolicy with Float16 data type", async () => {
+      const indexingPolicy: IndexingPolicy = {
+        vectorIndexes: [{ path: "/vector1", type: VectorIndexType.QuantizedFlat }],
+      };
+      const vectorEmbeddingPolicy: VectorEmbeddingPolicy = {
+        vectorEmbeddings: [
+          {
+            path: "/vector1",
+            dataType: VectorEmbeddingDataType.Float16,
+            dimensions: 500,
+            distanceFunction: VectorEmbeddingDistanceFunction.Euclidean,
+          },
+        ],
+      };
+      const containerName = "JSApp-vector embedding container float16";
+      try {
+        const { resource: containerdef } = await database.containers.createIfNotExists({
+          id: containerName,
+          vectorEmbeddingPolicy: vectorEmbeddingPolicy,
+          indexingPolicy: indexingPolicy,
+        });
 
+        assert(containerdef.vectorEmbeddingPolicy !== undefined);
+        assert(containerdef.vectorEmbeddingPolicy.vectorEmbeddings.length === 1);
+        assert(containerdef.vectorEmbeddingPolicy.vectorEmbeddings[0].path === "/vector1");
+        assert(
+          containerdef.vectorEmbeddingPolicy.vectorEmbeddings[0].dataType ===
+            VectorEmbeddingDataType.Float16,
+        );
+      } catch (e) {
+        assert.fail(`Container creation failed for Float16 data type with error: ${e}`);
+      }
+      try {
+        await database.container(containerName).delete();
+      } catch {
+        // Ignore if container is not found
+      }
+    });
     it("should fail to create vector indexing policy", async () => {
       const vectorEmbeddingPolicy: VectorEmbeddingPolicy = {
         vectorEmbeddings: [


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/36701

### Describe the problem that is addressed by this PR
This PR adds support for `float16` data type in Vector Embeddings.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
Yes

### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
