### PR TITLE
Fix 36840

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -3,12 +3,12 @@
 import type { ClientContext } from "../../ClientContext.js";
 import type { DiagnosticNodeInternal } from "../../diagnostics/DiagnosticNodeInternal.js";
 import {
+  assertItemResourceIsValid,
   Constants,
   copyObject,
   createDocumentUri,
   getIdFromLink,
   getPathFromLink,
-  isItemResourceValid,
   ResourceType,
   StatusCodes,
 } from "../../common/index.js";
@@ -255,11 +255,10 @@ export class Item {
         this.container,
         this.partitionKey,
       );
+
+      assertItemResourceIsValid(body);
+
       let partitionKey = this.partitionKey;
-      const err = {};
-      if (!isItemResourceValid(body, err)) {
-        throw err;
-      }
       let url = this.url;
 
       let response: Response<T & Resource>;

--- a/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Item.ts
@@ -249,7 +249,7 @@ export class Item {
     body: T,
     options: RequestOptions = {},
   ): Promise<ItemResponse<T>> {
-    return withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
+    return await withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
       this.partitionKey = await setPartitionKeyIfUndefined(
         diagnosticNode,
         this.container,

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -5,11 +5,11 @@ import { ChangeFeedIterator } from "../../ChangeFeedIterator.js";
 import type { ChangeFeedOptions } from "../../ChangeFeedOptions.js";
 import type { ClientContext } from "../../ClientContext.js";
 import {
+  assertItemResourceIsValid,
   Constants,
   copyObject,
   getIdFromLink,
   getPathFromLink,
-  isItemResourceValid,
   ResourceType,
   StatusCodes,
   SubStatusCodes,
@@ -544,10 +544,9 @@ export class Items {
 
           partitionKey = extractPartitionKeys(body, partitionKeyDefinition);
         }
-        const err = {};
-        if (!isItemResourceValid(body, err)) {
-          throw err;
-        }
+        
+        assertItemResourceIsValid(body);
+
         const path = getPathFromLink(this.container.url, ResourceType.item);
         const id = getIdFromLink(this.container.url);
 
@@ -710,10 +709,7 @@ export class Items {
           partitionKey = extractPartitionKeys(body, partitionKeyDefinition);
         }
 
-        const err = {};
-        if (!isItemResourceValid(body, err)) {
-          throw err;
-        }
+        assertItemResourceIsValid(body);
 
         const path = getPathFromLink(this.container.url, ResourceType.item);
         const id = getIdFromLink(this.container.url);

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -515,7 +515,7 @@ export class Items {
     // Generate random document id if the id is missing in the payload and
     // options.disableAutomaticIdGeneration != true
 
-    return withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
+    return await withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
       if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {
         body.id = randomUUID();
       }
@@ -676,7 +676,7 @@ export class Items {
     body: T,
     options: RequestOptions = {},
   ): Promise<ItemResponse<T>> {
-    return withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
+    return await withDiagnostics(async (diagnosticNode: DiagnosticNodeInternal) => {
       // Generate random document id if the id is missing in the payload and
       // options.disableAutomaticIdGeneration != true
       if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {

--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -235,25 +235,24 @@ export function isResourceValid(resource: { id?: string }, err: { message?: stri
 /**
  * @hidden
  */
-export function isItemResourceValid(resource: { id?: string }, err: { message?: string }): boolean {
+export function assertItemResourceIsValid(resource: { id?: string }) {
   // TODO: fix strictness issues so that caller contexts respects the types of the functions
-  if (resource.id) {
-    if (typeof resource.id !== "string") {
-      err.message = "Id must be a string.";
-      return false;
-    }
-
-    if (
-      resource.id.indexOf("/") !== -1 ||
-      resource.id.indexOf("\\") !== -1 ||
-      resource.id.indexOf("#") !== -1
-    ) {
-      err.message = "Id contains illegal chars.";
-      return false;
-    }
+  if (resource.id === undefined) {
+    return;
   }
-  return true;
+
+  const actualType = typeof resource.id;
+
+  if (actualType !== 'string') {
+    throw new Error(`Id must be a string. Got ${actualType}`);
+  }
+
+  if (illegalIdCharactersRegex.test(resource.id)) {
+    throw new Error("Id contains illegal chars.");
+  }
 }
+
+const illegalIdCharactersRegex = /[\/\\#]/;
 
 /** @hidden */
 export function getIdFromLink(resourceLink: string): string {


### PR DESCRIPTION
### Packages impacted by this PR

@azure/cosmos

### Issues associated with this PR

#36840 

### Describe the problem that is addressed by this PR

Some methods (described in the issue) used to throw non-Error objects, which makes debugging of such errors difficult to users, due to lack of stack traces

Fixed:

- Replace `isItemResourceValid()` snippets with `assertItemResourceValid()`, that has the same logic, but instead of setting `err.message`, it throws `new Error()` with such message instead

- Refactor the code of function to follow a bit easier. Replace 3 `indexOf()` with the equivalent regex check

- Use `return await withDiagnostics()` in `Items.create()`, `Items.upsert()` and `Item.replace()` for better stack traces†

† - on better stack traces:

There is a difference between `return asyncFn()` and `return await asyncFn()` - it affect stack traces. Compare:

```ts
async function foo() {
  return goo()
}

async function goo() {
  // Make sure throwing happens after await
  await fetch('https://example.com')
  
  throw new Error()
}

void foo()
```

Giving output without `foo` in the stack trace:

```
file:///Users/user/src/issues/azure-cosmos-nodejs-unhandled-rejections/src/foo.js:9
  throw new Error()
        ^

Error
    at goo (file:///Users/user/src/issues/azure-cosmos-nodejs-unhandled-rejections/src/foo.js:9:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

And

```ts
async function foo() {
  return await goo()
}

async function goo() {
  // Make sure throwing happens after await
  await fetch('https://example.com')
  
  throw new Error()
}

void foo()
```

Giving output with `foo()` 

```
file:///Users/user/src/issues/azure-cosmos-nodejs-unhandled-rejections/src/foo.js:9
  throw new Error()
        ^

Error
    at goo (file:///Users/user/src/issues/azure-cosmos-nodejs-unhandled-rejections/src/foo.js:9:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async foo (file:///Users/user/src/issues/azure-cosmos-nodejs-unhandled-rejections/src/foo.js:2:10)

Node.js v22.18.0
```

You may want to find and replace all `return withDiagnostics()` with `return await withDiagnostics()`. Apart from stack traces, that must not change the behavior of the code

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Throwing `Error` seems like the most obvious and simple solution

### Are there test cases added in this PR? _(If not, why?)_

No, the logic remained largely the same, the bugs are very unlikely

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary) - **not sure if it is**
