### PR TITLE
[Monitor OpenTelemetry Exporter] Use Latest Retry-After Time

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bugs Fixed
 
-- When multiple `Retry-After` headers are received, the exporter now uses the longest delay to ensure envelopes are sent at the latest required time.
+- When multiple `Retry-After` headers are received, the exporter now compares absolute deadlines to ensure envelopes are sent at the latest required time.
 
 ## 1.0.0-beta.39 (2026-02-20)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -38,7 +38,7 @@ export abstract class BaseSender {
   private readonly persister: PersistentStorage;
   private numConsecutiveRedirects: number;
   private retryTimer: NodeJS.Timeout | null;
-  private retryTimerDelayMs: number = 0;
+  private retryTimerDeadlineMs: number = 0;
   private networkStatsbeatMetrics: NetworkStatsbeatMetrics | undefined;
   private customerSDKStatsMetrics: CustomerSDKStatsMetrics | undefined;
   private longIntervalStatsbeatMetrics;
@@ -399,17 +399,19 @@ export abstract class BaseSender {
 
   private scheduleRetryTimer(retryAfterMs?: number): void {
     const delay = retryAfterMs ?? this.batchSendRetryIntervalMs;
-    // Reschedule if a new Retry-After would fire later than the existing timer
-    if (this.retryTimer && retryAfterMs !== undefined && delay > this.retryTimerDelayMs) {
+    const newDeadline = Date.now() + delay;
+    // Reschedule if a new Retry-After results in a later absolute deadline
+    if (this.retryTimer && retryAfterMs !== undefined && newDeadline > this.retryTimerDeadlineMs) {
       clearTimeout(this.retryTimer);
       this.retryTimer = null;
     }
     if (!this.retryTimer) {
-      this.retryTimerDelayMs = delay;
+      const adjustedDelay = Math.max(newDeadline - Date.now(), 0);
+      this.retryTimerDeadlineMs = newDeadline;
       this.retryTimer = setTimeout(() => {
         this.retryTimer = null;
         this.sendFirstPersistedFile();
-      }, delay);
+      }, adjustedDelay);
       this.retryTimer.unref();
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -706,34 +706,41 @@ describe("BaseSender", () => {
       setTimeoutSpy.mockRestore();
     });
 
-    it("should reschedule retry timer when new retryAfterMs is longer", async () => {
+    it("should reschedule retry timer when new retryAfterMs results in a later absolute deadline", async () => {
+      vi.useFakeTimers();
       const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       const { isRetriable } = await import("../../src/utils/breezeUtils.js");
       vi.mocked(isRetriable).mockImplementation(
         (statusCode) => statusCode === 429 || statusCode === 200,
       );
 
-      // First call with a short retryAfterMs
-      sender.sendMock.mockResolvedValue({
-        statusCode: 200,
-        result: "success",
-        retryAfterMs: 5_000,
-      });
-      await sender.exportEnvelopes([{ name: "test", time: new Date() }]);
-
-      // Second call with a longer retryAfterMs should reschedule
+      // First call with a 30s retryAfterMs at T=0 → deadline = T+30s
       sender.sendMock.mockResolvedValue({
         statusCode: 200,
         result: "success",
         retryAfterMs: 30_000,
       });
+      await sender.exportEnvelopes([{ name: "test", time: new Date() }]);
+
+      // Advance 20s, then second call with 15s retryAfterMs → deadline = T+35s (later)
+      vi.advanceTimersByTime(20_000);
+      sender.sendMock.mockResolvedValue({
+        statusCode: 200,
+        result: "success",
+        retryAfterMs: 15_000,
+      });
       await sender.exportEnvelopes([{ name: "test2", time: new Date() }]);
 
-      // Verify setTimeout was called with the longer delay
-      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
+      // clearTimeout should have been called to reschedule
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      // The rescheduled timer should use the adjusted delay (~15s)
+      expect(setTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 15_000);
 
+      clearTimeoutSpy.mockRestore();
       setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This pull request addresses a bug in the retry logic for throttled telemetry in the OpenTelemetry exporter. The main improvement ensures that when multiple `Retry-After` headers are received, the exporter uses the longest delay, preventing premature retries and improving envelope delivery reliability.

Bug Fixes:

* Updated the retry timer logic in `baseSender.ts` to reschedule when a new `Retry-After` value is longer than the existing timer, ensuring envelopes are sent at the latest required time.
* Modified the corresponding unit test in `baseSender.spec.ts` to verify that the retry timer is rescheduled for longer delays, aligning test behavior with the new logic.
* Added a changelog entry documenting the bug fix regarding multiple `Retry-After` headers and the use of the longest delay.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
