### PR TITLE
chore(containerregistry): update container registry owner group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,7 +180,7 @@
 # PRLabel: %Container Registry
 /sdk/containerregistry/    @Azure/azure-sdk-write-acr
 
-# AzureSdkOwners: @jeremymeng @timovv
+# AzureSdkOwners: @Azure/azure-sdk-write-acr
 # ServiceLabel: %Container Registry
 
 # PRLabel: %Cosmos


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Current ownership group for container registry is out of date. This PR updates the group ownership to the current group