### PR TITLE
[core] Restrict redirectPolicy to same-origin redirects by default

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4536,7 +4536,7 @@ importers:
         specifier: ^1.6.2
         version: link:../../core/core-paging
       '@azure/core-rest-pipeline':
-        specifier: ^1.22.3
+        specifier: ^1.23.0
         version: link:../../core/core-rest-pipeline
       tslib:
         specifier: ^2.8.1
@@ -7342,7 +7342,7 @@ importers:
         specifier: ^1.6.2
         version: link:../../core/core-paging
       '@azure/core-rest-pipeline':
-        specifier: ^1.22.3
+        specifier: ^1.23.0
         version: link:../../core/core-rest-pipeline
       '@azure/core-tracing':
         specifier: ^1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4536,7 +4536,7 @@ importers:
         specifier: ^1.6.2
         version: link:../../core/core-paging
       '@azure/core-rest-pipeline':
-        specifier: ^1.18.2
+        specifier: ^1.22.3
         version: link:../../core/core-rest-pipeline
       tslib:
         specifier: ^2.8.1
@@ -7342,7 +7342,7 @@ importers:
         specifier: ^1.6.2
         version: link:../../core/core-paging
       '@azure/core-rest-pipeline':
-        specifier: ^1.18.2
+        specifier: ^1.22.3
         version: link:../../core/core-rest-pipeline
       '@azure/core-tracing':
         specifier: ^1.2.0
@@ -8362,7 +8362,7 @@ importers:
         specifier: ^1.3.0
         version: link:../logger
       '@typespec/ts-http-runtime':
-        specifier: ^0.3.0
+        specifier: ^0.3.4
         version: link:../ts-http-runtime
       tslib:
         specifier: ^2.6.2

--- a/sdk/commerce/arm-commerce/CHANGELOG.md
+++ b/sdk/commerce/arm-commerce/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+- Opted in to cross-origin redirects to ensure RateCard API requests continue to work when the service redirects to an API gateway. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+- Updated minimum dependency on `@azure/core-rest-pipeline` to `^1.22.3`.
+
 ## 4.0.0-beta.3 (2022-11-17)
 
 The package of @azure/arm-commerce is using our next generation design principles since version 4.0.0-beta.3, which contains breaking changes.

--- a/sdk/commerce/arm-commerce/CHANGELOG.md
+++ b/sdk/commerce/arm-commerce/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Other Changes
 
 - Opted in to cross-origin redirects to ensure RateCard API requests continue to work when the service redirects to an API gateway. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
-- Updated minimum dependency on `@azure/core-rest-pipeline` to `^1.22.3`.
+- Updated minimum dependency on `@azure/core-rest-pipeline` to `^1.23.0`.
 
 ## 4.0.0-beta.3 (2022-11-17)
 

