### PR TITLE
[EngSys] bump identity catalog:internal version to latest 4.13.0

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -40,7 +40,7 @@
     "@_ts/max": "npm:typescript@latest",
     "@_ts/min": "npm:typescript@~4.2.4",
     "@arethetypeswrong/cli": "^0.17.4",
-    "@azure/identity": "4.12.0",
+    "@azure/identity": "catalog:internal",
     "@microsoft/api-extractor": "^7.52.4",
     "@microsoft/api-extractor-model": "^7.30.5",
     "@pnpm/catalogs.config": "^1000.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ catalogs:
       version: 5.9.3
   internal:
     '@azure/identity':
-      specifier: 4.11.1
-      version: 4.11.1
+      specifier: 4.13.0
+      version: 4.13.0
   testing:
     '@rollup/plugin-inject':
       specifier: ^5.0.5
@@ -117,8 +117,8 @@ importers:
         specifier: ^0.17.4
         version: 0.17.4
       '@azure/identity':
-        specifier: 4.12.0
-        version: 4.12.0
+        specifier: catalog:internal
+        version: 4.13.0
       '@microsoft/api-extractor':
         specifier: ^7.52.4
         version: 7.55.0(@types/node@20.19.25)
@@ -456,7 +456,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -535,7 +535,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -617,7 +617,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -693,7 +693,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -772,7 +772,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/monitor-opentelemetry':
         specifier: ^1.11.1
         version: link:../../monitor/monitor-opentelemetry
@@ -881,7 +881,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.36
         version: link:../../monitor/monitor-opentelemetry-exporter
@@ -1005,7 +1005,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/monitor-opentelemetry':
         specifier: ^1.14.2
         version: link:../../monitor/monitor-opentelemetry
@@ -1105,7 +1105,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -1184,7 +1184,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -1251,7 +1251,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -1333,7 +1333,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -1534,7 +1534,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -1607,7 +1607,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -1695,7 +1695,7 @@ importers:
         version: link:../../eventgrid/eventgrid
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/keyvault-secrets':
         specifier: ^4.2.0
         version: link:../../keyvault/keyvault-secrets
@@ -1826,7 +1826,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -1899,7 +1899,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -1972,7 +1972,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -2042,7 +2042,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -2121,7 +2121,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -2194,7 +2194,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -2273,7 +2273,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2340,7 +2340,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2413,7 +2413,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -2495,7 +2495,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2562,7 +2562,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2629,7 +2629,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2702,7 +2702,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2781,7 +2781,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -2857,7 +2857,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2921,7 +2921,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -2991,7 +2991,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3070,7 +3070,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -3146,7 +3146,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3222,7 +3222,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3310,7 +3310,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/keyvault-keys':
         specifier: workspace:^
         version: link:../../keyvault/keyvault-keys
@@ -3389,7 +3389,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3462,7 +3462,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3532,7 +3532,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3605,7 +3605,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -3681,7 +3681,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3754,7 +3754,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -3827,7 +3827,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -3891,7 +3891,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -3967,7 +3967,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -4049,7 +4049,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -4134,7 +4134,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -4225,7 +4225,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/storage-blob':
         specifier: ^12.26.0
         version: link:../../storage/storage-blob
@@ -4359,7 +4359,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -4432,7 +4432,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -4496,7 +4496,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -4569,7 +4569,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -4654,7 +4654,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -4754,7 +4754,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/service-bus':
         specifier: ^7.9.5
         version: 7.9.5
@@ -4933,7 +4933,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -5024,7 +5024,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5118,7 +5118,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/msal-node':
         specifier: ^2.16.1
         version: 2.16.3
@@ -5200,7 +5200,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5294,7 +5294,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5391,7 +5391,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5482,7 +5482,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5570,7 +5570,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5661,7 +5661,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5749,7 +5749,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5840,7 +5840,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -5928,7 +5928,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6007,7 +6007,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -6086,7 +6086,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -6165,7 +6165,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6244,7 +6244,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6326,7 +6326,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6402,7 +6402,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6484,7 +6484,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6560,7 +6560,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -6630,7 +6630,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6703,7 +6703,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -6782,7 +6782,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -6858,7 +6858,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -6925,7 +6925,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -6998,7 +6998,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -7071,7 +7071,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -7159,7 +7159,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -7278,7 +7278,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -7360,7 +7360,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -7445,7 +7445,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -7527,7 +7527,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -7606,7 +7606,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -8634,7 +8634,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -8722,7 +8722,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/debug':
         specifier: ^4.1.4
         version: 4.1.12
