### PR TITLE
[EngSys] bump some dep versions in pnpm-workspace.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   arm:
     '@azure/arm-cognitiveservices':
-      specifier: 7.6.0
-      version: 7.6.0
+      specifier: 8.1.0
+      version: 8.1.0
     '@azure/arm-resources':
-      specifier: ^5.0.0
-      version: 5.2.0
+      specifier: 7.0.1
+      version: 7.0.1
     '@azure/arm-storage':
       specifier: 18.5.0
       version: 18.5.0
     '@azure/arm-webpubsub':
-      specifier: 1.2.0
-      version: 1.2.0
+      specifier: 1.2.2
+      version: 1.2.2
   default:
     '@types/node':
       specifier: ^20.19.25
@@ -61,22 +61,22 @@ catalogs:
       specifier: ^8.0.2
       version: 8.0.2
     '@vitest/browser-playwright':
-      specifier: ^4.0.8
+      specifier: ^4.1.2
       version: 4.1.2
     '@vitest/coverage-istanbul':
-      specifier: ^4.0.8
+      specifier: ^4.1.2
       version: 4.1.2
     '@vitest/expect':
-      specifier: ^4.0.6
+      specifier: ^4.1.2
       version: 4.1.2
     chai:
-      specifier: ^6.2.0
+      specifier: ^6.2.2
       version: 6.2.2
     chai-as-promised:
-      specifier: ^8.0.1
+      specifier: ^8.0.2
       version: 8.0.2
     chai-exclude:
-      specifier: ^3.0.0
+      specifier: ^3.0.1
       version: 3.0.1
     dotenv:
       specifier: ^16.6.1
@@ -85,10 +85,10 @@ catalogs:
       specifier: ^13.5.6
       version: 13.5.6
     playwright:
-      specifier: ^1.56.1
+      specifier: ^1.58.2
       version: 1.58.2
     vitest:
-      specifier: ^4.0.8
+      specifier: ^4.1.2
       version: 4.1.2
 
 importers:
@@ -1018,7 +1018,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -3157,7 +3157,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: 5.2.0
+        version: link:../../resources/arm-resources
       '@azure/arm-storage':
         specifier: catalog:arm
         version: 18.5.0
@@ -3254,7 +3254,7 @@ importers:
         version: link:../../keyvault/arm-keyvault
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: 5.2.0
+        version: link:../../resources/arm-resources
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -3345,7 +3345,7 @@ importers:
         version: link:../../keyvault/arm-keyvault
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: 5.2.0
+        version: link:../../resources/arm-resources
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -4133,7 +4133,7 @@ importers:
         version: link:../../test-utils/recorder
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/core-util':
         specifier: workspace:^
         version: link:../../core/core-util
@@ -4221,7 +4221,7 @@ importers:
         version: link:../../test-utils/recorder
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/core-util':
         specifier: workspace:^
         version: link:../../core/core-util
@@ -11631,7 +11631,7 @@ importers:
         version: link:../../core/abort-controller
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/arm-storage':
         specifier: catalog:arm
         version: 18.5.0
@@ -13872,7 +13872,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/arm-storage':
         specifier: catalog:arm
         version: 18.5.0
@@ -17866,7 +17866,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: 5.2.0
+        version: link:../../resources/arm-resources
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -22231,7 +22231,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/arm-search':
         specifier: ^3.2.0
         version: link:../../search/arm-search
@@ -28605,8 +28605,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/storage-blob':
-        specifier: 12.29.0
-        version: 12.29.0
+        specifier: 12.31.0
+        version: 12.31.0
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.37
@@ -30929,7 +30929,7 @@ importers:
         version: link:../../test-utils/recorder
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -31258,7 +31258,7 @@ importers:
         version: link:../../test-utils/recorder
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -31334,7 +31334,7 @@ importers:
         version: link:../../test-utils/recorder
       '@azure/arm-cognitiveservices':
         specifier: catalog:arm
-        version: 7.6.0
+        version: link:../../cognitiveservices/arm-cognitiveservices
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -31936,7 +31936,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-webpubsub':
         specifier: catalog:arm
-        version: 1.2.0
+        version: link:../arm-webpubsub
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -32474,10 +32474,6 @@ packages:
     resolution: {integrity: sha1-ru73sUmGrXAAFWPiTJb1tbW1tmo=}
     engines: {node: '>=18.0.0'}
 
-  '@azure/arm-cognitiveservices@7.6.0':
-    resolution: {integrity: sha1-57As5vST8j7PbPZuT4ysWQ/z7t4=}
-    engines: {node: '>=18.0.0'}
-
   '@azure/arm-cosmosdb@16.0.0-beta.6':
     resolution: {integrity: sha1-BbFUloKpxuHjesmLNzt4OyXQdYE=}
     engines: {node: '>=14.0.0'}
