### PR TITLE
Replace `azd config list` with `azd auth status` in TROUBLESHOOTING.md

### DIFF
--- a/sdk/identity/identity/TROUBLESHOOTING.md
+++ b/sdk/identity/identity/TROUBLESHOOTING.md
@@ -394,11 +394,19 @@ az account get-access-token --output json --resource https://management.core.win
 
 ### Verify the Azure Developer CLI can obtain tokens
 
-You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. First, use the `auth status` command to verify the account which is currently logged in to the Azure Developer CLI.
+You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. Execute the command corresponding to your CLI version to verify the account currently logged in.
 
-```bash
-azd auth status
-```
+- In Azure Developer CLI versions >= 1.23.0:
+
+    ```sh
+    azd auth status
+    ```
+
+- In Azure Developer CLI versions < 1.23.0:
+
+    ```sh
+    azd config list
+    ```
 
 Once you've verified the Azure Developer CLI is using the correct account, validate that it's able to obtain tokens for this account.
 


### PR DESCRIPTION
The `azd config list` command is no longer the recommended way to verify the logged-in Azure Developer CLI account. Update the troubleshooting guide to use `azd auth status` instead.