### PR TITLE
Bump emitter version in mid-Nov

### DIFF
--- a/.scripts/automation_generate.sh
+++ b/.scripts/automation_generate.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-code-gen-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@^6.0.51 --typespecEmitter=@azure-tools/typespec-ts
+code-gen-pipeline --inputJsonPath=$1 --outputJsonPath=$2 --use=@autorest/typescript@^6.0.52 --typespecEmitter=@azure-tools/typespec-ts

--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -6,23 +6,23 @@
     "": {
       "name": "typescript-emitter-package",
       "dependencies": {
-        "@azure-tools/typespec-autorest": "0.61.1",
-        "@azure-tools/typespec-azure-core": "0.61.0",
-        "@azure-tools/typespec-azure-resource-manager": "0.61.1",
-        "@azure-tools/typespec-azure-rulesets": "0.61.0",
-        "@azure-tools/typespec-client-generator-core": "0.61.3",
+        "@azure-tools/typespec-autorest": "0.62.0",
+        "@azure-tools/typespec-azure-core": "0.62.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.62.0",
+        "@azure-tools/typespec-azure-rulesets": "0.62.0",
+        "@azure-tools/typespec-client-generator-core": "0.62.0",
         "@azure-tools/typespec-liftr-base": "0.11.0",
-        "@azure-tools/typespec-ts": "0.46.0",
-        "@typespec/compiler": "1.5.0",
-        "@typespec/http": "1.5.0",
-        "@typespec/rest": "0.75.0",
-        "@typespec/versioning": "0.75.0"
+        "@azure-tools/typespec-ts": "0.46.1",
+        "@typespec/compiler": "1.6.0",
+        "@typespec/http": "1.6.0",
+        "@typespec/rest": "0.76.0",
+        "@typespec/versioning": "0.76.0"
       }
     },
     "node_modules/@azure-tools/rlc-common": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/rlc-common/-/rlc-common-0.46.0.tgz",