@@ -32498,20 +32494,12 @@ packages:
     resolution: {integrity: sha1-xhCsgrCAoBid/WnFP8GwR1gkT9E=}
     engines: {node: '>=14.0.0'}
 
-  '@azure/arm-resources@5.2.0':
-    resolution: {integrity: sha1-xiBCl23pI+AEgEJRHOwkzOuZigk=}
-    engines: {node: '>=14.0.0'}
-
   '@azure/arm-servicebus@6.1.0':
     resolution: {integrity: sha1-obGbSgdm7IM//UUfsGTJdsrxacA=}
     engines: {node: '>=14.0.0'}
 
   '@azure/arm-storage@18.5.0':
     resolution: {integrity: sha1-hHzWoKc3k3aMCxqEesNscjBgZrE=}
-    engines: {node: '>=18.0.0'}
-
-  '@azure/arm-webpubsub@1.2.0':
-    resolution: {integrity: sha1-mfACuVCTDGJNhvkWsqXe5eKtOGQ=}
     engines: {node: '>=18.0.0'}
 
   '@azure/communication-common@2.4.0':
@@ -32685,11 +32673,6 @@ packages:
   '@azure/service-bus@7.9.5':
     resolution: {integrity: sha1-rVpvPK+eMmnF6DjXsV7NAw4tjTM=}
     engines: {node: '>=18.0.0'}
-
-  '@azure/storage-blob@12.29.0':
-    resolution: {integrity: sha1-1BQU2kYx+KCSFR416DKBD/Q4jio=}
-    engines: {node: '>=20.0.0'}
-    deprecated: Unplanned Release
 
   '@azure/storage-blob@12.31.0':
     resolution: {integrity: sha1-l7Cb4r9qtZc5uGLt2BJHmDYs5yA=}
@@ -33029,11 +33012,101 @@ packages:
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha1-EHPl3ubdVAQQeEmQ63PkrNJcmBM=}
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha1-TFhQAvetaU04/g6Mv1z9k5zP8yc=}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha1-diXQlSw7QC0+3iA6Fsnyt4+KSCc=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha1-mgzx0SmX7Ebd37Ms5n6byoQjgaw=}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha1-BuH9xig/zNa8aq3WdUr85s+W9C4=}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha1-bFUO5sAnO8sPrCREeP9yfCZ1XYA=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha1-7XoSXp8lzgCRua/3g+6UP2umy4Y=}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha1-WX3I5xYdunHbTBZWExwfHp12YMY=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha1-6hcfn08A76qOnT/ouqG3XXV9GzY=}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha1-5S1X8gI2k4bm28szcKF6BJGrFGQ=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha1-XgwLY0kIrbzgoCzr66izrKwmP7Y=}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha1-X5DwHxMWUkc+wGsDihTEloPhTsc=}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha1-Y7rP/bmVdMkxj5r70N1P/3aoN+M=}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha1-xLaVLspqjv/2f+42caNTbI5nt+s=}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha1-bepn09mMaYbxt3aeTxhI5a5HrVg=}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha1-mtK0w8BQLGutqcgZl7tWxZeFNIk=}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha1-xD08/QcwQspvXFK7m8MT7SBmzig=}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
 
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha1-RfoXPgWRrHTYDTz3ZwRxPhTipKY=}
@@ -33041,10 +33114,52 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha1-NmsO9AzbmG/HUcva0W6MJf4bqHk=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha1-6YXUmjZo/SBENDBx1S4a6BURKz4=}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha1-b7Sre3P35Vcs5eyc+RwT/23USEI=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha1-ZB8FIECg15hD1oiY9XkWOKAm2YM=}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha1-/B0z6snYGuCkM7PtHdYXGiDU4xc=}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha1-ryzVyoQtbQVxIfZqGS1PeX3ij1M=}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha1-eOx+WbsGQEWD1MlRHmIdsxx2DeM=}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha1-DmFqpIi37l0lkqsHD/nsBqn93xE=}
+    engines: {node: '>=18'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.4':
@@ -34071,10 +34186,101 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    resolution: {integrity: sha1-fhWN38FveNqZwNXMuubK5APvMoQ=}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.0':
+    resolution: {integrity: sha1-SfSuDiK2+f+804GLmgdY+i0Qsc0=}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    resolution: {integrity: sha1-uyACaQaaz1wcTXmtFCUk936LgjY=}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.60.0':
     resolution: {integrity: sha1-G/epKyfr3V4NHUhQPHgRFgdzvho=}
     cpu: [x64]
     os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    resolution: {integrity: sha1-XM9Te5nFF1AIREcCGTrQscNvfxY=}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    resolution: {integrity: sha1-EZbs179OEoYk74PNH514URRHSnc=}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    resolution: {integrity: sha1-zBR2M6SvIp/ug6c3vyM0+6w9wo4=}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    resolution: {integrity: sha1-NVn58GAVPqVFlKQsO4eil77cwm4=}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    resolution: {integrity: sha1-6R+IexVBI0hc/EtZvv4ggPzY8t8=}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    resolution: {integrity: sha1-ZgdS8EDfm6RKJHZd9piSiRfAvyE=}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    resolution: {integrity: sha1-yw6Tml+keczvJk8/RbMZcWlfhpw=}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    resolution: {integrity: sha1-QvhvvILNGoG+LTRkdt0yMc9e5EI=}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    resolution: {integrity: sha1-OXdqZHp4ncleoEknfF748Jjfd/k=}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    resolution: {integrity: sha1-Rm8gApqOizuylUx93ryVhkIMrCw=}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    resolution: {integrity: sha1-z/mHfHjxLnqmJG9pAq2RPpntsrc=}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    resolution: {integrity: sha1-mnYvuZtagqkhAX9WSRt+iSufsX0=}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    resolution: {integrity: sha1-nSWtisfatoGTW694rF6pLRRinN8=}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha1-XlE54RgZ+jigUjaNp5Qiy0r89GY=}
