### PR TITLE
refactor(ci-runner): use pnpm short flag -F instead of --filter

### DIFF
--- a/eng/tools/ci-runner/src/runner.js
+++ b/eng/tools/ci-runner/src/runner.js
@@ -27,13 +27,13 @@ const CMD_LENGTH_THRESHOLD = 7000;
  * exclusions in JavaScript, and return short `--filter name` args.
  *
  * @param {string[]} filters - The full filter list from getFilteredPackages (may contain `!pkg` exclusions)
- * @returns {string[]} - flat `["--filter", "name", ...]` args safe for any shell
+ * @returns {string[]} - flat `["-F", "name", ...]` args safe for any shell
  */
 function resolveFiltersToConcreteNames(filters) {
   const inclusionFilters = filters.filter((f) => !f.startsWith("!"));
   const exclusionSet = new Set(filters.filter((f) => f.startsWith("!")).map((f) => f.slice(1)));
 
-  const inclusionArgs = inclusionFilters.flatMap((f) => ["--filter", f]);
+  const inclusionArgs = inclusionFilters.flatMap((f) => ["-F", f]);
 
   let resolvedNames;
   try {
@@ -49,7 +49,7 @@ function resolveFiltersToConcreteNames(filters) {
     resolvedNames = parsed.map((/** @type {{ name: string }} */ p) => p.name);
   } catch (e) {
     console.error("Failed to resolve packages via pnpm list, falling back to original filters", e);
-    return filters.flatMap((f) => ["--filter", f]);
+    return filters.flatMap((f) => ["-F", f]);
   }
 
   const filtered = resolvedNames.filter((/** @type {string} */ name) => !exclusionSet.has(name));
@@ -62,7 +62,7 @@ function resolveFiltersToConcreteNames(filters) {
     console.warn(
       "Filter resolution produced no concrete packages; falling back to original filter list",
     );
-    return filters.flatMap((f) => ["--filter", f]);
+    return filters.flatMap((f) => ["-F", f]);
   }
 
   console.log(
@@ -70,7 +70,7 @@ function resolveFiltersToConcreteNames(filters) {
       `excluded ${resolvedNames.length - filtered.length}, testing ${filtered.length}`,
   );
 
-  return filtered.flatMap((/** @type {string} */ name) => ["--filter", name]);
+  return filtered.flatMap((/** @type {string} */ name) => ["-F", name]);
 }
 
 /**
@@ -89,7 +89,7 @@ export function runAllWithDirection(action, filters, extraParams, ciFlag) {
   });
 
   let packages = filters.flatMap((pkg) => {
-    return ["--filter", pkg];
+    return ["-F", pkg];
   });
 
   // If the command line would exceed the Windows cmd.exe 8191-char limit,

--- a/eng/tools/ci-runner/test/actions.spec.js
+++ b/eng/tools/ci-runner/test/actions.spec.js
@@ -38,7 +38,7 @@ describe("executeActions", () => {
   it("should run build commands for affected packages", () => {
     executeActions("build", ["appconfiguration"], [], "azure-app-configuration");
     assert.deepEqual(vi.mocked(spawnPnpm).mock.calls, [
-      [baseDir, "build", "--filter", "...@azure/app-configuration..."],
+      [baseDir, "build", "-F", "...@azure/app-configuration..."],
     ]);
   });
 
@@ -54,17 +54,17 @@ describe("executeActions", () => {
       [
         baseDir,
         "test:node",
-        "--filter",
+        "-F",
         "@azure/communication-identity",
-        "--filter",
+        "-F",
         "@azure-rest/synapse-access-control",
-        "--filter",
+        "-F",
         "@azure/arm-resources",
-        "--filter",
+        "-F",
         "@azure/identity",
-        "--filter",
+        "-F",
         "@azure/service-bus",
-        "--filter",
+        "-F",
         "@azure/template",
       ],
     ]);
@@ -73,7 +73,7 @@ describe("executeActions", () => {
   it("should handle arbitrary run commands", () => {
     executeActions("foo", ["appconfiguration"], [], "azure-app-configuration");
     assert.deepEqual(vi.mocked(spawnPnpm).mock.calls, [
-      [baseDir, "foo", "--filter", "@azure/app-configuration..."],
+      [baseDir, "foo", "-F", "@azure/app-configuration..."],
     ]);
   });
 
@@ -81,7 +81,7 @@ describe("executeActions", () => {
     const runArgs = ["--logLevel", "info"];
     executeActions("build", ["appconfiguration"], runArgs, "azure-app-configuration");
     assert.deepEqual(vi.mocked(spawnPnpm).mock.calls, [
-      [baseDir, "build", "--filter", "...@azure/app-configuration...", ...runArgs],
+      [baseDir, "build", "-F", "...@azure/app-configuration...", ...runArgs],
     ]);
   });
 

--- a/eng/tools/ci-runner/test/runner.spec.js
+++ b/eng/tools/ci-runner/test/runner.spec.js
@@ -33,7 +33,7 @@ describe("runAllWithDirection two-pass resolution", () => {
       "should not call pnpm list for short commands",
     );
     const call = vi.mocked(spawnPnpm).mock.calls[0];
-    assert.ok(call.includes("--filter"));
+    assert.ok(call.includes("-F"));
     assert.ok(call.includes("@azure/app-configuration"));
   });
 
@@ -76,7 +76,7 @@ describe("runAllWithDirection two-pass resolution", () => {
     );
 
     // No ...P or !P patterns in final command
-    const finalFilters = testCall.filter((a, i) => i > 0 && testCall[i - 1] === "--filter");
+    const finalFilters = testCall.filter((a, i) => i > 0 && testCall[i - 1] === "-F");
     for (const f of finalFilters) {
       assert.ok(!f.startsWith("..."), `should not have ...prefix: ${f}`);
       assert.ok(!f.startsWith("!"), `should not have !exclusion: ${f}`);
@@ -183,7 +183,7 @@ describe("runAllWithDirection two-pass resolution", () => {
 
     // Verify pnpm list only got inclusion filters
     const listCall = vi.mocked(spawnPnpmWithOutput).mock.calls[0];
-    const listFilterCount = listCall.filter((a) => a === "--filter").length;
+    const listFilterCount = listCall.filter((a) => a === "-F").length;
     assert.strictEqual(listFilterCount, 3, "pnpm list should have exactly 3 inclusion filters");
 
     // Verify final command is short (exclude cwd argument at index 0)
@@ -220,7 +220,7 @@ describe("runAllWithDirection two-pass resolution", () => {
     runAllWithDirection("test:node", filters, [], false);
 
     const testCall = vi.mocked(spawnPnpm).mock.calls[0];
-    const finalFilters = testCall.filter((a, i) => i > 0 && testCall[i - 1] === "--filter");
+    const finalFilters = testCall.filter((a, i) => i > 0 && testCall[i - 1] === "-F");
     assert.deepStrictEqual(finalFilters, ["@azure/app-configuration"]);
   });
 


### PR DESCRIPTION
Follow-up to #37898 per @jeremymeng's suggestion.

Replaces all `--filter` flags with pnpm's short form `-F`, saving ~6 characters per filter argument. This further reduces command line length on Windows where `cmd.exe` has an 8191-character limit.

All 55 ci-runner tests pass.