### PR TITLE
Reference Azure SDK MCP in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,13 @@
 - Infra/cache in `eng/*`, docs in `documentation/*`, samples in `samples/*`.
 
 ## Build, Test, and Development Commands
+- Use Azure SDK MCP tools where available
 - `pnpm install` — install workspace deps (Node current LTS, pnpm v10).
 - **Building packages**: Due to workspace linking, `npm run clean && npm run build` under a package directory will NOT work if dependencies aren't built. Always use: `pnpm turbo build --filter=<package name>... --token 1` (the trailing `...` builds the package and all its dependencies; `--token 1` enables remote cache read).
 - Full build: `pnpm build` — builds all packages via Turborepo (avoid).
-- Tests: `pnpm test`; or `pnpm test:node` / `pnpm test:browser`.
-- Lint/format: `pnpm lint`, `pnpm lint:fix`, `pnpm format`, `pnpm check-format`.
-- Filter examples: `pnpm test --filter @azure/web-pubsub`, `pnpm turbo build --filter sdk/web-pubsub/web-pubsub...`.
+- Tests: use the Azure SDK MCP tool `azsdk_package_run_tests`.
+- Lint/format: use the Azure SDK MCP tool `azsdk_package_run_check`, specifying lint or format.
+- Filter examples: `pnpm turbo build --filter sdk/web-pubsub/web-pubsub...`.
 
 ## Coding Style & Naming Conventions
 - TypeScript; 2-space indent; semicolons; printWidth 100; double quotes (see `.prettierrc.json`).


### PR DESCRIPTION
### Issues associated with this PR

- Fix https://github.com/Azure/azure-sdk-tools/issues/13417

Also related is https://github.com/Azure/azure-sdk-for-js/issues/36510, which is about which instructions files we should actually be using. But while we wait for that discussion to resolve we can still make this quick fix.

### Description

We want the agent to use the SDK MCP server to run tests instead of using `pnpm` directly, at least right now. This is a quick fix to the AGENTS.md file to point it in the right direction, in light of issues we were seeing during the inner loop bug bash where it was bypassing the MCP server. Testing suggests that rephrasing here makes the agent use the MCP tool for tests much more reliably.