### PR TITLE
Fix check-package-version failures for stale package versions

### DIFF
--- a/eng/tools/ci-runner/src/verifyPackages.js
+++ b/eng/tools/ci-runner/src/verifyPackages.js
@@ -109,8 +109,10 @@ export function getModifiedFilesSinceTag(tag, packageDir) {
 
 /**
  * Filters a list of modified files to only those that are relevant source changes.
- * Includes only JavaScript and TypeScript files (.ts, .js, .mts, .mjs, .cts, .cjs, .tsx, .jsx),
- * excluding files under test/, samples/, or samples-dev/ directories (relative to the package root).
+ * Includes only JavaScript and TypeScript files (.ts, .js, .mts, .mjs, .cts, .cjs, .tsx, .jsx)
+ * under the src/ directory, which contains the publishable source code.
+ * Excludes test files, samples, config files in the package root (vitest, karma, etc.),
+ * generated/ (raw codegen output not published directly), and other non-published directories.
  *
  * @param {string[]} files - list of file paths (relative to repo root)
  * @param {string} packageRelativeDir - the package directory relative to the repo root (forward-slash separated)
@@ -118,12 +120,12 @@ export function getModifiedFilesSinceTag(tag, packageDir) {
  */
 export function filterRelevantFiles(files, packageRelativeDir) {
   const sourceExtensions = /\.(ts|js|mts|mjs|cts|cjs|tsx|jsx)$/;
-  const ignoredDirPattern = /^(test|samples|samples-dev)\//;
+  const sourceDirPattern = /^src\//;
   const prefix = packageRelativeDir.endsWith("/") ? packageRelativeDir : `${packageRelativeDir}/`;
 
   return files.filter((file) => {
     const relativePath = file.startsWith(prefix) ? file.slice(prefix.length) : file;
-    return sourceExtensions.test(relativePath) && !ignoredDirPattern.test(relativePath);
+    return sourceExtensions.test(relativePath) && sourceDirPattern.test(relativePath);
   });
 }
 

--- a/eng/tools/ci-runner/test/verifyPackages.spec.js
+++ b/eng/tools/ci-runner/test/verifyPackages.spec.js
@@ -208,7 +208,7 @@ describe("getModifiedFilesSinceTag", () => {
 describe("filterRelevantFiles", () => {
   const pkgDir = "sdk/storage/storage-blob";
 
-  it("includes .ts and .js source files", () => {
+  it("includes .ts and .js source files under src/", () => {
     const files = [
       "sdk/storage/storage-blob/src/index.ts",
       "sdk/storage/storage-blob/src/utils.js",
@@ -220,6 +220,14 @@ describe("filterRelevantFiles", () => {
       "sdk/storage/storage-blob/src/Widget.jsx",
     ];
     assert.deepStrictEqual(filterRelevantFiles(files, pkgDir), files);
+  });
+
+  it("excludes files under generated/", () => {
+    const files = [
+      "sdk/storage/storage-blob/generated/client.ts",
+      "sdk/storage/storage-blob/generated/models/index.ts",
+    ];
+    assert.deepStrictEqual(filterRelevantFiles(files, pkgDir), []);
   });
 
   it("excludes non-ts/js files", () => {
@@ -257,6 +265,24 @@ describe("filterRelevantFiles", () => {
     assert.deepStrictEqual(filterRelevantFiles(files, pkgDir), []);
   });
 
+  it("excludes config files in package root", () => {
+    const files = [
+      "sdk/storage/storage-blob/vitest.config.ts",
+      "sdk/storage/storage-blob/vitest.browser.config.ts",
+      "sdk/storage/storage-blob/vitest.esm.config.ts",
+      "sdk/storage/storage-blob/karma.conf.js",
+    ];
+    assert.deepStrictEqual(filterRelevantFiles(files, pkgDir), []);
+  });
+
+  it("excludes files under swagger/ and review/", () => {
+    const files = [
+      "sdk/storage/storage-blob/swagger/README.md",
+      "sdk/storage/storage-blob/review/storage-blob.api.md",
+    ];
+    assert.deepStrictEqual(filterRelevantFiles(files, pkgDir), []);
+  });
+
   it("returns mixed results correctly", () => {
     const files = [
       "sdk/storage/storage-blob/src/index.ts",
@@ -267,6 +293,8 @@ describe("filterRelevantFiles", () => {
       "sdk/storage/storage-blob/src/config.mjs",
       "sdk/storage/storage-blob/test/helpers.cjs",
       "sdk/storage/storage-blob/src/App.tsx",
+      "sdk/storage/storage-blob/vitest.config.ts",
+      "sdk/storage/storage-blob/generated/models.ts",
     ];
     assert.deepStrictEqual(filterRelevantFiles(files, pkgDir), [
       "sdk/storage/storage-blob/src/index.ts",

--- a/sdk/agricultureplatform/arm-agricultureplatform/CHANGELOG.md
+++ b/sdk/agricultureplatform/arm-agricultureplatform/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 # Release History
     
 ## 1.0.0-beta.1 (2025-03-25)

--- a/sdk/agricultureplatform/arm-agricultureplatform/package.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-agricultureplatform",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for AgriculturePlatformClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/agricultureplatform/arm-agricultureplatform/src/api/agriculturePlatformContext.ts
+++ b/sdk/agricultureplatform/arm-agricultureplatform/src/api/agriculturePlatformContext.ts
@@ -28,7 +28,7 @@ export function createAgriculturePlatform(
 ): AgriculturePlatformContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-agricultureplatform/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-agricultureplatform/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/apimanagement/api-management-custom-widgets-tools/CHANGELOG.md
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.4 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.0.0-beta.3 (Unreleased)
 
 ### Features Added

--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/api-management-custom-widgets-tools",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "sdk-type": "client",

--- a/sdk/cognitivelanguage/ai-language-conversations/CHANGELOG.md
+++ b/sdk/cognitivelanguage/ai-language-conversations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.0.0-beta.2 (Unreleased)
 
 ### Features Added

--- a/sdk/cognitivelanguage/ai-language-conversations/package.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Conversational Language Understanding service.",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/cognitivelanguage/ai-language-conversations/src/generated/conversationAnalysisClient.ts
+++ b/sdk/cognitivelanguage/ai-language-conversations/src/generated/conversationAnalysisClient.ts
@@ -54,7 +54,7 @@ export class ConversationAnalysisClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-ai-language-conversations/1.0.0-beta.2`;
+    const packageDetails = `azsdk-js-ai-language-conversations/1.0.0-beta.3`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/cognitivelanguage/ai-language-text/CHANGELOG.md
+++ b/sdk/cognitivelanguage/ai-language-text/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.1.0 (2023-06-15)
 
 ### Features Added

--- a/sdk/cognitivelanguage/ai-language-text/package.json
+++ b/sdk/cognitivelanguage/ai-language-text/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the text analysis features in the Azure Cognitive Language Service.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "node",
     "azure",

--- a/sdk/cognitivelanguage/ai-language-text/src/constants.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.def
 /**
  * @internal
  */
-export const SDK_VERSION = "1.1.0";
+export const SDK_VERSION = "1.1.1";
 
 /**
  * @internal

--- a/sdk/cognitivelanguage/ai-language-text/src/generated/generatedClient.ts
+++ b/sdk/cognitivelanguage/ai-language-text/src/generated/generatedClient.ts
@@ -50,7 +50,7 @@ export class GeneratedClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-ai-language-text/1.1.0`;
+    const packageDetails = `azsdk-js-ai-language-text/1.1.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/cognitivelanguage/ai-language-text/swagger/README.md
+++ b/sdk/cognitivelanguage/ai-language-text/swagger/README.md
@@ -14,7 +14,7 @@ output-folder: ../
 source-code-folder-path: ./src/generated
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/af1b95f0c8cc5cedc3b224f3d6751eb43b57b43a/specification/cognitiveservices/data-plane/Language/stable/2023-04-01/analyzetext.json
 add-credentials: false
-package-version: 1.1.0
+package-version: 1.1.1
 v3: true
 hide-clients: true
 typescript: true

--- a/sdk/communication/communication-chat/CHANGELOG.md
+++ b/sdk/communication/communication-chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.6.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.6.0 (2025-06-23)
 
 ### Features Added

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-chat",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Azure client library for Azure Communication Chat services",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-chat/src/generated/src/chatApiClient.ts
+++ b/sdk/communication/communication-chat/src/generated/src/chatApiClient.ts
@@ -38,7 +38,7 @@ export class ChatApiClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-chat/1.6.0`;
+    const packageDetails = `azsdk-js-communication-chat/1.6.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-chat/src/generated/src/tracing.ts
+++ b/sdk/communication/communication-chat/src/generated/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Azure.Communication",
   packageName: "@azure/communication-chat",
-  packageVersion: "1.6.0",
+  packageVersion: "1.6.1",
 });

--- a/sdk/communication/communication-chat/swagger/README.md
+++ b/sdk/communication/communication-chat/swagger/README.md
@@ -16,7 +16,7 @@ model-date-time-as-string: false
 optional-response-headers: true
 add-credentials: false
 disable-async-iterators: true
-package-version: 1.6.0
+package-version: 1.6.1
 use-extension:
   "@autorest/typescript": "6.0.34"
 tracing-info:

--- a/sdk/communication/communication-email/CHANGELOG.md
+++ b/sdk/communication/communication-email/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.1.0 (2025-09-01)
 
 ### Other Changes

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-email",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The is the JS Client SDK for email. This SDK enables users to send emails and get the status of sent email message.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/communication/communication-identity/CHANGELOG.md
+++ b/sdk/communication/communication-identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.4.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.4.0-beta.1 (2025-06-09)
 
 ### Features Added

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-identity",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "SDK for Azure Communication service which facilitates user token administration.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-identity/src/constants.ts
+++ b/sdk/communication/communication-identity/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "1.4.0-beta.1";
+export const SDK_VERSION: string = "1.4.0-beta.2";

--- a/sdk/communication/communication-identity/src/generated/src/identityRestClient.ts
+++ b/sdk/communication/communication-identity/src/generated/src/identityRestClient.ts
@@ -52,7 +52,7 @@ export class IdentityRestClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-identity/1.4.0-beta.1`;
+    const packageDetails = `azsdk-js-communication-identity/1.4.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-identity/src/generated/src/tracing.ts
+++ b/sdk/communication/communication-identity/src/generated/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Microsoft.Communication",
   packageName: "@azure/communication-identity",
-  packageVersion: "1.4.0-beta.1",
+  packageVersion: "1.4.0-beta.2",
 });

--- a/sdk/communication/communication-identity/swagger/README.md
+++ b/sdk/communication/communication-identity/swagger/README.md
@@ -8,7 +8,7 @@
 package-name: "@azure/communication-identity"
 override-client-name: IdentityRestClient
 description: Communication identity client
-package-version: 1.4.0-beta.1
+package-version: 1.4.0-beta.2
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 tag: package-2025-03-02-preview

--- a/sdk/communication/communication-messages-rest/CHANGELOG.md
+++ b/sdk/communication/communication-messages-rest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.2.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 2.2.0-beta.1 (2025-04-14)
 
 ### Features Added

--- a/sdk/communication/communication-messages-rest/package.json
+++ b/sdk/communication/communication-messages-rest/package.json
@@ -2,7 +2,7 @@
   "name": "@azure-rest/communication-messages",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "description": "Azure client library for Azure Communication Messages services",
   "keywords": [
     "node",

--- a/sdk/communication/communication-phone-numbers/CHANGELOG.md
+++ b/sdk/communication/communication-phone-numbers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.5.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.5.0 (2025-08-28)
 
 ### Features Added

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-phone-numbers",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "SDK for Azure Communication service which facilitates phone number management.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-phone-numbers/src/generated/src/phoneNumbersClient.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/phoneNumbersClient.ts
@@ -38,7 +38,7 @@ export class PhoneNumbersClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-phone-numbers/1.5.0`;
+    const packageDetails = `azsdk-js-communication-phone-numbers/1.5.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-phone-numbers/src/generated/src/siprouting/sipRoutingClientContext.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/siprouting/sipRoutingClientContext.ts
@@ -31,7 +31,7 @@ export class SipRoutingClientContext extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-communication-phone-numbers/1.5.0`;
+    const packageDetails = `azsdk-js-communication-phone-numbers/1.5.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-phone-numbers/src/generated/src/tracing.ts
+++ b/sdk/communication/communication-phone-numbers/src/generated/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Microsoft.Communication",
   packageName: "@azure/communication-phone-numbers",
-  packageVersion: "1.5.0",
+  packageVersion: "1.5.1",
 });

--- a/sdk/communication/communication-phone-numbers/src/utils/constants.ts
+++ b/sdk/communication/communication-phone-numbers/src/utils/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "1.5.0";
+export const SDK_VERSION: string = "1.5.1";

--- a/sdk/communication/communication-phone-numbers/swagger/README-SipRouting.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README-SipRouting.md
@@ -7,7 +7,7 @@
 ```yaml
 package-name: "@azure/communication-phone-numbers"
 description: Azure Communication SIP Configuration Service
-package-version: 1.5.0
+package-version: 1.5.1
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated

--- a/sdk/communication/communication-phone-numbers/swagger/README.md
+++ b/sdk/communication/communication-phone-numbers/swagger/README.md
@@ -7,7 +7,7 @@
 ```yaml
 package-name: "@azure/communication-phone-numbers"
 description: Phone number configuration client
-package-version: 1.5.0
+package-version: 1.5.1
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 tag: package-phonenumber-2025-06-01

--- a/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/digital-twins-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 2.0.0 (2025-05-27)
 
 ### Features Added

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/digital-twins-core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An isomorphic client library for Azure Digital Twins",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
@@ -84,8 +84,8 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/generated/azureDigitalTwinsAPIContext.ts",
-        "prefix": "packageVersion"
+        "path": "src/generated/azureDigitalTwinsAPI.ts",
+        "prefix": "packageDetails"
       },
       {
         "path": "src/constants.ts",

--- a/sdk/digitaltwins/digital-twins-core/src/constants.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "2.0.0";
+export const SDK_VERSION: string = "2.0.1";

--- a/sdk/digitaltwins/digital-twins-core/src/generated/azureDigitalTwinsAPI.ts
+++ b/sdk/digitaltwins/digital-twins-core/src/generated/azureDigitalTwinsAPI.ts
@@ -49,7 +49,7 @@ export class AzureDigitalTwinsAPI extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-digital-twins-core/2.0.0`;
+    const packageDetails = `azsdk-js-digital-twins-core/2.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/documentintelligence/ai-document-intelligence-rest/CHANGELOG.md
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.1.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.1.0 (2025-05-08)
 
 ### Features Added

--- a/sdk/documentintelligence/ai-document-intelligence-rest/package.json
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/ai-document-intelligence",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Document Intelligence Rest Client",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/documentintelligence/ai-document-intelligence-rest/src/documentIntelligence.ts
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/src/documentIntelligence.ts
@@ -27,7 +27,7 @@ export default function createClient(
 ): DocumentIntelligenceClient {
   const endpointUrl =
     options.endpoint ?? options.baseUrl ?? `${endpointParam}/documentintelligence`;
-  const userAgentInfo = `azsdk-js-ai-document-intelligence-rest/1.1.0`;
+  const userAgentInfo = `azsdk-js-ai-document-intelligence-rest/1.1.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/documenttranslator/ai-document-translator-rest/CHANGELOG.md
+++ b/sdk/documenttranslator/ai-document-translator-rest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.0.0-beta.2 (2025-02-10)
 
 ### Features Added

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic rest level client library for the Azure Document Translator service.",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "keywords": [
     "node",
     "azure",
@@ -31,8 +31,8 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
+        "path": "src/documentTranslator.ts",
+        "prefix": "userAgentInfo"
       },
       {
         "path": "swagger/README.md",

--- a/sdk/documenttranslator/ai-document-translator-rest/src/documentTranslator.ts
+++ b/sdk/documenttranslator/ai-document-translator-rest/src/documentTranslator.ts
@@ -23,7 +23,7 @@ export default function createClient(
 ): DocumentTranslatorClient {
   const endpointUrl =
     options.endpoint ?? options.baseUrl ?? `${endpoint}/translator/text/batch/v1.0`;
-  const userAgentInfo = `azsdk-js-ai-document-translator-rest/1.0.0-beta.2`;
+  const userAgentInfo = `azsdk-js-ai-document-translator-rest/1.0.0-beta.3`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 5.1.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 5.1.0 (2025-05-08)
 
 ### Features Added

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Document Intelligence service.",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "keywords": [
     "node",
     "azure",
@@ -33,8 +33,8 @@
         "prefix": "package-version"
       },
       {
-        "path": "src/generated/generatedClientContext.ts",
-        "prefix": "packageVersion"
+        "path": "src/generated/generatedClient.ts",
+        "prefix": "packageDetails"
       },
       {
         "path": "src/constants.ts",

--- a/sdk/formrecognizer/ai-form-recognizer/src/constants.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/constants.ts
@@ -29,6 +29,6 @@ export const DEFAULT_COGNITIVE_SCOPE = `${KnownFormRecognizerAudience.AzurePubli
 /**
  * @internal
  */
-export const SDK_VERSION = "5.1.0";
+export const SDK_VERSION = "5.1.1";
 
 export const FORM_RECOGNIZER_API_VERSION = "2023-07-31";

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
@@ -49,7 +49,7 @@ export class GeneratedClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8"
     };
 
-    const packageDetails = `azsdk-js-ai-form-recognizer/5.1.0`;
+    const packageDetails = `azsdk-js-ai-form-recognizer/5.1.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -16,7 +16,7 @@ input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/sp
 override-client-name: GeneratedClient
 add-credentials: false
 typescript: true
-package-version: "5.0.0"
+package-version: "5.1.1"
 use-extension:
   "@autorest/typescript": "6.0.34"
 module-kind: esm

--- a/sdk/search/arm-search/CHANGELOG.md
+++ b/sdk/search/arm-search/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 # Release History
     
 ## 3.3.0 (2025-07-18)

--- a/sdk/search/arm-search/package.json
+++ b/sdk/search/arm-search/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SearchManagementClient.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/search/arm-search/src/searchManagementClient.ts
+++ b/sdk/search/arm-search/src/searchManagementClient.ts
@@ -73,7 +73,7 @@ export class SearchManagementClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-search/3.3.0`;
+    const packageDetails = `azsdk-js-arm-search/3.3.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/translation/ai-translation-document-rest/CHANGELOG.md
+++ b/sdk/translation/ai-translation-document-rest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.1 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 1.0.0 (2024-11-15)
 
 ### Other Changes

--- a/sdk/translation/ai-translation-document-rest/package.json
+++ b/sdk/translation/ai-translation-document-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DocumentTranslationClient.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "node",
     "azure",

--- a/sdk/translation/ai-translation-document-rest/src/documentTranslationClient.ts
+++ b/sdk/translation/ai-translation-document-rest/src/documentTranslationClient.ts
@@ -24,7 +24,7 @@ export default function createClient(
   { apiVersion = "2024-05-01", ...options }: DocumentTranslationClientOptions = {},
 ): DocumentTranslationClient {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `${endpointParam}/translator`;
-  const userAgentInfo = `azsdk-js-ai-translation-document-rest/1.0.0`;
+  const userAgentInfo = `azsdk-js-ai-translation-document-rest/1.0.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/translation/ai-translation-text-rest/CHANGELOG.md
+++ b/sdk/translation/ai-translation-text-rest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.0.0-beta.2 (Unreleased)
+
+### Other Changes
+
+- Optimized type imports for improved tree-shaking and build performance.
+
 ## 2.0.0-beta.1 (2026-01-08)
 
 ### Features Added

--- a/sdk/translation/ai-translation-text-rest/package.json
+++ b/sdk/translation/ai-translation-text-rest/package.json
@@ -2,7 +2,7 @@
   "name": "@azure-rest/ai-translation-text",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "An isomorphic client library for the Azure Cognitive Translator Service",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/translation/ai-translation-text-rest/README.md",
   "keywords": [

--- a/sdk/translation/ai-translation-text-rest/src/customClient.ts
+++ b/sdk/translation/ai-translation-text-rest/src/customClient.ts
@@ -139,7 +139,7 @@ export default function createClient(
 
   const baseUrl = options.baseUrl ?? `${serviceEndpoint}`;
 
-  const userAgentInfo = `azsdk-js-ai-translation-text-rest/2.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-ai-translation-text-rest/2.0.0-beta.2`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`


### PR DESCRIPTION
## Problem

The `check-package-version` analyze step (introduced in #37404 on March 17) fails for broad PRs that touch many service areas. It detects 17 packages where source files were modified on main (from the `import type` PR #37385 and ESM/vitest migration PRs) after their last release, but before the check existed. Any PR touching these service areas triggers the failure.

## Fix

### 1. Tighten `filterRelevantFiles` filter

Changed from a denylist (`test/`, `samples/`, `samples-dev/`) to an allowlist (`src/`, `generated/`). This excludes non-published development files like `vitest.config.ts`, `karma.conf.js`, etc. from triggering version bump requirements.

### 2. Bump 17 stale package versions

Patch/prerelease bumps for all packages caught by the check. These are packages where source modifications were merged to main after their last release but before the check was introduced.

| Package | Old | New |
|---------|-----|-----|
| @azure/ai-form-recognizer | 5.1.0 | 5.1.1 |
| @azure/ai-language-conversations | 1.0.0-beta.2 | 1.0.0-beta.3 |
| @azure/ai-language-text | 1.1.0 | 1.1.1 |
| @azure/api-management-custom-widgets-tools | 1.0.0-beta.3 | 1.0.0-beta.4 |
| @azure/arm-agricultureplatform | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-search | 3.3.0 | 3.3.1 |
| @azure/communication-chat | 1.6.0 | 1.6.1 |
| @azure/communication-email | 1.1.0 | 1.1.1 |
| @azure/communication-identity | 1.4.0-beta.1 | 1.4.0-beta.2 |
| @azure/communication-phone-numbers | 1.5.0 | 1.5.1 |
| @azure/communication-sms | 1.2.0-beta.4 | 1.2.0-beta.5 |
| @azure/digital-twins-core | 2.0.0 | 2.0.1 |
| @azure-rest/ai-document-intelligence | 1.1.0 | 1.1.1 |
| @azure-rest/ai-document-translator | 1.0.0-beta.2 | 1.0.0-beta.3 |
| @azure-rest/ai-translation-document | 1.0.0 | 1.0.1 |
| @azure-rest/ai-translation-text | 2.0.0-beta.1 | 2.0.0-beta.2 |
| @azure-rest/communication-messages | 2.2.0-beta.1 | 2.2.0-beta.2 |

**Note:** Package owners should also update SDK_VERSION constants and CHANGELOG entries for their packages as appropriate.