### PR TITLE
ci: cache pnpm store with Cache@2 to speed up installs

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -109,9 +109,7 @@ jobs:
                 Pool: $(Pool)
                 ${{ insert }}: ${{ parameters.EnvVars }}
 
-      - script: |
-          npm install -g pnpm
-        displayName: "Install Pnpm"
+      - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
       - script: |
           pnpm install

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -178,9 +178,7 @@ stages:
                           node ./eng/tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
                         displayName: Increment package version
 
-                      - bash: |
-                          npm install -g pnpm
-                        displayName: Install Pnpm
+                      - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
                       - bash: |
                           pnpm install --no-frozen-lockfile

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -66,9 +66,7 @@ steps:
     workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/analyze-deps
     displayName: "Analyze library dependencies"
 
-  - script: |
-      npm install -g pnpm
-    displayName: "Install Pnpm"
+  - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
   - script: |
       pnpm install

--- a/eng/pipelines/templates/steps/build.yml
+++ b/eng/pipelines/templates/steps/build.yml
@@ -25,9 +25,7 @@ steps:
   # we are not passing service directory, so we only ever set dev build to true
   - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
 
-  - script: |
-      npm install -g pnpm
-    displayName: "Install Pnpm"
+  - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
   - script: |
       npm ci

--- a/eng/pipelines/templates/steps/install-pnpm.yml
+++ b/eng/pipelines/templates/steps/install-pnpm.yml
@@ -1,0 +1,22 @@
+steps:
+  - script: |
+      npm install -g pnpm
+    displayName: "Install pnpm"
+
+  - pwsh: |
+      $storePath = Join-Path "$(Pipeline.Workspace)" ".pnpm-store"
+      Write-Host "pnpm store path: $storePath"
+      Write-Host "##vso[task.setvariable variable=PnpmStoreDir]$storePath"
+    displayName: "Set pnpm store directory"
+
+  - task: Cache@2
+    inputs:
+      key: 'pnpm | "$(Agent.OS)" | pnpm-lock.yaml'
+      restoreKeys: |
+        pnpm | "$(Agent.OS)"
+      path: $(PnpmStoreDir)
+    displayName: "Cache pnpm store"
+
+  - script: |
+      pnpm config set store-dir "$(PnpmStoreDir)"
+    displayName: "Configure pnpm store"

--- a/eng/pipelines/templates/steps/test-eslint.yml
+++ b/eng/pipelines/templates/steps/test-eslint.yml
@@ -2,9 +2,7 @@ parameters:
   ServiceDirectory: ''
 
 steps:
-  - script: |
-      npm install -g pnpm
-    displayName: "Install Pnpm"
+  - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
   - script: |
       pnpm install

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -13,9 +13,7 @@ steps:
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}
 
-  - script: |
-      npm install -g pnpm
-    displayName: "Install Pnpm"
+  - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
   - script: |
       pnpm install


### PR DESCRIPTION
Add shared install-pnpm.yml template that installs pnpm globally, restores the pnpm content-addressable store from Azure DevOps cache (keyed on OS + pnpm-lock.yaml), and configures pnpm to use it.

Replace bare 'npm install -g pnpm' in 6 pipeline templates with a reference to the new shared template. This avoids re-downloading hundreds of megabytes of packages from the registry on every job when the lockfile has not changed.