### PR TITLE
Remove unsupported cwd from github-agentic-workflows MCP server config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -13,8 +13,7 @@
       "args": [
         "aw",
         "mcp-server"
-      ],
-      "cwd": "${workspaceFolder}"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

The `github-agentic-workflows` MCP server entry in `.vscode/mcp.json` includes `"cwd": "${workspaceFolder}"`, which is not supported by Copilot CLI. This causes a `spawn gh ENOENT` error when the MCP server tries to start.

## Fix

Remove the unsupported `cwd` property from the server configuration.

## Reference

- https://github.com/githubnext/agentics/issues/242