### PR TITLE
Update outdated TypeScript and @types/node in sample packages

### DIFF
--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/samples/v1-beta/typescript/package.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/samples/v1-beta/typescript/package.json
@@ -34,7 +34,7 @@
     "@azure/identity": "^4.2.1"
   },
   "devDependencies": {
-    "@types/node": "^14.0.0",
+    "@types/node": "^20.0.0",
     "typescript": "~5.8.2",
     "rimraf": "latest"
   }

--- a/sdk/compute/arm-compute-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/compute/arm-compute-rest/samples/v1-beta/typescript/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "~5.6.2",
+    "typescript": "~5.9.3",
     "rimraf": "latest"
   }
 }

--- a/sdk/containerservice/arm-containerservice-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/containerservice/arm-containerservice-rest/samples/v1-beta/typescript/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "~5.6.2",
+    "typescript": "~5.9.3",
     "rimraf": "latest"
   }
 }

--- a/sdk/maps/maps-timezone-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/maps/maps-timezone-rest/samples/v1-beta/typescript/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "~5.5.3",
+    "typescript": "~5.9.3",
     "rimraf": "latest"
   }
 }

--- a/sdk/migrate/arm-migrationassessment/samples/v1-beta/typescript/package.json
+++ b/sdk/migrate/arm-migrationassessment/samples/v1-beta/typescript/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "~5.7.2",
+    "typescript": "~5.9.3",
     "rimraf": "latest"
   }
 }

--- a/sdk/network/arm-network-rest/samples/v1-beta/typescript/package.json
+++ b/sdk/network/arm-network-rest/samples/v1-beta/typescript/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "~5.6.2",
+    "typescript": "~5.9.3",
     "rimraf": "latest"
   }
 }

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/samples/v1/typescript/package.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/samples/v1/typescript/package.json
@@ -35,7 +35,7 @@
     "@azure/identity": "^4.10.0"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "typescript": "~5.8.2",
     "rimraf": "latest"
   }

--- a/sdk/resources/arm-resources/samples/v7/typescript/package.json
+++ b/sdk/resources/arm-resources/samples/v7/typescript/package.json
@@ -35,7 +35,7 @@
     "@azure/identity": "^4.6.0"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "typescript": "~5.8.2",
     "rimraf": "latest"
   }

--- a/sdk/vision/ai-vision-image-analysis-rest/samples/typescript/package.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/samples/typescript/package.json
@@ -13,8 +13,10 @@
     "@azure/cognitiveservices-computervision": "^7.0.0",
     "@azure/core-auth": "^1.5.0",
     "@azure-rest/ai-vision-image-analysis": "next",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
     "cross-env": "^7.0.3",
-    "dotenv": "^16.3.1",
-    "typescript": "^4.1.2"
+    "typescript": "~5.9.3"
   }
 }

--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/package.json
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "~5.9.3",
     "vite": "^5.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
## Description

Bring 10 outlier sample packages in line with repo conventions. The vast majority of sample packages (406/413) already use `typescript: ~5.8.2` or `~5.9.3` and `@types/node: ^20.0.0`. These 10 were missed by prior bulk updates.

## Changes

### TypeScript updated to `~5.9.3` (7 packages)

| Previous | Package |
|---|---|
| `^4.1.2` | `sdk/vision/ai-vision-image-analysis-rest/samples/typescript/` |
| `^5.0.0` | `sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/` |
| `~5.5.3` | `sdk/maps/maps-timezone-rest/samples/v1-beta/typescript/` |
| `~5.6.2` | `sdk/compute/arm-compute-rest/samples/v1-beta/typescript/` |
| `~5.6.2` | `sdk/containerservice/arm-containerservice-rest/samples/v1-beta/typescript/` |
| `~5.6.2` | `sdk/network/arm-network-rest/samples/v1-beta/typescript/` |
| `~5.7.2` | `sdk/migrate/arm-migrationassessment/samples/v1-beta/typescript/` |

### `@types/node` updated to `^20.0.0` (3 packages)

| Previous | Package |
|---|---|
| `^14.0.0` | `sdk/baremetalinfrastructure/arm-baremetalinfrastructure/samples/v1-beta/typescript/` |
| `^18.0.0` | `sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/samples/v1/typescript/` |
| `^18.0.0` | `sdk/resources/arm-resources/samples/v7/typescript/` |

## Rationale

- Workspace catalog specifies `typescript: ~5.9.3`
- Monorepo root requires Node.js `>=20` (`engines` in root `package.json`)
- Sample packages are standalone (not workspace-linked), so they need explicit version alignment