### PR TITLE
Fix attestation CI test failures by increasing timeValidationSlack

### DIFF
--- a/sdk/attestation/attestation/test/utils/recordedClient.ts
+++ b/sdk/attestation/attestation/test/utils/recordedClient.ts
@@ -19,6 +19,12 @@ const envSetupForPlayback: { [k: string]: string } = {
   ATTESTATION_ISOLATED_SIGNING_KEY: "isolated_signing_key",
 };
 
+/**
+ * Tolerance (in seconds) for clock drift between CI runners and the attestation service.
+ * Used in both {@link createRecordedClient} and {@link createRecordedAdminClient}.
+ */
+const TIME_VALIDATION_SLACK_IN_SECONDS = 60;
+
 export const recorderOptions: RecorderStartOptions = {
   envSetupForPlayback,
   // token is not a secret
@@ -77,7 +83,7 @@ export function createRecordedClient(
         validateExpirationTime: !isPlaybackMode(),
         validateNotBeforeTime: !isPlaybackMode(),
         validateIssuer: !isPlaybackMode(),
-        timeValidationSlack: 10, // 10 seconds slack in validation time.
+        timeValidationSlack: TIME_VALIDATION_SLACK_IN_SECONDS,
         expectedIssuer: getAttestationUri(endpointType),
       },
     };
@@ -110,7 +116,7 @@ export function createRecordedAdminClient(
         validateToken: true,
         validateExpirationTime: !isPlaybackMode(),
         validateNotBeforeTime: !isPlaybackMode(),
-        timeValidationSlack: 10, // 10 seconds slack in validation time.
+        timeValidationSlack: TIME_VALIDATION_SLACK_IN_SECONDS,
         validateIssuer: !isPlaybackMode(),
         expectedIssuer: getAttestationUri(endpointType),
       },


### PR DESCRIPTION
## Issue

Fixes #37849

## Description

The live AAD attestation tests fail in CI with:
```
AttestationToken is not yet valid.
```

The 10-second `timeValidationSlack` is no longer sufficient to handle clock skew between CI runners and the attestation service.

## Changes

Increase `timeValidationSlack` from 10 to 60 seconds in both `createRecordedClient()` and `createRecordedAdminClient()` test helpers in `sdk/attestation/attestation/test/utils/recordedClient.ts`.

This only affects **test configuration** — the production `AttestationTokenValidationOptions` API is unchanged. The 60-second slack is consistent with the repo's existing clock-skew patterns (e.g., storage SAS tests use 5-minute offsets).

## Validation

- ✅ Build passes (`pnpm turbo build --filter=@azure/attestation...`)
- ✅ All tests pass in playback mode (43 passed, 5 skipped)