### PR TITLE
[ts-http-runtime] address one more case of duplicate '/' between host and path

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Remove duplicate `/` between request host and path.
+
 ## 0.3.4 (2026-03-05)
 
 ### Features Added

--- a/sdk/core/ts-http-runtime/src/client/urlHelpers.ts
+++ b/sdk/core/ts-http-runtime/src/client/urlHelpers.ts
@@ -92,7 +92,9 @@ function appendPath(endpoint: string, pathToAppend: string): string {
   // This is to maintain compatibility with old behavior for cases where the endpoint has been provided with extra forward slashes,
   // while still allowing for intentional consecutive forward slashes in the path to be preserved.
   const baseEndpoint = endpointParts[0].replace(/(^[^:]+:\/\/[^/]+)\/\/+/, "$1/");
-  const basePathToAppend = pathParts[0];
+  // Replace the leading consecutive forward slashes in the path to append with a single forward slash to prevent issues with double slashes when appending to the endpoint.
+  const basePathToAppend = pathParts[0].replace(/^\/+/, "/");
+
   let combinedUrl = baseEndpoint;
   if (!baseEndpoint.endsWith("/") && !basePathToAppend.startsWith("/") && basePathToAppend !== "") {
     combinedUrl += `/${basePathToAppend}`;

--- a/sdk/core/ts-http-runtime/test/client/urlHelpers.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/urlHelpers.spec.ts
@@ -13,6 +13,19 @@ describe("urlHelpers", () => {
     assert.equal(result, `https://example.org/foo/one`);
   });
 
+  it("should remove consecutive forward slashes in path", () => {
+    const result = buildRequestUrl(
+      `${mockBaseUrl}/`,
+      "///providers/Microsoft.Authorization/roleDefinitions?api%2Dversion=7.6",
+      [],
+    );
+
+    assert.equal(
+      result,
+      `https://example.org/providers/Microsoft.Authorization/roleDefinitions?api%2Dversion=7.6`,
+    );
+  });
+
   it("should remove extra consecutive forward slashes between host and path in endpoint", () => {
     const result = buildRequestUrl(`${mockBaseUrl}//container///blob`, "", []);
 


### PR DESCRIPTION
- added test coverage
- trim leading consecutive '/' from path part as well.