--- a/sdk/commerce/arm-commerce/package.json
+++ b/sdk/commerce/arm-commerce/package.json
@@ -11,7 +11,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
-    "@azure/core-rest-pipeline": "^1.22.3",
+    "@azure/core-rest-pipeline": "^1.23.0",
     "tslib": "^2.8.1"
   },
   "keywords": [

--- a/sdk/commerce/arm-commerce/package.json
+++ b/sdk/commerce/arm-commerce/package.json
@@ -11,7 +11,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
-    "@azure/core-rest-pipeline": "^1.18.2",
+    "@azure/core-rest-pipeline": "^1.22.3",
     "tslib": "^2.8.1"
   },
   "keywords": [

--- a/sdk/commerce/arm-commerce/src/usageManagementClient.ts
+++ b/sdk/commerce/arm-commerce/src/usageManagementClient.ts
@@ -64,9 +64,8 @@ export class UsageManagementClient extends coreClient.ServiceClient {
         userAgentPrefix
       },
       redirectOptions: {
+        allowCrossOriginRedirects: true,
         ...options?.redirectOptions,
-        allowCrossOriginRedirects:
-          options?.redirectOptions?.allowCrossOriginRedirects ?? true
       },
       endpoint:
         options.endpoint ?? options.baseUri ?? "https://management.azure.com"

--- a/sdk/commerce/arm-commerce/src/usageManagementClient.ts
+++ b/sdk/commerce/arm-commerce/src/usageManagementClient.ts
@@ -63,6 +63,7 @@ export class UsageManagementClient extends coreClient.ServiceClient {
       userAgentOptions: {
         userAgentPrefix
       },
+      redirectOptions: { ...options?.redirectOptions, allowCrossOriginRedirects: true },
       endpoint:
         options.endpoint ?? options.baseUri ?? "https://management.azure.com"
     };

--- a/sdk/commerce/arm-commerce/src/usageManagementClient.ts
+++ b/sdk/commerce/arm-commerce/src/usageManagementClient.ts
@@ -63,7 +63,11 @@ export class UsageManagementClient extends coreClient.ServiceClient {
       userAgentOptions: {
         userAgentPrefix
       },
-      redirectOptions: { ...options?.redirectOptions, allowCrossOriginRedirects: true },
+      redirectOptions: {
+        ...options?.redirectOptions,
+        allowCrossOriginRedirects:
+          options?.redirectOptions?.allowCrossOriginRedirects ?? true
+      },
       endpoint:
         options.endpoint ?? options.baseUri ?? "https://management.azure.com"
     };

--- a/sdk/containerregistry/container-registry/CHANGELOG.md
+++ b/sdk/containerregistry/container-registry/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Other Changes
 
 - Opted in to cross-origin redirects to ensure blob downloads continue to work when the service redirects to Blob Storage. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
-- Updated minimum dependency on `@azure/core-rest-pipeline` to `^1.22.3`.
+- Updated minimum dependency on `@azure/core-rest-pipeline` to `^1.23.0`.
 
 ## 1.1.0 (2023-05-09)
 

--- a/sdk/containerregistry/container-registry/CHANGELOG.md
+++ b/sdk/containerregistry/container-registry/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+- Opted in to cross-origin redirects to ensure blob downloads continue to work when the service redirects to Blob Storage. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+- Updated minimum dependency on `@azure/core-rest-pipeline` to `^1.22.3`.
+
 ## 1.1.0 (2023-05-09)
 
 ### Features Added

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -67,7 +67,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
-    "@azure/core-rest-pipeline": "^1.18.2",
+    "@azure/core-rest-pipeline": "^1.22.3",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "tslib": "^2.8.1"

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -67,7 +67,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
-    "@azure/core-rest-pipeline": "^1.22.3",
+    "@azure/core-rest-pipeline": "^1.23.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "tslib": "^2.8.1"

--- a/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
+++ b/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
@@ -121,7 +121,11 @@ export class ContainerRegistryClient {
 
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
-      redirectOptions: { ...options?.redirectOptions, allowCrossOriginRedirects: true },
+      redirectOptions: {
+        ...options?.redirectOptions,
+        allowCrossOriginRedirects:
+          options?.redirectOptions?.allowCrossOriginRedirects ?? true,
+      },
       loggingOptions: {
         logger: logger.info,
         // This array contains header names we want to log that are not already

--- a/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
+++ b/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
@@ -121,6 +121,7 @@ export class ContainerRegistryClient {
 
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
+      redirectOptions: { ...options?.redirectOptions, allowCrossOriginRedirects: true },
       loggingOptions: {
         logger: logger.info,
         // This array contains header names we want to log that are not already

--- a/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
+++ b/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
@@ -123,8 +123,7 @@ export class ContainerRegistryClient {
       ...options,
       redirectOptions: {
         ...options?.redirectOptions,
-        allowCrossOriginRedirects:
-          options?.redirectOptions?.allowCrossOriginRedirects ?? true,
+        allowCrossOriginRedirects: options?.redirectOptions?.allowCrossOriginRedirects ?? true,
       },
       loggingOptions: {
         logger: logger.info,

--- a/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
+++ b/sdk/containerregistry/container-registry/src/containerRegistryClient.ts
@@ -122,8 +122,8 @@ export class ContainerRegistryClient {
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
       redirectOptions: {
+        allowCrossOriginRedirects: true,
         ...options?.redirectOptions,
-        allowCrossOriginRedirects: options?.redirectOptions?.allowCrossOriginRedirects ?? true,
       },
       loggingOptions: {
         logger: logger.info,

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -135,6 +135,7 @@ export class ContainerRegistryContentClient {
 
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
+      redirectOptions: { ...options?.redirectOptions, allowCrossOriginRedirects: true },
       loggingOptions: {
         logger: logger.info,
         // This array contains header names we want to log that are not already

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -136,8 +136,8 @@ export class ContainerRegistryContentClient {
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
       redirectOptions: {
+        allowCrossOriginRedirects: true,
         ...options.redirectOptions,
-        allowCrossOriginRedirects: options.redirectOptions?.allowCrossOriginRedirects ?? true,
       },
       loggingOptions: {
         logger: logger.info,

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -136,9 +136,10 @@ export class ContainerRegistryContentClient {
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
       redirectOptions:
-        options.redirectOptions?.allowCrossOriginRedirects === undefined
-          ? { ...options.redirectOptions, allowCrossOriginRedirects: true }
-          : options.redirectOptions,
+      {
+        ...options.redirectOptions,
+        allowCrossOriginRedirects: options.redirectOptions?.allowCrossOriginRedirects ?? true
+      },
       loggingOptions: {
         logger: logger.info,
         // This array contains header names we want to log that are not already

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -135,7 +135,10 @@ export class ContainerRegistryContentClient {
 
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
-      redirectOptions: { ...options?.redirectOptions, allowCrossOriginRedirects: true },
+      redirectOptions:
+        options.redirectOptions?.allowCrossOriginRedirects === undefined
+          ? { ...options.redirectOptions, allowCrossOriginRedirects: true }
+          : options.redirectOptions,
       loggingOptions: {
         logger: logger.info,
         // This array contains header names we want to log that are not already

--- a/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
+++ b/sdk/containerregistry/container-registry/src/content/containerRegistryContentClient.ts
@@ -135,10 +135,9 @@ export class ContainerRegistryContentClient {
 
     const internalPipelineOptions: InternalPipelineOptions = {
       ...options,
-      redirectOptions:
-      {
+      redirectOptions: {
         ...options.redirectOptions,
-        allowCrossOriginRedirects: options.redirectOptions?.allowCrossOriginRedirects ?? true
+        allowCrossOriginRedirects: options.redirectOptions?.allowCrossOriginRedirects ?? true,
       },
       loggingOptions: {
         logger: logger.info,

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 1.22.3 (Unreleased)
+## 1.23.0 (Unreleased)
 
 ### Features Added
+
+- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 
 ### Breaking Changes
 
 ### Bugs Fixed
 
-- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+- The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features Added
 
-- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
-
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -90,7 +90,7 @@
     "@azure/core-tracing": "^1.3.0",
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.3.0",
-    "@typespec/ts-http-runtime": "^0.3.0",
+    "@typespec/ts-http-runtime": "^0.3.4",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-rest-pipeline/review/core-rest-pipeline-node.api.md
+++ b/sdk/core/core-rest-pipeline/review/core-rest-pipeline-node.api.md
@@ -369,6 +369,7 @@ export const redirectPolicyName = "redirectPolicy";
 
 // @public
 export interface RedirectPolicyOptions {
+    allowCrossOriginRedirects?: boolean;
     maxRetries?: number;
 }
 

--- a/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/redirectPolicy.ts
@@ -22,6 +22,13 @@ export interface RedirectPolicyOptions {
    * failing.  Defaults to 20.
    */
   maxRetries?: number;
+  /**
+   * Whether to follow redirects to a different origin (scheme + host + port).
+   * When false (the default), cross-origin redirects are not followed and the
+   * redirect response is returned directly to the caller.
+   * Defaults to false.
+   */
+  allowCrossOriginRedirects?: boolean;
 }
 
 /**

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Features Added
 
+- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
-- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
+- The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 
 ### Other Changes
 

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features Added
 
-- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
-
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 
 ### Other Changes
 

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-node.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-node.api.md
@@ -83,6 +83,7 @@ export const redirectPolicyName = "redirectPolicy";
 
 // @public
 export interface RedirectPolicyOptions {
+    allowCrossOriginRedirects?: boolean;
     maxRetries?: number;
 }
 

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime-node.api.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime-node.api.md
@@ -441,6 +441,7 @@ export type RawResponseCallback = (rawResponse: FullOperationResponse, error?: u
 
 // @public
 export interface RedirectPolicyOptions {
+    allowCrossOriginRedirects?: boolean;
     maxRetries?: number;
 }
 

--- a/sdk/core/ts-http-runtime/src/policies/redirectPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/redirectPolicy.ts
@@ -23,6 +23,13 @@ export interface RedirectPolicyOptions {
    * failing.  Defaults to 20.
    */
   maxRetries?: number;
+  /**
+   * Whether to follow redirects to a different origin (scheme + host + port).
+   * When false (the default), cross-origin redirects are not followed and the
+   * redirect response is returned directly to the caller.
+   * Defaults to false.
+   */
+  allowCrossOriginRedirects?: boolean;
 }
 
 /**
@@ -32,12 +39,12 @@ export interface RedirectPolicyOptions {
  * @param options - Options to control policy behavior.
  */
 export function redirectPolicy(options: RedirectPolicyOptions = {}): PipelinePolicy {
-  const { maxRetries = 20 } = options;
+  const { maxRetries = 20, allowCrossOriginRedirects = false } = options;
   return {
     name: redirectPolicyName,
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       const response = await next(request);
-      return handleRedirect(next, response, maxRetries);
+      return handleRedirect(next, response, maxRetries, allowCrossOriginRedirects);
     },
   };
 }
@@ -46,6 +53,7 @@ async function handleRedirect(
   next: SendRequest,
   response: PipelineResponse,
   maxRetries: number,
+  allowCrossOriginRedirects: boolean,
   currentRetries: number = 0,
 ): Promise<PipelineResponse> {
   const { request, status, headers } = response;
@@ -60,6 +68,15 @@ async function handleRedirect(
     currentRetries < maxRetries
   ) {
     const url = new URL(locationHeader, request.url);
+
+    // Only follow redirects to the same origin by default.
+    if (!allowCrossOriginRedirects) {
+      const originalUrl = new URL(request.url);
+      if (url.origin !== originalUrl.origin) {
+        return response;
+      }
+    }
+
     request.url = url.toString();
 
     // POST request with Status code 303 should be converted into a
@@ -73,7 +90,7 @@ async function handleRedirect(
     request.headers.delete("Authorization");
 
     const res = await next(request);
-    return handleRedirect(next, res, maxRetries, currentRetries + 1);
+    return handleRedirect(next, res, maxRetries, allowCrossOriginRedirects, currentRetries + 1);
   }
 
   return response;

--- a/sdk/core/ts-http-runtime/src/policies/redirectPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/redirectPolicy.ts
@@ -3,6 +3,7 @@
 
 import type { PipelineRequest, PipelineResponse, SendRequest } from "../interfaces.js";
 import type { PipelinePolicy } from "../pipeline.js";
+import { logger } from "../log.js";
 
 /**
  * The programmatic identifier of the redirectPolicy.
@@ -73,6 +74,9 @@ async function handleRedirect(
     if (!allowCrossOriginRedirects) {
       const originalUrl = new URL(request.url);
       if (url.origin !== originalUrl.origin) {
+        logger.verbose(
+          `Skipping cross-origin redirect from ${originalUrl.origin} to ${url.origin}.`,
+        );
         return response;
       }
     }

--- a/sdk/core/ts-http-runtime/test/redirectPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/redirectPolicy.spec.ts
@@ -343,4 +343,135 @@ describe("RedirectPolicy", () => {
     await policy.sendRequest(request, next);
     assert.isFalse(next.mock.calls[1][0].headers.has("Authorization"));
   });
+
+  it("should not follow cross-origin redirect by default", async function () {
+    const request = createPipelineRequest({
+      url: "https://example.com/api",
+      method: "GET",
+    });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({
+        location: "https://other-host.com/capture",
+      }),
+      request,
+      status: 302,
+    };
+
+    const policy = redirectPolicy();
+    const next = vi.fn<SendRequest>();
+    next.mockResolvedValueOnce(redirectResponse);
+
+    const result = await policy.sendRequest(request, next);
+
+    // The redirect response is returned as-is; no second request is made
+    assert.strictEqual(result.status, 302);
+    expect(next).toHaveBeenCalledTimes(1);
+    assert.strictEqual(request.url, "https://example.com/api");
+  });
+
+  it("should follow cross-origin redirect when allowCrossOriginRedirects is true", async function () {
+    const request = createPipelineRequest({
+      url: "https://example.com/api",
+      method: "GET",
+    });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({
+        location: "https://other-host.com/resource",
+      }),
+      request,
+      status: 302,
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+
+    const policy = redirectPolicy({ allowCrossOriginRedirects: true });
+    const next = vi.fn<SendRequest>();
+    next.mockResolvedValueOnce(redirectResponse);
+    next.mockResolvedValueOnce(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, 200);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it("should follow same-origin redirect even when allowCrossOriginRedirects is false", async function () {
+    const request = createPipelineRequest({
+      url: "https://example.com/api",
+      method: "GET",
+    });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({
+        location: "https://example.com/new-path",
+      }),
+      request,
+      status: 302,
+    };
+
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+
+    const policy = redirectPolicy({ allowCrossOriginRedirects: false });
+    const next = vi.fn<SendRequest>();
+    next.mockResolvedValueOnce(redirectResponse);
+    next.mockResolvedValueOnce(successResponse);
+
+    const result = await policy.sendRequest(request, next);
+    assert.strictEqual(result.status, 200);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it("should block cross-origin redirect for different scheme (https to http)", async function () {
+    const request = createPipelineRequest({
+      url: "https://example.com/api",
+      method: "GET",
+    });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({
+        location: "http://example.com/api",
+      }),
+      request,
+      status: 302,
+    };
+
+    const policy = redirectPolicy();
+    const next = vi.fn<SendRequest>();
+    next.mockResolvedValueOnce(redirectResponse);
+
+    const result = await policy.sendRequest(request, next);
+
+    // Different scheme = different origin, so redirect is blocked
+    assert.strictEqual(result.status, 302);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("should block cross-origin redirect for different port", async function () {
+    const request = createPipelineRequest({
+      url: "https://example.com/api",
+      method: "GET",
+    });
+    const redirectResponse: PipelineResponse = {
+      headers: createHttpHeaders({
+        location: "https://example.com:8443/api",
+      }),
+      request,
+      status: 302,
+    };
+
+    const policy = redirectPolicy();
+    const next = vi.fn<SendRequest>();
+    next.mockResolvedValueOnce(redirectResponse);
+
+    const result = await policy.sendRequest(request, next);
+
+    // Different port = different origin, so redirect is blocked
+    assert.strictEqual(result.status, 302);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

The `redirectPolicy` currently follows redirects to any host. This aligns the default behavior with what browsers already do natively - only follow same-origin redirects unless explicitly opted in.

### Changes

- Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions` (defaults to `false`)
- When the redirect `Location` targets a different origin (scheme + host + port), the policy returns the redirect response directly instead of following it
- Same-origin redirects are unaffected
- Callers that need cross-origin redirect support can opt in via `redirectOptions: { allowCrossOriginRedirects: true }`

I checked the existing SDK consumers that interact with the redirect policy, and while some feature do rely on this, it is rare and easy to opt-in:
- **Confidential Ledger** already removes the default redirect policy and uses a custom one
- **Monitor / App Insights** already removes the default redirect policy entirely
- **KeyVault / CAE challenges** operate via 401 responses, not HTTP redirects
- **Container Registry** is impacted due to its redirect to blob storage, and I will release a new version with the opt-in
- **ARM Commerce** is impacted; however, given that it has never GA'd and hardly used we may wait-and-see if a release is even needed

### Testing

Added tests covering:
- Cross-origin redirect blocked by default
- Cross-origin redirect followed with opt-in
- Same-origin redirect continues to work
- Scheme downgrade (https → http) treated as cross-origin
- Port difference treated as cross-origin