### PR TITLE
ci: exclude redundant coverage jobs from PR CI pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -66,6 +66,7 @@ extends:
               MatrixFilters:
                 - TestType=node|browser
                 - DependencyVersion=^$
+                - PublishCodeCoverage=^$
                 - ${{ each filter in parameters.MatrixFilters }}:
                     - ${{ filter}}
               MatrixReplace: ${{ parameters.MatrixReplace }}


### PR DESCRIPTION
The coverage scenario in platform-matrix.json sets PublishCodeCoverage=true but the CI test template (ci.tests.yml/test.yml) never uses this variable - there is no PublishCodeCoverageResults task. This means coverage jobs run the exact same test:node command as the regular Windows Node jobs, producing identical results.

Add a MatrixFilter 'PublishCodeCoverage=^$' to archetype-sdk-client.yml to exclude these jobs from PR CI builds. This would have saved ~40 redundant jobs in https://github.com/Azure/azure-sdk-for-js/pull/37372 (> 11 hours of compute).

Coverage publishing is only wired up in live.tests.yml (archetype-sdk-tests), which is unaffected by this change since it uses its own filter configuration.