### PR TITLE
[ts-http-runtime] Fix URL construction in urlHelpers.ts

### DIFF
--- a/sdk/core/ts-http-runtime/src/client/urlHelpers.ts
+++ b/sdk/core/ts-http-runtime/src/client/urlHelpers.ts
@@ -167,7 +167,10 @@ function simpleParseQueryParams(queryString: string): Map<string, string | strin
   const pairs = queryString.split("&");
 
   for (const pair of pairs) {
-    const [name, value] = pair.split("=", 2);
+    const eqIndex = pair.indexOf("=");
+    const name = eqIndex === -1 ? pair : pair.substring(0, eqIndex);
+    const value = eqIndex === -1 ? "" : pair.substring(eqIndex + 1);
+
     const existingValue = result.get(name);
     if (existingValue !== undefined) {
       if (Array.isArray(existingValue)) {

--- a/sdk/core/ts-http-runtime/test/client/urlHelpers.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/urlHelpers.spec.ts
@@ -476,5 +476,11 @@ describe("urlHelpers", () => {
         "https://example.org/samplename?api-version=2020-08-01&api-version=2021-08-01&api-version=2022-08-01",
       );
     });
+
+    it("should keep encoded search value that is not encoded", () => {
+      const url = "https://example.org/samplename?api-version=a=b=c=d";
+      const result = appendQueryParams(url, { queryParameters: { e: "f" } });
+      assert.strictEqual(result, "https://example.org/samplename?api-version=a=b=c=d&e=f");
+    });
   });
 });


### PR DESCRIPTION
There are cases where the `routePath` isn't a real path, but in the form of `"?restype=service&comp=properties"`.  They are supposed to be query parameters but today are appended to the endpoint directly.  This caused issues when the endpoint already contains query parameters (e.g., storage SAS URL).

This PR handles this case.


### Packages impacted by this PR
`@typespec/ts-http-runtime`
