### PR TITLE
Argument parsing errors and breaks command execution

### DIFF
--- a/eng/scripts/update-changelog-content.ps1
+++ b/eng/scripts/update-changelog-content.ps1
@@ -60,7 +60,7 @@ try {
   # Run the update-changelog command using npm exec
   Write-Host "Updating CHANGELOG.md..." -ForegroundColor Cyan
   Write-Host ""
-  $command = "npm --prefix $releaseToolsPath exec --no -- update-changelog -- --sdkRepoPath `"$SdkRepoPath`" --packagePath `"$PackagePath`""
+  $command = "npm --prefix $releaseToolsPath exec update-changelog -- --sdkRepoPath `"$SdkRepoPath`" --packagePath `"$PackagePath`""
   Invoke-LoggedCommand $command
   
   Write-Host ""

--- a/eng/scripts/update-version.ps1
+++ b/eng/scripts/update-version.ps1
@@ -100,7 +100,7 @@ try {
   # Run the update-version command using npm exec
   Write-Host "Updating package version..." -ForegroundColor Cyan
   Write-Host ""
-  $command = "npm --prefix $releaseToolsPath exec --no -- update-version -- $cmdArgs"
+  $command = "npm --prefix $releaseToolsPath exec update-version -- $cmdArgs"
   Invoke-LoggedCommand $command
   
   Write-Host ""


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/issues/13215
Remove unnecessary '--no' flag from npm exec commands in update scripts
### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