@@ -8813,7 +8813,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -8886,7 +8886,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -8959,7 +8959,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9035,7 +9035,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -9117,7 +9117,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -9184,7 +9184,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9257,7 +9257,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9330,7 +9330,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9400,7 +9400,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9473,7 +9473,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9543,7 +9543,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9613,7 +9613,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9686,7 +9686,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9759,7 +9759,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9829,7 +9829,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -9911,7 +9911,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -9987,7 +9987,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -10066,7 +10066,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10148,7 +10148,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10221,7 +10221,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -10285,7 +10285,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -10358,7 +10358,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -10434,7 +10434,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10504,7 +10504,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -10583,7 +10583,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10665,7 +10665,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10741,7 +10741,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -10823,7 +10823,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10905,7 +10905,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -10981,7 +10981,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11051,7 +11051,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11121,7 +11121,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11206,7 +11206,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -11282,7 +11282,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11355,7 +11355,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11428,7 +11428,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -11513,7 +11513,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -11592,7 +11592,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -11668,7 +11668,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -11747,7 +11747,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11823,7 +11823,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -11899,7 +11899,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -11969,7 +11969,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -12045,7 +12045,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -12115,7 +12115,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -12188,7 +12188,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -12261,7 +12261,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -12331,7 +12331,7 @@ importers:
         version: 3.5.1
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -12407,7 +12407,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -12483,7 +12483,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/service-bus':
         specifier: ^7.9.5
         version: 7.9.5
@@ -12571,7 +12571,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -12760,7 +12760,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -12830,7 +12830,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -12924,7 +12924,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/keyvault-secrets':
         specifier: ^4.9.0
         version: link:../../keyvault/keyvault-secrets
@@ -13100,7 +13100,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@rollup/plugin-inject':
         specifier: catalog:testing
         version: 5.0.5(rollup@4.53.2)
@@ -13200,7 +13200,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@rollup/plugin-inject':
         specifier: catalog:testing
         version: 5.0.5(rollup@4.53.2)
@@ -13358,7 +13358,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -13437,7 +13437,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -13516,7 +13516,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -13586,7 +13586,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -13650,7 +13650,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -13738,7 +13738,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@rollup/plugin-node-resolve':
         specifier: ^15.0.0
         version: 15.3.1(rollup@4.53.2)
@@ -13869,7 +13869,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -13942,7 +13942,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14009,7 +14009,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14082,7 +14082,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14158,7 +14158,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -14237,7 +14237,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14313,7 +14313,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14383,7 +14383,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14462,7 +14462,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -14544,7 +14544,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.25
@@ -14623,7 +14623,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -14705,7 +14705,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -14787,7 +14787,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -14866,7 +14866,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -14945,7 +14945,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -15021,7 +15021,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -15094,7 +15094,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -15170,7 +15170,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -15614,7 +15614,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -15693,7 +15693,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -15769,7 +15769,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -15988,7 +15988,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -16064,7 +16064,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -16143,7 +16143,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -16222,7 +16222,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -16301,7 +16301,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -16377,7 +16377,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -16450,7 +16450,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -16538,7 +16538,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/keyvault-keys':
         specifier: ^4.9.0
         version: link:../keyvault-keys
@@ -16635,7 +16635,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/keyvault-secrets':
         specifier: ^4.9.0
         version: link:../keyvault-secrets
@@ -16848,7 +16848,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -16988,7 +16988,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -17110,7 +17110,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -17183,7 +17183,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.2.0
         version: link:../../core/logger
@@ -17250,7 +17250,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.2.0
         version: link:../../core/logger
@@ -17323,7 +17323,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.2.0
         version: link:../../core/logger
@@ -17396,7 +17396,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -17475,7 +17475,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -17551,7 +17551,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -17624,7 +17624,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -17703,7 +17703,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -17779,7 +17779,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -17858,7 +17858,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -17934,7 +17934,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18013,7 +18013,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -18086,7 +18086,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18156,7 +18156,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18293,7 +18293,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -18360,7 +18360,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@playwright/test':
         specifier: ^1.51.1
         version: 1.56.1
