### PR TITLE
[EngSys] bump dev dependency `node-forge` version to ^1.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,13 +59,13 @@ catalogs:
       version: 8.0.2
     '@vitest/browser-playwright':
       specifier: ^4.0.8
-      version: 4.0.13
+      version: 4.0.14
     '@vitest/coverage-istanbul':
       specifier: ^4.0.8
-      version: 4.0.13
+      version: 4.0.14
     '@vitest/expect':
       specifier: ^4.0.6
-      version: 4.0.13
+      version: 4.0.14
     chai:
       specifier: ^6.2.0
       version: 6.2.1
@@ -83,10 +83,10 @@ catalogs:
       version: 13.5.6
     playwright:
       specifier: ^1.56.1
-      version: 1.56.1
+      version: 1.57.0
     vitest:
       specifier: ^4.0.8
-      version: 4.0.13
+      version: 4.0.14
 
 importers:
 
@@ -221,7 +221,7 @@ importers:
         version: 0.10.11
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -245,7 +245,7 @@ importers:
         version: 8.46.4(eslint@9.39.1)(typescript@5.9.3)
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   common/tools/eslint-plugin-azure-sdk:
     dependencies:
@@ -315,7 +315,7 @@ importers:
         version: 8.46.4(eslint@9.39.1)(typescript@5.8.3)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -324,7 +324,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
@@ -336,7 +336,7 @@ importers:
         version: 3.1.0
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   common/tools/vite-plugin-browser-test-map:
     dependencies:
@@ -398,7 +398,7 @@ importers:
         version: 20.19.25
       '@vitest/coverage-istanbul':
         specifier: ^4.0.0
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       eslint:
         specifier: ^9.9.0
         version: 9.39.1
@@ -422,7 +422,7 @@ importers:
         version: 8.46.4(eslint@9.39.1)(typescript@5.8.3)
       vitest:
         specifier: ^4.0.0
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/advisor/arm-advisor:
     dependencies:
@@ -462,10 +462,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -474,7 +474,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -489,7 +489,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/agricultureplatform/arm-agricultureplatform:
     dependencies:
@@ -541,10 +541,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -556,7 +556,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -571,7 +571,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/agrifood/agrifood-farming-rest:
     dependencies:
@@ -623,10 +623,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -638,7 +638,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -653,7 +653,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/agrifood/arm-agrifood:
     dependencies:
@@ -699,10 +699,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -717,7 +717,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/ai/ai-agents:
     dependencies:
@@ -796,10 +796,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -814,7 +814,7 @@ importers:
         version: 3.0.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: ^3.2.5
         version: 3.6.2
@@ -829,7 +829,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/ai/ai-inference-rest:
     dependencies:
@@ -902,10 +902,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -923,7 +923,7 @@ importers:
         version: 3.0.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -938,7 +938,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/ai/ai-projects:
     dependencies:
@@ -1026,10 +1026,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1044,7 +1044,7 @@ importers:
         version: 3.0.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1059,7 +1059,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/ai/ai-voicelive:
     dependencies:
@@ -1114,10 +1114,10 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1129,7 +1129,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1144,7 +1144,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/analysisservices/arm-analysisservices:
     dependencies:
@@ -1190,10 +1190,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1208,7 +1208,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/anomalydetector/ai-anomaly-detector-rest:
     dependencies:
@@ -1257,10 +1257,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -1278,7 +1278,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1293,7 +1293,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/apicenter/arm-apicenter:
     dependencies:
@@ -1339,10 +1339,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1360,7 +1360,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/apimanagement/api-management-custom-widgets-scaffolder:
     dependencies:
@@ -1409,7 +1409,7 @@ importers:
         version: 21.0.3
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1436,7 +1436,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/apimanagement/api-management-custom-widgets-tools:
     dependencies:
@@ -1467,10 +1467,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1479,7 +1479,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1494,7 +1494,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/apimanagement/arm-apimanagement:
     dependencies:
@@ -1543,10 +1543,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1555,7 +1555,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -1567,7 +1567,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appcomplianceautomation/arm-appcomplianceautomation:
     dependencies:
@@ -1613,10 +1613,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1625,7 +1625,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -1637,7 +1637,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appconfiguration/app-configuration:
     dependencies:
@@ -1707,10 +1707,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1725,7 +1725,7 @@ importers:
         version: 13.5.6
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1740,7 +1740,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appconfiguration/app-configuration-perf-tests:
     dependencies:
@@ -1835,10 +1835,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1847,7 +1847,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -1859,7 +1859,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appcontainers/arm-appcontainers:
     dependencies:
@@ -1908,10 +1908,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1923,7 +1923,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -1938,7 +1938,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/applicationinsights/arm-appinsights:
     dependencies:
@@ -1978,10 +1978,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -1990,7 +1990,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2002,7 +2002,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appservice/arm-appservice:
     dependencies:
@@ -2051,10 +2051,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2066,7 +2066,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -2081,7 +2081,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appservice/arm-appservice-profile-2020-09-01-hybrid:
     dependencies:
@@ -2127,10 +2127,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2139,7 +2139,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2151,7 +2151,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/appservice/arm-appservice-rest:
     dependencies:
@@ -2200,10 +2200,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -2218,7 +2218,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -2233,7 +2233,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/astro/arm-astro:
     dependencies:
@@ -2282,10 +2282,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2294,7 +2294,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2306,7 +2306,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/attestation/arm-attestation:
     dependencies:
@@ -2349,16 +2349,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2370,7 +2370,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/attestation/attestation:
     dependencies:
@@ -2419,10 +2419,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       buffer:
         specifier: ^6.0.0
         version: 6.0.3
@@ -2437,7 +2437,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -2455,7 +2455,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/authorization/arm-authorization:
     dependencies:
@@ -2504,10 +2504,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2516,7 +2516,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2528,7 +2528,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/authorization/arm-authorization-profile-2020-09-01-hybrid:
     dependencies:
@@ -2571,10 +2571,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2583,7 +2583,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2595,7 +2595,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/automanage/arm-automanage:
     dependencies:
@@ -2638,10 +2638,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2650,7 +2650,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2662,7 +2662,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/automation/arm-automation:
     dependencies:
@@ -2711,10 +2711,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2723,7 +2723,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2735,7 +2735,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/avs/arm-avs:
     dependencies:
@@ -2787,10 +2787,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -2802,7 +2802,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -2817,7 +2817,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/azureadexternalidentities/arm-azureadexternalidentities:
     dependencies:
@@ -2866,16 +2866,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2887,7 +2887,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/azurestack/arm-azurestack:
     dependencies:
@@ -2930,16 +2930,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -2951,7 +2951,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/azurestackhci/arm-azurestackhci:
     dependencies:
@@ -3000,10 +3000,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3012,7 +3012,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3024,7 +3024,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/azurestackhcivm/arm-azurestackhcivm:
     dependencies:
@@ -3076,10 +3076,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3091,7 +3091,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -3106,7 +3106,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/baremetalinfrastructure/arm-baremetalinfrastructure:
     dependencies:
@@ -3155,10 +3155,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3167,7 +3167,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3179,7 +3179,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/batch/arm-batch:
     dependencies:
@@ -3231,10 +3231,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3243,7 +3243,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3255,7 +3255,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/batch/batch-rest:
     dependencies:
@@ -3319,10 +3319,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       dotenv:
         specifier: catalog:testing
         version: 16.6.1
@@ -3334,7 +3334,7 @@ importers:
         version: 2.30.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -3349,7 +3349,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/billing/arm-billing:
     dependencies:
@@ -3398,10 +3398,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3410,7 +3410,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3422,7 +3422,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/billingbenefits/arm-billingbenefits:
     dependencies:
@@ -3471,16 +3471,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3492,7 +3492,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/botservice/arm-botservice:
     dependencies:
@@ -3541,10 +3541,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3553,7 +3553,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3565,7 +3565,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/carbonoptimization/arm-carbonoptimization:
     dependencies:
@@ -3611,10 +3611,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3626,7 +3626,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -3641,7 +3641,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cdn/arm-cdn:
     dependencies:
@@ -3690,10 +3690,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3702,7 +3702,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3714,7 +3714,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/certificateregistration/arm-certificateregistration:
     dependencies:
@@ -3763,10 +3763,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3778,7 +3778,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -3793,7 +3793,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/changeanalysis/arm-changeanalysis:
     dependencies:
@@ -3836,16 +3836,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3857,7 +3857,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/changes/arm-changes:
     dependencies:
@@ -3897,16 +3897,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -3918,7 +3918,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/chaos/arm-chaos:
     dependencies:
@@ -3973,10 +3973,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -3988,7 +3988,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4003,7 +4003,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cloudhealth/arm-cloudhealth:
     dependencies:
@@ -4055,10 +4055,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4070,7 +4070,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4085,7 +4085,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cognitivelanguage/ai-language-conversations:
     dependencies:
@@ -4143,10 +4143,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4158,7 +4158,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4173,7 +4173,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cognitivelanguage/ai-language-text:
     dependencies:
@@ -4237,10 +4237,10 @@ importers:
         version: 0.10.11
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       chai-exclude:
         specifier: catalog:testing
         version: 3.0.1(chai@6.2.1)
@@ -4255,7 +4255,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4273,7 +4273,7 @@ importers:
         version: 0.12.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cognitivelanguage/ai-language-text-perf-tests:
     dependencies:
@@ -4368,10 +4368,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4383,7 +4383,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4398,7 +4398,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/commerce/arm-commerce:
     dependencies:
@@ -4441,16 +4441,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -4462,7 +4462,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/commerce/arm-commerce-profile-2020-09-01-hybrid:
     dependencies:
@@ -4505,10 +4505,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4517,7 +4517,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -4529,7 +4529,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/arm-communication:
     dependencies:
@@ -4578,10 +4578,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4590,7 +4590,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -4602,7 +4602,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-alpha-ids:
     dependencies:
@@ -4660,10 +4660,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4675,7 +4675,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4690,7 +4690,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-call-automation:
     dependencies:
