### PR TITLE
[engsys] Exclude node_modules from README verification scan

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -24,6 +24,7 @@ omitted_paths:
   - sdk/storage/storage-internal-avro/*
   - sdk/test-utils/*/README.md
   - sdk/identity/identity/integration/*
+  - "**/node_modules/**"
 
 language: js
 root_check_enabled: True


### PR DESCRIPTION
To fix Azure/azure-sdk-tools#13207 in conjunction with release of https://github.com/Azure/azure-sdk-tools/pull/13585