-      "integrity": "sha512-tMmotzf1shkcXciAdQxRJTIUSBZyOViFpQP39Ym/pqfc3JRjmfhvLtbuU8Vfg+dwrRpujle5/XWdnANmQKbItQ==",
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/rlc-common/-/rlc-common-0.46.1.tgz",
+      "integrity": "sha512-gHBP6Pxsi88vBYa+9BCykTqkZsE0jetAbTzCU1ExxOvNqxgaU3Nr068KN1k3zzDnpyLnO7AbUbRlyxBtk75qOA==",
       "license": "ISC",
       "dependencies": {
         "handlebars": "^4.7.7",
@@ -31,23 +31,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.61.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.61.1.tgz",
-      "integrity": "sha512-wv7Pk6c0HfWPTpR3jv5OsgzI0UmxhuriqiHu8X/0SRQBGlL4+Lwbf1UATEkLaqXpqlHZ80p7HKfUZOtDR4/yVg==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.62.0.tgz",
+      "integrity": "sha512-XftwipfGGMk9e3qGzbRMBvVpfIqLMJKc8H+XlPHFymnCfexBniZn4Qu2t8nzOVM9fgOoFDjNDzk8W5lf59U5Dg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.61.1",
-        "@azure-tools/typespec-client-generator-core": "^0.61.3",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/versioning": "^0.75.0",
-        "@typespec/xml": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.62.0",
+        "@azure-tools/typespec-client-generator-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/versioning": "^0.76.0",
+        "@typespec/xml": "^0.76.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -56,23 +56,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.61.0.tgz",
-      "integrity": "sha512-sqOYBUghAtVMBiAWwT3fMRVSDNwR7IU3AQ96n/ErhAthwWjTe7PFVfK/MPjpI1mO3cdyLeS2DGyI3gt/waWP4g==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.62.0.tgz",
+      "integrity": "sha512-4LIFqNHhKO1/jiCH0U2rfI+yH7vkWcFuwpjNyRTWXw/YghAI2d+aIEwtT4oM8jWeYR3KUQfA6AqGPRCm90AXYA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/rest": "^0.75.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/rest": "^0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.61.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.61.1.tgz",
-      "integrity": "sha512-+BVZf1OfSZfEaXsOp1ZUCyjjZjC465ieIAr1zEz4yD7KaWGW+yE/w+HXbsRNNw0B52FhgVcWX6iVuvBtMZpNMQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.62.0.tgz",
+      "integrity": "sha512-e8lO9DhIkZJ3+1o2VItq1P4gEcy9EyA5G7AhTz8qICCfU23e5xUAUfscDHYH8JAfuO9vYLvCee/MKY01MQJ0vA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -82,33 +82,33 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/versioning": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/versioning": "^0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.61.0.tgz",
-      "integrity": "sha512-EWArbj6dgTz7Xi0mAkp0ru6PoWqfXLHlk8Kt7BzVcHCPojBYK14JW9RYSxBta+h2fAEQTSQu+X1r7Y7PhJE8rA==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.62.0.tgz",
+      "integrity": "sha512-jEsR9ogSYkYxcOc5biEKbwbYS77ffD8avjT8Sbf5r+8VMPZj46uK3V0FaySbtPh+EEgoBrVj2jcbGGKDFrse1A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.61.0",
-        "@azure-tools/typespec-client-generator-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.62.0",
+        "@azure-tools/typespec-client-generator-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.61.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.61.3.tgz",
-      "integrity": "sha512-CUhw8vkMzDTYlRfddQERT0ZEJAtwjKteRNuhs1S3IrDceJlHEiXTK+FpPwen/F5DBbj1w2SgnSFfaJ3fL171/w==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.62.0.tgz",
+      "integrity": "sha512-fZilNfvqIW6Jzb97SuM5f+i9p5b0261InQRbQcTbeuYGtb5z5M0v8tuGglE4adU8NqQ1OmEv/oRjQjSeSjlxwA==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -119,16 +119,16 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": "^0.75.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/openapi": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/sse": "^0.75.0",
-        "@typespec/streams": "^0.75.0",
-        "@typespec/versioning": "^0.75.0",
-        "@typespec/xml": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": "^0.76.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/openapi": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/sse": "^0.76.0",
+        "@typespec/streams": "^0.76.0",
+        "@typespec/versioning": "^0.76.0",
+        "@typespec/xml": "^0.76.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
@@ -137,12 +137,12 @@
       "integrity": "sha512-XwHRt6GnmTT51iHHUxyFPts6LnhOE+IkANCkh3lhnDdZjHgr5asA3+NXI8UXHbKmAOLReb+eov8tBoN93aS0Ww=="
     },
     "node_modules/@azure-tools/typespec-ts": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-ts/-/typespec-ts-0.46.0.tgz",
