### PR TITLE
Fix flaky fileSystemPersist expiration tests in monitor-opentelemetry-exporter

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.spec.ts
@@ -290,10 +290,10 @@ describe("FileSystemPersist", () => {
 
       // Push the "expired" batch first
       await persister.push(expiredBatch);
-      await sleep(100);
+      await sleep(1000);
 
-      // Set a very short retention so the first file is expired
-      persister.fileRetemptionPeriod = 50;
+      // Set retention so the first file (1s+ old) is expired but the fresh one isn't
+      persister.fileRetemptionPeriod = 500;
 
       // Push the "fresh" batch
       await persister.push(freshBatch);
@@ -334,15 +334,15 @@ describe("FileSystemPersist", () => {
 
       // Push old batch (will become expired)
       await persister.push(oldBatch);
-      await sleep(200);
+      await sleep(1000);
 
       // Push new batches close together so they won't expire
       await persister.push(newBatch1);
       await sleep(50);
       await persister.push(newBatch2);
 
-      // Set retention so only the old file (200ms+ ago) is expired, not the new ones (<100ms ago)
-      persister.fileRetemptionPeriod = 150;
+      // Set retention so only the old file (1s+ ago) is expired, not the new ones (<200ms ago)
+      persister.fileRetemptionPeriod = 500;
 
       // Clean expired files
       await persister.cleanExpiredFiles();


### PR DESCRIPTION
## Problem

The fileSystemPersist.spec.ts tests intermittently fail on CI (especially macOS) with a duplicate null result when the fresh file is incorrectly cleaned.

## Root Cause

Two tests use very tight timing margins (50ms retention, 100ms sleep). On slow CI machines, the gap between pushing a fresh file and running cleanExpiredFiles() can exceed the retention period, causing both files to be cleaned.

## Fix

Increase timing margins: sleep 100ms->1000ms, retention 50ms->500ms. Gives ~500ms headroom instead of ~50ms.