### PR TITLE
[test] use a lower port for vitest browser testing

### DIFF
--- a/vitest.browser.base.config.ts
+++ b/vitest.browser.base.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       "test-dist/stress/**/*.js",
     ],
     browser: {
+      api: 43315,
       instances: [
         {
           browser: "chromium",


### PR DESCRIPTION
In build pipelines there are intermittent failure in vitest browser testing even before any tests. They usually pass after re-run.

> [vitest] Error: listen EACCES: permission denied ::1:63315

It's possible that app or service is using 63315 port as 49152–65535 is the IANA-designated dynamic/ephemeral port range.

This PR attempts to improve the test reliability by using port lower port number of 43315.

### Packages impacted by this PR
N/A
