### PR TITLE
Remove all MixedReality SDKs

### DIFF
--- a/dataplane.code-workspace
+++ b/dataplane.code-workspace
@@ -244,10 +244,6 @@
       "path": "sdk/digitaltwins/digital-twins-core",
     },
     {
-      "name": "mixed-reality-authentication",
-      "path": "sdk/mixedreality/mixed-reality-authentication",
-    },
-    {
       "name": "attestation",
       "path": "sdk/attestation/attestation",
     },


### PR DESCRIPTION
All mixed reality services are retired and the last references to these SDKs can be removed.