### PR TITLE
Bump @azure/communication-call-automation to 1.5.2 (Unreleased)

### DIFF
--- a/sdk/communication/communication-call-automation/CHANGELOG.md
+++ b/sdk/communication/communication-call-automation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.5.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.5.1 (2026-01-22)
 
 ### Bugs Fixed

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-call-automation",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Azure client library for Azure Communication Call Automation services",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-call-automation/src/generated/src/callAutomationApiClient.ts
+++ b/sdk/communication/communication-call-automation/src/generated/src/callAutomationApiClient.ts
@@ -66,7 +66,7 @@ export class CallAutomationApiClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-call-automation/1.5.1`;
+    const packageDetails = `azsdk-js-communication-call-automation/1.5.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-call-automation/swagger/README.md
+++ b/sdk/communication/communication-call-automation/swagger/README.md
@@ -15,7 +15,7 @@ module-kind: esm
 tag: package-2025-06-15
 require:
   - https://github.com/Azure/azure-rest-api-specs/blob/b359b43e76ee17d4f1c5aa83b58577653c0fb51b/specification/communication/data-plane/CallAutomation/readme.md
-package-version: 1.5.1
+package-version: 1.5.2
 model-date-time-as-string: false
 optional-response-headers: true
 typescript: true


### PR DESCRIPTION
Prepares the next release cycle for `@azure/communication-call-automation` by bumping to 1.5.2 with an unreleased changelog entry.

### Changes
- `package.json`: 1.5.1 → 1.5.2
- `CHANGELOG.md`: Add 1.5.2 (Unreleased) section
- `callAutomationApiClient.ts`: Update user-agent version
- `swagger/README.md`: Update package-version