### PR TITLE
[dev-tool] Add Package version field in api extractor output

### DIFF
--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -53,7 +53,6 @@ async function getTsconfigFile(projectPath: string, runtime: string): Promise<st
 }
 
 interface ApiJson {
-  [key: string]: unknown;
   metadata: Record<string, unknown>;
   members: {
     kind: string;


### PR DESCRIPTION
### Packages impacted by this PR
- All

### Issues associated with this PR
https://github.com/Azure/azure-sdk-tools/issues/13913#issuecomment-3880255349

### Describe the problem that is addressed by this PR

#### Summary

  Adds the package version field to all .api.json output files generated by dev-tool run extract-api.

  #### What changed

  File: common/tools/dev-tool/src/commands/run/extract-api.ts

   - Reads the version from the package's package.json
   - Injects it into every .api.json output file (per-runtime files, merged files, and the non-exports fallback path)
   - Positions the version field immediately after name in the JSON output using a new insertKeyAfter helper
   - Updated the ApiJson interface to reflect the actual root-level structure of the generated JSON

  Example output

  Before:

   { "metadata": {...}, "kind": "Package", "name": "@azure/core-util", "members": [...] }

  After:

   { "metadata": {...}, "kind": "Package", "name": "@azure/core-util", "version": "1.13.2", "members": [...] }

  #### Testing

  Verified by running dev-tool run extract-api on @azure/core-util — all three output files (core-util-node.api.json,
  core-util-browser.api.json, core-util-react-native.api.json) contain the version field in the correct position.


