### PR TITLE
[Monitor OpenTelemetry Exporter] Revert Custom Properties Length

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- The `AZURE_MONITOR_DISABLE_CUSTOM_DIMENSIONS_LIMIT` environment variable is no longer supported. All custom dimension values are truncated to 64KB by default.
+- The `AZURE_MONITOR_DISABLE_CUSTOM_DIMENSIONS_LIMIT` environment variable is no longer supported. All custom dimension values are truncated to 8KB by default.
 
 ### Features Added
 
@@ -14,6 +14,10 @@
 - The exporter now respects the `Retry-After` header from the backend when scheduling retries for retriable responses.
 - Throttled telemetry (429 responses) is now persisted to disk for retry instead of being silently dropped.
 - Specific GenAI properties are now truncated to 256KB instead of being exempt from truncation limits.
+
+### Other Changes
+
+- Revert custom properties limit to 8KB.
 
 ### Bugs Fixed
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts
@@ -307,13 +307,13 @@ export function isSyntheticSource(attributes: Attributes): boolean {
 /**
  * Truncates each custom dimension value individually.
  * Gen AI properties in {@link CUSTOM_DIMENSIONS_GENAI_KEYS} are truncated to 256KB;
- * all other properties are truncated to 64KB.
+ * all other properties are truncated to 8KB.
  * @internal
  */
 export function truncateCustomDimensions(properties: Record<string, unknown>): {
   [propertyName: string]: string;
 } {
-  const defaultMaxSize = MaxPropertyLengths.SIXTEEN_BIT;
+  const defaultMaxSize = MaxPropertyLengths.THIRTEEN_BIT;
   const genaiMaxSize = MaxPropertyLengths.EIGHTEEN_BIT;
   const result: { [propertyName: string]: string } = {};
   let truncated = false;

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/customDimensionsLimits.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/customDimensionsLimits.spec.ts
@@ -8,7 +8,7 @@ import { describe, it, assert } from "vitest";
 
 describe("Custom Dimensions Size Limits", () => {
   describe("#truncateCustomDimensions", () => {
-    it("should return properties unchanged when under 64KB limit", () => {
+    it("should return properties unchanged when under 8KB limit", () => {
       const properties: { [key: string]: string } = {
         key1: "value1",
         key2: "value2",
@@ -23,18 +23,18 @@ describe("Custom Dimensions Size Limits", () => {
       assert.deepStrictEqual(result, {});
     });
 
-    it("should truncate a single value that exceeds 64KB", () => {
-      const largeValue = "x".repeat(MaxPropertyLengths.SIXTEEN_BIT + 1000);
+    it("should truncate a single value that exceeds 8KB", () => {
+      const largeValue = "x".repeat(MaxPropertyLengths.THIRTEEN_BIT + 1000);
       const properties: { [key: string]: string } = {
         largeKey: largeValue,
       };
 
       const result = truncateCustomDimensions(properties);
 
-      // Value should be truncated to the 64KB limit
+      // Value should be truncated to the 8KB limit
       assert.isTrue(
-        Buffer.byteLength(result["largeKey"], "utf-8") <= MaxPropertyLengths.SIXTEEN_BIT,
-        "largeKey value should be truncated to 64KB",
+        Buffer.byteLength(result["largeKey"], "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+        "largeKey value should be truncated to 8KB",
       );
       assert.isTrue(
         Buffer.byteLength(result["largeKey"], "utf-8") < Buffer.byteLength(largeValue, "utf-8"),
@@ -42,11 +42,11 @@ describe("Custom Dimensions Size Limits", () => {
       );
     });
 
-    it("should only truncate values that individually exceed 64KB", () => {
+    it("should only truncate values that individually exceed 8KB", () => {
       const smallValue = "hello";
       const properties: { [key: string]: string } = {
         small: smallValue,
-        large: "x".repeat(MaxPropertyLengths.SIXTEEN_BIT + 500),
+        large: "x".repeat(MaxPropertyLengths.THIRTEEN_BIT + 500),
       };
 
       const result = truncateCustomDimensions(properties);
@@ -54,16 +54,16 @@ describe("Custom Dimensions Size Limits", () => {
       // Small property should be unchanged
       assert.strictEqual(result["small"], smallValue);
 
-      // Large property should be truncated to 64KB
+      // Large property should be truncated to 8KB
       assert.isTrue(
-        Buffer.byteLength(result["large"], "utf-8") <= MaxPropertyLengths.SIXTEEN_BIT,
-        "large property should be truncated to 64KB",
+        Buffer.byteLength(result["large"], "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+        "large property should be truncated to 8KB",
       );
     });
 
-    it("should not truncate values that are each under 64KB even if combined total exceeds it", () => {
-      // Two properties that together exceed 64KB but each is under 64KB individually
-      const halfSize = 40 * 1024;
+    it("should not truncate values that are each under 8KB even if combined total exceeds it", () => {
+      // Two properties that together exceed 8KB but each is under 8KB individually
+      const halfSize = 5 * 1024;
       const properties: { [key: string]: string } = {
         key1: "a".repeat(halfSize),
         key2: "b".repeat(halfSize),
@@ -71,21 +71,21 @@ describe("Custom Dimensions Size Limits", () => {
 
       const result = truncateCustomDimensions(properties);
 
-      // Neither value should be truncated since each is under 64KB
+      // Neither value should be truncated since each is under 8KB
       assert.strictEqual(result["key1"].length, halfSize);
       assert.strictEqual(result["key2"].length, halfSize);
     });
 
-    it("should truncate gen_ai keys at 256KB instead of 64KB", () => {
-      const over64KBValue = "x".repeat(MaxPropertyLengths.SIXTEEN_BIT + 1000);
+    it("should truncate gen_ai keys at 256KB instead of 8KB", () => {
+      const over8KBValue = "x".repeat(MaxPropertyLengths.THIRTEEN_BIT + 1000);
       const over256KBValue = "x".repeat(MaxPropertyLengths.EIGHTEEN_BIT + 1000);
 
       for (const genAiKey of CUSTOM_DIMENSIONS_GENAI_KEYS) {
-        // Value over 64KB but under 256KB should NOT be truncated
-        const smallResult = truncateCustomDimensions({ [genAiKey]: over64KBValue });
+        // Value over 8KB but under 256KB should NOT be truncated
+        const smallResult = truncateCustomDimensions({ [genAiKey]: over8KBValue });
         assert.strictEqual(
           smallResult[genAiKey],
-          over64KBValue,
+          over8KBValue,
           `Gen AI key '${genAiKey}' under 256KB should not be truncated`,
         );
 
@@ -98,8 +98,8 @@ describe("Custom Dimensions Size Limits", () => {
       }
     });
 
-    it("should truncate non-gen_ai keys at 64KB while gen_ai keys use 256KB limit", () => {
-      const largeValue = "x".repeat(MaxPropertyLengths.SIXTEEN_BIT + 1000);
+    it("should truncate non-gen_ai keys at 8KB while gen_ai keys use 256KB limit", () => {
+      const largeValue = "x".repeat(MaxPropertyLengths.THIRTEEN_BIT + 1000);
       const properties: { [key: string]: string } = {
         "gen_ai.input.messages": largeValue,
         regularKey: largeValue,
@@ -110,15 +110,15 @@ describe("Custom Dimensions Size Limits", () => {
       // Gen AI key should be preserved (under 256KB)
       assert.strictEqual(result["gen_ai.input.messages"], largeValue);
 
-      // Non-gen_ai key should be truncated to 64KB
+      // Non-gen_ai key should be truncated to 8KB
       assert.isTrue(
-        Buffer.byteLength(result["regularKey"], "utf-8") <= MaxPropertyLengths.SIXTEEN_BIT,
-        "Non-gen_ai key should be truncated to 64KB",
+        Buffer.byteLength(result["regularKey"], "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+        "Non-gen_ai key should be truncated to 8KB",
       );
     });
 
     it("should truncate keys not in the gen_ai list even if they start with gen_ai", () => {
-      const largeValue = "x".repeat(MaxPropertyLengths.SIXTEEN_BIT + 1000);
+      const largeValue = "x".repeat(MaxPropertyLengths.THIRTEEN_BIT + 1000);
       const properties: { [key: string]: string } = {
         "gen_ai.other_attribute": largeValue,
       };
@@ -126,21 +126,21 @@ describe("Custom Dimensions Size Limits", () => {
       const result = truncateCustomDimensions(properties);
       assert.isTrue(
         Buffer.byteLength(result["gen_ai.other_attribute"], "utf-8") <=
-          MaxPropertyLengths.SIXTEEN_BIT,
+          MaxPropertyLengths.THIRTEEN_BIT,
         "Non-listed gen_ai key should still be truncated",
       );
     });
 
     it("should not drop entries regardless of total size", () => {
       const properties: { [key: string]: string } = {};
-      // Many small entries whose combined size exceeds 64KB
+      // Many small entries whose combined size exceeds 8KB
       for (let i = 0; i < 128; i++) {
         properties["k".repeat(512) + i.toString()] = "value" + i;
       }
 
       const result = truncateCustomDimensions(properties);
 
-      // All entries should be preserved since no individual value exceeds 64KB
+      // All entries should be preserved since no individual value exceeds 8KB
       assert.strictEqual(
         Object.keys(result).length,
         Object.keys(properties).length,
@@ -148,8 +148,8 @@ describe("Custom Dimensions Size Limits", () => {
       );
     });
 
-    it("should truncate multiple values that each exceed 64KB independently", () => {
-      const oversize = MaxPropertyLengths.SIXTEEN_BIT + 2000;
+    it("should truncate multiple values that each exceed 8KB independently", () => {
+      const oversize = MaxPropertyLengths.THIRTEEN_BIT + 2000;
       const properties: { [key: string]: string } = {
         big1: "a".repeat(oversize),
         big2: "b".repeat(oversize),
@@ -157,22 +157,22 @@ describe("Custom Dimensions Size Limits", () => {
 
       const result = truncateCustomDimensions(properties);
 
-      // Both values should be truncated to 64KB
+      // Both values should be truncated to 8KB
       assert.isTrue(
-        Buffer.byteLength(result["big1"], "utf-8") <= MaxPropertyLengths.SIXTEEN_BIT,
-        "big1 should be truncated to 64KB",
+        Buffer.byteLength(result["big1"], "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+        "big1 should be truncated to 8KB",
       );
       assert.isTrue(
-        Buffer.byteLength(result["big2"], "utf-8") <= MaxPropertyLengths.SIXTEEN_BIT,
-        "big2 should be truncated to 64KB",
+        Buffer.byteLength(result["big2"], "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+        "big2 should be truncated to 8KB",
       );
       // Both entries should still exist
       assert.isDefined(result["big1"]);
       assert.isDefined(result["big2"]);
     });
 
-    it("should verify default limit is 64KB", () => {
-      assert.strictEqual(MaxPropertyLengths.SIXTEEN_BIT, 64 * 1024);
+    it("should verify default limit is 8KB", () => {
+      assert.strictEqual(MaxPropertyLengths.THIRTEEN_BIT, 8 * 1024);
     });
 
     it("should verify gen_ai limit is 256KB", () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -432,8 +432,8 @@ describe("logUtils.ts", () => {
       );
     });
 
-    it("should not truncate custom properties at 13-bit limit", () => {
-      // Create a property value that exceeds the old 13-bit (8192 character) limit
+    it("should truncate custom properties at 13-bit limit", () => {
+      // Create a property value that exceeds the 13-bit (8192 byte) limit
       const longPropertyValue = "a".repeat(MaxPropertyLengths.THIRTEEN_BIT + 1000);
       testLogRecord.body = "Test message";
       testLogRecord.severityLevel = "Information";
@@ -444,16 +444,13 @@ describe("logUtils.ts", () => {
 
       const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
 
-      // Verify the property value is NOT truncated
-      assert.strictEqual(
-        (envelope?.data?.baseData as MessageData)?.properties?.["custom.longProperty"],
-        longPropertyValue,
-        "Custom properties should not be truncated at 13-bit limit",
-      );
-      assert.strictEqual(
-        (envelope?.data?.baseData as MessageData)?.properties?.["custom.longProperty"]?.length,
-        MaxPropertyLengths.THIRTEEN_BIT + 1000,
-        "Custom property length should exceed the old 13-bit limit",
+      // Verify the property value IS truncated to 8KB
+      const resultValue = (envelope?.data?.baseData as MessageData)?.properties?.[
+        "custom.longProperty"
+      ];
+      assert.isTrue(
+        Buffer.byteLength(resultValue!, "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+        "Custom properties should be truncated at 13-bit limit",
       );
     });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/spanUtils.spec.ts
@@ -1572,8 +1572,8 @@ describe("spanUtils.ts", () => {
       expectedBaseData,
     );
   });
-  it("should not truncate custom properties at 13-bit limit for spans", () => {
-    // Create a property value that exceeds the old 13-bit (8192 character) limit
+  it("should truncate custom properties at 13-bit limit for spans", () => {
+    // Create a property value that exceeds the 13-bit (8192 byte) limit
     const longPropertyValue = "a".repeat(MaxPropertyLengths.THIRTEEN_BIT + 1000);
     const spanOptions: SpanOptions = {
       kind: SpanKind.SERVER,
@@ -1589,20 +1589,15 @@ describe("spanUtils.ts", () => {
     const readableSpan = spanToReadableSpan(span);
     const envelope = readableSpanToEnvelope(readableSpan, "ikey");
 
-    // Verify the property value is NOT truncated
-    assert.strictEqual(
-      (envelope as any).data?.baseData?.properties?.["custom.longProperty"],
-      longPropertyValue,
-      "Custom properties should not be truncated at 13-bit limit",
-    );
-    assert.strictEqual(
-      (envelope as any).data?.baseData?.properties?.["custom.longProperty"]?.length,
-      MaxPropertyLengths.THIRTEEN_BIT + 1000,
-      "Custom property length should exceed the old 13-bit limit",
+    // Verify the property value IS truncated to 8KB
+    const resultValue = (envelope as any).data?.baseData?.properties?.["custom.longProperty"];
+    assert.isTrue(
+      Buffer.byteLength(resultValue, "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+      "Custom properties should be truncated at 13-bit limit",
     );
   });
-  it("should not truncate custom properties at 13-bit limit for span events", () => {
-    // Create a property value that exceeds the old 13-bit (8192 character) limit
+  it("should truncate custom properties at 13-bit limit for span events", () => {
+    // Create a property value that exceeds the 13-bit (8192 byte) limit
     const longPropertyValue = "b".repeat(MaxPropertyLengths.THIRTEEN_BIT + 500);
     const spanOptions: SpanOptions = {
       kind: SpanKind.SERVER,
@@ -1614,17 +1609,13 @@ describe("spanUtils.ts", () => {
     span.end();
     const envelopes = spanEventsToEnvelopes(spanToReadableSpan(span), "ikey");
 
-    // Verify the property value is NOT truncated
-    assert.strictEqual(
-      (envelopes[0].data?.baseData as MessageData)?.properties?.["custom.longEventProperty"],
-      longPropertyValue,
-      "Custom properties on span events should not be truncated at 13-bit limit",
-    );
-    assert.strictEqual(
-      (envelopes[0].data?.baseData as MessageData)?.properties?.["custom.longEventProperty"]
-        ?.length,
-      MaxPropertyLengths.THIRTEEN_BIT + 500,
-      "Custom property length on span events should exceed the old 13-bit limit",
+    // Verify the property value IS truncated to 8KB
+    const resultValue = (envelopes[0].data?.baseData as MessageData)?.properties?.[
+      "custom.longEventProperty"
+    ];
+    assert.isTrue(
+      Buffer.byteLength(resultValue!, "utf-8") <= MaxPropertyLengths.THIRTEEN_BIT,
+      "Custom properties on span events should be truncated at 13-bit limit",
     );
   });
   it("should ensure ATTR_ENDUSER_ID is not included in properties", () => {

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - Restructured `samples-dev` to use the standard Azure SDK dev-tool format with `@summary` tags.
 
-### Other Changes
-
-- Restructured `samples-dev` to use the standard Azure SDK dev-tool format with `@summary` tags.
-
 ### Features Added
 
 - Added support for the AKS resource detector from `@opentelemetry/resource-detector-azure`.


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Describe the problem that is addressed by this PR
This pull request reverts the custom properties size limit for non-GenAI custom dimensions in the Azure Monitor OpenTelemetry Exporter from 64KB back to 8KB. It updates the implementation, tests, and documentation to reflect this change, ensuring that all non-GenAI custom dimension values are now truncated to 8KB by default, while GenAI properties continue to be truncated at 256KB.

**Custom Dimension Size Limit Changes:**

* Changed the truncation limit for non-GenAI custom dimension values from 64KB to 8KB in the `truncateCustomDimensions` function (`common.ts`).
* Updated all related tests to verify and enforce the new 8KB limit instead of 64KB, including test cases and assertions in `customDimensionsLimits.spec.ts`. [[1]](diffhunk://#diff-5f131eb6bad52da364006d621eef4601c333ff847389f8845f12a97741c18a73L11-R11) [[2]](diffhunk://#diff-5f131eb6bad52da364006d621eef4601c333ff847389f8845f12a97741c18a73L26-R88) [[3]](diffhunk://#diff-5f131eb6bad52da364006d621eef4601c333ff847389f8845f12a97741c18a73L101-R102) [[4]](diffhunk://#diff-5f131eb6bad52da364006d621eef4601c333ff847389f8845f12a97741c18a73L113-R175)

**Documentation Updates:**

* Updated the `CHANGELOG.md` to state that the default truncation limit is now 8KB, not 64KB, and clarified that the `AZURE_MONITOR_DISABLE_CUSTOM_DIMENSIONS_LIMIT` environment variable is no longer supported.
* Added a note in the changelog about reverting the custom properties limit to 8KB.

**Other Minor Changes:**

* Added a summary of the restructuring of `samples-dev` to use the standard Azure SDK dev-tool format with `@summary` tags in the `monitor-opentelemetry` changelog.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
