### PR TITLE
Clean up stale recorder v1/v3 references in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,11 +152,9 @@ By default, these npm scripts run previously recorded tests. The recordings have
 
 Most of the tests in our projects run in playback mode by default, i.e they make no network requests to the real services. For HTTP requests made in each test case, there is a recorded response that reproduces the service behavior. The readme file in the `test` folder of each package will indicate whether the package uses recorded tests or not.
 
-At the moment, tests in our repo depend on one of the two different versions of the recorder tool (`@azure-tools/test-recorder`) - `1.a.b` and `4.m.n`.
-Currently, version `4.m.n` is maintained in the repository which is built as part of a cross-language unification effort in terms of the tests and recordings.
-Eventually, all the tests will be migrated to depend on the `4.m.n` version of the recorder that depends on the language-agnostic [test proxy server].
+Tests in our repo use version `4.x` of the recorder tool (`@azure-tools/test-recorder`), which depends on the language-agnostic [test proxy server] and stores recordings externally via the [asset-sync workflow](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/ASSET_SYNC_WORKFLOW.md).
 
-Refer to the [Migration Guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/ASSET_SYNC_WORKFLOW.md#migration-steps-for-existing-recordings) for more information on migrating the tests from recorder v4.
+Refer to the [asset-sync workflow guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/ASSET_SYNC_WORKFLOW.md) for more information on managing test recordings.
 
 #### Live tests
 

--- a/documentation/Quickstart-on-how-to-write-tests.md
+++ b/documentation/Quickstart-on-how-to-write-tests.md
@@ -34,7 +34,7 @@ This page is to help you write and run tests quickly for Javascript Codegen SDK 
 
 The Azure SDK test framework uses the [`test-recorder`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/README.md) library, which in turn rests upon on a HTTP recording system ([testproxy](https://github.com/Azure/azure-sdk-tools/tree/main/tools/test-proxy)) that enables tests dependent on network interaction to be run offline.
 
-Please notice that this quickstart is based on 3.x.y version of recorder tool (`@azure-tools/test-recorder`).
+Please note that this quickstart is based on version 4.x of the recorder tool (`@azure-tools/test-recorder`), which uses the language-agnostic [test proxy server](https://github.com/Azure/azure-sdk-tools/tree/main/tools/test-proxy) and the [asset-sync workflow](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/recorder/ASSET_SYNC_WORKFLOW.md).
 
 # Prerequisites
 

--- a/documentation/RLC-Swagger-quickstart.md
+++ b/documentation/RLC-Swagger-quickstart.md
@@ -135,7 +135,7 @@ See the [JavaScript Codegen Quick Start for Test](https://github.com/Azure/azure
       - Make sure `pwsh` command works at this step (If you follow the above link, `pwsh` is typically added to the system environment variables by default)
     - Add `dev-tool` to the `devDependencies` in the `package.json`.
 
-    The package you are migrating needs to be using the new version of the recorder that uses the test proxy (`@azure-tools/test-recorder@^3.0.0`).
+    The package needs to use the current version of the recorder that uses the test proxy (`@azure-tools/test-recorder@^4.0.0`).
 
     Then, we need to generate a `assets.json` file. If your package is new or has never been pushed before, you could use below commands:
 


### PR DESCRIPTION
## What

Removes outdated references to recorder v1/v3 from documentation. All 356 recorded-test packages now use recorder v4.

### Changes
- **CONTRIBUTING.md**: Remove claim that recorder v1 and v4 coexist
- **Quickstart-on-how-to-write-tests.md**: Update version reference to 4.x; fix grammar ("Please notice" → "Please note")
- **RLC-Swagger-quickstart.md**: Update recorder dependency to `^4.0.0`

Split from #37866.