### PR TITLE
[Monitor-OpenTelemetry] Improve Double-Instrumentation Logging

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -37,9 +37,8 @@ let browserSdkLoader: BrowserSdkLoader | undefined;
 
 /**
  * Check if auto-attach (autoinstrumentation) is enabled and warn about double instrumentation.
- * @internal
  */
-export function sendAttachWarning(): void {
+function sendAttachWarning(): void {
   if (process.env[AZURE_MONITOR_AUTO_ATTACH] === "true" && !isFunctionApp()) {
     // TODO: When AKS attach is public, update this message with disablement instructions for AKS
     const message =

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -5,12 +5,7 @@ import type { Context, TracerProvider } from "@opentelemetry/api";
 import { metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import type { AzureMonitorOpenTelemetryOptions } from "../../../src/index.js";
-import {
-  useAzureMonitor,
-  shutdownAzureMonitor,
-  _getSdkInstance,
-  sendAttachWarning,
-} from "../../../src/index.js";
+import { useAzureMonitor, shutdownAzureMonitor, _getSdkInstance } from "../../../src/index.js";
 import type { MeterProvider, ViewOptions } from "@opentelemetry/sdk-metrics";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
@@ -28,7 +23,6 @@ import type { LogRecordProcessor, SdkLogRecord } from "@opentelemetry/sdk-logs";
 import { getInstance } from "../../../src/utils/statsbeat.js";
 import type { Instrumentation, InstrumentationConfig } from "@opentelemetry/instrumentation";
 import { describe, it, beforeEach, afterEach, expect, assert, vi, afterAll } from "vitest";
-import { Logger } from "../../../src/shared/logging/index.js";
 
 const testInstrumentation: Instrumentation = {
   instrumentationName: "@opentelemetry/instrumentation-fs",
@@ -617,53 +611,5 @@ describe("Main functions", () => {
     assert.isTrue(hasOTLPReader, "Should have OTLP metric reader");
 
     void shutdownAzureMonitor();
-  });
-
-  describe("sendAttachWarning", () => {
-    const expectedMessage =
-      "Distro detected that automatic instrumentation may have occurred. Only use autoinstrumentation if you " +
-      "are not using manual instrumentation of OpenTelemetry in your code, such as with " +
-      "@azure/monitor-opentelemetry or @azure/monitor-opentelemetry-exporter. For App Service resources, disable " +
-      "autoinstrumentation in the Application Insights experience on your App Service resource or by setting " +
-      "the ApplicationInsightsAgent_EXTENSION_VERSION app setting to 'disabled'.";
-
-    it("should warn when auto-attach is enabled and not on functions", () => {
-      process.env.AZURE_MONITOR_AUTO_ATTACH = "true";
-      delete process.env.FUNCTIONS_WORKER_RUNTIME;
-
-      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const loggerWarnSpy = vi.spyOn(Logger.getInstance(), "warn").mockImplementation(() => {});
-
-      sendAttachWarning();
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expectedMessage);
-      expect(loggerWarnSpy).toHaveBeenCalledWith(expectedMessage);
-    });
-
-    it("should not warn when auto-attach is not enabled", () => {
-      delete process.env.AZURE_MONITOR_AUTO_ATTACH;
-      delete process.env.FUNCTIONS_WORKER_RUNTIME;
-
-      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const loggerWarnSpy = vi.spyOn(Logger.getInstance(), "warn").mockImplementation(() => {});
-
-      sendAttachWarning();
-
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(loggerWarnSpy).not.toHaveBeenCalled();
-    });
-
-    it("should not warn when on functions even if auto-attach is enabled", () => {
-      process.env.AZURE_MONITOR_AUTO_ATTACH = "true";
-      process.env.FUNCTIONS_WORKER_RUNTIME = "node";
-
-      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const loggerWarnSpy = vi.spyOn(Logger.getInstance(), "warn").mockImplementation(() => {});
-
-      sendAttachWarning();
-
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(loggerWarnSpy).not.toHaveBeenCalled();
-    });
   });
 });


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry

### Describe the problem that is addressed by this PR
This pull request adds a new feature to help users detect double instrumentation scenarios (when both autoinstrumentation and manual instrumentation are enabled), and surfaces a warning both in the log stream and diagnostic logs. It also introduces tests to ensure this warning is correctly emitted or suppressed based on environment conditions.

New double-instrumentation detection and warning:

* Added the `_sendAttachWarning` function in `src/index.ts` to check for double instrumentation and emit a warning via `console.warn` and the `Logger` when autoinstrumentation is enabled and not running in Azure Functions. This helps users avoid configuration issues and provides guidance on how to disable autoinstrumentation.
* Integrated `_sendAttachWarning` into the `useAzureMonitor` initialization flow to ensure the warning is surfaced when the SDK is started.
* Updated the changelog to document the new warning feature for double-instrumentation scenarios.

Testing improvements:

* Added unit tests in `main.test.ts` to verify that `_sendAttachWarning` emits or suppresses warnings appropriately depending on environment variables, ensuring reliability and correct behavior.

Internal refactoring:

* Updated imports in `src/index.ts` and `main.test.ts` to support the new functionality and testing. [[1]](diffhunk://#diff-e7e1dcf8f0ac5c3aea3811994ab032c757ad020b9ca8855dec69d18bb5343ef3L27-R29) [[2]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7L8-R13) [[3]](diffhunk://#diff-6ff281b26957b1a05c658f2ed7620197d583bb345dc0bf7caa26fb496c33d8f7R31)

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
