### PR TITLE
[Samples] add doc about package sample authoring

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -41,7 +41,6 @@ The `//sampleConfiguration` section in the `package.json` holds the package-leve
 
 ```json
   "//sampleConfiguration": {
-    "disableDocsMs": true,
     "productName": "Azure Schema Registry",
     "productSlugs": [
       "azure",
@@ -52,6 +51,8 @@ The `//sampleConfiguration` section in the `package.json` holds the package-leve
     }
   },
 ```
+
+If you do not want to publish samples to learn.microsoft.com, add `"disableDocsMs": true` in the sample configuration.
 
 ### Azure SDK Metadata Tags for Samples
 


### PR DESCRIPTION
There are comments in dev-tool source code but they are not easily accessible to SDK authors. This PR adds information about authoring package samples to `samples/README.md` so we can share with SDK authors.