### PR TITLE
[Identity] Fix MI pipeline resources creation

### DIFF
--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -31,7 +31,7 @@ param(
   $RemainingArguments
 )
 
-if (![string]::IsNullOrEmpty($DeploymentOutputs['IDENTITY_WEBAPP_NAME'])) {
+if ([string]::IsNullOrEmpty($DeploymentOutputs['IDENTITY_WEBAPP_NAME'])) {
     Write-Host "Skipping post-provisioning script because resources weren't deployed"
     exit
 }


### PR DESCRIPTION
- JS MI pipeline relies on passing `ArmTemplateParameters` to `AdditionalParameters` in `deploy-test-resources` to properly enable `deployMIResources` from `managed-identity-matrix.json` to resource creation post-script. However, since #37311, the two variables are separate out. This causes the pipeline to fail
- When passing `AdditionalParameters` through `tests.yml`, the post-script does not have the correct variable because `AdditionalParameters` is not defined in `live.tests.yml`. Thus, it is not passed through to the `deploy-test-resources.yml`. This PR addresses the gap in propagating additional parameters from the pipelines via `AdditionalParameters`