-      "integrity": "sha512-iHW5GZyasWcONV/K5utycCJU5evjO0vqfG8S54kOGqV+uE0lyFFYP7lU6N4Q134DzHj39IZvOHqGroqC+YAR4w==",
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-ts/-/typespec-ts-0.46.1.tgz",
+      "integrity": "sha512-OF1KgVp+C8kbDGcxEFDISAMy3Qicmdf424Rte2gidHjNHWOBdxSU8WG8KmlkGdbOc0c/1hLKbQGC00Ye4Rwuww==",
       "license": "MIT",
       "dependencies": {
-        "@azure-tools/rlc-common": "^0.46.0",
+        "@azure-tools/rlc-common": "^0.46.1",
         "fs-extra": "^11.1.0",
         "lodash": "^4.17.21",
         "prettier": "^3.3.3",
@@ -150,13 +150,13 @@
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.61.0",
-        "@azure-tools/typespec-client-generator-core": "^0.61.0",
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/rest": "^0.75.0",
-        "@typespec/versioning": "^0.75.0",
-        "@typespec/xml": "^0.75.0"
+        "@azure-tools/typespec-azure-core": "^0.62.0",
+        "@azure-tools/typespec-client-generator-core": "^0.62.0",
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/rest": "^0.76.0",
+        "@typespec/versioning": "^0.76.0",
+        "@typespec/xml": "^0.76.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.5.0.tgz",
-      "integrity": "sha512-REJgZOEZ9g9CC72GGT0+nLbjW+5WVlCfm1d6w18N5RsUo7vLXs8IPXwq7xZJzoqU99Q9B4keqzPuTU4OrDUTrA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.6.0.tgz",
+      "integrity": "sha512-yxyV+ch8tnqiuU2gClv/mQEESoFwpkjo6177UkYfV0nVA9PzTg4zVVc7+WIMZk04wiLRRT3H1uc11FB1cwLY3g==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.27.1",
@@ -598,13 +598,13 @@
         "ajv": "~8.17.1",
         "change-case": "~5.4.4",
         "env-paths": "^3.0.0",
-        "globby": "~14.1.0",
+        "globby": "~15.0.0",
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
         "picocolors": "~1.1.1",
         "prettier": "~3.6.2",
         "semver": "^7.7.1",
-        "tar": "^7.4.3",
+        "tar": "^7.5.2",
         "temporal-polyfill": "^0.3.0",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
@@ -620,29 +620,29 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.75.0.tgz",
-      "integrity": "sha512-V7unXnj+sZoa/1wQG8G6x2TiQqotx18S/qFbDzdfJRPCVpH/Z3xIpppce4jTZALXT97tKZK5GDHijn2zWuWWxg==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.76.0.tgz",
+      "integrity": "sha512-mdjYQ5HA3Y4ZeyAEmiIDdRa9hbc/5qey5hU9UCA0gL+YWVYgoqLPbZQQTwqq3smM35+5cWp9GTGPyNHcOoRwOA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.5.0.tgz",
-      "integrity": "sha512-52XLXwqSY2SY6nSvfkiTsNiJzlMeIAZ6MFIVJ5YkoibA21TNAP4DtjTZgC2GieZLY2NNN/rqDCqBX+DyWqTrfQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.6.0.tgz",
+      "integrity": "sha512-q/JwVw21CF4buE3ZS+xSoy2TKAOwyhZ7g3kdNqCgm69BI5p5GGu+3ZlUA+4Blk8hkt0G8XcIN8fhJP+a4O6KAw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/streams": "^0.75.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/streams": "^0.76.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -651,84 +651,84 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.5.0.tgz",
-      "integrity": "sha512-27sXkSK2r1sAmVMLv+pwlN/Cm+yg9nEK8iuGyJRuEkBk7hcsJDbTnBlsEvlRTI8DqljtzA7YECDHBLK88zZHeg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.6.0.tgz",
+      "integrity": "sha512-KuxYAzfP5ljM0PUhSGclNZgTG0H+kyTQcwn6cf4TKhO72R2QMQmiMtN2plqvzsfkL+TLwad1iZhMWTCAMFAQ4w==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.75.0.tgz",
-      "integrity": "sha512-rQ+RP0kcrKWjbpCIkBd8hpxYSNc3CfQxl0MLP1+MYGRHlHL8ss4xbwdANIYZXZZ2i2Hqt19B7cEUGD4MLoCHvw==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.76.0.tgz",
+      "integrity": "sha512-6jtQWdcmuKyG9cmqWsJjaq64f6N5B/1DS4X3ZoTNgYhHA27Hnsxo1HZWXcpv7Wl+MxLAZM6kgpML0ugDEZcrYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/http": "^1.5.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/http": "^1.6.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.75.0.tgz",
-      "integrity": "sha512-8iODUY3C/0hR9sTzyHeTgYfZkKeqZM+/P0OmN1ZWlLUokXQ67yydGXIqnjl+yaeuntwN8H2DDwLguU15c+j+UQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.76.0.tgz",
+      "integrity": "sha512-mCd4oAXr0Tt990T2PDjx+6H0jmPHINyCH0XRU2HrWtGW5lG/NQVIs5oOxElc7NGg629HrolfLTw0oW8hdMD7Eg==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0",
-        "@typespec/events": "^0.75.0",
-        "@typespec/http": "^1.5.0",
-        "@typespec/streams": "^0.75.0"
+        "@typespec/compiler": "^1.6.0",
+        "@typespec/events": "^0.76.0",
+        "@typespec/http": "^1.6.0",
+        "@typespec/streams": "^0.76.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.75.0.tgz",
-      "integrity": "sha512-ubvxCN+SZwN9aEarz8CPtMJgnopeu8dXyut47q0FAPp9nykmXy7s+dmsopR+7OX0Fhcnh8ZFYTQcJzJ3QftOiQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.76.0.tgz",
+      "integrity": "sha512-7gQPtsokyn0Mjr43MAik6ZkQt1PZjseU+KcBE2iGT9P6oWYYTH3K1C4LLGXHZAbgEtBvFn4S+U8HPbDhj4nEhw==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.75.0.tgz",
-      "integrity": "sha512-wdLcVx5UW4WRks/OXfqLiaDTtWfAWgv/nj69u99gRJU6iY9ExEvK5x9NQszZQKYnu6tM7nkoYMg4zu+7YBUBaw==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.76.0.tgz",
+      "integrity": "sha512-dguO/B+mwlCyenWGG+M+16cMQuGHSTJbU5Z0pyUou1uyWrB1px//s4pW7PKD14S+fPutJE0wTMQm+CctOq6quA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.75.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.75.0.tgz",
-      "integrity": "sha512-JVafN1nZE3BcQrKbaAFVWw/IleTRdsJpwT3oZ2m7EfWnG30sKtoR9inF9dRoW+XXIjNzCfeYqjkwzEkEnIrCww==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.76.0.tgz",
+      "integrity": "sha512-+I7hdWZDO3qBfzRT3St+1Dg/NQAMNLz8w1OydutSnVMx0G3KWg/ESonaByszBUfdq6Z5iTtls3gvj4wgrw80gA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.5.0"
+        "@typespec/compiler": "^1.6.0"
       }
     },
     "node_modules/ajv": {
@@ -1079,20 +1079,20 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-15.0.0.tgz",
+      "integrity": "sha512-oB4vkQGqlMl682wL1IlWd02tXCbquGWM4voPEI85QmNKCaw8zGTm1f1rubFgkg3Eli2PtKlFgrnmUqasbQWlkw==",
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
+        "ignore": "^7.0.5",
         "path-type": "^6.0.0",
         "slash": "^5.1.0",
         "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -2,16 +2,16 @@
   "name": "typescript-emitter-package",
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-ts": "0.46.0",
-    "@azure-tools/typespec-azure-core": "0.61.0",
-    "@azure-tools/typespec-autorest": "0.61.1",
-    "@azure-tools/typespec-client-generator-core": "0.61.3",
-    "@azure-tools/typespec-azure-resource-manager": "0.61.1",
-    "@azure-tools/typespec-azure-rulesets": "0.61.0",
+    "@azure-tools/typespec-ts": "0.46.1",
+    "@azure-tools/typespec-azure-core": "0.62.0",
+    "@azure-tools/typespec-autorest": "0.62.0",
+    "@azure-tools/typespec-client-generator-core": "0.62.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.62.0",
+    "@azure-tools/typespec-azure-rulesets": "0.62.0",
     "@azure-tools/typespec-liftr-base": "0.11.0",
-    "@typespec/compiler": "1.5.0",
-    "@typespec/http": "1.5.0",
-    "@typespec/rest": "0.75.0",
-    "@typespec/versioning": "0.75.0"
+    "@typespec/compiler": "1.6.0",
+    "@typespec/http": "1.6.0",
+    "@typespec/rest": "0.76.0",
+    "@typespec/versioning": "0.76.0"
   }
 }


### PR DESCRIPTION
Bump dependencies for typespec packages and update code-gen-pipeline version
## Version Changes
@autorest/typescript: 6.0.51→ 6.0.52
@azure-tools/typespec-ts: 0.46.0→ 0.46.1


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
