### PR TITLE
Add Olga Kroshkina to attestation SDK CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,10 +61,10 @@
 # ServiceOwners: @jimmyca15 @zhenlan
 
 # PRLabel: %Attestation
-/sdk/attestation/    @anilba06 @gkostal @olkroshk
+/sdk/attestation/    @anilba06 @daaltobe @gkostal @olkroshk
 
 # ServiceLabel: %Attestation
-# ServiceOwners: @anilba06 @gkostal @olkroshk
+# ServiceOwners: @anilba06 @daaltobe @gkostal @olkroshk
 
 # ServiceLabel: %Azure Load Testing
 # PRLabel: %Azure Load Testing


### PR DESCRIPTION
Adds @olkroshk (Olga Kroshkina) to the attestation SDK ownership in CODEOWNERS — both the PR reviewer list and ServiceOwners.