### PR TITLE
[test][eventgrid-namespaces] fix assertion on number of received events

### DIFF
--- a/sdk/eventgrid/eventgrid-namespaces/test/public/eventGridNamespacesClient.spec.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/test/public/eventGridNamespacesClient.spec.ts
@@ -110,15 +110,20 @@ describe("Event Grid Namespace Client", () => {
       ];
       await senderClient.sendEvents(cloudEvents);
 
-      const receiveResult: ReceiveResult<any> = await receiverClient.receiveEvents({
-        maxEvents: 2,
-      });
+      // receiveEvents may return fewer than maxEvents, so loop until we collect all 2 events
+      const allDetails: ReceiveResult<any>["details"] = [];
+      const maxAttempts = 5;
+      for (let attempt = 0; attempt < maxAttempts && allDetails.length < 2; attempt++) {
+        const receiveResult: ReceiveResult<any> = await receiverClient.receiveEvents({
+          maxEvents: 2 - allDetails.length,
+        });
+        allDetails.push(...receiveResult.details);
+      }
 
-      assert.isAtLeast(receiveResult.details.length, 1);
-      assert.isAtMost(receiveResult.details.length, 2);
+      assert.equal(allDetails.length, 2, "Expected to receive exactly 2 events");
 
       const deserializer: EventGridDeserializer = new EventGridDeserializer();
-      for (const value of receiveResult.details) {
+      for (const value of allDetails) {
         const result: CloudEvent<any>[] = await deserializer.deserializeCloudEvents(
           JSON.stringify(value.event),
         );


### PR DESCRIPTION
This test failed most of the time because only one event is received.

according to the doc it is expected:

>  /** Max wait time value for receive operation in Seconds. It is the time in seconds that the server approximately waits for the availability of an event and responds to the request. If an event is available, the broker responds immediately to the client. Minimum value is 10 seconds, while maximum value is 120 seconds. If not specified, the default value is 60 seconds. */
  maxWaitTime?: number;

This PR update the assertion to check that number of received messages is between 1 and 2.