### PR TITLE
Remove the lockdown mode for mgmt agentic workflow since no `GH_AW_GITHUB_TOKEN` env var

### DIFF
--- a/.github/workflows/mgmt-review.lock.yml
+++ b/.github/workflows/mgmt-review.lock.yml
@@ -23,7 +23,7 @@
 #
 # Review a pull request for management-plane SDKs
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"086f828ae015310438128559ef95dea9688a7b7750c0230df9c5bef6ea943481","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d63f706132ebe7061391afd14c695c5002975b011d8e90186b316f238865ffd7","compiler_version":"v0.57.2"}
 
 name: "Management SDK PR Review"
 "on":
@@ -81,10 +81,7 @@ jobs:
           GH_AW_INFO_AWF_VERSION: "v0.23.0"
           GH_AW_INFO_AWMG_VERSION: ""
           GH_AW_INFO_FIREWALL_TYPE: "squid"
-          GH_AW_COMPILED_STRICT: "true"
-          GITHUB_MCP_LOCKDOWN_EXPLICIT: "true"
-          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
-          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+          GH_AW_COMPILED_STRICT: "false"
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
@@ -357,6 +354,16 @@ jobs:
         run: /opt/gh-aw/actions/install_copilot_cli.sh latest
       - name: Install awf binary
         run: bash /opt/gh-aw/actions/install_awf_binary.sh v0.23.0
+      - name: Determine automatic lockdown mode for GitHub MCP Server
+        id: determine-automatic-lockdown
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
+        with:
+          script: |
+            const determineAutomaticLockdown = require('/opt/gh-aw/actions/determine_automatic_lockdown.cjs');
+            await determineAutomaticLockdown(github, context, core);
       - name: Download container images
         run: bash /opt/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.23.0 ghcr.io/github/gh-aw-firewall/api-proxy:0.23.0 ghcr.io/github/gh-aw-firewall/squid:0.23.0 ghcr.io/github/gh-aw-mcpg:v0.1.8 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -720,6 +727,7 @@ jobs:
           GH_AW_SAFE_OUTPUTS: ${{ env.GH_AW_SAFE_OUTPUTS }}
           GH_AW_SAFE_OUTPUTS_API_KEY: ${{ steps.safe-outputs-start.outputs.api_key }}
           GH_AW_SAFE_OUTPUTS_PORT: ${{ steps.safe-outputs-start.outputs.port }}
+          GITHUB_MCP_LOCKDOWN: ${{ steps.determine-automatic-lockdown.outputs.lockdown == 'true' && '1' || '0' }}
           GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
@@ -747,7 +755,7 @@ jobs:
                 "type": "stdio",
                 "container": "ghcr.io/github/github-mcp-server:v0.32.0",
                 "env": {
-                  "GITHUB_LOCKDOWN_MODE": "1",
+                  "GITHUB_LOCKDOWN_MODE": "$GITHUB_MCP_LOCKDOWN",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
                   "GITHUB_TOOLSETS": "context,repos,pull_requests,actions"

--- a/.github/workflows/mgmt-review.md
+++ b/.github/workflows/mgmt-review.md
@@ -8,10 +8,10 @@ permissions:
   contents: read
   pull-requests: read
   actions: read
+strict: false
 tools:
   github:
     toolsets: [context, repos, pull_requests, actions]
-    lockdown: true
   bash: true
   cache-memory:
   repo-memory:


### PR DESCRIPTION
Remove the lockdown mode for mgmt agentic workflow to fix the pipeline issue because we don't have `GH_AW_GITHUB_TOKEN` env set in SDK repo - https://github.com/Azure/azure-sdk-for-js/actions/runs/23225975982/job/67508665602?pr=37700

```
GH_AW_GITHUB_TOKEN configured: false
GH_AW_GITHUB_MCP_SERVER_TOKEN configured: false
Custom github-token configured: false
Error: Lockdown mode is enabled (lockdown: true) but no custom GitHub token is configured.\n\nPlease configure one of the following as a repository secret:\n  - GH_AW_GITHUB_TOKEN (recommended)\n  - GH_AW_GITHUB_MCP_SERVER_TOKEN (alternative)\n  - Custom github-token in your workflow frontmatter\n\nSee: [https://github.com/github/gh-aw/blob/main/docs/src/content/docs/reference/auth.mdx\n\nTo](https://github.com/github/gh-aw/blob/main/docs/src/content/docs/reference/auth.mdx/n/nTo) set a token:\n  gh aw secrets set GH_AW_GITHUB_TOKEN --value "YOUR_FINE_GRAINED_PAT"
Error: Unhandled error: Error: Lockdown mode is enabled (lockdown: true) but no custom GitHub token is configured.\n\nPlease configure one of the following as a repository secret:\n  - GH_AW_GITHUB_TOKEN (recommended)\n  - GH_AW_GITHUB_MCP_SERVER_TOKEN (alternative)\n  - Custom github-token in your workflow frontmatter\n\nSee: [https://github.com/github/gh-aw/blob/main/docs/src/content/docs/reference/auth.mdx\n\nTo](https://github.com/github/gh-aw/blob/main/docs/src/content/docs/reference/auth.mdx/n/nTo) set a token:\n  gh aw secrets set GH_AW_GITHUB_TOKEN --value "YOUR_FINE_GRAINED_PAT"
```

Testing is done by this link: https://github.com/MaryGao/azure-sdk-for-js/actions/runs/23226288983/job/67509586847