@@ -18433,7 +18433,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18497,7 +18497,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18570,7 +18570,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18637,7 +18637,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18707,7 +18707,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18780,7 +18780,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18844,7 +18844,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18914,7 +18914,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -18978,7 +18978,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19045,7 +19045,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19118,7 +19118,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19191,7 +19191,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19264,7 +19264,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19328,7 +19328,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19395,7 +19395,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -19538,7 +19538,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -19620,7 +19620,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -19705,7 +19705,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -19790,7 +19790,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -19875,7 +19875,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -19954,7 +19954,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20018,7 +20018,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20100,7 +20100,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -20213,7 +20213,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20286,7 +20286,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20359,7 +20359,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20432,7 +20432,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20511,7 +20511,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -20593,7 +20593,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -20681,7 +20681,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20748,7 +20748,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -20833,7 +20833,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/monitor-query-logs':
         specifier: ^1.0.0
         version: link:../monitor-query-logs
@@ -21267,7 +21267,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.36
         version: link:../monitor-opentelemetry-exporter
@@ -21358,7 +21358,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
         specifier: 1.0.0-beta.36
         version: link:../monitor-opentelemetry-exporter
@@ -21440,7 +21440,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -21513,7 +21513,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -21583,7 +21583,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -21662,7 +21662,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -21744,7 +21744,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -21820,7 +21820,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -21899,7 +21899,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -21975,7 +21975,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -22054,7 +22054,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -22133,7 +22133,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22203,7 +22203,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -22282,7 +22282,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22358,7 +22358,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22519,7 +22519,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22595,7 +22595,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -22665,7 +22665,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -22738,7 +22738,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22826,7 +22826,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22899,7 +22899,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -22975,7 +22975,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -23051,7 +23051,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -23124,7 +23124,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -23197,7 +23197,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -23273,7 +23273,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -23355,7 +23355,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -23437,7 +23437,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -23519,7 +23519,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -23714,7 +23714,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -23784,7 +23784,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -23857,7 +23857,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -23924,7 +23924,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -23997,7 +23997,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24073,7 +24073,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -24143,7 +24143,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -24216,7 +24216,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -24289,7 +24289,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -24359,7 +24359,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -24438,7 +24438,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24520,7 +24520,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24596,7 +24596,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -24663,7 +24663,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24736,7 +24736,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24818,7 +24818,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24897,7 +24897,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -24973,7 +24973,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -25052,7 +25052,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25128,7 +25128,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25216,7 +25216,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -25295,7 +25295,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -25368,7 +25368,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25447,7 +25447,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -25523,7 +25523,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25596,7 +25596,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25672,7 +25672,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25745,7 +25745,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:^
         version: link:../../core/logger
@@ -25824,7 +25824,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25897,7 +25897,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -25970,7 +25970,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26037,7 +26037,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26101,7 +26101,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26174,7 +26174,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26241,7 +26241,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26314,7 +26314,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26387,7 +26387,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26460,7 +26460,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -26536,7 +26536,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26609,7 +26609,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -26685,7 +26685,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -26770,7 +26770,7 @@ importers:
         version: link:../../eventhub/event-hubs
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@rollup/plugin-inject':
         specifier: catalog:testing
         version: 5.0.5(rollup@4.53.2)
@@ -26910,7 +26910,7 @@ importers:
         version: link:../../eventhub/event-hubs
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@rollup/plugin-inject':
         specifier: catalog:testing
         version: 5.0.5(rollup@4.53.2)
@@ -26995,7 +26995,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27068,7 +27068,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27156,7 +27156,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/openai':
         specifier: 1.0.0-beta.12
         version: 1.0.0-beta.12
@@ -27284,7 +27284,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27357,7 +27357,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27430,7 +27430,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27503,7 +27503,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27567,7 +27567,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27631,7 +27631,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27704,7 +27704,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -27819,7 +27819,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@rollup/plugin-inject':
         specifier: catalog:testing
         version: 5.0.5(rollup@4.53.2)
@@ -27977,7 +27977,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28056,7 +28056,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -28141,7 +28141,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -28211,7 +28211,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28284,7 +28284,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28363,7 +28363,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -28439,7 +28439,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28518,7 +28518,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -28594,7 +28594,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28667,7 +28667,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28740,7 +28740,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28816,7 +28816,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -28895,7 +28895,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -28971,7 +28971,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -29047,7 +29047,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -29147,7 +29147,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/storage-file-share':
         specifier: ^12.27.0
         version: link:../storage-file-share
