### PR TITLE
Authenticate npmrc in common.yml

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -27,6 +27,11 @@ stages:
             parameters:
               NodeVersion: $(NODE_VERSION_LTS_MAINTENANCE)
 
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(CommonNpmrcPath)
+              registryUrl: '$(PublicDevOpsRegistry)'
+
           - task: PowerShell@2
             inputs:
               targetType: 'filePath'

--- a/eng/pipelines/run-for-all-packages.yml
+++ b/eng/pipelines/run-for-all-packages.yml
@@ -19,6 +19,11 @@ stages:
             parameters:
               NodeVersion: $(NODE_VERSION_LTS_ACTIVE)
 
+          - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+            parameters:
+              npmrcPath: $(CommonNpmrcPath)
+              registryUrl: '$(PublicDevOpsRegistry)'
+
           - template: ./templates/steps/generate-doc.yml
             parameters:
               ServiceDirectory: core

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -29,6 +29,9 @@ parameters:
 jobs:
   - job: "Build"
 
+    variables:
+      - template: ../variables/globals.yml
+
     ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
       timeoutInMinutes: 240
 
@@ -60,6 +63,9 @@ jobs:
           IncludeRelease: ${{ parameters.IncludeRelease }}
 
   - job: "Analyze"
+
+    variables:
+      - template: ../variables/globals.yml
 
     ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
       timeoutInMinutes: 240

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -24,6 +24,11 @@ jobs:
       steps:
         - template: /eng/pipelines/templates/steps/use-node-version.yml
 
+        - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+          parameters:
+            npmrcPath: $(CommonNpmrcPath)
+            registryUrl: '$(PublicDevOpsRegistry)'
+
         # As of npm v7, "npm install -g" no longer installs local dependencies as part of the global install.
         # As a workaround, we run "npm install --prod" before "npm install -g".
         # https://github.com/npm/cli/issues/2968

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -4,3 +4,8 @@ steps:
       AgentImage: $(OSVmImage)
 
   - template: use-node-version.yml
+
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(CommonNpmrcPath)
+      registryUrl: '$(PublicDevOpsRegistry)'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -18,3 +18,5 @@ variables:
   PublicNpmRegistry: https://registry.npmjs.org/
   PublicDevOpsRegistry: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
   PrivateDevOpsRegistry: https://pkgs.dev.azure.com/azure-sdk/internal/_packaging/azure-sdk-for-js-pr/npm/registry/
+  CommonNpmrcPath: $(Agent.TempDirectory)/common/.npmrc
+  NPM_CONFIG_USERCONFIG: $(CommonNpmrcPath)


### PR DESCRIPTION
### Packages impacted by this PR
All

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/37076

### Describe the problem that is addressed by this PR
- CFS needs authentication when a brand new package is added. 
- This add `.npmrc` authentication in a common step so that pipeline does not fail if contributor fails to run `pnpm install` locally