### PR TITLE
Fix flaky cosmos fuzzy continuation token tests

### DIFF
--- a/sdk/cosmosdb/cosmos/test/public/functional/continuationTokenComplete.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/continuationTokenComplete.spec.ts
@@ -1325,10 +1325,9 @@ describe("Comprehensive Continuation Token Tests", { timeout: 120000 }, () => {
             allCollectedItems.push(item);
           }
 
-          // Store the latest continuation token
-          if (response.continuationToken) {
-            sessionToken = response.continuationToken;
-          }
+          // Always store the continuation token from the latest response,
+          // even if undefined, to avoid resuming from a stale token
+          sessionToken = response.continuationToken;
         }
 
         // If we have a continuation token, create a new iterator
@@ -1426,10 +1425,9 @@ describe("Comprehensive Continuation Token Tests", { timeout: 120000 }, () => {
             allCollectedItems.push(item);
           }
 
-          // Store the latest continuation token
-          if (response.continuationToken) {
-            sessionToken = response.continuationToken;
-          }
+          // Always store the continuation token from the latest response,
+          // even if undefined, to avoid resuming from a stale token
+          sessionToken = response.continuationToken;
         }
 
         // If we have a continuation token, create a new iterator


### PR DESCRIPTION
## Problem

The two fuzzy continuation token tests in `continuationTokenComplete.spec.ts` intermittently fail with `DUPLICATE ID DETECTED`:

- *should handle fuzzy SELECT \* query with random continuation token usage patterns*
- *should handle fuzzy ORDER BY query with random continuation token usage patterns*

## Root Cause

Both tests run an inner loop of 2-4 `fetchNext()` calls, but only update `sessionToken` when `response.continuationToken` is truthy:

```typescript
if (response.continuationToken) {
  sessionToken = response.continuationToken;
}
```

When the last `fetchNext()` returns items but no continuation token (end of partition data), `sessionToken` retains the stale value from an earlier iteration. The outer loop then creates a new query iterator from that stale token, re-fetching items already collected → duplicate ID detection fires.

## Fix

Unconditionally assign `sessionToken = response.continuationToken` after each `fetchNext()`. If the last response has no token, `sessionToken` becomes `undefined`, the outer guard `(sessionToken && hasMoreResults())` correctly evaluates false, and we break without re-fetching.