### PR TITLE
fix(containerregistry): update readme link exceptions based on current failure on main branch

### DIFF
--- a/eng/ignore-links.txt
+++ b/eng/ignore-links.txt
@@ -66,7 +66,6 @@ https://learn.microsoft.com/javascript/api/@azure/arm-computebulkactions?view=az
 https://learn.microsoft.com/javascript/api/@azure/container-registry
 https://www.npmjs.com/package/@azure/arm-computebulkactions
 https://www.npmjs.com/package/@azure/arm-edgeactions
-https://www.npmjs.com/package/@azure/arm-containerregistrytasks
 https://www.npmjs.com/package/@azure/arm-artifactsigning
 https://learn.microsoft.com/javascript/api/@azure/arm-disconnectedoperations
 https://learn.microsoft.com/rest/api/aifoundry/aiagents/operation-groups?view=rest-aifoundry-aiagents-v1


### PR DESCRIPTION
The link https://learn.microsoft.com/javascript/api/@azure/container-registry currently returns 404 on main, and is blocking release pipelines for separate work. This PR adds the link to repo ignore-links. It also removes a previously ignored link that is now confirmed present