### PR TITLE
fix: fix flaky CI tests for identity-broker and storage-file-share

### DIFF
--- a/sdk/identity/identity-broker/test/internal/node/interactiveBrowserCredential.spec.ts
+++ b/sdk/identity/identity-broker/test/internal/node/interactiveBrowserCredential.spec.ts
@@ -5,7 +5,6 @@ import type { InteractiveBrowserCredentialNodeOptions } from "@azure/identity";
 import { InteractiveBrowserCredential, useIdentityPlugin } from "@azure/identity";
 import { PublicClientApplication } from "@azure/msal-node";
 import { Recorder, env } from "@azure-tools/test-recorder";
-import { nativeBrokerPlugin } from "../../../src/index.js";
 import type http from "node:http";
 import type { MockInstance } from "vitest";
 import { describe, it, assert, expect, vi, beforeEach, afterEach } from "vitest";
@@ -53,6 +52,7 @@ describe("InteractiveBrowserCredential (internal)", () => {
   // - The test requires user interaction, so it cannot run in live mode
   // - The test with broker is hanging, so it's skipped in playback mode for CI
   it.skip("Accepts interactiveBrowserCredentialOptions", async () => {
+    const { nativeBrokerPlugin } = await import("../../../src/index.js");
     useIdentityPlugin(nativeBrokerPlugin);
     const winHandle = Buffer.from("srefleqr93285329lskadjffa");
     const interactiveBrowserCredentialOptions: InteractiveBrowserCredentialNodeOptions = {

--- a/sdk/identity/identity-broker/vitest.config.ts
+++ b/sdk/identity/identity-broker/vitest.config.ts
@@ -14,6 +14,11 @@ export default mergeConfig(
   defineConfig({
     test: {
       globalSetup: [path.resolve(__dirname, "test/utils/globalSetup.ts")],
+      exclude: [
+        // Manual tests require user interaction and native broker dependencies
+        // (keytar/libsecret) that are not available on all CI platforms.
+        "test/manual/**/*.spec.ts",
+      ],
     },
   })
 );

--- a/sdk/storage/storage-file-share/vitest.config.ts
+++ b/sdk/storage/storage-file-share/vitest.config.ts
@@ -2,6 +2,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.shared.config.ts";
 
-export default viteConfig;
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      fileParallelism: false,
+    },
+  }),
+);


### PR DESCRIPTION
## Problem

Two packages have flaky CI test failures unrelated to any code changes:

### identity-broker
Tests fail on Ubuntu CI with:
```
Error: libsecret-1.so.0: cannot open shared object file: No such file or directory
```
Root cause: `nativeBrokerPlugin` is imported eagerly at module load time, which loads `keytar`, which requires `libsecret`. Even though all tests are `it.skip()`, the import crashes before vitest can skip them.

### storage-file-share  
Tests fail on macOS CI with:
```
There is no active playback session under recording id ...
```
Root cause: Test proxy sessions overlap when test files run in parallel. Other recorder-heavy packages (event-hubs, openai, storage-blob-changefeed) already set `fileParallelism: false`.

## Fix

**identity-broker:**
- Exclude `test/manual/**/*.spec.ts` from vitest config (manual tests need user interaction and native broker deps not available on CI)
- Replace eager top-level import of `nativeBrokerPlugin` with dynamic import to prevent `keytar`/`libsecret` crash at module load time

**storage-file-share:**
- Add `fileParallelism: false` to vitest config, matching the pattern used by other recorder-heavy packages