### PR TITLE
ServiceBus BugFix: Ensure Purge call deletes all the applicable messages in a ServiceBus entity

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -513,9 +513,9 @@ export class ServiceBusReceiverImpl implements ServiceBusReceiver {
     logger.verbose(
       `${this.logPrefix} receiver '${this.identifier}' deleted ${deletedCount} messages.`,
     );
-    if (deletedCount === MaxDeleteMessageCount) {
-      let batchCount = MaxDeleteMessageCount;
-      while (batchCount === MaxDeleteMessageCount) {
+    if (deletedCount > 0) {
+      let batchCount = deletedCount;
+      while (batchCount > 0) {
         batchCount = await this.deleteMessages({
           maxMessageCount: MaxDeleteMessageCount,
           beforeEnqueueTime: options?.beforeEnqueueTime,


### PR DESCRIPTION
### Packages impacted by this PR
Service Bus JS SDK

### Issues associated with this PR
When a purge call is made, it is not guaranteed that all the applicable messages within that entity will be deleted.

### Describe the problem that is addressed by this PR
Currently the way purge api is implemented; It checks if maxDeleteCount messages are deleted or not in order to decide whether or not to make a subsequent DeleteMessages call. But due to the way DeleteMessages is implemented in the service this sometimes leads to partial purge (i.e. not all the messages are deleted)

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
To fix the issue at hand, if it purges messages iteratively until no messages are deleted in the previous call then we can guarantee that by making a purge call all the messages in an entity will indeed get deleted.

### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