@@ -4763,10 +4763,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4781,7 +4781,7 @@ importers:
         version: 2.0.4
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4796,7 +4796,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-chat:
     dependencies:
@@ -4860,10 +4860,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4875,7 +4875,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4890,7 +4890,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-common:
     dependencies:
@@ -4942,10 +4942,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -4960,7 +4960,7 @@ importers:
         version: 13.5.6
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -4975,7 +4975,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-email:
     dependencies:
@@ -5030,10 +5030,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5045,7 +5045,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5060,7 +5060,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-identity:
     dependencies:
@@ -5127,10 +5127,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5142,7 +5142,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5157,7 +5157,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-job-router-rest:
     dependencies:
@@ -5206,10 +5206,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -5224,7 +5224,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5239,7 +5239,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-messages-rest:
     dependencies:
@@ -5300,10 +5300,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -5318,7 +5318,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5333,7 +5333,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-phone-numbers:
     dependencies:
@@ -5397,10 +5397,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5412,7 +5412,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5427,7 +5427,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-recipient-verification:
     dependencies:
@@ -5488,10 +5488,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5503,7 +5503,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5518,7 +5518,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-rooms:
     dependencies:
@@ -5576,10 +5576,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5591,7 +5591,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5606,7 +5606,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-short-codes:
     dependencies:
@@ -5667,10 +5667,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5682,7 +5682,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5697,7 +5697,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-sms:
     dependencies:
@@ -5755,10 +5755,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5770,7 +5770,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5785,7 +5785,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-tiering:
     dependencies:
@@ -5846,10 +5846,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5861,7 +5861,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5876,7 +5876,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/communication/communication-toll-free-verification:
     dependencies:
@@ -5934,10 +5934,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -5949,7 +5949,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -5964,7 +5964,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/compute/arm-compute:
     dependencies:
@@ -6016,10 +6016,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6031,7 +6031,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6046,7 +6046,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/compute/arm-compute-profile-2020-09-01-hybrid:
     dependencies:
@@ -6095,10 +6095,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6107,7 +6107,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -6119,7 +6119,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/compute/arm-compute-rest:
     dependencies:
@@ -6171,10 +6171,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -6189,7 +6189,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6204,7 +6204,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/compute/arm-computerecommender:
     dependencies:
@@ -6250,10 +6250,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6265,7 +6265,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6280,7 +6280,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/computefleet/arm-computefleet:
     dependencies:
@@ -6332,10 +6332,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6347,7 +6347,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6362,7 +6362,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/computelimit/arm-computelimit:
     dependencies:
@@ -6408,10 +6408,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6423,7 +6423,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6438,7 +6438,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/computeschedule/arm-computeschedule:
     dependencies:
@@ -6490,10 +6490,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6505,7 +6505,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6520,7 +6520,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/confidentialledger/arm-confidentialledger:
     dependencies:
@@ -6569,10 +6569,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6581,7 +6581,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -6593,7 +6593,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/confidentialledger/confidential-ledger-rest:
     dependencies:
@@ -6636,10 +6636,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6663,7 +6663,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/confluent/arm-confluent:
     dependencies:
@@ -6712,10 +6712,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6724,7 +6724,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -6736,7 +6736,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/connectedcache/arm-connectedcache:
     dependencies:
@@ -6788,10 +6788,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6803,7 +6803,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -6818,7 +6818,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/connectedvmware/arm-connectedvmware:
     dependencies:
@@ -6867,10 +6867,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6879,7 +6879,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -6891,7 +6891,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/consumption/arm-consumption:
     dependencies:
@@ -6934,10 +6934,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -6946,7 +6946,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -6958,7 +6958,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerinstance/arm-containerinstance:
     dependencies:
@@ -7007,10 +7007,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7019,7 +7019,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -7031,7 +7031,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerregistry/arm-containerregistry:
     dependencies:
@@ -7080,10 +7080,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7095,7 +7095,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7110,7 +7110,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerregistry/container-registry:
     dependencies:
@@ -7165,10 +7165,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7180,7 +7180,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7195,7 +7195,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerregistry/container-registry-perf-tests:
     dependencies:
@@ -7287,10 +7287,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7302,7 +7302,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7317,7 +7317,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerservice/arm-containerservice-rest:
     dependencies:
@@ -7366,10 +7366,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -7384,7 +7384,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7399,7 +7399,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerservice/arm-containerservicefleet:
     dependencies:
@@ -7451,10 +7451,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7466,7 +7466,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7481,7 +7481,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/containerservice/arm-containerservicesafeguards:
     dependencies:
@@ -7533,10 +7533,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7548,7 +7548,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7563,7 +7563,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/contentsafety/ai-content-safety-rest:
     dependencies:
@@ -7612,10 +7612,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -7630,7 +7630,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7648,7 +7648,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/abort-controller:
     dependencies:
@@ -7667,10 +7667,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7679,7 +7679,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7694,7 +7694,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-amqp:
     dependencies:
@@ -7755,10 +7755,10 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7770,7 +7770,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7785,7 +7785,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       ws:
         specifier: ^8.17.0
         version: 8.18.3
@@ -7813,10 +7813,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7825,7 +7825,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7840,7 +7840,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-client:
     dependencies:
@@ -7880,10 +7880,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7892,7 +7892,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7907,7 +7907,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-client-rest:
     dependencies:
@@ -7941,10 +7941,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -7953,7 +7953,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -7968,7 +7968,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-http-compat:
     dependencies:
@@ -7993,10 +7993,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8005,7 +8005,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8020,7 +8020,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-lro:
     dependencies:
@@ -8054,10 +8054,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8066,7 +8066,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8081,7 +8081,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-paging:
     dependencies:
@@ -8100,10 +8100,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8112,7 +8112,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8127,7 +8127,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-rest-pipeline:
     dependencies:
@@ -8167,10 +8167,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8179,7 +8179,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8194,7 +8194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-rest-pipeline-perf-tests:
     dependencies:
@@ -8292,10 +8292,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8310,7 +8310,7 @@ importers:
         version: 5.1.0
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8328,7 +8328,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-tracing:
     dependencies:
@@ -8350,10 +8350,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8362,7 +8362,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8377,7 +8377,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-util:
     dependencies:
@@ -8405,10 +8405,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8417,7 +8417,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8432,7 +8432,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/core-xml:
     dependencies:
@@ -8457,10 +8457,10 @@ importers:
         version: 2.0.7
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8469,7 +8469,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8484,7 +8484,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/logger:
     dependencies:
@@ -8506,10 +8506,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8521,7 +8521,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8536,7 +8536,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/core/ts-http-runtime:
     dependencies:
@@ -8564,10 +8564,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8576,7 +8576,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8594,7 +8594,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cosmosdb/arm-cosmosdb:
     dependencies:
@@ -8643,10 +8643,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8658,7 +8658,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8673,7 +8673,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cosmosdb/cosmos:
     dependencies:
@@ -8737,10 +8737,10 @@ importers:
         version: 1.1.4
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       assertion-error:
         specifier: ^2.0.1
         version: 2.0.1
@@ -8758,7 +8758,7 @@ importers:
         version: 13.5.6
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -8773,7 +8773,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql:
     dependencies:
@@ -8822,10 +8822,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8834,7 +8834,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -8846,7 +8846,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/cost-management/arm-costmanagement:
     dependencies:
@@ -8895,10 +8895,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -8907,7 +8907,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -8919,7 +8919,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/customer-insights/arm-customerinsights:
     dependencies:
@@ -8968,16 +8968,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -8989,7 +8989,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dashboard/arm-dashboard:
     dependencies:
@@ -9041,10 +9041,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9056,7 +9056,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -9071,7 +9071,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/databasewatcher/arm-databasewatcher:
     dependencies:
@@ -9123,10 +9123,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9138,7 +9138,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -9153,7 +9153,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/databoundaries/arm-databoundaries:
     dependencies:
@@ -9193,10 +9193,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9205,7 +9205,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9217,7 +9217,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/databox/arm-databox:
     dependencies:
@@ -9266,10 +9266,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9278,7 +9278,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9290,7 +9290,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/databoxedge/arm-databoxedge:
     dependencies:
@@ -9339,16 +9339,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9360,7 +9360,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid:
     dependencies:
@@ -9409,10 +9409,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9421,7 +9421,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9433,7 +9433,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/databricks/arm-databricks:
     dependencies:
@@ -9482,10 +9482,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9494,7 +9494,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9506,7 +9506,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/datacatalog/arm-datacatalog:
     dependencies:
@@ -9552,16 +9552,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9573,7 +9573,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/datadog/arm-datadog:
     dependencies:
@@ -9622,10 +9622,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9634,7 +9634,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9646,7 +9646,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/datafactory/arm-datafactory:
     dependencies:
@@ -9695,10 +9695,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9707,7 +9707,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9719,7 +9719,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/datalake-analytics/arm-datalake-analytics:
     dependencies:
@@ -9768,16 +9768,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -9789,7 +9789,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/datamigration/arm-datamigration:
     dependencies:
@@ -9838,10 +9838,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9850,7 +9850,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -9865,7 +9865,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dataprotection/arm-dataprotection:
     dependencies:
@@ -9917,10 +9917,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -9932,7 +9932,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -9947,7 +9947,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/defendereasm/arm-defendereasm:
     dependencies:
@@ -9996,10 +9996,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10008,7 +10008,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -10020,7 +10020,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dell/arm-dell-storage:
     dependencies:
@@ -10072,10 +10072,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10087,7 +10087,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10102,7 +10102,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dependencymap/arm-dependencymap:
     dependencies:
@@ -10154,10 +10154,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10169,7 +10169,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10184,7 +10184,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/deploymentmanager/arm-deploymentmanager:
     dependencies:
@@ -10230,16 +10230,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -10251,7 +10251,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/desktopvirtualization/arm-desktopvirtualization:
     dependencies:
@@ -10294,10 +10294,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10306,7 +10306,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -10318,7 +10318,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/devcenter/arm-devcenter:
     dependencies:
@@ -10367,10 +10367,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10379,7 +10379,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -10391,7 +10391,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/devcenter/developer-devcenter-rest:
     dependencies:
@@ -10440,10 +10440,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10455,7 +10455,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10470,7 +10470,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/devhub/arm-devhub:
     dependencies:
@@ -10513,10 +10513,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10525,7 +10525,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -10537,7 +10537,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/deviceprovisioningservices/arm-deviceprovisioningservices:
     dependencies:
@@ -10589,10 +10589,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10604,7 +10604,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10619,7 +10619,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/deviceregistry/arm-deviceregistry:
     dependencies:
@@ -10671,10 +10671,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10686,7 +10686,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10701,7 +10701,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/deviceupdate/arm-deviceupdate:
     dependencies:
@@ -10750,10 +10750,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10762,7 +10762,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -10774,7 +10774,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/deviceupdate/iot-device-update-rest:
     dependencies:
@@ -10829,10 +10829,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10844,7 +10844,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10859,7 +10859,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/devopsinfrastructure/arm-devopsinfrastructure:
     dependencies:
@@ -10911,10 +10911,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -10926,7 +10926,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -10941,7 +10941,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/devspaces/arm-devspaces:
     dependencies:
@@ -10990,16 +10990,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11011,7 +11011,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/devtestlabs/arm-devtestlabs:
     dependencies:
@@ -11060,16 +11060,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11081,7 +11081,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/digitaltwins/arm-digitaltwins:
     dependencies:
@@ -11130,10 +11130,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11142,7 +11142,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11154,7 +11154,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/digitaltwins/digital-twins-core:
     dependencies:
@@ -11212,10 +11212,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11227,7 +11227,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -11242,7 +11242,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dns/arm-dns:
     dependencies:
@@ -11291,10 +11291,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11303,7 +11303,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11315,7 +11315,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dns/arm-dns-profile-2020-09-01-hybrid:
     dependencies:
@@ -11364,10 +11364,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11376,7 +11376,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11388,7 +11388,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dnsresolver/arm-dnsresolver:
     dependencies:
@@ -11437,10 +11437,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11452,7 +11452,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -11467,7 +11467,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/documentintelligence/ai-document-intelligence-rest:
     dependencies:
@@ -11519,10 +11519,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11534,7 +11534,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -11549,7 +11549,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/documenttranslator/ai-document-translator-rest:
     dependencies:
@@ -11598,10 +11598,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11613,7 +11613,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -11628,7 +11628,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/domainregistration/arm-domainregistration:
     dependencies:
@@ -11677,10 +11677,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11692,7 +11692,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -11707,7 +11707,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/domainservices/arm-domainservices:
     dependencies:
@@ -11756,16 +11756,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11777,7 +11777,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/durabletask/arm-durabletask:
     dependencies:
@@ -11829,10 +11829,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11844,7 +11844,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -11859,7 +11859,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/dynatrace/arm-dynatrace:
     dependencies:
@@ -11908,10 +11908,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11920,7 +11920,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -11932,7 +11932,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/easm/defender-easm-rest:
     dependencies:
@@ -11975,10 +11975,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -11990,7 +11990,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12005,7 +12005,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/edgezones/arm-edgezones:
     dependencies:
@@ -12051,10 +12051,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12066,7 +12066,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12081,7 +12081,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/education/arm-education:
     dependencies:
@@ -12124,10 +12124,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12136,7 +12136,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -12148,7 +12148,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/elastic/arm-elastic:
     dependencies:
@@ -12197,10 +12197,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12212,7 +12212,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12227,7 +12227,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/elasticsans/arm-elasticsan:
     dependencies:
@@ -12276,10 +12276,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12288,7 +12288,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -12300,7 +12300,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/entra/functions-authentication-events:
     dependencies:
@@ -12343,10 +12343,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12358,7 +12358,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12373,7 +12373,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventgrid/arm-eventgrid:
     dependencies:
@@ -12422,10 +12422,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12434,7 +12434,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -12446,7 +12446,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventgrid/eventgrid:
     dependencies:
@@ -12498,10 +12498,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12513,7 +12513,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12528,7 +12528,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventgrid/eventgrid-namespaces:
     dependencies:
@@ -12583,10 +12583,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12598,7 +12598,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12613,7 +12613,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventgrid/eventgrid-perf-tests:
     dependencies:
@@ -12693,10 +12693,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12705,7 +12705,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -12720,7 +12720,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventhub/arm-eventhub:
     dependencies:
@@ -12772,10 +12772,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12784,7 +12784,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -12796,7 +12796,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid:
     dependencies:
@@ -12845,10 +12845,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -12857,7 +12857,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -12869,7 +12869,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventhub/event-hubs:
     dependencies:
@@ -12954,10 +12954,10 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       chai:
         specifier: catalog:testing
         version: 6.2.1
@@ -12986,11 +12986,11 @@ importers:
         specifier: ^7.0.0
         version: 7.0.6
       node-forge:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -13008,7 +13008,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       ws:
         specifier: ^8.2.0
         version: 8.18.3
@@ -13121,10 +13121,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -13148,7 +13148,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -13169,7 +13169,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventhub/eventhubs-checkpointstore-table:
     dependencies:
@@ -13221,10 +13221,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -13248,7 +13248,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -13269,7 +13269,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/eventhub/mock-hub:
     dependencies:
@@ -13294,10 +13294,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13309,7 +13309,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -13324,7 +13324,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/extendedlocation/arm-extendedlocation:
     dependencies:
@@ -13373,10 +13373,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13385,7 +13385,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -13397,7 +13397,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/fabric/arm-fabric:
     dependencies:
@@ -13449,10 +13449,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13464,7 +13464,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: ^3.2.5
         version: 3.6.2
@@ -13479,7 +13479,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/face/ai-vision-face-rest:
     dependencies:
@@ -13528,10 +13528,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13543,7 +13543,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: ^3.2.5
         version: 3.6.2
@@ -13558,7 +13558,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/features/arm-features:
     dependencies:
@@ -13601,16 +13601,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -13622,7 +13622,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/fluidrelay/arm-fluidrelay:
     dependencies:
@@ -13665,10 +13665,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13677,7 +13677,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -13689,7 +13689,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/formrecognizer/ai-form-recognizer:
     dependencies:
@@ -13753,10 +13753,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13771,7 +13771,7 @@ importers:
         version: 0.30.21
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
@@ -13789,7 +13789,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/formrecognizer/ai-form-recognizer-perf-tests:
     dependencies:
@@ -13884,10 +13884,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13896,7 +13896,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -13908,7 +13908,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/graphservices/arm-graphservices:
     dependencies:
@@ -13957,10 +13957,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -13969,7 +13969,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -13981,7 +13981,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/guestconfiguration/arm-guestconfiguration:
     dependencies:
@@ -14024,10 +14024,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14036,7 +14036,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -14048,7 +14048,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hanaonazure/arm-hanaonazure:
     dependencies:
@@ -14097,16 +14097,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -14118,7 +14118,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules:
     dependencies:
@@ -14170,10 +14170,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14185,7 +14185,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14200,7 +14200,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hdinsight/arm-hdinsight:
     dependencies:
@@ -14252,10 +14252,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14267,7 +14267,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -14279,7 +14279,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthbot/arm-healthbot:
     dependencies:
@@ -14328,16 +14328,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -14349,7 +14349,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthcareapis/arm-healthcareapis:
     dependencies:
@@ -14398,10 +14398,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14410,7 +14410,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -14422,7 +14422,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthdataaiservices/arm-healthdataaiservices:
     dependencies:
@@ -14474,10 +14474,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14489,7 +14489,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14504,7 +14504,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthdataaiservices/health-deidentification-rest:
     dependencies:
@@ -14556,10 +14556,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14571,7 +14571,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14586,7 +14586,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthinsights/health-insights-cancerprofiling-rest:
     dependencies:
@@ -14635,10 +14635,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -14653,7 +14653,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14668,7 +14668,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthinsights/health-insights-clinicalmatching-rest:
     dependencies:
@@ -14717,10 +14717,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -14735,7 +14735,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14750,7 +14750,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/healthinsights/health-insights-radiologyinsights-rest:
     dependencies:
@@ -14799,10 +14799,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -14817,7 +14817,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14832,7 +14832,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hybridcompute/arm-hybridcompute:
     dependencies:
@@ -14881,10 +14881,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14893,7 +14893,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -14905,7 +14905,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hybridconnectivity/arm-hybridconnectivity:
     dependencies:
@@ -14957,10 +14957,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -14972,7 +14972,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -14987,7 +14987,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hybridcontainerservice/arm-hybridcontainerservice:
     dependencies:
@@ -15036,10 +15036,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15048,7 +15048,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -15060,7 +15060,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hybridkubernetes/arm-hybridkubernetes:
     dependencies:
@@ -15109,10 +15109,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15121,7 +15121,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15136,7 +15136,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/hybridnetwork/arm-hybridnetwork:
     dependencies:
@@ -15185,10 +15185,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15197,7 +15197,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -15209,7 +15209,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/identity/identity:
     dependencies:
@@ -15273,10 +15273,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       assertion-error:
         specifier: ^2.0.1
         version: 2.0.1
@@ -15297,7 +15297,7 @@ importers:
         version: 2.1.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15312,7 +15312,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/identity/identity-broker:
     dependencies:
@@ -15364,10 +15364,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15388,7 +15388,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/identity/identity-cache-persistence:
     dependencies:
@@ -15434,10 +15434,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15449,7 +15449,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15464,7 +15464,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/identity/identity-perf-tests:
     dependencies:
@@ -15550,10 +15550,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15565,7 +15565,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15580,7 +15580,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/imagebuilder/arm-imagebuilder:
     dependencies:
@@ -15629,10 +15629,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15641,7 +15641,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -15653,7 +15653,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/impactreporting/arm-impactreporting:
     dependencies:
@@ -15705,10 +15705,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15720,7 +15720,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15735,7 +15735,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/informatica/arm-informaticadatamanagement:
     dependencies:
@@ -15784,10 +15784,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15796,7 +15796,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -15808,7 +15808,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/instrumentation/opentelemetry-instrumentation-azure-sdk:
     dependencies:
@@ -15854,10 +15854,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15869,7 +15869,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15884,7 +15884,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/iot/iot-modelsrepository:
     dependencies:
@@ -15927,10 +15927,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -15939,7 +15939,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -15954,7 +15954,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/iotcentral/arm-iotcentral:
     dependencies:
@@ -16003,16 +16003,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -16024,7 +16024,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/iotfirmwaredefense/arm-iotfirmwaredefense:
     dependencies:
@@ -16076,10 +16076,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16091,7 +16091,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16106,7 +16106,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/iothub/arm-iothub:
     dependencies:
@@ -16158,10 +16158,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16173,7 +16173,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16188,7 +16188,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/iothub/arm-iothub-profile-2020-09-01-hybrid:
     dependencies:
@@ -16237,10 +16237,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16249,7 +16249,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -16261,7 +16261,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/iotoperations/arm-iotoperations:
     dependencies:
@@ -16313,10 +16313,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16328,7 +16328,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16343,7 +16343,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/arm-keyvault:
     dependencies:
@@ -16392,10 +16392,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16407,7 +16407,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16422,7 +16422,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid:
     dependencies:
@@ -16471,10 +16471,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16483,7 +16483,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -16495,7 +16495,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/keyvault-admin:
     dependencies:
@@ -16559,10 +16559,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16574,7 +16574,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16589,7 +16589,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/keyvault-certificates:
     dependencies:
@@ -16656,10 +16656,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16671,7 +16671,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16686,7 +16686,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/keyvault-certificates-perf-tests:
     dependencies:
@@ -16775,10 +16775,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16787,7 +16787,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16802,7 +16802,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/keyvault-keys:
     dependencies:
@@ -16866,10 +16866,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -16881,7 +16881,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -16896,7 +16896,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/keyvault-keys-perf-tests:
     dependencies:
@@ -17006,10 +17006,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17021,7 +17021,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -17036,7 +17036,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/keyvault/keyvault-secrets-perf-tests:
     dependencies:
@@ -17131,10 +17131,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17143,7 +17143,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17155,7 +17155,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions:
     dependencies:
@@ -17204,10 +17204,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17216,7 +17216,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17228,7 +17228,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes:
     dependencies:
@@ -17271,10 +17271,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17283,7 +17283,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17295,7 +17295,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations:
     dependencies:
@@ -17344,10 +17344,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17356,7 +17356,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17368,7 +17368,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes:
     dependencies:
@@ -17417,10 +17417,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17429,7 +17429,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17441,7 +17441,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/kubernetesruntime/arm-containerorchestratorruntime:
     dependencies:
@@ -17493,10 +17493,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17508,7 +17508,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -17523,7 +17523,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/kusto/arm-kusto:
     dependencies:
@@ -17572,10 +17572,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17584,7 +17584,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17596,7 +17596,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/labservices/arm-labservices:
     dependencies:
@@ -17645,10 +17645,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17657,7 +17657,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17669,7 +17669,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute:
     dependencies:
@@ -17721,10 +17721,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17736,7 +17736,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -17751,7 +17751,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/largeinstance/arm-largeinstance:
     dependencies:
@@ -17800,10 +17800,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17812,7 +17812,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17824,7 +17824,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/liftrarize/arm-arizeaiobservabilityeval:
     dependencies:
@@ -17876,10 +17876,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17891,7 +17891,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -17906,7 +17906,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/liftrqumulo/arm-qumulo:
     dependencies:
@@ -17955,10 +17955,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -17967,7 +17967,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -17979,7 +17979,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/liftrweightsandbiases/arm-weightsandbiases:
     dependencies:
@@ -18031,10 +18031,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18046,7 +18046,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -18061,7 +18061,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/links/arm-links:
     dependencies:
@@ -18107,16 +18107,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18128,7 +18128,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/loadtesting/arm-loadtesting:
     dependencies:
@@ -18177,10 +18177,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18189,7 +18189,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18201,7 +18201,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/loadtesting/create-playwright:
     dependencies:
@@ -18232,10 +18232,10 @@ importers:
         version: 2.4.9
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18256,7 +18256,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/loadtesting/load-testing-rest:
     dependencies:
@@ -18311,10 +18311,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -18329,7 +18329,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -18344,7 +18344,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/loadtesting/playwright:
     dependencies:
@@ -18375,7 +18375,7 @@ importers:
         version: 4.13.0
       '@playwright/test':
         specifier: ^1.51.1
-        version: 1.56.1
+        version: 1.57.0
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -18384,10 +18384,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18396,7 +18396,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -18411,7 +18411,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/locks/arm-locks:
     dependencies:
@@ -18454,16 +18454,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18475,7 +18475,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/locks/arm-locks-profile-2020-09-01-hybrid:
     dependencies:
@@ -18518,10 +18518,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18530,7 +18530,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18542,7 +18542,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/logic/arm-logic:
     dependencies:
@@ -18591,10 +18591,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18603,7 +18603,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18615,7 +18615,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/machinelearning/arm-commitmentplans:
     dependencies:
@@ -18658,16 +18658,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18679,7 +18679,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/machinelearning/arm-machinelearning:
     dependencies:
@@ -18728,10 +18728,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -18740,7 +18740,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18752,7 +18752,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/machinelearning/arm-webservices:
     dependencies:
@@ -18801,16 +18801,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18822,7 +18822,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/machinelearning/arm-workspaces:
     dependencies:
@@ -18865,16 +18865,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18886,7 +18886,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/machinelearningcompute/arm-machinelearningcompute:
     dependencies:
@@ -18935,16 +18935,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -18956,7 +18956,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/machinelearningexperimentation/arm-machinelearningexperimentation:
     dependencies:
@@ -18999,10 +18999,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19011,7 +19011,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19023,7 +19023,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maintenance/arm-maintenance:
     dependencies:
@@ -19066,10 +19066,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19078,7 +19078,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19090,7 +19090,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/managedapplications/arm-managedapplications:
     dependencies:
@@ -19139,10 +19139,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19151,7 +19151,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19163,7 +19163,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/managednetworkfabric/arm-managednetworkfabric:
     dependencies:
@@ -19212,10 +19212,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19224,7 +19224,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19236,7 +19236,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/managementgroups/arm-managementgroups:
     dependencies:
@@ -19285,16 +19285,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19306,7 +19306,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/managementpartner/arm-managementpartner:
     dependencies:
@@ -19349,10 +19349,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19361,7 +19361,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19373,7 +19373,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/arm-maps:
     dependencies:
@@ -19416,10 +19416,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19428,7 +19428,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19440,7 +19440,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/maps-common:
     dependencies:
@@ -19480,10 +19480,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -19492,7 +19492,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -19507,7 +19507,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/maps-geolocation-rest:
     dependencies:
@@ -19556,10 +19556,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -19574,7 +19574,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -19589,7 +19589,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/maps-render-rest:
     dependencies:
@@ -19638,10 +19638,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -19656,7 +19656,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -19671,7 +19671,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/maps-route-rest:
     dependencies:
@@ -19723,10 +19723,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -19741,7 +19741,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -19756,7 +19756,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/maps-search-rest:
     dependencies:
@@ -19808,10 +19808,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -19826,7 +19826,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -19841,7 +19841,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/maps/maps-timezone-rest:
     dependencies:
@@ -19893,10 +19893,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -19911,7 +19911,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -19926,7 +19926,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/mariadb/arm-mariadb:
     dependencies:
@@ -19975,16 +19975,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -19996,7 +19996,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/marketplaceordering/arm-marketplaceordering:
     dependencies:
@@ -20039,10 +20039,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20051,7 +20051,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20063,7 +20063,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/metricsadvisor/ai-metrics-advisor:
     dependencies:
@@ -20118,10 +20118,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20133,7 +20133,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -20148,7 +20148,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/metricsadvisor/ai-metrics-advisor-perf-tests:
     dependencies:
@@ -20234,10 +20234,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20246,7 +20246,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20258,7 +20258,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/migrate/arm-migrationassessment:
     dependencies:
@@ -20307,10 +20307,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20319,7 +20319,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20331,7 +20331,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/migrationdiscovery/arm-migrationdiscoverysap:
     dependencies:
@@ -20380,10 +20380,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20392,7 +20392,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20404,7 +20404,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/mobilenetwork/arm-mobilenetwork:
     dependencies:
@@ -20453,10 +20453,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20465,7 +20465,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20477,7 +20477,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/mongocluster/arm-mongocluster:
     dependencies:
@@ -20529,10 +20529,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20544,7 +20544,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -20559,7 +20559,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/mongodbatlas/arm-mongodbatlas:
     dependencies:
@@ -20611,10 +20611,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20626,7 +20626,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -20641,7 +20641,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/arm-monitor:
     dependencies:
@@ -20702,10 +20702,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20714,7 +20714,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20726,7 +20726,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/arm-monitor-profile-2020-09-01-hybrid:
     dependencies:
@@ -20769,10 +20769,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20781,7 +20781,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -20793,7 +20793,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/monitor-ingestion:
     dependencies:
@@ -20857,10 +20857,10 @@ importers:
         version: 2.0.4
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -20872,7 +20872,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -20887,7 +20887,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/monitor-ingestion-perf-tests:
     dependencies:
@@ -20984,10 +20984,10 @@ importers:
         version: 0.54.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-pg':
         specifier: ^0.61.0
-        version: 0.61.0(@opentelemetry/api@1.9.0)
+        version: 0.61.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-redis':
         specifier: ^0.57.0
-        version: 0.57.0(@opentelemetry/api@1.9.0)
+        version: 0.57.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-winston':
         specifier: ^0.53.0
         version: 0.53.0(@opentelemetry/api@1.9.0)
@@ -21045,10 +21045,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21072,7 +21072,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/monitor-opentelemetry-exporter:
     dependencies:
@@ -21142,10 +21142,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21160,7 +21160,7 @@ importers:
         version: 13.5.6
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -21175,7 +21175,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/monitor-opentelemetry-perf-tests:
     dependencies:
@@ -21297,10 +21297,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21312,7 +21312,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -21327,7 +21327,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/monitor/monitor-query-metrics:
     dependencies:
@@ -21388,10 +21388,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21403,7 +21403,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -21418,7 +21418,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/msi/arm-msi:
     dependencies:
@@ -21461,10 +21461,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21473,7 +21473,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -21485,7 +21485,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/mysql/arm-mysql:
     dependencies:
@@ -21534,16 +21534,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -21555,7 +21555,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/mysql/arm-mysql-flexible:
     dependencies:
@@ -21604,10 +21604,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21616,7 +21616,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -21628,7 +21628,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/neonpostgres/arm-neonpostgres:
     dependencies:
@@ -21680,10 +21680,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21695,7 +21695,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -21710,7 +21710,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/netapp/arm-netapp:
     dependencies:
@@ -21762,10 +21762,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21777,7 +21777,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -21792,7 +21792,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/network/arm-network:
     dependencies:
@@ -21841,10 +21841,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21856,7 +21856,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -21871,7 +21871,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/network/arm-network-profile-2020-09-01-hybrid:
     dependencies:
@@ -21920,10 +21920,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -21932,7 +21932,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -21944,7 +21944,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/network/arm-network-rest:
     dependencies:
@@ -21993,10 +21993,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -22011,7 +22011,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22026,7 +22026,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/networkcloud/arm-networkcloud:
     dependencies:
@@ -22075,10 +22075,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22090,7 +22090,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22105,7 +22105,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/networkfunction/arm-networkfunction:
     dependencies:
@@ -22154,16 +22154,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -22175,7 +22175,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/newrelicobservability/arm-newrelicobservability:
     dependencies:
@@ -22224,10 +22224,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22239,7 +22239,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22254,7 +22254,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/nginx/arm-nginx:
     dependencies:
@@ -22303,10 +22303,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22315,7 +22315,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -22327,7 +22327,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/notificationhubs/arm-notificationhubs:
     dependencies:
@@ -22379,10 +22379,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22394,7 +22394,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22409,7 +22409,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/notificationhubs/notification-hubs:
     dependencies:
@@ -22461,10 +22461,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22476,7 +22476,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22491,7 +22491,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/oep/arm-oep:
     dependencies:
@@ -22540,16 +22540,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -22561,7 +22561,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/onlineexperimentation/arm-onlineexperimentation:
     dependencies:
@@ -22613,10 +22613,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22628,7 +22628,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22643,7 +22643,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/onlineexperimentation/onlineexperimentation-rest:
     dependencies:
@@ -22683,10 +22683,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22698,7 +22698,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22713,7 +22713,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/openai/openai:
     dependencies:
@@ -22762,10 +22762,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22780,7 +22780,7 @@ importers:
         version: 6.9.1(ws@8.18.3)(zod@3.25.76)
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -22795,7 +22795,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -22847,10 +22847,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -22859,7 +22859,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -22871,7 +22871,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/operationsmanagement/arm-operations:
     dependencies:
@@ -22920,16 +22920,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -22941,7 +22941,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/oracledatabase/arm-oracledatabase:
     dependencies:
@@ -22993,10 +22993,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23008,7 +23008,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23023,7 +23023,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/orbital/arm-orbital:
     dependencies:
@@ -23072,10 +23072,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23084,7 +23084,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -23096,7 +23096,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw:
     dependencies:
@@ -23145,10 +23145,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23160,7 +23160,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23175,7 +23175,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/peering/arm-peering:
     dependencies:
@@ -23218,16 +23218,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -23239,7 +23239,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/pineconevectordb/arm-pineconevectordb:
     dependencies:
@@ -23291,10 +23291,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23306,7 +23306,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23321,7 +23321,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/planetarycomputer/arm-planetarycomputer:
     dependencies:
@@ -23373,10 +23373,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23388,7 +23388,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23403,7 +23403,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/playwright/arm-playwright:
     dependencies:
@@ -23455,10 +23455,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23470,7 +23470,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23485,7 +23485,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/playwrighttesting/arm-playwrighttesting:
     dependencies:
@@ -23537,10 +23537,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23552,7 +23552,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23567,7 +23567,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/playwrighttesting/create-microsoft-playwright-testing:
     dependencies:
@@ -23598,10 +23598,10 @@ importers:
         version: 2.4.9
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23622,7 +23622,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/playwrighttesting/microsoft-playwright-testing:
     dependencies:
@@ -23653,7 +23653,7 @@ importers:
         version: link:../../../common/tools/eslint-plugin-azure-sdk
       '@playwright/test':
         specifier: ^1.51.1
-        version: 1.56.1
+        version: 1.57.0
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -23662,10 +23662,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23674,7 +23674,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23689,7 +23689,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/policy/arm-policy:
     dependencies:
@@ -23735,10 +23735,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23747,7 +23747,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -23762,7 +23762,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/policy/arm-policy-profile-2020-09-01-hybrid:
     dependencies:
@@ -23805,10 +23805,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23817,7 +23817,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -23829,7 +23829,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/policyinsights/arm-policyinsights:
     dependencies:
@@ -23878,10 +23878,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23890,7 +23890,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -23902,7 +23902,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/portal/arm-portal:
     dependencies:
@@ -23945,10 +23945,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -23957,7 +23957,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -23969,7 +23969,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/portalservices/arm-portalservicescopilot:
     dependencies:
@@ -24015,10 +24015,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24030,7 +24030,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24045,7 +24045,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/postgresql/arm-postgresql:
     dependencies:
@@ -24094,16 +24094,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -24115,7 +24115,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/postgresql/arm-postgresql-flexible:
     dependencies:
@@ -24164,10 +24164,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24176,7 +24176,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -24188,7 +24188,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/powerbidedicated/arm-powerbidedicated:
     dependencies:
@@ -24237,10 +24237,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24249,7 +24249,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -24261,7 +24261,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/powerbiembedded/arm-powerbiembedded:
     dependencies:
@@ -24310,16 +24310,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -24331,7 +24331,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/privatedns/arm-privatedns:
     dependencies:
@@ -24380,10 +24380,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24392,7 +24392,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -24404,7 +24404,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/programmableconnectivity/arm-programmableconnectivity:
     dependencies:
@@ -24456,10 +24456,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24471,7 +24471,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24486,7 +24486,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purestorageblock/arm-purestorageblock:
     dependencies:
@@ -24538,10 +24538,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24553,7 +24553,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24568,7 +24568,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purview/arm-purview:
     dependencies:
@@ -24617,16 +24617,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -24638,7 +24638,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purview/purview-administration-rest:
     dependencies:
@@ -24681,10 +24681,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24696,7 +24696,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24711,7 +24711,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purview/purview-datamap-rest:
     dependencies:
@@ -24754,10 +24754,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -24772,7 +24772,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24787,7 +24787,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purview/purview-scanning-rest:
     dependencies:
@@ -24836,10 +24836,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -24851,7 +24851,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24866,7 +24866,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purview/purview-sharing-rest:
     dependencies:
@@ -24915,10 +24915,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -24933,7 +24933,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -24948,7 +24948,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/purview/purview-workflow-rest:
     dependencies:
@@ -24991,10 +24991,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -25009,7 +25009,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -25024,7 +25024,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/quantum/arm-quantum:
     dependencies:
@@ -25073,10 +25073,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25085,7 +25085,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25097,7 +25097,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/quantum/quantum-jobs:
     dependencies:
@@ -25152,10 +25152,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -25170,7 +25170,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -25185,7 +25185,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/quota/arm-quota:
     dependencies:
@@ -25234,10 +25234,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25246,7 +25246,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -25261,7 +25261,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/recoveryservices/arm-recoveryservices:
     dependencies:
@@ -25313,16 +25313,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       dotenv:
         specifier: catalog:testing
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -25337,7 +25337,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/recoveryservicesbackup/arm-recoveryservicesbackup:
     dependencies:
@@ -25389,10 +25389,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25401,7 +25401,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25413,7 +25413,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication:
     dependencies:
@@ -25465,10 +25465,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25480,7 +25480,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -25495,7 +25495,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery:
     dependencies:
@@ -25544,10 +25544,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25556,7 +25556,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25568,7 +25568,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/redhatopenshift/arm-redhatopenshift:
     dependencies:
@@ -25617,10 +25617,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25629,7 +25629,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25641,7 +25641,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/redis/arm-rediscache:
     dependencies:
@@ -25693,10 +25693,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25705,7 +25705,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25717,7 +25717,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/redisenterprise/arm-redisenterprisecache:
     dependencies:
@@ -25766,10 +25766,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25781,7 +25781,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -25796,7 +25796,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/relay/arm-relay:
     dependencies:
@@ -25845,10 +25845,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25857,7 +25857,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25869,7 +25869,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/reservations/arm-reservations:
     dependencies:
@@ -25918,10 +25918,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -25930,7 +25930,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -25942,7 +25942,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resourceconnector/arm-resourceconnector:
     dependencies:
@@ -25991,10 +25991,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26003,7 +26003,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26015,7 +26015,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resourcegraph/arm-resourcegraph:
     dependencies:
@@ -26058,16 +26058,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26079,7 +26079,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resourcehealth/arm-resourcehealth:
     dependencies:
@@ -26122,10 +26122,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26134,7 +26134,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26146,7 +26146,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resourcemover/arm-resourcemover:
     dependencies:
@@ -26195,10 +26195,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26207,7 +26207,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26219,7 +26219,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resources-subscriptions/arm-resources-subscriptions:
     dependencies:
@@ -26262,10 +26262,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26274,7 +26274,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26286,7 +26286,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resources/arm-resources:
     dependencies:
@@ -26335,10 +26335,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26347,7 +26347,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26359,7 +26359,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resources/arm-resources-profile-2020-09-01-hybrid:
     dependencies:
@@ -26408,10 +26408,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26420,7 +26420,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26432,7 +26432,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resources/arm-resourcesbicep:
     dependencies:
@@ -26478,10 +26478,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26493,7 +26493,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -26508,7 +26508,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resources/arm-resourcesdeployments:
     dependencies:
@@ -26557,10 +26557,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26569,7 +26569,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26581,7 +26581,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks:
     dependencies:
@@ -26630,10 +26630,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26642,7 +26642,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -26654,7 +26654,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/schemaregistry/schema-registry:
     dependencies:
@@ -26703,10 +26703,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -26718,7 +26718,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -26733,7 +26733,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/schemaregistry/schema-registry-avro:
     dependencies:
@@ -26791,10 +26791,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -26809,7 +26809,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -26830,7 +26830,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/schemaregistry/schema-registry-avro-perf-tests:
     dependencies:
@@ -26931,10 +26931,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -26952,7 +26952,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -26967,7 +26967,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/scvmm/arm-scvmm:
     dependencies:
@@ -27016,10 +27016,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27028,7 +27028,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27040,7 +27040,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/search/arm-search:
     dependencies:
@@ -27089,10 +27089,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27101,7 +27101,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -27116,7 +27116,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/search/search-documents:
     dependencies:
@@ -27177,10 +27177,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27192,7 +27192,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -27210,7 +27210,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/search/search-documents-perf-tests:
     dependencies:
@@ -27305,10 +27305,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27317,7 +27317,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27329,7 +27329,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/securitydevops/arm-securitydevops:
     dependencies:
@@ -27378,10 +27378,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27390,7 +27390,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27402,7 +27402,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/securityinsight/arm-securityinsight:
     dependencies:
@@ -27451,10 +27451,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27463,7 +27463,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27475,7 +27475,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/selfhelp/arm-selfhelp:
     dependencies:
@@ -27524,10 +27524,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27536,7 +27536,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27548,7 +27548,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/serialconsole/arm-serialconsole:
     dependencies:
@@ -27588,16 +27588,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27609,7 +27609,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/service-map/arm-servicemap:
     dependencies:
@@ -27652,10 +27652,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27664,7 +27664,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27676,7 +27676,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicebus/arm-servicebus:
     dependencies:
@@ -27725,10 +27725,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -27737,7 +27737,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -27749,7 +27749,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicebus/service-bus:
     dependencies:
@@ -27852,10 +27852,10 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       chai:
         specifier: catalog:testing
         version: 6.2.1
@@ -27885,7 +27885,7 @@ importers:
         version: 7.0.6
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -27900,7 +27900,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       ws:
         specifier: ^8.0.0
         version: 8.18.3
@@ -27998,10 +27998,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28010,7 +28010,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28022,7 +28022,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicefabric/arm-servicefabric-rest:
     dependencies:
@@ -28074,10 +28074,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -28092,7 +28092,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -28107,7 +28107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters:
     dependencies:
@@ -28159,10 +28159,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28174,7 +28174,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -28189,7 +28189,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicefabricmesh/arm-servicefabricmesh:
     dependencies:
@@ -28232,10 +28232,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28244,7 +28244,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28256,7 +28256,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicelinker/arm-servicelinker:
     dependencies:
@@ -28305,10 +28305,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28317,7 +28317,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28329,7 +28329,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/servicenetworking/arm-servicenetworking:
     dependencies:
@@ -28381,10 +28381,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28396,7 +28396,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -28411,7 +28411,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/signalr/arm-signalr:
     dependencies:
@@ -28460,10 +28460,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28472,7 +28472,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28484,7 +28484,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/sitemanager/arm-sitemanager:
     dependencies:
@@ -28536,10 +28536,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28551,7 +28551,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -28566,7 +28566,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/sphere/arm-sphere:
     dependencies:
@@ -28615,10 +28615,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28627,7 +28627,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28639,7 +28639,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/springappdiscovery/arm-springappdiscovery:
     dependencies:
@@ -28688,10 +28688,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28700,7 +28700,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28712,7 +28712,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/sql/arm-sql:
     dependencies:
@@ -28761,10 +28761,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28773,7 +28773,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -28788,7 +28788,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/sqlvirtualmachine/arm-sqlvirtualmachine:
     dependencies:
@@ -28837,10 +28837,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28849,7 +28849,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -28861,7 +28861,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/standbypool/arm-standbypool:
     dependencies:
@@ -28913,10 +28913,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -28928,7 +28928,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -28943,7 +28943,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/arm-storage:
     dependencies:
@@ -28992,10 +28992,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29004,7 +29004,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29019,7 +29019,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/arm-storage-profile-2020-09-01-hybrid:
     dependencies:
@@ -29068,10 +29068,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29080,7 +29080,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -29092,7 +29092,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-blob:
     dependencies:
@@ -29168,10 +29168,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29183,7 +29183,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29198,7 +29198,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-blob-changefeed:
     dependencies:
@@ -29262,10 +29262,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29277,7 +29277,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29292,7 +29292,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-blob-perf-tests:
     dependencies:
@@ -29384,10 +29384,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29396,7 +29396,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29411,7 +29411,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-file-datalake:
     dependencies:
@@ -29484,10 +29484,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29499,7 +29499,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29514,7 +29514,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-file-datalake-perf-tests:
     dependencies:
@@ -29630,10 +29630,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29645,7 +29645,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29660,7 +29660,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-file-share-perf-tests:
     dependencies:
@@ -29734,10 +29734,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29749,7 +29749,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29764,7 +29764,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storage/storage-queue:
     dependencies:
@@ -29828,10 +29828,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29843,7 +29843,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29858,7 +29858,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storageactions/arm-storageactions:
     dependencies:
@@ -29913,10 +29913,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -29928,7 +29928,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -29943,7 +29943,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storagecache/arm-storagecache:
     dependencies:
@@ -29992,10 +29992,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30004,7 +30004,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -30019,7 +30019,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storagediscovery/arm-storagediscovery:
     dependencies:
@@ -30071,10 +30071,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30086,7 +30086,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -30101,7 +30101,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storageimportexport/arm-storageimportexport:
     dependencies:
@@ -30144,10 +30144,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30156,7 +30156,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30168,7 +30168,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storagemover/arm-storagemover:
     dependencies:
@@ -30220,10 +30220,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30235,7 +30235,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -30250,7 +30250,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storagesync/arm-storagesync:
     dependencies:
@@ -30299,16 +30299,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30320,7 +30320,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storsimple1200series/arm-storsimple1200series:
     dependencies:
@@ -30369,16 +30369,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30390,7 +30390,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/storsimple8000series/arm-storsimple8000series:
     dependencies:
@@ -30439,16 +30439,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30460,7 +30460,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/streamanalytics/arm-streamanalytics:
     dependencies:
@@ -30509,10 +30509,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30521,7 +30521,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30533,7 +30533,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/subscription/arm-subscriptions:
     dependencies:
@@ -30582,10 +30582,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30597,7 +30597,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -30612,7 +30612,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid:
     dependencies:
@@ -30655,10 +30655,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30667,7 +30667,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30679,7 +30679,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/support/arm-support:
     dependencies:
@@ -30728,10 +30728,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30740,7 +30740,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30752,7 +30752,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/arm-synapse:
     dependencies:
@@ -30801,10 +30801,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30813,7 +30813,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -30825,7 +30825,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/synapse-access-control:
     dependencies:
@@ -30871,10 +30871,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30886,7 +30886,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -30901,7 +30901,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/synapse-access-control-rest:
     dependencies:
@@ -30947,10 +30947,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -30962,7 +30962,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -30977,7 +30977,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/synapse-artifacts:
     dependencies:
@@ -31029,10 +31029,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31044,7 +31044,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31059,7 +31059,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/synapse-managed-private-endpoints:
     dependencies:
@@ -31105,10 +31105,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31120,7 +31120,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31135,7 +31135,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/synapse-monitoring:
     dependencies:
@@ -31178,10 +31178,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31190,7 +31190,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31205,7 +31205,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/synapse/synapse-spark:
     dependencies:
@@ -31248,10 +31248,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31263,7 +31263,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31278,7 +31278,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/tables/data-tables:
     dependencies:
@@ -31336,10 +31336,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31351,7 +31351,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31366,7 +31366,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/tables/data-tables-perf-tests:
     dependencies:
@@ -31461,10 +31461,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31476,7 +31476,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31491,7 +31491,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/template/template-dpg:
     dependencies:
@@ -31534,10 +31534,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31549,7 +31549,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31564,7 +31564,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/template/template-perf-tests:
     dependencies:
@@ -31656,16 +31656,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -31677,7 +31677,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/terraform/arm-terraform:
     dependencies:
@@ -31729,10 +31729,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31744,7 +31744,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31759,7 +31759,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/test-utils/perf:
     dependencies:
@@ -31802,7 +31802,7 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31854,10 +31854,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -31872,7 +31872,7 @@ importers:
         version: 5.1.0
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31890,7 +31890,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/test-utils/test-credential:
     dependencies:
@@ -31924,10 +31924,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -31936,7 +31936,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -31951,7 +31951,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/test-utils/test-utils-vitest:
     dependencies:
@@ -31975,7 +31975,7 @@ importers:
         version: 2.8.1
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     devDependencies:
       '@azure/dev-tool':
         specifier: workspace:^
@@ -31988,13 +31988,13 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       '@vitest/expect':
         specifier: catalog:testing
-        version: 4.0.13
+        version: 4.0.14
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32003,7 +32003,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32070,10 +32070,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32085,7 +32085,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32100,7 +32100,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/textanalytics/ai-text-analytics-perf-tests:
     dependencies:
@@ -32195,10 +32195,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32207,7 +32207,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -32219,7 +32219,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/trafficmanager/arm-trafficmanager:
     dependencies:
@@ -32262,10 +32262,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32274,7 +32274,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -32286,7 +32286,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/translation/ai-translation-document-rest:
     dependencies:
@@ -32341,10 +32341,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -32359,7 +32359,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32374,7 +32374,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/translation/ai-translation-text-rest:
     dependencies:
@@ -32417,10 +32417,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -32435,7 +32435,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32450,7 +32450,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/trustedsigning/arm-trustedsigning:
     dependencies:
@@ -32502,10 +32502,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32517,7 +32517,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32532,7 +32532,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/vision/ai-vision-image-analysis-rest:
     dependencies:
@@ -32575,10 +32575,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       autorest:
         specifier: 'catalog:'
         version: 3.7.2
@@ -32593,7 +32593,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32608,7 +32608,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/visualstudio/arm-visualstudio:
     dependencies:
@@ -32654,16 +32654,16 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -32675,7 +32675,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/vmwarecloudsimple/arm-vmwarecloudsimple:
     dependencies:
@@ -32724,10 +32724,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32736,7 +32736,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -32748,7 +32748,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/voiceservices/arm-voiceservices:
     dependencies:
@@ -32797,10 +32797,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32809,7 +32809,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -32821,7 +32821,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/web-pubsub/arm-webpubsub:
     dependencies:
@@ -32870,10 +32870,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32882,7 +32882,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -32894,7 +32894,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/web-pubsub/web-pubsub:
     dependencies:
@@ -32955,10 +32955,10 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -32970,7 +32970,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -32985,7 +32985,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       ws:
         specifier: ^8.18.0
         version: 8.18.3
@@ -33037,10 +33037,10 @@ importers:
         version: 8.18.1
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -33052,7 +33052,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -33067,7 +33067,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/web-pubsub/web-pubsub-client-protobuf:
     dependencies:
@@ -33107,10 +33107,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cpy-cli:
         specifier: ^6.0.0
         version: 6.0.0
@@ -33128,7 +33128,7 @@ importers:
         version: 3.0.0
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -33146,7 +33146,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/web-pubsub/web-pubsub-express:
     dependencies:
@@ -33180,10 +33180,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -33198,7 +33198,7 @@ importers:
         version: 5.1.0
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -33213,7 +33213,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/workloadorchestration/arm-workloadorchestration:
     dependencies:
@@ -33265,10 +33265,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -33280,7 +33280,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -33295,7 +33295,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/workloads/arm-workloads:
     dependencies:
@@ -33344,10 +33344,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -33356,7 +33356,7 @@ importers:
         version: 16.6.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.2
@@ -33368,7 +33368,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
   sdk/workloads/arm-workloadssapvirtualinstance:
     dependencies:
@@ -33420,10 +33420,10 @@ importers:
         version: 20.19.25
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+        version: 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.0.13(vitest@4.0.13)
+        version: 4.0.14(vitest@4.0.14)
       cross-env:
         specifier: 'catalog:'
         version: 7.0.3
@@ -33435,7 +33435,7 @@ importers:
         version: 9.39.1
       playwright:
         specifier: catalog:testing
-        version: 1.56.1
+        version: 1.57.0
       prettier:
         specifier: 'catalog:'
         version: 3.6.2
@@ -33450,7 +33450,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
 packages:
 
