### PR TITLE
Prepare releases for 2026-03-05: ts-http-runtime, core-rest-pipeline, container-registry

### DIFF
--- a/sdk/containerregistry/container-registry/CHANGELOG.md
+++ b/sdk/containerregistry/container-registry/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.1.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-03-05)
 
 ### Other Changes
 

--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,18 +1,14 @@
 # Release History
 
-## 1.23.0 (Unreleased)
+## 1.23.0 (2026-03-05)
 
 ### Features Added
 
 - Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
-
-### Other Changes
 
 ## 1.22.2 (2025-11-06)
 

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -1,19 +1,15 @@
 # Release History
 
-## 0.3.4 (Unreleased)
+## 0.3.4 (2026-03-05)
 
 ### Features Added
 
 - Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
 - Support function type and `Blob` type for request body. ([#37300](https://github.com/Azure/azure-sdk-for-js/pull/37300), [#37424](https://github.com/Azure/azure-sdk-for-js/pull/37424))
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - The redirect policy now only follows same-origin redirects by default. Set `allowCrossOriginRedirects` to `true` to restore the previous behavior. [#37384](https://github.com/Azure/azure-sdk-for-js/pull/37384)
-
-### Other Changes
 
 ## 0.3.3 (2026-02-05)
 


### PR DESCRIPTION
## Summary

Prepares the following packages for release on 2026-03-05:

| Package | Version | Release Type |
|---|---|---|
| `@typespec/ts-http-runtime` | 0.3.4 | patch |
| `@azure/core-rest-pipeline` | 1.23.0 | minor |
| `@azure/container-registry` | 1.1.2 | patch |

### Highlights
- **ts-http-runtime / core-rest-pipeline**: Added `allowCrossOriginRedirects` option to `RedirectPolicyOptions`. Redirect policy now only follows same-origin redirects by default.
- **ts-http-runtime**: Support function type and `Blob` type for request body.
- **container-registry**: Opted into cross-origin redirects for blob downloads; bumped `core-rest-pipeline` dependency to `^1.23.0`.