### PR TITLE
[core-xml] Bump fast-xml-parser to ^5.5.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8444,8 +8444,8 @@ importers:
   sdk/core/core-xml:
     dependencies:
       fast-xml-parser:
-        specifier: ^5.3.7
-        version: 5.4.2
+        specifier: ^5.5.6
+        version: 5.5.6
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -34858,11 +34858,11 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha1-wK4/OYLQYcPWV+yScZb7tH4i/mQ=}
 
-  fast-xml-builder@1.0.0:
-    resolution: {integrity: sha1-pIXX6DgfHbmDzwBvhJ0QZuKTUkE=}
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha1-DEB6HZ1ZljNsDNdvf/eFysZBMBc=}
 
-  fast-xml-parser@5.4.2:
-    resolution: {integrity: sha1-f8ZkY7WSYLDF/Vft9GFIpBi95os=}
+  fast-xml-parser@5.5.6:
+    resolution: {integrity: sha1-b8YfWuBqVaHwWKvWpPS10+mXLNA=}
     hasBin: true
 
   fastify-plugin@5.1.0:
@@ -35838,6 +35838,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha1-pqrZSJIAsh+rMeSc8JJ35RFvuec=}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-expression-matcher@1.1.3:
+    resolution: {integrity: sha1-i/fGKdwbEU5CtjPAcfBtFGJbTg0=}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
@@ -37253,7 +37257,7 @@ snapshots:
 
   '@azure/core-xml@1.5.0':
     dependencies:
-      fast-xml-parser: 5.4.2
+      fast-xml-parser: 5.5.6
       tslib: 2.8.1
 
   '@azure/functions-extensions-base@0.2.0': {}
@@ -40458,11 +40462,14 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.0.0: {}
-
-  fast-xml-parser@5.4.2:
+  fast-xml-builder@1.1.4:
     dependencies:
-      fast-xml-builder: 1.0.0
+      path-expression-matcher: 1.1.3
+
+  fast-xml-parser@5.5.6:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.1.3
       strnum: 2.2.0
 
   fastify-plugin@5.1.0: {}
@@ -41443,6 +41450,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
+
+  path-expression-matcher@1.1.3: {}
 
   path-is-absolute@1.0.1: {}
 

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Bump minimum dependency `fast-xml-parser` version to `^5.3.7` to address security issues [GHSA-jmr7-xgp7-cmfj](https://github.com/advisories/GHSA-jmr7-xgp7-cmfj) and [GHSA-m7jm-9gc2-mpf2](https://github.com/advisories/GHSA-m7jm-9gc2-mpf2)
+- Bump `fast-xml-parser` dependency to `^5.5.6` [#37665](https://github.com/Azure/azure-sdk-for-js/issues/37665)
 
 ## 1.5.0 (2025-07-10)
 

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -68,7 +68,7 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "fast-xml-parser": "^5.3.7",
+    "fast-xml-parser": "^5.5.6",
     "tslib": "^2.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Bumps `fast-xml-parser` from `^5.3.7` to `^5.5.6` in `sdk/core/core-xml`.

Fixes #37665

## Changes

- `sdk/core/core-xml/package.json`: updated `fast-xml-parser` version constraint
- `sdk/core/core-xml/CHANGELOG.md`: added unreleased changelog entry
- `pnpm-lock.yaml`: updated lockfile to resolve `fast-xml-parser@5.5.6` (also picks up `fast-xml-builder@1.1.4` and transitive dep `path-expression-matcher@1.1.3`)

## Backwards Compatibility

The public API used by `core-xml` is fully preserved across 5.3.7 → 5.5.6:
- `XMLBuilder`, `XMLParser`, `XMLValidator` exports are unchanged
- All options used (`attributesGroupName`, `textNodeName`, `parseTagValue`, `stopNodes`, etc.) still exist
- Changes between versions are purely additive: new options, security fixes, and bug fixes