### PR TITLE
[EngSys] upgrade dependency `@modelcontextprotocol/sdk` to ^1.25.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,8 +1016,8 @@ importers:
         specifier: 1.0.0-beta.7
         version: 1.0.0-beta.7
       '@modelcontextprotocol/sdk':
-        specifier: ^1.25.1
-        version: 1.25.1(hono@4.11.3)(zod@4.3.5)
+        specifier: ^1.25.2
+        version: 1.25.2(hono@4.11.3)(zod@4.3.5)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -34513,8 +34513,8 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@modelcontextprotocol/sdk@1.25.1':
-    resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -40107,7 +40107,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.3.5)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5)':
     dependencies:
       '@hono/node-server': 1.19.7(hono@4.11.3)
       ajv: 8.17.1

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -90,7 +90,7 @@
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",
-    "@modelcontextprotocol/sdk": "^1.25.1",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "zod": "^4.2.1",
     "cross-env": "catalog:",
     "dotenv": "catalog:testing",

--- a/sdk/ai/ai-projects/samples/v2-beta/javascript/package.json
+++ b/sdk/ai/ai-projects/samples/v2-beta/javascript/package.json
@@ -31,7 +31,7 @@
     "@azure/identity": "^4.13.0",
     "openai": "^6.16.0",
     "@azure/arm-cognitiveservices": "7.6.0",
-    "@modelcontextprotocol/sdk": "^1.25.1",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@azure/monitor-opentelemetry": "^1.14.2",
     "@opentelemetry/api": "^1.9.0"
   },

--- a/sdk/ai/ai-projects/samples/v2-beta/typescript/package.json
+++ b/sdk/ai/ai-projects/samples/v2-beta/typescript/package.json
@@ -35,7 +35,7 @@
     "@azure/identity": "^4.13.0",
     "openai": "^6.16.0",
     "@azure/arm-cognitiveservices": "7.6.0",
-    "@modelcontextprotocol/sdk": "^1.25.1",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@azure/monitor-opentelemetry": "^1.14.2",
     "@opentelemetry/api": "^1.9.0"
   },


### PR DESCRIPTION
to address security alert.