### PR TITLE
[ts-http-runtime] stop passing headers to proxy agent constructor

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Request headers are no longer included in proxy agent's additional headers.
+
 ### Other Changes
 
 ## 0.3.4 (2026-03-05)

--- a/sdk/core/ts-http-runtime/src/policies/proxyPolicy.ts
+++ b/sdk/core/ts-http-runtime/src/policies/proxyPolicy.ts
@@ -183,16 +183,14 @@ function setProxyAgentOnRequest(
     );
   }
 
-  const headers = request.headers.toJSON();
-
   if (isInsecure) {
     if (!cachedAgents.httpProxyAgent) {
-      cachedAgents.httpProxyAgent = new HttpProxyAgent(proxyUrl, { headers });
+      cachedAgents.httpProxyAgent = new HttpProxyAgent(proxyUrl);
     }
     request.agent = cachedAgents.httpProxyAgent;
   } else {
     if (!cachedAgents.httpsProxyAgent) {
-      cachedAgents.httpsProxyAgent = new HttpsProxyAgent(proxyUrl, { headers });
+      cachedAgents.httpsProxyAgent = new HttpsProxyAgent(proxyUrl);
     }
     request.agent = cachedAgents.httpsProxyAgent;
   }


### PR DESCRIPTION
The CONNECT requests to proxy servers are supposed to be minimal. The only
purpose of CONNECT is to ask the proxy to open a raw TCP tunnel. It is not a
regular HTTP request, so most headers are meaningless. In fact some proxy
servers reject CONNECT request with extra headers for security or compliance
reasons.

This PR stops passing the request headers when creating proxy agents in proxy
policy as those are sent to proxy servers in each requests. Non-CONNECT requests
are still sent with their headers as usual.