@@ -34744,14 +34744,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-pg@0.61.0':
-    resolution: {integrity: sha512-UeV7KeTnRSM7ECHa3YscoklhUtTQPs6V6qYpG283AB7xpnPGCUCUfECFT9jFg6/iZOQTt3FHkB1wGTJCNZEvPw==}
+  '@opentelemetry/instrumentation-pg@0.61.1':
+    resolution: {integrity: sha512-VKKts/XcOCa7IPBxVjL2B4UyG+YTNa4Dh1Xx2vqL0jOEQBJlNsv++I12BUw/8NRLEr2K/gOM5tpVU7QqhWA65A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-redis@0.57.0':
-    resolution: {integrity: sha512-bCxTHQFXzrU3eU1LZnOZQ3s5LURxQPDlU3/upBzlWY77qOI1GZuGofazj3jtzjctMJeBEJhNwIFEgRPBX1kp/Q==}
+  '@opentelemetry/instrumentation-redis@0.57.1':
+    resolution: {integrity: sha512-iP564P8On9NPPi06T2MyL56sBN0RsF29DX/RC5fW0yOOFdUHcvCDmJnp11eZyymTvYj5HX8tvpoO+vDb6+Lv8A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -34989,8 +34989,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -35493,27 +35493,27 @@ packages:
     resolution: {integrity: sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==}
     engines: {node: '>=20.0.0'}
 
-  '@vitest/browser-playwright@4.0.13':
-    resolution: {integrity: sha512-oaRY+/pvwS4/sN2rE2aZh9jdli8EkXm5AidmXEbWRu2wW0omG9PmgChWCX2jsD9qRLQxXTSLl5oKezANNF6LnQ==}
+  '@vitest/browser-playwright@4.0.14':
+    resolution: {integrity: sha512-rUvyz6wX6wDjcYzf/7fgXYfca2bAu0Axoq/v9LYdELzcBSS9UKjnZ7MaMY4UDP78HHHCdmdtceuSao1s51ON8A==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.0.13
+      vitest: 4.0.14
 
-  '@vitest/browser@4.0.13':
-    resolution: {integrity: sha512-lruSgrYPVAJzKmX6EJYCg9nY+0A4VkeTLpTzf1jRD/XMjNbzD9yy7D499xmVKglwJczANYJXBvZSPGcRlon+0w==}
+  '@vitest/browser@4.0.14':
+    resolution: {integrity: sha512-vO0uqR8SnPTd8ykp14yaIuUyMZ9HEBYuoZrVdUp7RrEp76VEnkrX9fDkGnK0NyBdfWXB6cqp7BmqVekd8yKHFQ==}
     peerDependencies:
-      vitest: 4.0.13
+      vitest: 4.0.14
 
-  '@vitest/coverage-istanbul@4.0.13':
-    resolution: {integrity: sha512-bkoHarZBdrLDMLEQV3AJ+wcD3cETOLCjZrKO+nA4IbIY74uPPJ2pT7CEvdp8OF5AR5NNSYyafn6kAXTJBbDAaA==}
+  '@vitest/coverage-istanbul@4.0.14':
+    resolution: {integrity: sha512-weQA5DR6/GaHL61WK0mnq9fzEeWxkpEawM4mp2WodMewLHKc1mCITJcmofNSMON2x0O951RjdnFsXsKi8WzSWg==}
     peerDependencies:
-      vitest: 4.0.13
+      vitest: 4.0.14
 
-  '@vitest/expect@4.0.13':
-    resolution: {integrity: sha512-zYtcnNIBm6yS7Gpr7nFTmq8ncowlMdOJkWLqYvhr/zweY6tFbDkDi8BPPOeHxEtK1rSI69H7Fd4+1sqvEGli6w==}
+  '@vitest/expect@4.0.14':
+    resolution: {integrity: sha512-RHk63V3zvRiYOWAV0rGEBRO820ce17hz7cI2kDmEdfQsBjT2luEKB5tCOc91u1oSQoUOZkSv3ZyzkdkSLD7lKw==}
 
-  '@vitest/mocker@4.0.13':
-    resolution: {integrity: sha512-eNCwzrI5djoauklwP1fuslHBjrbR8rqIVbvNlAnkq1OTa6XT+lX68mrtPirNM9TnR69XUPt4puBCx2Wexseylg==}
+  '@vitest/mocker@4.0.14':
+    resolution: {integrity: sha512-RzS5NujlCzeRPF1MK7MXLiEFpkIXeMdQ+rN3Kk3tDI9j0mtbr7Nmuq67tpkOJQpgyClbOltCXMjLZicJHsH5Cg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -35523,20 +35523,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.13':
-    resolution: {integrity: sha512-ooqfze8URWbI2ozOeLDMh8YZxWDpGXoeY3VOgcDnsUxN0jPyPWSUvjPQWqDGCBks+opWlN1E4oP1UYl3C/2EQA==}
+  '@vitest/pretty-format@4.0.14':
+    resolution: {integrity: sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==}
 
-  '@vitest/runner@4.0.13':
-    resolution: {integrity: sha512-9IKlAru58wcVaWy7hz6qWPb2QzJTKt+IOVKjAx5vb5rzEFPTL6H4/R9BMvjZ2ppkxKgTrFONEJFtzvnyEpiT+A==}
+  '@vitest/runner@4.0.14':
+    resolution: {integrity: sha512-BsAIk3FAqxICqREbX8SetIteT8PiaUL/tgJjmhxJhCsigmzzH8xeadtp7LRnTpCVzvf0ib9BgAfKJHuhNllKLw==}
 
-  '@vitest/snapshot@4.0.13':
-    resolution: {integrity: sha512-hb7Usvyika1huG6G6l191qu1urNPsq1iFc2hmdzQY3F5/rTgqQnwwplyf8zoYHkpt7H6rw5UfIw6i/3qf9oSxQ==}
+  '@vitest/snapshot@4.0.14':
+    resolution: {integrity: sha512-aQVBfT1PMzDSA16Y3Fp45a0q8nKexx6N5Amw3MX55BeTeZpoC08fGqEZqVmPcqN0ueZsuUQ9rriPMhZ3Mu19Ag==}
 
-  '@vitest/spy@4.0.13':
-    resolution: {integrity: sha512-hSu+m4se0lDV5yVIcNWqjuncrmBgwaXa2utFLIrBkQCQkt+pSwyZTPFQAZiiF/63j8jYa8uAeUZ3RSfcdWaYWw==}
+  '@vitest/spy@4.0.14':
+    resolution: {integrity: sha512-JmAZT1UtZooO0tpY3GRyiC/8W7dCs05UOq9rfsUUgEZEdq+DuHLmWhPsrTt0TiW7WYeL/hXpaE07AZ2RCk44hg==}
 
-  '@vitest/utils@4.0.13':
-    resolution: {integrity: sha512-ydozWyQ4LZuu8rLp47xFUWis5VOKMdHjXCWhs1LuJsTNKww+pTHQNK4e0assIB9K80TxFyskENL6vCu3j34EYA==}
+  '@vitest/utils@4.0.14':
+    resolution: {integrity: sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==}
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -35685,8 +35685,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.30:
-    resolution: {integrity: sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==}
+  baseline-browser-mapping@2.8.31:
+    resolution: {integrity: sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==}
     hasBin: true
 
   bl@4.1.0:
@@ -35695,8 +35695,8 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+  body-parser@2.2.1:
+    resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
 
   brace-expansion@1.1.12:
@@ -35765,8 +35765,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001756:
-    resolution: {integrity: sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==}
+  caniuse-lite@1.0.30001757:
+    resolution: {integrity: sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==}
 
   catharsis@0.9.0:
     resolution: {integrity: sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==}
@@ -35913,8 +35913,8 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+  cookie@1.1.0:
+    resolution: {integrity: sha512-vXiThu1/rlos7EGu8TuNZQEg2e9TvhH9dmS4T4ZVzB7Ao1agEZ6EG3sn5n+hZRYUgduISd1HpngFzAZiDGm5vQ==}
     engines: {node: '>=18'}
 
   copy-file@11.1.0:
@@ -36114,8 +36114,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.259:
-    resolution: {integrity: sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==}
+  electron-to-chromium@1.5.260:
+    resolution: {integrity: sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -37244,8 +37244,8 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.2:
+    resolution: {integrity: sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==}
     engines: {node: '>= 6.13.0'}
 
   node-int64@0.4.0:
@@ -37271,6 +37271,9 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -37452,13 +37455,13 @@ packages:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -38349,27 +38352,24 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.13:
-    resolution: {integrity: sha512-QSD4I0fN6uZQfftryIXuqvqgBxTvJ3ZNkF6RWECd82YGAYAfhcppBLFXzXJHQAAhVFyYEuFTrq6h0hQqjB7jIQ==}
+  vitest@4.0.14:
+    resolution: {integrity: sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/debug': ^4.1.12
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.13
-      '@vitest/browser-preview': 4.0.13
-      '@vitest/browser-webdriverio': 4.0.13
-      '@vitest/ui': 4.0.13
+      '@vitest/browser-playwright': 4.0.14
+      '@vitest/browser-preview': 4.0.14
+      '@vitest/browser-webdriverio': 4.0.14
+      '@vitest/ui': 4.0.14
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
       '@opentelemetry/api':
-        optional: true
-      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -40258,7 +40258,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.61.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-pg@0.61.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
@@ -40270,7 +40270,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-redis@0.57.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-redis@0.57.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
@@ -40577,9 +40577,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.56.1':
+  '@playwright/test@1.57.0':
     dependencies:
-      playwright: 1.56.1
+      playwright: 1.57.0
 
   '@pnpm/catalogs.config@1000.0.5':
     dependencies:
@@ -41167,13 +41167,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)':
+  '@vitest/browser-playwright@4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)':
     dependencies:
-      '@vitest/browser': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
-      '@vitest/mocker': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
-      playwright: 1.56.1
+      '@vitest/browser': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
+      '@vitest/mocker': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -41181,29 +41181,29 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)':
+  '@vitest/browser-playwright@4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)':
     dependencies:
-      '@vitest/browser': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
-      '@vitest/mocker': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
-      playwright: 1.56.1
+      '@vitest/browser': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
+      '@vitest/mocker': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)':
+  '@vitest/browser@4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)':
     dependencies:
-      '@vitest/mocker': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
-      '@vitest/utils': 4.0.13
+      '@vitest/mocker': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/utils': 4.0.14
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -41212,16 +41212,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)':
+  '@vitest/browser@4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)':
     dependencies:
-      '@vitest/mocker': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
-      '@vitest/utils': 4.0.13
+      '@vitest/mocker': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/utils': 4.0.14
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -41229,68 +41229,68 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-istanbul@4.0.13(vitest@4.0.13)':
+  '@vitest/coverage-istanbul@4.0.14(vitest@4.0.14)':
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
       magicast: 0.5.1
+      obug: 2.1.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.0.13':
+  '@vitest/expect@4.0.14':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.13
-      '@vitest/utils': 4.0.13
+      '@vitest/spy': 4.0.14
+      '@vitest/utils': 4.0.14
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      '@vitest/spy': 4.0.13
+      '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.7.3(@types/node@20.19.25)(typescript@5.8.3)
       vite: 7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      '@vitest/spy': 4.0.13
+      '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.7.3(@types/node@20.19.25)(typescript@5.9.3)
       vite: 7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vitest/pretty-format@4.0.13':
+  '@vitest/pretty-format@4.0.14':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.13':
+  '@vitest/runner@4.0.14':
     dependencies:
-      '@vitest/utils': 4.0.13
+      '@vitest/utils': 4.0.14
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.13':
+  '@vitest/snapshot@4.0.14':
     dependencies:
-      '@vitest/pretty-format': 4.0.13
+      '@vitest/pretty-format': 4.0.14
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.13': {}
+  '@vitest/spy@4.0.14': {}
 
-  '@vitest/utils@4.0.13':
+  '@vitest/utils@4.0.14':
     dependencies:
-      '@vitest/pretty-format': 4.0.13
+      '@vitest/pretty-format': 4.0.14
       tinyrainbow: 3.0.3
 
   abab@2.0.6:
@@ -41426,7 +41426,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.30: {}
+  baseline-browser-mapping@2.8.31: {}
 
   bl@4.1.0:
     dependencies:
@@ -41436,13 +41436,13 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.2.0:
+  body-parser@2.2.1:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.6.3
+      iconv-lite: 0.7.0
       on-finished: 2.4.1
       qs: 6.14.0
       raw-body: 3.0.2
@@ -41468,9 +41468,9 @@ snapshots:
 
   browserslist@4.28.0:
     dependencies:
-      baseline-browser-mapping: 2.8.30
-      caniuse-lite: 1.0.30001756
-      electron-to-chromium: 1.5.259
+      baseline-browser-mapping: 2.8.31
+      caniuse-lite: 1.0.30001757
+      electron-to-chromium: 1.5.260
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
@@ -41525,7 +41525,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001756: {}
+  caniuse-lite@1.0.30001757: {}
 
   catharsis@0.9.0:
     dependencies:
@@ -41657,7 +41657,7 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cookie@1.0.2: {}
+  cookie@1.1.0: {}
 
   copy-file@11.1.0:
     dependencies:
@@ -41892,7 +41892,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.259: {}
+  electron-to-chromium@1.5.260: {}
 
   emoji-regex@10.6.0: {}
 
@@ -42130,7 +42130,7 @@ snapshots:
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.2.1
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -42848,7 +42848,7 @@ snapshots:
 
   light-my-request@6.6.0:
     dependencies:
-      cookie: 1.0.2
+      cookie: 1.1.0
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
@@ -43166,7 +43166,7 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.2: {}
 
   node-int64@0.4.0: {}
 
@@ -43190,6 +43190,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -43378,11 +43380,11 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
-  playwright-core@1.56.1: {}
+  playwright-core@1.57.0: {}
 
-  playwright@1.56.1:
+  playwright@1.57.0:
     dependencies:
-      playwright-core: 1.56.1
+      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -44305,19 +44307,19 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
-      '@vitest/expect': 4.0.13
-      '@vitest/mocker': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
-      '@vitest/pretty-format': 4.0.13
-      '@vitest/runner': 4.0.13
-      '@vitest/snapshot': 4.0.13
-      '@vitest/spy': 4.0.13
-      '@vitest/utils': 4.0.13
-      debug: 4.4.3
+      '@vitest/expect': 4.0.14
+      '@vitest/mocker': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.14
+      '@vitest/runner': 4.0.14
+      '@vitest/snapshot': 4.0.14
+      '@vitest/spy': 4.0.14
+      '@vitest/utils': 4.0.14
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.10.0
@@ -44329,9 +44331,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/debug': 4.1.12
       '@types/node': 20.19.25
-      '@vitest/browser-playwright': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+      '@vitest/browser-playwright': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.8.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       jsdom: 16.7.0
     transitivePeerDependencies:
       - jiti
@@ -44342,24 +44343,23 @@ snapshots:
       - sass-embedded
       - stylus
       - sugarss
-      - supports-color
       - terser
       - tsx
       - yaml
 
-  vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.13)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/browser-playwright@4.0.14)(jsdom@16.7.0)(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
-      '@vitest/expect': 4.0.13
-      '@vitest/mocker': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
-      '@vitest/pretty-format': 4.0.13
-      '@vitest/runner': 4.0.13
-      '@vitest/snapshot': 4.0.13
-      '@vitest/spy': 4.0.13
-      '@vitest/utils': 4.0.13
-      debug: 4.4.3
+      '@vitest/expect': 4.0.14
+      '@vitest/mocker': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.14
+      '@vitest/runner': 4.0.14
+      '@vitest/snapshot': 4.0.14
+      '@vitest/spy': 4.0.14
+      '@vitest/utils': 4.0.14
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.10.0
@@ -44371,9 +44371,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/debug': 4.1.12
       '@types/node': 20.19.25
-      '@vitest/browser-playwright': 4.0.13(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.56.1)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.13)
+      '@vitest/browser-playwright': 4.0.14(msw@2.7.3(@types/node@20.19.25)(typescript@5.9.3))(playwright@1.57.0)(vite@7.2.4(@types/node@20.19.25)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.14)
       jsdom: 16.7.0
     transitivePeerDependencies:
       - jiti
@@ -44384,7 +44383,6 @@ snapshots:
       - sass-embedded
       - stylus
       - sugarss
-      - supports-color
       - terser
       - tsx
       - yaml

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -135,7 +135,7 @@
     "dotenv": "catalog:testing",
     "eslint": "catalog:",
     "https-proxy-agent": "^7.0.0",
-    "node-forge": "^1.3.1",
+    "node-forge": "^1.3.2",
     "playwright": "catalog:testing",
     "prettier": "catalog:",
     "rimraf": "catalog:",


### PR DESCRIPTION
to address security alert.