### PR TITLE
feat(warp): validate no direct imports bypassing #imports

### DIFF
--- a/common/tools/warp/src/build.ts
+++ b/common/tools/warp/src/build.ts
@@ -12,7 +12,12 @@ import {
   getExportsDiff,
   verifyDistFiles,
 } from "./exports.ts";
-import { readPackageImports, resolveImportsInDir, buildConditionsSet } from "./resolveImports.ts";
+import {
+  readPackageImports,
+  resolveImportsInDir,
+  buildConditionsSet,
+  validateNoDirectImports,
+} from "./resolveImports.ts";
 import { generateSizeReport, formatSizeReport, writeSizeReportJson } from "./sizeReport.ts";
 import type { SizeReport } from "./sizeReport.ts";
 import type { WarpConfig, ResolvedWarpConfig } from "./types.ts";
@@ -139,6 +144,7 @@ async function compileStep(
   } else {
     results = await compileAllTargets(parsedConfigs, {
       clean: options.clean ?? true,
+      packageRoot,
     });
   }
 
@@ -244,6 +250,37 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
     return { success: true, config, totalTimeMs: performance.now() - buildStart };
   }
 
+  // Read imports map once — used for validation (step 1b) and post-compile resolution (step 2b)
+  const importsMap = await readPackageImports(packageRoot);
+
+  // Step 1b: Validate no direct imports bypassing #imports
+  if (importsMap) {
+    const allSourceFiles = new Set<string>();
+    for (const pc of parsedConfigs) {
+      for (const f of pc.parsedConfig.fileNames) allSourceFiles.add(f);
+    }
+    const violations = validateNoDirectImports([...allSourceFiles], importsMap, packageRoot);
+    if (violations.length > 0) {
+      log.error(
+        `\n[warp] Found ${violations.length} direct import(s) bypassing the #imports mechanism:`,
+      );
+      for (const v of violations) {
+        log.error(
+          `  ${path.relative(packageRoot, v.file)}:${v.line}  ${v.specifier}  →  use ${v.suggestedImport}`,
+        );
+      }
+      log.error(
+        `\n[warp] These files are mapped via package.json "imports". Use the #-prefixed specifier to ensure correct platform-specific resolution.`,
+      );
+      log.flush();
+      return {
+        success: false,
+        config,
+        totalTimeMs: performance.now() - buildStart,
+      };
+    }
+  }
+
   // Step 2: Compile
   const { results, compileTimeMs } = await compileStep(parsedConfigs, options, packageRoot);
 
@@ -271,7 +308,6 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
   // Step 2b: Resolve #-prefixed imports in output.
   // Automatic: when package.json has an "imports" field, all targets get
   // their #-prefixed specifiers resolved to concrete relative paths.
