### PR TITLE
fix(arm-batch): resolve Vite module cache conflict for @azure/core-lro in browser tests

### DIFF
--- a/sdk/batch/arm-batch/vitest.browser.config.ts
+++ b/sdk/batch/arm-batch/vitest.browser.config.ts
@@ -2,5 +2,21 @@
 // Licensed under the MIT License.
 
 import viteConfig from "../../../vitest.browser.shared.config.ts";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    optimizeDeps: {
+      // Prevent Vite from pre-bundling @azure/core-lro into a single shared chunk.
+      // Without this, Vite caches the first resolution (2.x from @azure/arm-storage
+      // or @azure/arm-resources devDeps) and serves it to all importers, including
+      // arm-batch's own code which requires the workspace 3.x version.
+      exclude: ["@azure/core-lro"],
+      include: [
+        "@azure/arm-resources > @azure/core-lro",
+        "@azure/arm-storage > @azure/core-lro",
+      ],
+    },
+  }),
+);


### PR DESCRIPTION
## Problem

`@azure/arm-batch` browser test (`batchAccountOperations create test`) consistently fails with:

```
AssertionError: expected undefined to equal 'myaccountxxx'
```

## Root Cause

`@azure/arm-batch` depends on `@azure/core-lro@3.x` (workspace) directly, but its devDependencies (`@azure/arm-storage@18.5.0`, `@azure/arm-resources@5.2.0`) bring in `@azure/core-lro@2.7.2`.

In browser tests, Vite's `optimizeDeps` pre-bundles the first resolution of `@azure/core-lro` it encounters (2.7.2 from arm-storage) and caches it globally. When arm-batch's own `pollingHelpers.js` imports `createHttpPoller` from `@azure/core-lro`, Vite serves the cached 2.x version instead of the workspace 3.x version.

The 2.x `createHttpPoller` has different LRO mode detection and result processing behavior, causing the batch account create LRO to return `undefined` instead of the correctly deserialized `BatchAccount` result.

This is the same root cause as the `@azure/batch` fix in PR #37899.

## Fix

Add `optimizeDeps` configuration to `sdk/batch/arm-batch/vitest.browser.config.ts`:
- **exclude** `@azure/core-lro` from pre-bundling so Vite doesn't flatten it into one shared chunk
- **include** the transitive dependency paths explicitly so each consumer gets its own correct version

## Verification

- Node tests continue to pass (unaffected)
- Browser test `batchAccountOperations create test` should now pass with the correct core-lro 3.x version