@@ -29244,7 +29244,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -29466,7 +29466,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -29609,7 +29609,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/storage-blob':
         specifier: 12.27.0
         version: 12.27.0
@@ -29810,7 +29810,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -29895,7 +29895,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -29971,7 +29971,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30053,7 +30053,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -30123,7 +30123,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30202,7 +30202,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -30278,7 +30278,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30348,7 +30348,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30418,7 +30418,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30488,7 +30488,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30561,7 +30561,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -30634,7 +30634,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30707,7 +30707,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30780,7 +30780,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -30926,7 +30926,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -31318,7 +31318,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -31443,7 +31443,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -31635,7 +31635,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -31711,7 +31711,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -32052,7 +32052,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -32174,7 +32174,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -32241,7 +32241,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -32320,7 +32320,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/storage-blob':
         specifier: ^12.26.0
         version: link:../../storage/storage-blob
@@ -32399,7 +32399,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -32484,7 +32484,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -32557,7 +32557,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -32633,7 +32633,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -32703,7 +32703,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -32776,7 +32776,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -32849,7 +32849,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -32931,7 +32931,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/jsonwebtoken':
         specifier: ^9.0.7
         version: 9.0.10
@@ -33013,7 +33013,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/web-pubsub':
         specifier: ^1.1.3
         version: link:../web-pubsub
@@ -33086,7 +33086,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/web-pubsub':
         specifier: ^1.1.0
         version: link:../web-pubsub
@@ -33247,7 +33247,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -33323,7 +33323,7 @@ importers:
         version: link:../../../common/tools/dev-tool
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -33402,7 +33402,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@azure/identity':
         specifier: catalog:internal
-        version: 4.11.1
+        version: 4.13.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.25
@@ -33595,14 +33595,6 @@ packages:
   '@azure/functions@4.9.0':
     resolution: {integrity: sha512-IlgCl2/OiSXjMaow5oUhtMQMlsxEAZwsk7BXoT44vgzdIaiZz1VjCzGK9D/7pi6bd0FSyDo6H/1mZASzcD0K6A==}
     engines: {node: '>=20.0'}
-
-  '@azure/identity@4.11.1':
-    resolution: {integrity: sha512-0ZdsLRaOyLxtCYgyuqyWqGU5XQ9gGnjxgfoNTt1pvELGkkUFrMATABZFIq8gusM7N1qbqpVtwLOhk0d/3kacLg==}
-    engines: {node: '>=20.0.0'}
-
-  '@azure/identity@4.12.0':
-    resolution: {integrity: sha512-6vuh2R3Cte6SD6azNalLCjIDoryGdcvDVEV7IDRPtm5lHX5ffkDlIalaoOp5YJU08e4ipjJENel20kSMDLAcug==}
-    engines: {node: '>=20.0.0'}
 
   '@azure/identity@4.13.0':
     resolution: {integrity: sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==}
@@ -38578,7 +38570,7 @@ snapshots:
   '@azure/app-configuration-provider@2.2.0':
     dependencies:
       '@azure/app-configuration': 1.10.0
-      '@azure/identity': 4.11.1
+      '@azure/identity': 4.13.0
       '@azure/keyvault-secrets': 4.10.0
       jsonc-parser: 3.3.1
     transitivePeerDependencies:
@@ -38897,38 +38889,6 @@ snapshots:
       cookie: 0.7.2
       long: 4.0.0
       undici: 5.29.0
-
-  '@azure/identity@4.11.1':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
-      '@azure/msal-browser': 4.26.1
-      '@azure/msal-node': 3.8.2
-      open: 10.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/identity@4.12.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-rest-pipeline': 1.22.2
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/logger': 1.3.0
-      '@azure/msal-browser': 4.26.1
-      '@azure/msal-node': 3.8.2
-      open: 10.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@azure/identity@4.13.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalogs:
     '@azure/arm-storage': 18.5.0
     '@azure/arm-webpubsub': 1.2.0
   internal:
-    '@azure/identity': 4.11.1
+    '@azure/identity': 4.13.0
   testing:
     '@rollup/plugin-inject': ^5.0.5
     '@types/chai': ^5.2.1


### PR DESCRIPTION
This unifies our internal version and avoids downloading multiple versions when installing dependencies.