-  const importsMap = await readPackageImports(packageRoot);
 
   if (importsMap) {
     let hasResolveErrors = false;

--- a/common/tools/warp/src/index.ts
+++ b/common/tools/warp/src/index.ts
@@ -44,12 +44,16 @@ export {
   readPackageImports,
   buildConditionsSet,
   sourcePathToOutputPath,
+  collectImportTargetPaths,
+  buildImportTargetIndex,
+  validateNoDirectImports,
 } from "./resolveImports.ts";
 export type {
   ImportsMap,
   ResolveImportsResult,
   UnresolvedSpecifier,
   MissingResolvedTarget,
+  DirectImportViolation,
 } from "./resolveImports.ts";
 export { Logger, getLogger, setLogLevel } from "./logger.ts";
 export type { LogLevel } from "./logger.ts";

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -67,31 +67,39 @@ export function resolveSubpathImport(
   importsMap: ImportsMap,
   conditions: ReadonlySet<string>,
 ): string | undefined {
-  // Step 1: Exact match — key has no wildcard
+  const entry = matchImportEntry(specifier, importsMap);
+  if (!entry) return undefined;
+  return resolvePackageTarget(entry.target, conditions, entry.patternMatch);
+}
+
+/**
+ * Find the imports map entry matching a specifier key.
+ * Returns the target value and pattern match (for wildcard entries).
+ */
+function matchImportEntry(
+  specifier: string,
+  importsMap: ImportsMap,
+): { target: PackageTarget; patternMatch: string | null } | undefined {
   if (specifier in importsMap) {
-    return resolvePackageTarget(importsMap[specifier], conditions, null);
+    return { target: importsMap[specifier], patternMatch: null };
   }
 
-  // Step 2: Pattern match — get pre-sorted pattern keys, try each in order.
-  const patternKeys = getSortedPatternKeys(importsMap);
-
-  for (const key of patternKeys) {
+  for (const key of getSortedPatternKeys(importsMap)) {
     const starIdx = key.indexOf("*");
     const prefix = key.slice(0, starIdx);
     const suffix = key.slice(starIdx + 1);
 
     if (
       specifier.startsWith(prefix) &&
-      specifier.length >= key.length && // spec: matchKey.length >= expansionKey.length (pattern match must be ≥1 char)
+      specifier.length >= key.length &&
       (suffix === "" || specifier.endsWith(suffix))
     ) {
       const patternMatch = suffix
         ? specifier.slice(prefix.length, -suffix.length)
         : specifier.slice(prefix.length);
-      return resolvePackageTarget(importsMap[key], conditions, patternMatch);
+      return { target: importsMap[key], patternMatch };
     }
   }
-
   return undefined;
 }
 
@@ -539,6 +547,348 @@ export async function resolveImportsInDir(
   }
 
   return { filesProcessed: files.length, filesChanged, unresolvedSpecifiers, missingTargets };
+}
+
+// ---------------------------------------------------------------------------
+// Direct import bypass validation
+// ---------------------------------------------------------------------------
+
+/** A direct import that bypasses the `#imports` mechanism. */
+export interface DirectImportViolation {
+  /** Absolute path of the source file containing the violation. */
+  file: string;
+  /** The relative import specifier that bypasses `#imports`. */
+  specifier: string;
+  /** The `#`-prefixed key that should be used instead. */
+  suggestedImport: string;
+  /** 1-based line number of the offending import. */
+  line: number;
+}
+
+/**
+ * A pattern entry from a wildcard imports map target.
+ * The `*` in the target is replaced with a regex capture group.
+ */
+interface WildcardPattern {
+  /** Regex that matches absolute file paths for this target pattern. */
+  regex: RegExp;
+  /** The `#`-prefixed key (with `*`) from the imports map, e.g., `#platform/*`. */
+  key: string;
+}
+
+/**
+ * Build lookup structures for matching resolved file paths against an imports map.
+ *
+ * Returns:
+ * - `exactPaths`: Map from absolute path → `#key` for non-wildcard entries
+ * - `wildcardPatterns`: Array of regex patterns for wildcard (`*`) entries
+ */
+export function buildImportTargetIndex(
+  importsMap: ImportsMap,
+  packageRoot: string,
+): { exactPaths: Map<string, string>; wildcardPatterns: WildcardPattern[] } {
+  const exactPaths = new Map<string, string>();
+  const wildcardPatterns: WildcardPattern[] = [];
+  // Deduplicate wildcard regexes by their source string
+  const seenPatterns = new Set<string>();
+
+  function collectFromTarget(target: PackageTarget, key: string, hasWildcard: boolean): void {
+    if (target === null || target === undefined) return;
+    if (typeof target === "string") {
+      if (hasWildcard && target.includes("*")) {
+        // Convert wildcard target to regex: "./src/*-browser.mts" → /^\/abs\/src\/(.+)-browser\.mts$/
+        const abs = path.resolve(packageRoot, target);
+        const escaped = abs.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const regexSource = "^" + escaped.replace("\\*", "(.+)") + "$";
+        if (!seenPatterns.has(regexSource)) {
+          seenPatterns.add(regexSource);
+          wildcardPatterns.push({ regex: new RegExp(regexSource), key });
+        }
+      } else {
+        const abs = path.resolve(packageRoot, target);
+        exactPaths.set(abs, key);
+      }
+      return;
+    }
+    if (Array.isArray(target)) {
+      for (const item of target) collectFromTarget(item, key, hasWildcard);
+      return;
+    }
+    // Conditional object — recurse into all branches
+    for (const nested of Object.values(target)) {
+      collectFromTarget(nested, key, hasWildcard);
+    }
+  }
+
+  for (const [key, target] of Object.entries(importsMap)) {
+    const asteriskCount = (key.match(/\*/g) || []).length;
+    if (asteriskCount > 1) {
+      throw new Error(`Invalid imports key "${key}": must contain at most one asterisk`);
+    }
+    collectFromTarget(target, key, asteriskCount === 1);
+  }
+
+  return { exactPaths, wildcardPatterns };
+}
+
+/**
+ * Look up a resolved file path in the import target index.
+ * Returns the `#`-prefixed key if the path is a target, or undefined.
+ *
+ * For wildcard matches, the `*` in the returned key is replaced with the
+ * matched portion (e.g., `#platform/*` → `#platform/sha256`).
+ */
+function lookupImportTarget(
+  resolvedPath: string,
+  exactPaths: Map<string, string>,
+  wildcardPatterns: WildcardPattern[],
+): string | undefined {
+  // Fast exact check first
+  const exactKey = exactPaths.get(resolvedPath);
+  if (exactKey) return exactKey;
+
+  // Try wildcard patterns
+  for (const { regex, key } of wildcardPatterns) {
+    const match = resolvedPath.match(regex);
+    if (match && match[1]) {
+      // Replace * in key with matched portion
+      return key.replace("*", match[1]);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Collect all concrete file paths that appear as targets in an imports map.
+ *
+ * Returns a map from the normalized absolute path of each target file to the
+ * `#`-prefixed key that maps to it. Only includes non-wildcard entries.
+ *
+ * For wildcard-aware validation, use {@link buildImportTargetIndex} instead.
+ */
+export function collectImportTargetPaths(
+  importsMap: ImportsMap,
+  packageRoot: string,
+): Map<string, string> {
+  return buildImportTargetIndex(importsMap, packageRoot).exactPaths;
+}
+
+/**
+ * Walk a parsed source file and collect every relative module specifier
+ * (starting with `.`).
+ */
+function collectRelativeSpecifiers(sourceFile: ts.SourceFile): { text: string; line: number }[] {
+  const specifiers: { text: string; line: number }[] = [];
+
+  function visit(node: ts.Node): void {
+    let specNode: ts.StringLiteral | undefined;
+
+    if (
+      ts.isImportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specNode = node.moduleSpecifier;
+    } else if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specNode = node.moduleSpecifier;
+    } else if (ts.isCallExpression(node)) {
+      const expr = node.expression;
+      const firstArg = node.arguments[0];
+      if (
+        (expr.kind === ts.SyntaxKind.ImportKeyword ||
+          (ts.isIdentifier(expr) && expr.text === "require")) &&
+        firstArg &&
+        ts.isStringLiteral(firstArg)
+      ) {
+        specNode = firstArg;
+      }
+    }
+
+    if (specNode && specNode.text.startsWith(".")) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(specNode.getStart(sourceFile));
+      specifiers.push({ text: specNode.text, line: line + 1 });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return specifiers;
+}
+
+/**
+ * Resolve a relative import specifier to an absolute file path, trying
+ * TypeScript's extension resolution order.
+ */
+function resolveRelativeSpecifier(specifier: string, fromFile: string): string | undefined {
+  const dir = path.dirname(fromFile);
+  const base = path.resolve(dir, specifier);
+  const ext = path.extname(base);
+
+  // If the specifier already has a JS extension, map to corresponding TS extension
+  if (ext === ".js" || ext === ".mjs" || ext === ".cjs") {
+    const tsExt = ext === ".js" ? ".ts" : ext === ".mjs" ? ".mts" : ".cts";
+    const tsPath = base.slice(0, -ext.length) + tsExt;
+    // Only return if the TS file actually exists — avoids false positives
+    // when a .js file has no corresponding .ts source
+    return ts.sys.fileExists(tsPath) ? tsPath : undefined;
+  }
+  if (ext === ".ts" || ext === ".mts" || ext === ".cts") {
+    return base;
+  }
+
+  // No extension — try TypeScript extensions in order
+  for (const tryExt of [".ts", ".mts", ".cts"]) {
+    if (ts.sys.fileExists(base + tryExt)) return base + tryExt;
+  }
+  // Directory import → index file
+  for (const indexName of ["index.ts", "index.mts", "index.cts"]) {
+    const indexPath = path.join(base, indexName);
+    if (ts.sys.fileExists(indexPath)) return indexPath;
+  }
+  return undefined;
+}
+
+/**
+ * Collect all leaf string targets from a conditional target tree,
+ * applying wildcard substitution when patternMatch is set.
+ */
+function collectLeafTargets(target: PackageTarget, patternMatch: string | null): string[] {
+  if (target === null || target === undefined) return [];
+  if (typeof target === "string") {
+    return [patternMatch !== null ? target.replaceAll("*", patternMatch) : target];
+  }
+  if (Array.isArray(target)) {
+    return target.flatMap((t) => collectLeafTargets(t, patternMatch));
+  }
+  return Object.values(target).flatMap((t) => collectLeafTargets(t, patternMatch));
+}
+
+/**
+ * Check whether an imports map key has divergent resolutions — i.e., the
+ * conditional tree contains multiple distinct leaf targets.
+ *
+ * For wildcard entries, at least two variant files must exist on disk.
+ */
+function hasDivergentResolutions(
+  key: string,
+  importsMap: ImportsMap,
+  packageRoot: string,
+  isWildcard: boolean,
+  cache: Map<string, boolean>,
+): boolean {
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const entry = matchImportEntry(key, importsMap);
+  if (!entry) {
+    cache.set(key, false);
+    return false;
+  }
+
+  const leaves = collectLeafTargets(entry.target, entry.patternMatch);
+  const unique = new Set(leaves);
+  let result: boolean;
+  if (unique.size <= 1) {
+    result = false;
+  } else if (!isWildcard) {
+    result = true;
+  } else {
+    // For wildcards, count how many distinct leaf files exist on disk
+    let existCount = 0;
+    for (const leaf of unique) {
+      if (ts.sys.fileExists(path.resolve(packageRoot, leaf))) {
+        existCount++;
+        if (existCount >= 2) break;
+      }
+    }
+    result = existCount >= 2;
+  }
+
+  cache.set(key, result);
+  return result;
+}
+
+/**
+ * Validate that no source file directly imports a file that should be accessed
+ * via the `#imports` mechanism.
+ *
+ * Scans the provided source files for relative imports and checks whether any
+ * of them resolve to a file that is a target in the package's imports map.
+ *
+ * @param sourceFiles - Absolute paths of source files to scan
+ * @param importsMap - The package.json `imports` field
+ * @param packageRoot - Absolute path to the package root
+ * @returns Array of violations found
+ */
+export function validateNoDirectImports(
+  sourceFiles: readonly string[],
+  importsMap: ImportsMap,
+  packageRoot: string,
+): DirectImportViolation[] {
+  const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, packageRoot);
+  const divergenceCache = new Map<string, boolean>();
+  const violations: DirectImportViolation[] = [];
+
+  for (const filePath of sourceFiles) {
+    // Skip implementation files — files that are targets of import map entries
+    // with divergent resolutions. These files only run under their specific
+    // condition (e.g., Node default), so their direct imports to other
+    // same-condition files are correct.
+    const selfKey = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
+    if (selfKey) {
+      const selfIsWildcard = selfKey !== exactPaths.get(filePath);
+      if (
+        hasDivergentResolutions(selfKey, importsMap, packageRoot, selfIsWildcard, divergenceCache)
+      ) {
+        continue;
+      }
+    }
+
+    const content = ts.sys.readFile(filePath);
+    if (!content) continue;
+
+    // Quick check: skip files without any relative import
+    if (!content.includes("./") && !content.includes("../")) continue;
+
+    const sourceFile = ts.createSourceFile(
+      path.basename(filePath),
+      content,
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ false,
+    );
+
+    const relativeSpecifiers = collectRelativeSpecifiers(sourceFile);
+
+    for (const { text: specifier, line } of relativeSpecifiers) {
+      const resolved = resolveRelativeSpecifier(specifier, filePath);
+      if (!resolved) continue;
+
+      const key = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
+      if (!key) continue;
+
+      // Only flag if the imported target has divergent resolutions.
+      // For example, importing `./helper.js` is fine if `#platform/helper`
+      // has only a `default` entry and no condition-specific variants.
+      const isWildcard = key !== exactPaths.get(resolved);
+      if (!hasDivergentResolutions(key, importsMap, packageRoot, isWildcard, divergenceCache)) {
+        continue;
+      }
+
+      violations.push({
+        file: filePath,
+        specifier,
+        suggestedImport: key,
+        line,
+      });
+    }
+  }
+
+  return violations;
 }
 
 // ---------------------------------------------------------------------------

--- a/common/tools/warp/test/public/build.spec.ts
+++ b/common/tools/warp/test/public/build.spec.ts
@@ -186,8 +186,8 @@ describe("build (integration)", () => {
     );
 
     // 3 targets with different module formats — all will fail type-checking
-    // due to the type error above. Each forms a distinct group because
-    // groupBySignature includes module/moduleResolution in the signature.
+    // due to the type error above. Each has a distinct optionsSignature because
+    // module/moduleResolution are included in the type-check identity.
     const esmTsconfig = {
       compilerOptions: {
         outDir: "./dist/esm",

--- a/common/tools/warp/test/public/resolveImports.spec.ts
+++ b/common/tools/warp/test/public/resolveImports.spec.ts
@@ -12,6 +12,9 @@ import {
   resolveImportsInDir,
   sourcePathToOutputPath,
   buildConditionsSet,
+  collectImportTargetPaths,
+  buildImportTargetIndex,
+  validateNoDirectImports,
   build,
 } from "../../src/index.ts";
 import type { ImportsMap } from "../../src/index.ts";
@@ -882,6 +885,635 @@ describe("build fails on unresolved # specifiers", () => {
           type: "module",
           imports: {
             "#platform/*": { default: "./src/*.ts" },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await fs.writeFile(
+      path.join(tmpDir, "tsconfig.esm.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          declaration: true,
+          outDir: "./dist/esm",
+          rootDir: "./src",
+          lib: ["ES2022"],
+          types: ["node"],
+          skipLibCheck: true,
+        },
+        include: ["./src/**/*.ts"],
+      }),
+    );
+
+    await fs.writeFile(
+      path.join(tmpDir, "warp.config.yml"),
+      stringify({
+        exports: { ".": "./src/index.ts" },
+        targets: [
+          {
+            name: "esm",
+            condition: "import",
+            tsconfig: "./tsconfig.esm.json",
+          },
+        ],
+      }),
+    );
+
+    const result = await build({ cwd: tmpDir });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: collectImportTargetPaths
+// ---------------------------------------------------------------------------
+
+describe("collectImportTargetPaths", () => {
+  it("collects all target file paths from an imports map", () => {
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        browser: "./src/nodeTypes-browser.mts",
+        "react-native": "./src/nodeTypes-react-native.mts",
+        default: "./src/nodeTypes.ts",
+      },
+    };
+
+    const result = collectImportTargetPaths(importsMap, "/pkg");
+    expect(result.size).toBe(3);
+    expect(result.get(path.resolve("/pkg", "./src/nodeTypes-browser.mts"))).toBe(
+      "#platform/nodeTypes",
+    );
+    expect(result.get(path.resolve("/pkg", "./src/nodeTypes-react-native.mts"))).toBe(
+      "#platform/nodeTypes",
+    );
+    expect(result.get(path.resolve("/pkg", "./src/nodeTypes.ts"))).toBe("#platform/nodeTypes");
+  });
+
+  it("handles wildcard patterns — returns only exact paths", () => {
+    const importsMap: ImportsMap = {
+      "#platform/*": {
+        browser: "./src/*-browser.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const result = collectImportTargetPaths(importsMap, "/pkg");
+    // Wildcard targets are not included in the exact paths map
+    expect(result.size).toBe(0);
+  });
+
+  it("handles null targets (unmapped)", () => {
+    const importsMap: ImportsMap = {
+      "#internal": null,
+      "#mapped": "./src/mapped.ts",
+    };
+
+    const result = collectImportTargetPaths(importsMap, "/pkg");
+    expect(result.size).toBe(1);
+    expect(result.get(path.resolve("/pkg", "./src/mapped.ts"))).toBe("#mapped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: buildImportTargetIndex
+// ---------------------------------------------------------------------------
+
+describe("buildImportTargetIndex", () => {
+  it("separates exact and wildcard entries", () => {
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        browser: "./src/nodeTypes-browser.mts",
+        default: "./src/nodeTypes.ts",
+      },
+      "#platform/*": {
+        browser: "./src/*-browser.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, "/pkg");
+
+    // Exact: nodeTypes entries
+    expect(exactPaths.size).toBe(2);
+    expect(exactPaths.get(path.resolve("/pkg", "./src/nodeTypes-browser.mts"))).toBe(
+      "#platform/nodeTypes",
+    );
+    expect(exactPaths.get(path.resolve("/pkg", "./src/nodeTypes.ts"))).toBe("#platform/nodeTypes");
+
+    // Wildcard: 2 patterns (browser + default)
+    expect(wildcardPatterns.length).toBe(2);
+  });
+
+  it("wildcard patterns match concrete file paths", () => {
+    const importsMap: ImportsMap = {
+      "#platform/*": {
+        browser: "./src/*-browser.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const { wildcardPatterns } = buildImportTargetIndex(importsMap, "/pkg");
+
+    // The browser pattern should match a concrete browser file
+    const browserPattern = wildcardPatterns.find((p) => p.regex.source.includes("browser"));
+    expect(browserPattern).toBeDefined();
+    const browserMatch = path
+      .resolve("/pkg", "./src/sha256-browser.mts")
+      .match(browserPattern!.regex);
+    expect(browserMatch).toBeTruthy();
+    expect(browserMatch![1]).toBe("sha256");
+
+    // The default pattern should match a concrete ts file
+    const defaultPattern = wildcardPatterns.find((p) => !p.regex.source.includes("browser"));
+    expect(defaultPattern).toBeDefined();
+    const defaultMatch = path.resolve("/pkg", "./src/sha256.ts").match(defaultPattern!.regex);
+    expect(defaultMatch).toBeTruthy();
+    expect(defaultMatch![1]).toBe("sha256");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: validateNoDirectImports
+// ---------------------------------------------------------------------------
+
+describe("validateNoDirectImports", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    await fs.mkdir(path.join(tmpDir, "src"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("detects direct imports of files behind the imports map", async () => {
+    // Create files
+    await fs.writeFile(
+      path.join(tmpDir, "src/nodeTypes.ts"),
+      "export type NodeReadableStream = NodeJS.ReadableStream;\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import type { NodeReadableStream } from "./nodeTypes.js";\nexport type { NodeReadableStream };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        browser: "./src/nodeTypes-browser.mts",
+        default: "./src/nodeTypes.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe("./nodeTypes.js");
+    expect(violations[0].suggestedImport).toBe("#platform/nodeTypes");
+    expect(violations[0].line).toBe(1);
+  });
+
+  it("does not flag imports that are not in the imports map", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/utils.ts"), "export function foo() { return 42; }\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { foo } from "./utils.js";\nexport { foo };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        default: "./src/nodeTypes.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("skips files that are themselves import targets (platform impl files)", async () => {
+    // nodeTypes.ts is a target — its internal imports are platform-specific
+    // and should not be flagged (the platform condition ensures correctness).
+    await fs.writeFile(
+      path.join(tmpDir, "src/nodeTypes.ts"),
+      'import { helper } from "./helper.js";\nexport type NodeReadableStream = NodeJS.ReadableStream;\n',
+    );
+    await fs.writeFile(path.join(tmpDir, "src/helper.ts"), "export function helper() {}\n");
+
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        default: "./src/nodeTypes.ts",
+      },
+      "#platform/helper": {
+        default: "./src/helper.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/nodeTypes.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("skips wildcard platform files that have platform variants", async () => {
+    // createPipelineFromOptions.ts is a Node-only file behind #platform/*,
+    // and has a -web.mts variant. It should be allowed to import other defaults directly.
+    await fs.writeFile(
+      path.join(tmpDir, "src/createPipelineFromOptions.ts"),
+      'import { decompressResponsePolicy } from "./policies/decompressResponsePolicy.js";\nexport { decompressResponsePolicy };\n',
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/createPipelineFromOptions-web.mts"),
+      "export const decompressResponsePolicy = undefined;\n",
+    );
+    await fs.mkdir(path.join(tmpDir, "src/policies"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "src/policies/decompressResponsePolicy.ts"),
+      "export function decompressResponsePolicy() {}\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/policies/decompressResponsePolicy-web.mts"),
+      "export function decompressResponsePolicy() {}\n",
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/*": {
+        browser: "./src/*-web.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/createPipelineFromOptions.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects .mts extension imports", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/nodeTypes-browser.mts"), "export const foo = 42;\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { foo } from "./nodeTypes-browser.mjs";\nexport { foo };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        browser: "./src/nodeTypes-browser.mts",
+        default: "./src/nodeTypes.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe("./nodeTypes-browser.mjs");
+    expect(violations[0].suggestedImport).toBe("#platform/nodeTypes");
+  });
+
+  it("detects dynamic imports", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "src/nodeTypes.ts"),
+      "export type NodeReadableStream = NodeJS.ReadableStream;\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'const mod = await import("./nodeTypes.js");\nexport default mod;\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/nodeTypes": {
+        browser: "./src/nodeTypes-browser.mts",
+        default: "./src/nodeTypes.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].suggestedImport).toBe("#platform/nodeTypes");
+  });
+
+  it("detects violations against wildcard imports map entries", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/sha256.ts"), "export function sha256() {}\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/sha256-browser.mts"),
+      "export function sha256() {}\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { sha256 } from "./sha256.js";\nexport { sha256 };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/*": {
+        browser: "./src/*-browser.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe("./sha256.js");
+    expect(violations[0].suggestedImport).toBe("#platform/sha256");
+  });
+
+  it("detects violations against wildcard browser variant imports", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/sha256.ts"), "export function sha256() {}\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/sha256-browser.mts"),
+      "export function sha256() {}\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { sha256 } from "./sha256-browser.mjs";\nexport { sha256 };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/*": {
+        browser: "./src/*-browser.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe("./sha256-browser.mjs");
+    expect(violations[0].suggestedImport).toBe("#platform/sha256");
+  });
+
+  it("does not flag when imports map entry has only a default (no divergence)", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/helper.ts"), "export function helper() {}\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { helper } from "./helper.js";\nexport { helper };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#internal/helper": {
+        default: "./src/helper.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects require/import condition divergence (non-platform)", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/state.ts"), "export const state = {};\n");
+    await fs.writeFile(path.join(tmpDir, "src/state-cjs.cts"), "exports.state = {};\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { state } from "./state.js";\nexport { state };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#state": {
+        require: "./src/state-cjs.cts",
+        default: "./src/state.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].suggestedImport).toBe("#state");
+  });
+
+  it("detects divergence from node condition", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/fetch.ts"), "export function fetch() {}\n");
+    await fs.writeFile(path.join(tmpDir, "src/fetch-node.mts"), "export function fetch() {}\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { fetch } from "./fetch.js";\nexport { fetch };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/fetch": {
+        node: "./src/fetch-node.mts",
+        default: "./src/fetch.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].suggestedImport).toBe("#platform/fetch");
+  });
+
+  it("handles nested condition objects", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/auth.ts"), "export function auth() {}\n");
+    await fs.writeFile(path.join(tmpDir, "src/auth-browser.mts"), "export function auth() {}\n");
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { auth } from "./auth.js";\nexport { auth };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/auth": {
+        import: {
+          browser: "./src/auth-browser.mts",
+          default: "./src/auth.ts",
+        },
+        default: "./src/auth.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].suggestedImport).toBe("#platform/auth");
+  });
+
+  it("does not flag wildcard default import when variant does not exist on disk", async () => {
+    await fs.writeFile(path.join(tmpDir, "src/utils.ts"), "export function utils() {}\n");
+    // Note: no utils-browser.mts on disk
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { utils } from "./utils.js";\nexport { utils };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/*": {
+        browser: "./src/*-browser.mts",
+        default: "./src/*.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("self-skips require variant files (non-platform divergence)", async () => {
+    // state-cjs.cts is itself behind #state with require/default divergence.
+    // Its internal imports should be skipped.
+    await fs.writeFile(
+      path.join(tmpDir, "src/state-cjs.cts"),
+      'import { helper } from "./helper.js";\nexport { helper };\n',
+    );
+    await fs.writeFile(path.join(tmpDir, "src/state.ts"), "export const state = {};\n");
+    await fs.writeFile(path.join(tmpDir, "src/helper.ts"), "export function helper() {}\n");
+
+    const importsMap: ImportsMap = {
+      "#state": {
+        require: "./src/state-cjs.cts",
+        default: "./src/state.ts",
+      },
+      "#helper": {
+        require: "./src/helper-cjs.cts",
+        default: "./src/helper.ts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/state-cjs.cts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("resolves directory imports via index.mts", async () => {
+    await fs.mkdir(path.join(tmpDir, "src/platform"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "src/platform/index.mts"),
+      "export function platform() {}\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/platform/index-browser.mts"),
+      "export function platform() {}\n",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src/consumer.ts"),
+      'import { platform } from "./platform";\nexport { platform };\n',
+    );
+
+    const importsMap: ImportsMap = {
+      "#platform/entry": {
+        browser: "./src/platform/index-browser.mts",
+        default: "./src/platform/index.mts",
+      },
+    };
+
+    const violations = validateNoDirectImports(
+      [path.join(tmpDir, "src/consumer.ts")],
+      importsMap,
+      tmpDir,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].suggestedImport).toBe("#platform/entry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test: build fails on direct import bypass
+// ---------------------------------------------------------------------------
+
+describe("build fails on direct imports bypassing #imports", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fails the build when a source file directly imports a file behind #imports", async () => {
+    const srcDir = path.join(tmpDir, "src");
+    await fs.mkdir(srcDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(srcDir, "nodeTypes.ts"),
+      "export type NodeReadableStream = NodeJS.ReadableStream;\n",
+    );
+    await fs.writeFile(
+      path.join(srcDir, "nodeTypes-browser.mts"),
+      "export type NodeReadableStream = never;\n",
+    );
+    // Bad import — directly references nodeTypes.ts instead of #platform/nodeTypes
+    await fs.writeFile(
+      path.join(srcDir, "index.ts"),
+      [
+        'import type { NodeReadableStream } from "./nodeTypes.js";',
+        "export type { NodeReadableStream };",
+        "",
+      ].join("\n"),
+    );
+
+    await fs.writeFile(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "test-direct-import-bypass",
+          type: "module",
+          imports: {
+            "#platform/nodeTypes": {
+              browser: "./src/nodeTypes-browser.mts",
+              default: "./src/nodeTypes.ts",
+            },
           },
         },
         null,


### PR DESCRIPTION
## Problem

When a package uses `#imports` (subpath imports in package.json) for platform abstraction (e.g. `#platform/nodeTypes`), there's no enforcement preventing source files from directly importing the platform-specific implementation files (e.g. `import "./nodeTypes.js"` instead of `import "#platform/nodeTypes"`). This silently bypasses the platform abstraction, causing wrong code to be bundled for browser/react-native targets.

## Solution

Add a build-time validation step (`validateNoDirectImports`) that detects source files importing platform implementation files directly instead of through `#imports` subpath specifiers.

### How it works

1. After config parse, warp reads the package.json `imports` field
2. `buildImportTargetIndex` collects all file paths that are targets of `#imports` mappings
3. `collectImportTargetPaths` scans source files for import specifiers that resolve to those target files
4. If any direct imports are found, the build fails with a clear error message showing the file, line, specifier, and suggested `#`-prefixed alternative

### Example output

```
[warp] Found 1 direct import(s) bypassing the #imports mechanism:
  src/index.ts:1  ./nodeTypes.js  →  use #platform/nodeTypes

[warp] These files are mapped via package.json "imports". Use the #-prefixed
specifier to ensure correct platform-specific resolution.
```

## Changes

- `resolveImports.ts`: Add `validateNoDirectImports`, `collectImportTargetPaths`, `buildImportTargetIndex`
- `build.ts`: Integrate validation into build pipeline (Step 1b, after config parse)
- `index.ts`: Export new helpers
- `resolveImports.spec.ts`: 9 new tests covering direct import detection
