### PR TITLE
[EngSys] remove eslint mcp server from .vscode/mcp.json

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,13 +8,6 @@
         "-Run"
       ]
     },
-    "ESLint": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "@eslint/mcp@latest"
-      ]
-    },
     "github-agentic-workflows": {
       "command": "gh",
       "args": [


### PR DESCRIPTION
We haven't seen any benefit so far and running off `@latest` is broken after
moving to CFS. This PR removes it.