### PR TITLE
Revert "load browser types from deps (#36876)"

### DIFF
--- a/tsconfig.browser.base.json
+++ b/tsconfig.browser.base.json
@@ -2,7 +2,6 @@
   "extends": ["./tsconfig.json", "./tsconfig.nonlib.json"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "customConditions": ["browser"],
     // Workaround for browser build-test:
     //   - Some core and storage package have mixed usage of NodeJS and browser types in same file.
     //   - TypeScript resolves our types from ESM because of `"moduleResolution": "NodeNext"`


### PR DESCRIPTION
This reverts commit b4fb08d01192107f9996f79fd18f25486433b8e0.

Many of our packages' browser test build in `test:browser` are not ready yet.