### PR TITLE
[azure monitor opentelemetry exporter] Update autogenerated client to use latest size specification

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/src/generated/models/index.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/generated/models/index.ts
@@ -411,7 +411,7 @@ export enum KnownContextTagKeys {
 export type ContextTagKeys = string;
 
 /** Optional parameters. */
-export interface TrackOptionalParams extends coreClient.OperationOptions { }
+export interface TrackOptionalParams extends coreClient.OperationOptions {}
 
 /** Contains response data for the track operation. */
 export type TrackOperationResponse = TrackResponse;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/generated/models/mappers.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/generated/models/mappers.ts
@@ -424,7 +424,7 @@ export const AvailabilityData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -459,7 +459,7 @@ export const TelemetryEventData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -513,7 +513,7 @@ export const TelemetryExceptionData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -554,7 +554,7 @@ export const MessageData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -592,7 +592,7 @@ export const MetricsData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
     },
@@ -618,7 +618,7 @@ export const PageViewData: coreClient.CompositeMapper = {
       },
       name: {
         constraints: {
-          MaxLength: 1024,
+          MaxLength: 512,
         },
         serializedName: "name",
         required: true,
@@ -654,7 +654,7 @@ export const PageViewData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -687,7 +687,7 @@ export const PageViewPerfData: coreClient.CompositeMapper = {
       },
       name: {
         constraints: {
-          MaxLength: 1024,
+          MaxLength: 512,
         },
         serializedName: "name",
         required: true,
@@ -744,7 +744,7 @@ export const PageViewPerfData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -838,7 +838,7 @@ export const RemoteDependencyData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {
@@ -925,7 +925,7 @@ export const RequestData: coreClient.CompositeMapper = {
         serializedName: "properties",
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, constraints: { MaxLength: 8192 } },
+          value: { type: { name: "String" } },
         },
       },
       measurements: {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

Updated using latest spec changes available here
https://github.com/Azure/azure-rest-api-specs/pull/39588