@@ -34088,9 +34294,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    resolution: {integrity: sha1-5uCe66pwErucczG0N6npkr2UyjU=}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    resolution: {integrity: sha1-99ma6FcDJJjlel5yWftxAP0kqH4=}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rollup/rollup-win32-arm64-msvc@4.60.0':
     resolution: {integrity: sha1-QeOS9dnzvxJT/a8vbW9rG/xFKFY=}
     cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    resolution: {integrity: sha1-9BsEkL4OXTz0WbTcB2oZK1Mq3qk=}
+    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.60.0':
@@ -34152,14 +34373,29 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@turbo/darwin-arm64@2.8.21':
+    resolution: {integrity: sha1-BGvGG/NY9tr//oVjstP0XkM7ZjA=}
+    cpu: [arm64]
+    os: [darwin]
+
   '@turbo/linux-64@2.8.21':
     resolution: {integrity: sha1-24Td14pRjE8DICtcnKcukWgi/fU=}
     cpu: [x64]
     os: [linux]
 
+  '@turbo/linux-arm64@2.8.21':
+    resolution: {integrity: sha1-LSWipnYCBov78Lga1laoPGpiVR8=}
+    cpu: [arm64]
+    os: [linux]
+
   '@turbo/windows-64@2.8.21':
     resolution: {integrity: sha1-S06TthP5+Xi7bRxpV/eOgZGuWXY=}
     cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.8.21':
+    resolution: {integrity: sha1-QbDt3LoQpdNTYJCnu5VK5kZFKLo=}
+    cpu: [arm64]
     os: [win32]
 
   '@types/argparse@1.0.38':
@@ -37358,18 +37594,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/arm-cognitiveservices@7.6.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-lro': 2.7.2
-      '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.23.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/arm-cosmosdb@16.0.0-beta.6':
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -37430,18 +37654,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/arm-resources@5.2.0':
-    dependencies:
-      '@azure/abort-controller': 1.1.0
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-lro': 2.7.2
-      '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.23.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/arm-servicebus@6.1.0':
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -37457,18 +37669,6 @@ snapshots:
   '@azure/arm-storage@18.5.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-lro': 2.7.2
-      '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.23.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/arm-webpubsub@1.2.0':
-    dependencies:
-      '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.10.1
       '@azure/core-client': 1.10.1
       '@azure/core-lro': 2.7.2
@@ -37876,25 +38076,6 @@ snapshots:
       long: 5.3.2
       process: 0.11.10
       rhea-promise: 3.0.3
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@azure/storage-blob@12.29.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.1
-      '@azure/core-http-compat': 2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)
-      '@azure/core-lro': 2.7.2
-      '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.23.0
-      '@azure/core-tracing': 1.3.1
-      '@azure/core-util': 1.13.1
-      '@azure/core-xml': 1.5.0
-      '@azure/logger': 1.3.0
-      '@azure/storage-common': 12.3.0(@azure/core-client@1.10.1)
-      events: 3.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -38316,13 +38497,79 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -39500,7 +39747,55 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.0
 
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
@@ -39509,7 +39804,16 @@ snapshots:
   '@rollup/rollup-linux-x64-musl@4.60.0':
     optional: true
 
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    optional: true
+
   '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.60.0':
