### PR TITLE
[dev-tool] quote vitest options if they include spaces

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -64,7 +64,9 @@ export default leafCommand(commandInfo, async (options) => {
   }
 
   const updatedArgs = options["--"]?.map((opt) =>
-    opt.includes("**") && !opt.startsWith("'") && !opt.startsWith('"') ? `"${opt}"` : opt,
+    (opt.includes("**") || opt.includes(" ")) && !opt.startsWith("'") && !opt.startsWith('"')
+      ? `"${opt}"`
+      : opt,
   );
 
   let args = "";


### PR DESCRIPTION
otherwise arguments like `-t "test case name"` are not passed to vitest properly.