### PR TITLE
[test] fix container-registry bicep

### DIFF
--- a/sdk/containerregistry/test-resources.bicep
+++ b/sdk/containerregistry/test-resources.bicep
@@ -27,6 +27,6 @@ resource anonymousContainerRegistry 'Microsoft.ContainerRegistry/registries@2023
 
 // Outputs
 output CONTAINER_REGISTRY_NAME string = baseName
-output CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
+output CONTAINER_REGISTRY_ENDPOINT string = 'https://${containerRegistry.properties.loginServer}'
 output CONTAINER_REGISTRY_ANONYMOUS_NAME string = anonRegistryName
-output CONTAINER_REGISTRY_ANONYMOUS_ENDPOINT string = anonymousContainerRegistry.properties.loginServer
+output CONTAINER_REGISTRY_ANONYMOUS_ENDPOINT string = 'https://${anonymousContainerRegistry.properties.loginServer}'


### PR DESCRIPTION
It appears that the `http://` part got lost in https://github.com/Azure/azure-sdk-for-js/pull/30861. `loginServer` doesn't have the protocol part.