@@ -39572,10 +39876,19 @@ snapshots:
   '@turbo/darwin-64@2.8.21':
     optional: true
 
+  '@turbo/darwin-arm64@2.8.21':
+    optional: true
+
   '@turbo/linux-64@2.8.21':
     optional: true
 
+  '@turbo/linux-arm64@2.8.21':
+    optional: true
+
   '@turbo/windows-64@2.8.21':
+    optional: true
+
+  '@turbo/windows-arm64@2.8.21':
     optional: true
 
   '@types/argparse@1.0.38': {}
@@ -40660,9 +40973,31 @@ snapshots:
 
   esbuild@0.27.4:
     optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
       '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
       '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
       '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
   escalade@3.2.0: {}
@@ -42232,10 +42567,29 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.0
+      '@rollup/rollup-android-arm64': 4.60.0
+      '@rollup/rollup-darwin-arm64': 4.60.0
       '@rollup/rollup-darwin-x64': 4.60.0
+      '@rollup/rollup-freebsd-arm64': 4.60.0
+      '@rollup/rollup-freebsd-x64': 4.60.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
+      '@rollup/rollup-linux-arm64-gnu': 4.60.0
+      '@rollup/rollup-linux-arm64-musl': 4.60.0
+      '@rollup/rollup-linux-loong64-gnu': 4.60.0
+      '@rollup/rollup-linux-loong64-musl': 4.60.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
+      '@rollup/rollup-linux-ppc64-musl': 4.60.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
+      '@rollup/rollup-linux-riscv64-musl': 4.60.0
+      '@rollup/rollup-linux-s390x-gnu': 4.60.0
       '@rollup/rollup-linux-x64-gnu': 4.60.0
       '@rollup/rollup-linux-x64-musl': 4.60.0
+      '@rollup/rollup-openbsd-x64': 4.60.0
+      '@rollup/rollup-openharmony-arm64': 4.60.0
       '@rollup/rollup-win32-arm64-msvc': 4.60.0
+      '@rollup/rollup-win32-ia32-msvc': 4.60.0
       '@rollup/rollup-win32-x64-gnu': 4.60.0
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
@@ -42614,8 +42968,11 @@ snapshots:
   turbo@2.8.21:
     optionalDependencies:
       '@turbo/darwin-64': 2.8.21
+      '@turbo/darwin-arm64': 2.8.21
       '@turbo/linux-64': 2.8.21
+      '@turbo/linux-arm64': 2.8.21
       '@turbo/windows-64': 2.8.21
+      '@turbo/windows-arm64': 2.8.21
 
   type-check@0.3.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,26 +30,26 @@ catalog:
 
 catalogs:
   arm:
-    '@azure/arm-cognitiveservices': 7.6.0
+    '@azure/arm-cognitiveservices': 8.1.0
     '@azure/arm-storage': 18.5.0
-    '@azure/arm-webpubsub': 1.2.0
-    '@azure/arm-resources': ^5.0.0
+    '@azure/arm-webpubsub': 1.2.2
+    '@azure/arm-resources': 7.0.1
   internal:
     '@azure/identity': 4.13.0
     express: ^5.2.1
   testing:
     '@rollup/plugin-inject': ^5.0.5
-    '@types/chai': ^5.2.1
+    '@types/chai': ^5.2.3
     '@types/chai-as-promised': ^8.0.2
-    '@vitest/browser-playwright': ^4.0.8
-    '@vitest/coverage-istanbul': ^4.0.8
-    '@vitest/expect': ^4.0.6
-    chai: ^6.2.0
-    chai-as-promised: ^8.0.1
-    chai-exclude: ^3.0.0
+    '@vitest/browser-playwright': ^4.1.2
+    '@vitest/coverage-istanbul': ^4.1.2
+    '@vitest/expect': ^4.1.2
+    chai: ^6.2.2
+    chai-as-promised: ^8.0.2
+    chai-exclude: ^3.0.1
     dotenv: ^16.6.1
     nock: ^13.5.6
-    playwright: ^1.56.1
-    vitest: ^4.0.8
+    playwright: ^1.58.2
+    vitest: ^4.1.2
 
 linkWorkspacePackages: true

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -111,7 +111,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/storage-blob": "12.29.0",
+    "@azure/storage-blob": "12.31.0",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",


### PR DESCRIPTION
and storage-file-share because storage-blob 12.29.0 is deprecated.
