### PR TITLE
[eng/tools] bump dependency `js-yaml` version to 4.1.1

### DIFF
--- a/eng/tools/analyze-deps/package-lock.json
+++ b/eng/tools/analyze-deps/package-lock.json
@@ -12,7 +12,7 @@
         "@azure-tools/eng-package-utils": "file:../eng-package-utils",
         "argparse": "^2.0.1",
         "handlebars": "^4.7.8",
-        "js-yaml": "^4.0.0",
+        "js-yaml": "^4.1.1",
         "json5": "^2.2.3",
         "semver": "^7.5.4",
         "tar": "^6.2.1"
@@ -92,9 +92,10 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/eng/tools/analyze-deps/package.json
+++ b/eng/tools/analyze-deps/package.json
@@ -13,7 +13,7 @@
     "argparse": "^2.0.1",
     "handlebars": "^4.7.8",
     "json5": "^2.2.3",
-    "js-yaml": "^4.0.0",
+    "js-yaml": "^4.1.1",
     "semver": "^7.5.4",
     "tar": "^6.2.1",
     "@azure-tools/eng-package-utils": "file:../eng-package-utils"

--- a/eng/tools/eng-package-utils/package-lock.json
+++ b/eng/tools/eng-package-utils/package-lock.json
@@ -380,9 +380,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/eng/tools/versioning/package-lock.json
+++ b/eng/tools/versioning/package-lock.json
@@ -1050,9 +1050,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
to address security alert