### PR TITLE
[engsys] Add back pre-publish checks for package validation

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -40,7 +40,6 @@ stages:
                   - script: >
                       ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz && npm install `ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz`
                     displayName: Validating package can be installed
-                    condition: succeeded()
                   - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                     parameters:
                       PackageName: ${{artifact.name}}
@@ -62,7 +61,6 @@ stages:
                       ReleaseSha: $(Build.SourceVersion)
                       RepoId: Azure/azure-sdk-for-js
                       WorkingDirectory: $(System.DefaultWorkingDirectory)
-
 
               - ${{ if ne(artifact.skipPublishPackage, 'true') }}:
                   - template: /eng/common/pipelines/templates/jobs/npm-publish.yml


### PR DESCRIPTION
### Packages impacted by this PR
N/A

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/issues/36575

### Describe the problem that is addressed by this PR
The pre-publish local tarball validation has been useful to ensure packages don't have dependency issues. We lost it in refactoring. This PR brings it back.