### PR TITLE
Fix @link reference: AzurePowershellCredential -> AzurePowerShellCred…

### DIFF
--- a/sdk/identity/identity/src/credentials/defaultAzureCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredentialOptions.ts
@@ -62,8 +62,8 @@ export interface DefaultAzureCredentialOptions
   tenantId?: string;
 
   /**
-   * Timeout configurable for making token requests for developer credentials, namely, {@link AzurePowershellCredential},
-   * {@link AzureDeveloperCliCredential} and {@link AzureCliCredential}.
+   * Timeout configurable for making token requests for developer credentials, namely, {@link AzurePowerShellCredential},
+   * {@link AzureDeveloperCliCredential}, and {@link AzureCliCredential}.
    * Process timeout for credentials should be provided in milliseconds.
    */
   processTimeoutInMs?: number;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-js/issues/36433

This pull request makes a small documentation update to the `DefaultAzureCredentialOptions` interface. The change corrects the spelling of `AzurePowerShellCredential` in the comment and adds a missing comma for clarity.

- Documentation fix: Corrected the spelling of `AzurePowerShellCredential` and improved punctuation in the JSDoc comment for the `processTimeoutInMs` property in `defaultAzureCredentialOptions.ts`.