### PR TITLE
Add node types to browser tsconfig and enable skipLibCheck

### DIFF
--- a/tsconfig.src.browser.json
+++ b/tsconfig.src.browser.json
@@ -6,7 +6,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["DOM", "DOM.Iterable", "DOM.AsyncIterable", "ES2023"],
-    "types": []
+    "types": ["node"],
+    "skipLibCheck": true
   },
   "include": ["${configDir}/src/**/*.ts"]
 }


### PR DESCRIPTION
This is needed because our browser dist folders still contain references to nodejs types.