### PR TITLE
Add step for publishing GA package to dev ops feed

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -70,6 +70,14 @@ stages:
                       ArtifactName: ${{ parameters.ArtifactName }}
                       ArtifactSubPath: '${{ artifact.name }}'
 
+                  - template: /eng/common/pipelines/templates/jobs/npm-publish.yml
+                    parameters:
+                      DependsOn: TagRepository
+                      DeploymentName: PublishPackage_${{ replace(artifact.name, '-', '_') }}_To_DevFeed
+                      ArtifactName: ${{ parameters.ArtifactName }}
+                      ArtifactSubPath: '${{ artifact.name }}'
+                      Registry: $(PublicDevOpsRegistry)
+
               - ${{ if ne(artifact.skipPublishDocMs, 'true') }}:
                   - job: PublishDocs
                     displayName: Docs.MS Release


### PR DESCRIPTION
### Packages impacted by this PR
All

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/37076

### Describe the problem that is addressed by this PR
- Adds step to publish GA packages to dev feed right after publishing to npmjs