### PR TITLE
[EngSys] remove `npm run clean` from `test:node` NPM script

### DIFF
--- a/sdk/dell/arm-dell-storage/package.json
+++ b/sdk/dell/arm-dell-storage/package.json
@@ -109,7 +109,7 @@
     "pack": "pnpm pack 2>&1",
     "test": "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run unit-test:browser && npm run integration-test",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
-    "test:node": "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
+    "test:node": "dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "dev-tool run test:vitest",

--- a/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
+++ b/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
@@ -101,7 +101,7 @@
     "pack": "pnpm pack 2>&1",
     "test": "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run unit-test:browser && npm run integration-test",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
-    "test:node": "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
+    "test:node": "dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "npm run build:test && dev-tool run test:vitest --browser",
     "unit-test:node": "dev-tool run test:vitest",


### PR DESCRIPTION
For consistency across the repo.