### PR TITLE
[dev-tool] move `attw` to global dev dependency list

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@_ts/max": "npm:typescript@latest",
     "@_ts/min": "npm:typescript@~4.2.4",
-    "@arethetypeswrong/cli": "^0.17.4",
     "@azure/identity": "catalog:internal",
     "@microsoft/api-extractor": "^7.52.4",
     "@microsoft/api-extractor-model": "^7.30.5",

--- a/common/tools/dev-tool/src/checks/release.ts
+++ b/common/tools/dev-tool/src/checks/release.ts
@@ -35,5 +35,5 @@ export const installable: Check = {
 export const areTheTypesWrong = scriptCheck({
   tags: ["release"],
   description: "are the types wrong must not display any errors",
-  checkCommand: "dev-tool run vendored attw --pack .",
+  checkCommand: "attw --pack .",
 });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "update-snippets": "turbo run update-snippets"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
     "cspell": "^9.3.1",
     "prettier-plugin-packagejson": "^2.5.19",
     "rimraf": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
 
   .:
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.17.4
+        version: 0.17.4
       cspell:
         specifier: ^9.3.1
         version: 9.4.0
@@ -119,9 +122,6 @@ importers:
       '@_ts/min':
         specifier: npm:typescript@~4.2.4
         version: typescript@4.2.4
-      '@arethetypeswrong/cli':
-        specifier: ^0.17.4
-        version: 0.17.4
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0


### PR DESCRIPTION
Per Pnpm recommendations tools for the whole mono repo should be included in
the workspace-level package.json. This PR moves dev dependencies
`@arethetypeswrong/cli` to global dev dependencies and update dev-tool command
that invokes it.