### PR TITLE
[EngSys] enable code coverage reports

### DIFF
--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -63,6 +63,10 @@ export function makeAliases(
   ] as const;
 }
 
+function shouldCollectCoverage(rootDir: string) {
+  return process.env["TEST_MODE"] === "live" || rootDir.includes("/sdk/core/") || rootDir.includes("\\sdk\\core\\");
+}
+
 function makeNodeAliases(rootDir: string) {
   const [dist, indexFile] = isInDevopsPipeline() ? ["dist/esm", "index.js"] : ["src", "index.ts"];
   return makeAliases(rootDir, { distDir: `./${dist}`, indexFile });
@@ -89,6 +93,7 @@ export default defineConfig({
     ],
     alias: [...makeNodeAliases(process.cwd())],
     coverage: {
+      enabled: shouldCollectCoverage(process.cwd()),
       include: ["src/**/*.ts"],
       exclude: [
         "src/**/*-browser.mts",


### PR DESCRIPTION
- if running live tests. because in some packages due to recorder limitation, not all tests are enabled for playback so code coverage data for playback tests are not accurate.
- or running azure core tests. because they don't have live tests.