### PR TITLE
docs: Add migration notes for subscription package

### DIFF
--- a/sdk/subscription/arm-subscriptions/CHANGELOG.md
+++ b/sdk/subscription/arm-subscriptions/CHANGELOG.md
@@ -33,7 +33,6 @@
       // ....
     }
     ```
-  - Removed Interface Location_2
   - Removed Interface SubscriptionPolicies
   - Removed Interface SubscriptionsGetOptionalParams
   - Removed Interface SubscriptionsListLocationsOptionalParams


### PR DESCRIPTION
Updated CHANGELOG.md to include migration instructions to @azure/arm-resources-subscriptions.

See suggestion by @MaryGao here: https://github.com/Azure/azure-sdk-for-js/issues/36822#issuecomment-3641006728
