### PR TITLE
[EngSys] fix out-of-memory issue with `pnpm outdate --recursive`

### DIFF
--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -79,9 +79,9 @@ function Set-GitHubIssue($Package) {
 Write-Host "Running pnpm update --recursive --no-save"
 pnpm update --recursive --no-save
 
-Write-Host "Running pnpm outdated --format json --recursive"
+Write-Host "Running 'pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-*  outdated --format json --recursive'"
 $env:NODE_OPTIONS = "--max-old-space-size=16384"
-$pnpmOutdatedOutput = pnpm outdated --format json --recursive
+$pnpmOutdatedOutput = & pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-* outdated --format json --recursive | Where-Object { -not ($_.StartsWith(" WARN ", [System.StringComparison]::OrdinalIgnoreCase)) }
 
 $availableUpdates = $pnpmOutdatedOutput | ConvertFrom-Json
 


### PR DESCRIPTION
With the ever-increasing number of packages in JS mono-repo, the `pnpm outdate
--recursive` command has been failing recently due to v8 heap out of memory even
we already allow max of 16 GB.

This PR excludes management packages when checking available dependency upgrades
since management packages are generated with a fix set of dependencies which are
already included in dependencies of non-management packages.