### PR TITLE
load browser types from deps

### DIFF
--- a/tsconfig.browser.base.json
+++ b/tsconfig.browser.base.json
@@ -2,6 +2,7 @@
   "extends": ["./tsconfig.json", "./tsconfig.nonlib.json"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "customConditions": ["browser"],
     // Workaround for browser build-test:
     //   - Some core and storage package have mixed usage of NodeJS and browser types in same file.
     //   - TypeScript resolves our types from ESM because of `"moduleResolution": "NodeNext"`


### PR DESCRIPTION
When the [customConditions](https://www.typescriptlang.org/tsconfig/#customConditions) array includes "browser", TypeScript resolves and loads the browser-specific type definitions declared under the browser condition in the dependency’s package.json exports field. Otherwise, node types will be loaded by default.