### PR TITLE
[test] Fix swapped assertion arguments across test files

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/helpers.spec.ts
@@ -82,13 +82,13 @@ describe("helper methods", () => {
 
   describe("quoteETag", () => {
     it("undefined", () => {
-      assert.equal(undefined, quoteETag(undefined));
+      assert.equal(quoteETag(undefined), undefined);
 
-      assert.equal('"etagishere"', quoteETag("etagishere"));
+      assert.equal(quoteETag("etagishere"), '"etagishere"');
 
-      assert.equal("'etagishere'", quoteETag("'etagishere'"));
+      assert.equal(quoteETag("'etagishere'"), "'etagishere'");
 
-      assert.equal("*", quoteETag("*"));
+      assert.equal(quoteETag("*"), "*");
     });
   });
 
@@ -109,8 +109,8 @@ describe("helper methods", () => {
         labelFilter: "label1",
       });
 
-      assert.equal("key1", result.key);
-      assert.equal("label1", result.label);
+      assert.equal(result.key, "key1");
+      assert.equal(result.label, "label1");
     });
 
     it("multiple values", () => {
@@ -119,8 +119,8 @@ describe("helper methods", () => {
         labelFilter: "label1,label2",
       });
 
-      assert.equal("key1,key2", result.key);
-      assert.equal("label1,label2", result.label);
+      assert.equal(result.key, "key1,key2");
+      assert.equal(result.label, "label1,label2");
     });
 
     it("fields map properly", () => {
@@ -128,14 +128,14 @@ describe("helper methods", () => {
         fields: ["isReadOnly", "value"],
       });
 
-      assert.deepEqual(["locked", "value"], result.select);
+      assert.deepEqual(result.select, ["locked", "value"]);
     });
   });
 
   describe("extractAfterTokenFromNextLink", () => {
     it("token is extracted and properly unescaped", () => {
       const token = extractAfterTokenFromNextLink("/kv?key=someKey&api-version=1.0&after=bGlah%3D");
-      assert.equal("bGlah=", token);
+      assert.equal(token, "bGlah=");
     });
 
     it("extractAfterTokenFromLinkHeader", () => {
@@ -228,7 +228,7 @@ describe("helper methods", () => {
     makeConfigurationSettingEmpty(response);
 
     // key isn't touched
-    assert.equal("mykey", response.key);
+    assert.equal(response.key, "mykey");
 
     for (const name of getAllConfigurationSettingFieldsMinusKey()) {
       assert.ok(!response[name], name);
@@ -237,8 +237,8 @@ describe("helper methods", () => {
     // These point is these properties are untouched and won't throw
     // since they're the only properties the user is allowed to touch on these
     // "body empty" objects.
-    assert.equal(204, response._response.status);
-    assert.equal(204, response.statusCode);
+    assert.equal(response._response.status, 204);
+    assert.equal(response.statusCode, 204);
   });
 
   it("transformKeyValue", () => {

--- a/sdk/appconfiguration/app-configuration/test/internal/node/http.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/internal/node/http.spec.ts
@@ -42,20 +42,20 @@ describe("http request related tests", () => {
         syncTokens.addSyncTokenFromHeaderValue("a=value;sn=0");
 
         // note that 'sn' is purposefully not serialized
-        assert.equal("a=value", syncTokens.getSyncTokenHeaderValue());
+        assert.equal(syncTokens.getSyncTokenHeaderValue(), "a=value");
 
         syncTokens.addSyncTokenFromHeaderValue("b=value2;sn=0");
-        assert.equal("a=value,b=value2", splitAndSort(syncTokens.getSyncTokenHeaderValue()));
+        assert.equal(splitAndSort(syncTokens.getSyncTokenHeaderValue()), "a=value,b=value2");
 
         // now we'll rev the sequence number field - it should overwrite the original value
         // for b
         syncTokens.addSyncTokenFromHeaderValue("b=value2.1;sn=1");
-        assert.equal("a=value,b=value2.1", splitAndSort(syncTokens.getSyncTokenHeaderValue()));
+        assert.equal(splitAndSort(syncTokens.getSyncTokenHeaderValue()), "a=value,b=value2.1");
 
         // sending in an older version of an existing key should do nothing
         syncTokens.addSyncTokenFromHeaderValue("b=value2.1;sn=0");
         // note that 'b' didn't change
-        assert.equal("a=value,b=value2.1", splitAndSort(syncTokens.getSyncTokenHeaderValue()));
+        assert.equal(splitAndSort(syncTokens.getSyncTokenHeaderValue()), "a=value,b=value2.1");
 
         // and sending in multiple values acts the same as passing them in one
         // at a time.

--- a/sdk/appconfiguration/app-configuration/test/public/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/etags.spec.ts
@@ -125,7 +125,7 @@ describe("etags", () => {
       "New content, new update, etags shouldn't match",
     );
 
-    assert.equal(200, updatedSetting.statusCode);
+    assert.equal(updatedSetting.statusCode, 200);
 
     // only get the setting if it changed (it has!)
     const configurationSetting = await client.getConfigurationSetting(originalSetting, {
@@ -133,7 +133,7 @@ describe("etags", () => {
     });
 
     // now our retrieved setting matches what's on the server
-    assert.equal("new world", configurationSetting.value);
+    assert.equal(configurationSetting.value, "new world");
     assert.equal(updatedSetting.etag, configurationSetting.etag);
   });
 

--- a/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/index.spec.ts
@@ -220,7 +220,7 @@ describe("AppConfigurationClient", () => {
 
       // delete configuration
       const deletedSetting = await client.deleteConfigurationSetting(result);
-      assert.equal(200, deletedSetting.statusCode);
+      assert.equal(deletedSetting.statusCode, 200);
 
       // confirm setting no longer exists
       try {
@@ -286,7 +286,7 @@ describe("AppConfigurationClient", () => {
       // delete actually happened (status code: 200) or if the setting wasn't
       // found which results in the same state but might matter to
       // the user(status code: 204)
-      assert.equal(204, response.statusCode);
+      assert.equal(response.statusCode, 204);
     });
 
     it("throws when deleting a configuration setting (invalid etag)", async () => {
@@ -497,7 +497,7 @@ describe("AppConfigurationClient", () => {
         },
       );
 
-      assert.equal("value1", settingAtPointInTime.value);
+      assert.equal(settingAtPointInTime.value, "value1");
     });
 
     it("Using `select` via `fields`", async () => {
@@ -962,7 +962,7 @@ describe("AppConfigurationClient", () => {
 
       // the fields we retrieved
       assert.equal(productionASettingId.key, settings[0].key);
-      assert.equal("[A] production value", settings[0].value);
+      assert.equal(settings[0].value, "[A] production value");
       assert.equal(uniqueLabel, settings[0].label);
 
       assert.ok(!settings[0].isReadOnly);

--- a/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/throwOrNotThrow.spec.ts
@@ -110,7 +110,7 @@ describe("Various error cases", () => {
         onlyIfChanged: true,
       });
 
-      assert.equal(304, response.statusCode);
+      assert.equal(response.statusCode, 304);
       assert.ok(!response.value);
     });
 

--- a/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTokenTests.spec.ts
@@ -26,14 +26,14 @@ describe("AttestationTokenTests", () => {
 
   it("#testUtf8ConversionFunctions", async () => {
     const buffer = stringToBytes("ABCDEF");
-    assert.equal(65, buffer[0]);
-    assert.equal(66, buffer[1]);
-    assert.equal(67, buffer[2]);
-    assert.equal(68, buffer[3]);
-    assert.equal(69, buffer[4]);
+    assert.equal(buffer[0], 65);
+    assert.equal(buffer[1], 66);
+    assert.equal(buffer[2], 67);
+    assert.equal(buffer[3], 68);
+    assert.equal(buffer[4], 69);
 
     const str = bytesToString(buffer);
-    assert.equal("ABCDEF", str);
+    assert.equal(str, "ABCDEF");
   });
 
   it("#createRsaSigningKey", async () => {
@@ -78,8 +78,8 @@ describe("AttestationTokenTests", () => {
     const token = AttestationTokenImpl.create({ body: sourceObject });
 
     const body = token.getBody();
-    assert.deepEqual({ foo: "foo", bar: 10 }, body);
-    assert.equal("none", token.algorithm);
+    assert.deepEqual(body, { foo: "foo", bar: 10 });
+    assert.equal(token.algorithm, "none");
   });
 
   /**
@@ -92,7 +92,7 @@ describe("AttestationTokenTests", () => {
     assert("eyJhbGciOiJub25lIn0..", token.serialize());
     const body = token.getBody();
     assert.isNull(body);
-    assert.equal("none", token.algorithm);
+    assert.equal(token.algorithm, "none");
   });
 
   /**
@@ -104,8 +104,8 @@ describe("AttestationTokenTests", () => {
 
     const token = AttestationTokenImpl.create({ privateKey: privKey, certificate: cert });
 
-    assert.notEqual("none", token.algorithm);
-    assert.equal(1, token.certificateChain?.certificates.length);
+    assert.notEqual(token.algorithm, "none");
+    assert.equal(token.certificateChain?.certificates.length, 1);
     if (token.certificateChain) {
       const pemCert: string = token.certificateChain.certificates[0];
 
@@ -119,7 +119,7 @@ describe("AttestationTokenTests", () => {
     }
 
     // The token of course should validate.
-    assert.deepEqual([], token.getTokenProblems());
+    assert.deepEqual(token.getTokenProblems(), []);
   });
 
   /**
@@ -153,7 +153,7 @@ describe("AttestationTokenTests", () => {
     const body = token.getBody();
     expect(sourceObject).to.deep.equal(body);
     assert.deepEqual(sourceObject, body);
-    assert.notEqual("none", token.algorithm);
+    assert.notEqual(token.algorithm, "none");
 
     expect(token.issuedAt?.getTime()).to.equal(currentDate.getTime());
     expect(token.notBefore?.getTime()).to.equal(currentDate.getTime());

--- a/sdk/core/core-client/test/serializer.spec.ts
+++ b/sdk/core/core-client/test/serializer.spec.ts
@@ -1401,8 +1401,8 @@ describe("Serializer", function () {
           "",
         );
 
-        assert.strictEqual("shark", result.fishtype);
-        assert.strictEqual(10, result.age);
+        assert.strictEqual(result.fishtype, "shark");
+        assert.strictEqual(result.age, 10);
       });
 
       it("should be deserialized properly when polymorphicDiscriminator specified in nested property", function () {
@@ -1479,10 +1479,10 @@ describe("Serializer", function () {
           "",
         );
 
-        assert.strictEqual("shark", result.fishtype);
-        assert.strictEqual(10, result.age);
-        assert.strictEqual("shark", result.sibling.fishtype);
-        assert.strictEqual(15, result.sibling.age);
+        assert.strictEqual(result.fishtype, "shark");
+        assert.strictEqual(result.age, 10);
+        assert.strictEqual(result.sibling.fishtype, "shark");
+        assert.strictEqual(result.sibling.age, 15);
       });
 
       it("should be deserialized properly when polymorphicDiscriminator specified in the parent", function () {
@@ -1555,10 +1555,10 @@ describe("Serializer", function () {
           "",
         );
 
-        assert.strictEqual("shark", result.fishtype);
-        assert.strictEqual(10, result.age);
-        assert.strictEqual("shark", result.sibling.fishtype);
-        assert.strictEqual(15, result.sibling.age);
+        assert.strictEqual(result.fishtype, "shark");
+        assert.strictEqual(result.age, 10);
+        assert.strictEqual(result.sibling.fishtype, "shark");
+        assert.strictEqual(result.sibling.age, 15);
       });
 
       it("should be deserialized properly when responseBody is an empty string", function () {

--- a/sdk/cosmosdb/cosmos/test/internal/unit/inMemoryCollectionRoutingMap.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/inMemoryCollectionRoutingMap.spec.ts
@@ -104,18 +104,18 @@ describe("InMemoryCollectionRoutingMap Tests", () => {
     const collectionRoutingMap = createCompleteRoutingMap(partitionRangeWithInfo);
 
     it("validate _orderedPartitionKeyRanges", () => {
-      assert.equal("0", collectionRoutingMap.getOrderedParitionKeyRanges()[0].id);
-      assert.equal("1", collectionRoutingMap.getOrderedParitionKeyRanges()[1].id);
-      assert.equal("2", collectionRoutingMap.getOrderedParitionKeyRanges()[2].id);
-      assert.equal("3", collectionRoutingMap.getOrderedParitionKeyRanges()[3].id);
+      assert.equal(collectionRoutingMap.getOrderedParitionKeyRanges()[0].id, "0");
+      assert.equal(collectionRoutingMap.getOrderedParitionKeyRanges()[1].id, "1");
+      assert.equal(collectionRoutingMap.getOrderedParitionKeyRanges()[2].id, "2");
+      assert.equal(collectionRoutingMap.getOrderedParitionKeyRanges()[3].id, "3");
     });
 
     // TODO: bad practice to test implementation details
     it("validate _orderedPartitionInfo", () => {
-      assert.equal(0, (collectionRoutingMap.orderedPartitionInfo as number[])[0]);
-      assert.equal(1, (collectionRoutingMap.orderedPartitionInfo as number[])[1]);
-      assert.equal(2, (collectionRoutingMap.orderedPartitionInfo as number[])[2]);
-      assert.equal(3, (collectionRoutingMap.orderedPartitionInfo as number[])[3]);
+      assert.equal((collectionRoutingMap.orderedPartitionInfo as number[])[0], 0);
+      assert.equal((collectionRoutingMap.orderedPartitionInfo as number[])[1], 1);
+      assert.equal((collectionRoutingMap.orderedPartitionInfo as number[])[2], 2);
+      assert.equal((collectionRoutingMap.orderedPartitionInfo as number[])[3], 3);
     });
 
     it("validate getOverlappingRanges", () => {
@@ -129,7 +129,7 @@ describe("InMemoryCollectionRoutingMap Tests", () => {
       const overlappingRanges = collectionRoutingMap
         .getOverlappingRanges([completeRange])
         .sort(compareId);
-      assert.equal(4, overlappingRanges.length);
+      assert.equal(overlappingRanges.length, 4);
 
       let onlyParitionRanges = partitionRangeWithInfo.map(function (item) {
         return item[0];
@@ -139,12 +139,12 @@ describe("InMemoryCollectionRoutingMap Tests", () => {
       assert.deepEqual(overlappingRanges, onlyParitionRanges);
 
       const noPoint = new QueryRange("", "", false, false);
-      assert.equal(0, collectionRoutingMap.getOverlappingRanges([noPoint]).length);
+      assert.equal(collectionRoutingMap.getOverlappingRanges([noPoint]).length, 0);
 
       const onePoint = new QueryRange("0000000040", "0000000040", true, true);
       let overlappingPartitionKeyRanges = collectionRoutingMap.getOverlappingRanges([onePoint]);
-      assert.equal(1, overlappingPartitionKeyRanges.length);
-      assert.equal("1", overlappingPartitionKeyRanges[0].id);
+      assert.equal(overlappingPartitionKeyRanges.length, 1);
+      assert.equal(overlappingPartitionKeyRanges[0].id, "1");
 
       const ranges = [
         new QueryRange("0000000040", "0000000045", true, true),
@@ -155,9 +155,9 @@ describe("InMemoryCollectionRoutingMap Tests", () => {
         .getOverlappingRanges(ranges)
         .sort(compareId);
 
-      assert.equal(2, overlappingPartitionKeyRanges.length);
-      assert.equal("1", overlappingPartitionKeyRanges[0].id);
-      assert.equal("2", overlappingPartitionKeyRanges[1].id);
+      assert.equal(overlappingPartitionKeyRanges.length, 2);
+      assert.equal(overlappingPartitionKeyRanges[0].id, "1");
+      assert.equal(overlappingPartitionKeyRanges[1].id, "2");
     });
   });
 

--- a/sdk/cosmosdb/cosmos/test/internal/unit/sessionContainer.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/internal/unit/sessionContainer.spec.ts
@@ -92,6 +92,6 @@ describe("SessionContainer", () => {
     // Remove tokens and get new token, should be empty
     sc.remove(nameBasedRequest);
     const emptyTokenString = sc.get(nameBasedRequest);
-    assert.equal("", emptyTokenString, "Session token string must be empty after removal");
+    assert.equal(emptyTokenString, "", "Session token string must be empty after removal");
   });
 });

--- a/sdk/cosmosdb/cosmos/test/public/functional/clientSideEncryption.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/clientSideEncryption.spec.ts
@@ -1020,7 +1020,7 @@ describe("ClientSideEncryption", () => {
       partitionKey,
     );
     assert.equal(StatusCodes.Conflict, response.result[0].statusCode);
-    assert.equal(1, response.result.length);
+    assert.equal(response.result.length, 1);
   });
 
   it("encryption patch items", async () => {

--- a/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/container.spec.ts
@@ -69,7 +69,7 @@ describe("Containers", { timeout: 10000 }, () => {
       );
       const container = database.container(containerDef.id);
       assert.equal(containerDefinition.id, containerDef.id);
-      assert.equal("consistent", containerDef.indexingPolicy.indexingMode);
+      assert.equal(containerDef.indexingPolicy.indexingMode, "consistent");
       if (containerDef.partitionKey) {
         const comparePaths =
           typeof containerDefinition.partitionKey === "string"
@@ -436,7 +436,7 @@ describe("Containers", { timeout: 10000 }, () => {
         "Unexpected includedPaths length",
       );
       // The first included path is what we created.
-      assert.equal("/*", containerWithIndexingPolicyDef.indexingPolicy.includedPaths[0].path);
+      assert.equal(containerWithIndexingPolicyDef.indexingPolicy.includedPaths[0].path, "/*");
       // And two excluded paths.
       assert.equal(
         2,
@@ -448,15 +448,15 @@ describe("Containers", { timeout: 10000 }, () => {
         containerWithIndexingPolicyDef.indexingPolicy.excludedPaths[0].path,
       );
       // Check for composite Index metrics
-      assert.equal("/a", containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[0][0].path);
-      assert.equal("/b", containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[0][1].path);
-      assert.equal("/c", containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[1][0].path);
-      assert.equal("/d", containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[1][1].path);
+      assert.equal(containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[0][0].path, "/a");
+      assert.equal(containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[0][1].path, "/b");
+      assert.equal(containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[1][0].path, "/c");
+      assert.equal(containerWithIndexingPolicyDef.indexingPolicy.compositeIndexes[1][1].path, "/d");
     });
 
     const checkDefaultIndexingPolicyPaths = function (indexingPolicy: IndexingPolicy): void {
-      assert.equal(1, indexingPolicy["excludedPaths"].length);
-      assert.equal(1, indexingPolicy["includedPaths"].length);
+      assert.equal(indexingPolicy["excludedPaths"].length, 1);
+      assert.equal(indexingPolicy["includedPaths"].length, 1);
 
       let rootIncludedPath: IndexedPath = null;
       if (indexingPolicy["includedPaths"][0]["path"] === "/*") {

--- a/sdk/cosmosdb/cosmos/test/public/functional/database.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/database.spec.ts
@@ -154,7 +154,7 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
         await client.databases.create({ id: "id_ends_with_space " });
         assert.fail("Must throw if id ends with a space");
       } catch (err: any) {
-        assert.equal("Id ends with a space.", err.message);
+        assert.equal(err.message, "Id ends with a space.");
       }
     });
 
@@ -164,7 +164,7 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
         await client.databases.create({ id: "id_with_illegal/_char" });
         assert.fail("Must throw if id has illegal characters");
       } catch (err: any) {
-        assert.equal("Id contains illegal chars.", err.message);
+        assert.equal(err.message, "Id contains illegal chars.");
       }
     });
 
@@ -174,7 +174,7 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
         await client.databases.create({ id: "id_with_illegal\\_char" });
         assert.fail("Must throw if id contains illegal characters");
       } catch (err: any) {
-        assert.equal("Id contains illegal chars.", err.message);
+        assert.equal(err.message, "Id contains illegal chars.");
       }
     });
 
@@ -184,7 +184,7 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
         await client.databases.create({ id: "id_with_illegal?_?char" });
         assert.fail("Must throw if id contains illegal characters");
       } catch (err: any) {
-        assert.equal("Id contains illegal chars.", err.message);
+        assert.equal(err.message, "Id contains illegal chars.");
       }
     });
 
@@ -194,7 +194,7 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
         await client.databases.create({ id: "id_with_illegal#_char" });
         assert.fail("Must throw if id contains illegal characters");
       } catch (err: any) {
-        assert.equal("Id contains illegal chars.", err.message);
+        assert.equal(err.message, "Id contains illegal chars.");
       }
     });
   });

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
@@ -67,7 +67,7 @@ const executeTestCase = async function (
       console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
       assert.strictEqual(err.code, scenario.expectedCreateStatusCode);
     } else {
-      assert.strictEqual(400, scenario.expectedCreateStatusCode);
+      assert.strictEqual(scenario.expectedCreateStatusCode, 400);
       if (err) {
         assert.strictEqual(err.message, scenario.expectedCreateErrorMessage);
       }

--- a/sdk/cosmosdb/cosmos/test/public/functional/spatial.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/spatial.spec.ts
@@ -58,8 +58,8 @@ describe("Spatial Indexes", { timeout: 10000 }, () => {
     const query =
       "SELECT * FROM root WHERE (ST_DISTANCE(root.Location, {type: 'Point', coordinates: [20.1, 20]}) < 20000) ";
     const { resources: results } = await container.items.query(query).fetchAll();
-    assert.equal(1, results.length);
-    assert.equal("location1", results[0].id);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, "location1");
   };
 
   it("nativeApi Should support spatial index name based", async () => {

--- a/sdk/cosmosdb/cosmos/test/public/integration/authorization.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/integration/authorization.spec.ts
@@ -122,7 +122,7 @@ describe("Authorization", { timeout: 10000 }, () => {
       permissionFeed: [collReadPermission],
       connectionPolicy: { enableBackgroundEndpointRefreshing: false },
     });
-    assert.equal("document1", createdDoc.id, "invalid documnet create");
+    assert.equal(createdDoc.id, "document1", "invalid documnet create");
 
     const { resource: readDoc } = await clientReadPermission
       .database(database.id)

--- a/sdk/deviceupdate/iot-device-update-rest/test/public/management.spec.ts
+++ b/sdk/deviceupdate/iot-device-update-rest/test/public/management.spec.ts
@@ -33,7 +33,7 @@ describe("device and deployment test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get device not found", async () => {
@@ -55,7 +55,7 @@ describe("device and deployment test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get group", async () => {
@@ -69,7 +69,7 @@ describe("device and deployment test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get group not found", async () => {
@@ -91,7 +91,7 @@ describe("device and deployment test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get device class not found", async () => {
@@ -121,7 +121,7 @@ describe("device and deployment test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("list best updates for group not found", async () => {
@@ -151,7 +151,7 @@ describe("device and deployment test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("list deployments for group not found", { timeout: 600000 }, async () => {

--- a/sdk/deviceupdate/iot-device-update-rest/test/public/update.spec.ts
+++ b/sdk/deviceupdate/iot-device-update-rest/test/public/update.spec.ts
@@ -35,7 +35,7 @@ describe("update test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("list names", async () => {
@@ -53,7 +53,7 @@ describe("update test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get name not found", async () => {
@@ -80,7 +80,7 @@ describe("update test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get version not found", async () => {
@@ -113,7 +113,7 @@ describe("update test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("get update not found", async () => {
@@ -147,7 +147,7 @@ describe("update test", () => {
       );
     }
 
-    assert.equal("200", response.status);
+    assert.equal(response.status, "200");
   });
 
   it("list files not found", { timeout: 600000 }, async () => {

--- a/sdk/easm/defender-easm-rest/test/public/assetsTest.spec.ts
+++ b/sdk/easm/defender-easm-rest/test/public/assetsTest.spec.ts
@@ -92,8 +92,8 @@ describe("Assets Test", () => {
 
     const task_response = assetPageResponse.body;
 
-    assert.strictEqual("complete", task_response.state);
-    assert.strictEqual("complete", task_response.phase);
+    assert.strictEqual(task_response.state, "complete");
+    assert.strictEqual(task_response.phase, "complete");
     assert.isNotEmpty(task_response.id?.match(UUID_REGEX));
   });
 });

--- a/sdk/easm/defender-easm-rest/test/public/savedFiltersTest.spec.ts
+++ b/sdk/easm/defender-easm-rest/test/public/savedFiltersTest.spec.ts
@@ -91,7 +91,7 @@ describe("Saved Filters Test", () => {
     assert.strictEqual(put_saved_filter_name, saved_filter.name);
     assert.strictEqual(put_saved_filter_name, saved_filter.id);
     // assert.strictEqual(put_saved_filter_name, saved_filter.displayName);
-    assert.strictEqual("Sample description", saved_filter.description);
+    assert.strictEqual(saved_filter.description, "Sample description");
   });
 
   it("Should delete a saved filter", async () => {

--- a/sdk/eventgrid/eventgrid-namespaces/test/public/eventGridNamespacesClient.spec.ts
+++ b/sdk/eventgrid/eventgrid-namespaces/test/public/eventGridNamespacesClient.spec.ts
@@ -114,7 +114,7 @@ describe("Event Grid Namespace Client", () => {
         maxEvents: 2,
       });
 
-      assert.equal(2, receiveResult.details.length);
+      assert.equal(receiveResult.details.length, 2);
 
       const deserializer: EventGridDeserializer = new EventGridDeserializer();
       for (const value of receiveResult.details) {

--- a/sdk/healthdataaiservices/health-deidentification-rest/test/public/jobOperationsTest.spec.ts
+++ b/sdk/healthdataaiservices/health-deidentification-rest/test/public/jobOperationsTest.spec.ts
@@ -74,7 +74,7 @@ describe("Batch", () => {
       assert.isNotNull(jobOutput.body.createdAt, "Job should have createdAt");
       assert.isNotNull(jobOutput.body.lastUpdatedAt, "Job should have lastUpdatedAt");
       assert.isUndefined(jobOutput.body.startedAt, "Job should not have startedAt");
-      assert.equal("NotStarted", jobOutput.body.status, "Job status should be NotStarted");
+      assert.equal(jobOutput.body.status, "NotStarted", "Job status should be NotStarted");
       assert.isUndefined(jobOutput.body.error, "Job should not have error");
       assert.isUndefined(
         jobOutput.body.customizations?.redactionFormat,
@@ -138,7 +138,7 @@ describe("Batch", () => {
       assert.isNotNull(foundJob!.createdAt, "Job should have createdAt");
       assert.isNotNull(foundJob!.lastUpdatedAt, "Job should have lastUpdatedAt");
       assert.isNotNull(foundJob!.startedAt, "Job should have startedAt");
-      assert.equal("NotStarted", foundJob!.status, "Job status should be NotStarted");
+      assert.equal(foundJob!.status, "NotStarted", "Job status should be NotStarted");
       assert.isUndefined(foundJob!.error, "Job should not have error");
       assert.isUndefined(
         foundJob!.customizations?.redactionFormat,
@@ -278,7 +278,7 @@ describe("Batch", () => {
       assert.equal(cancelledJob.status, "200", "Job should be canceled");
 
       const cancelledJobOutput = cancelledJob.body as DeidentificationJobOutput;
-      assert.equal("Canceled", cancelledJobOutput.status, "Job status should be Canceled");
+      assert.equal(cancelledJobOutput.status, "Canceled", "Job status should be Canceled");
 
       const deleteRequest = await client.path("/jobs/{name}", jobName).delete();
       assert.equal(deleteRequest.status, "204", "Job should be deleted");
@@ -315,7 +315,7 @@ describe("Batch", () => {
       assert.equal(createdJob.status, "404", "Job should not be found");
       const createdJobOutput = createdJob.body as ErrorResponse;
       assert.isNotNull(createdJobOutput.error, "Job should have error");
-      assert.equal("JobNotFound", createdJobOutput.error.code, "Error code should be JobNotFound");
+      assert.equal(createdJobOutput.error.code, "JobNotFound", "Error code should be JobNotFound");
       assert.isTrue(
         createdJobOutput.error!.message.length > 10,
         "Error message should be descriptive",

--- a/sdk/keyvault/keyvault-keys/test/public/node/crypto.spec.ts
+++ b/sdk/keyvault/keyvault-keys/test/public/node/crypto.spec.ts
@@ -149,7 +149,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
         const unwrappedResult = await cryptoClient.unwrapKey("RSA1_5", wrapped.result);
         const unwrappedText = uint8ArrayToString(unwrappedResult.result);
         assert.equal(text, unwrappedText);
-        assert.equal("RSA1_5", unwrappedResult.algorithm);
+        assert.equal(unwrappedResult.algorithm, "RSA1_5");
       });
 
       it("wrap and unwrap with RSA-OAEP", async (ctx) => {
@@ -164,7 +164,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
         const unwrappedResult = await cryptoClient.unwrapKey("RSA-OAEP", wrapped.result);
         const unwrappedText = uint8ArrayToString(unwrappedResult.result);
         assert.equal(text, unwrappedText);
-        assert.equal("RSA-OAEP", unwrappedResult.algorithm);
+        assert.equal(unwrappedResult.algorithm, "RSA-OAEP");
       });
     }
 

--- a/sdk/loadtesting/load-testing-rest/test/public/node/testRun.spec.ts
+++ b/sdk/loadtesting/load-testing-rest/test/public/node/testRun.spec.ts
@@ -113,7 +113,7 @@ describe("Test Run Operations", () => {
       throw stopResult.body.error;
     }
 
-    assert.equal("200", stopResult.status);
+    assert.equal(stopResult.status, "200");
   });
 
   it("should be able to create a test run and poll", async () => {

--- a/sdk/search/search-documents/test/public/node/searchClient.spec.ts
+++ b/sdk/search/search-documents/test/public/node/searchClient.spec.ts
@@ -129,7 +129,7 @@ describe("SearchClient", { timeout: 20_000 }, () => {
       for await (const result of searchResults.results) {
         resultIds.push(result.document.hotelId);
       }
-      assert.deepEqual(["1", "9", "3"], resultIds);
+      assert.deepEqual(resultIds, ["1", "9", "3"]);
     });
 
     it("count returns the correct document count", async () => {
@@ -466,7 +466,7 @@ describe("SearchClient", { timeout: 20_000 }, () => {
       for await (const result of searchResults.results) {
         resultIds.push(result.document.hotelId);
       }
-      assert.deepEqual(["1"], resultIds);
+      assert.deepEqual(resultIds, ["1"]);
     });
 
     it("search with vector", async () => {

--- a/sdk/servicebus/service-bus/test/internal/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/smoketest.spec.ts
@@ -472,7 +472,7 @@ describe("ConstructorHelpers for track 2", () => {
     "Endpoint=sb://host/;SharedAccessKeyName=queueall;SharedAccessKey=thesharedkey=";
 
   it("getEntityNameFromConnectionString", () => {
-    assert.equal("myEntity", getEntityNameFromConnectionString(entityConnectionString));
+    assert.equal(getEntityNameFromConnectionString(entityConnectionString), "myEntity");
     assert.throws(() => getEntityNameFromConnectionString(serviceBusConnectionString));
   });
 });
@@ -496,5 +496,5 @@ async function waitAndValidate(
   const remainingMessages = (await receiver.peekMessages(1)).map((m) => m.body);
   assert.isEmpty(errors);
   assert.isEmpty(remainingMessages);
-  assert.deepEqual([expectedMessage], receivedBodies);
+  assert.deepEqual(receivedBodies, [expectedMessage]);
 }

--- a/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/batchingReceiver.spec.ts
@@ -510,22 +510,22 @@ describe("BatchingReceiver unit tests", () => {
       let fn = getRemainingWaitTimeInMsFn(10, 2);
       // 1ms has elapsed so we're comparing 9ms vs 2ms
       vi.advanceTimersByTime(1);
-      assert.equal(2, fn());
+      assert.equal(fn(), 2);
 
       fn = getRemainingWaitTimeInMsFn(10, 2);
       // 9ms has elapsed so we're comparing 1ms vs 2ms
       vi.advanceTimersByTime(9);
-      assert.equal(1, fn());
+      assert.equal(fn(), 1);
 
       fn = getRemainingWaitTimeInMsFn(10, 2);
       // 8ms has elapsed so we're comparing 2ms vs 2ms
       vi.advanceTimersByTime(8);
-      assert.equal(2, fn());
+      assert.equal(fn(), 2);
 
       fn = getRemainingWaitTimeInMsFn(10, 2);
       // 11ms has elapsed so we're comparing -1ms vs 2ms (we'll just treat that as "don't wait, just return what you have")
       vi.advanceTimersByTime(11);
-      assert.equal(0, fn());
+      assert.equal(fn(), 0);
     });
   });
 
@@ -849,7 +849,7 @@ describe("BatchingReceiver unit tests", () => {
 
     const results = await receiveMessagesPromise;
 
-    assert.equal(1, results.length);
+    assert.equal(results.length, 1);
   });
 });
 

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -213,7 +213,7 @@ describe("LinkEntity unit tests", () => {
         await linkEntity.initLink({});
         assert.fail("Should throw");
       } catch (err: any) {
-        assert.equal("Link has been permanently closed. Not reopening.", err.message);
+        assert.equal(err.message, "Link has been permanently closed. Not reopening.");
         assert.isFalse(linkEntity.isOpen(), "Link was closed and will remain closed");
         // We shouldn't attempt to re-open the link.
         expect(negotiateClaimSpy).not.toHaveBeenCalled();

--- a/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiver.spec.ts
@@ -102,7 +102,7 @@ describe("Receiver unit tests", () => {
         await messageReceiver2["_init"]({} as ReceiverOptions);
         assert.fail("Should throw");
       } catch (err: any) {
-        assert.equal("Link has been permanently closed. Not reopening.", err.message);
+        assert.equal(err.message, "Link has been permanently closed. Not reopening.");
         assert.equal(err.name, "AbortError");
         assert.isFalse(negotiateClaimWasCalled);
       }
@@ -290,7 +290,7 @@ describe("Receiver unit tests", () => {
         await iter.next();
         assert.fail("Should have thrown");
       } catch (err: any) {
-        assert.equal("AbortError", err.name);
+        assert.equal(err.name, "AbortError");
       }
 
       await impl.close();

--- a/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/receiverCommon.spec.ts
@@ -456,7 +456,7 @@ it("getMessageIterator doesn't yield empty responses", async () => {
     }
     assert.fail("Should throw");
   } catch (err: any) {
-    assert.equal("We're okay to end it now", err.message);
+    assert.equal(err.message, "We're okay to end it now");
     assert.deepEqual(
       [
         {

--- a/sdk/storage/storage-blob-changefeed/test/blobchangefeedclient.spec.ts
+++ b/sdk/storage/storage-blob-changefeed/test/blobchangefeedclient.spec.ts
@@ -245,7 +245,7 @@ describe(
       const changeFeedEvent = rawEventToBlobChangeFeedEvent(eventObject);
 
       // Assert
-      assert.equal(1, changeFeedEvent.schemaVersion);
+      assert.equal(changeFeedEvent.schemaVersion, 1);
       assert.equal(
         "/subscriptions/dd40261b-437d-43d0-86cf-ef222b78fd15/resourceGroups/haambaga/providers/Microsoft.Storage/storageAccounts/HAAMBAGA-DEV",
         changeFeedEvent.topic,
@@ -254,20 +254,20 @@ describe(
         "/blobServices/default/containers/apitestcontainerver/blobs/20220217_125928329_Blob_oaG6iu7ImEB1cX8M",
         changeFeedEvent.subject,
       );
-      assert.equal("BlobCreated", changeFeedEvent.eventType);
+      assert.equal(changeFeedEvent.eventType, "BlobCreated");
       assert.equal(
         new Date("2022-02-17T12:59:41.4003102Z").valueOf(),
         changeFeedEvent.eventTime.valueOf(),
       );
-      assert.equal("322343e3-8020-0000-00fe-233467066726", changeFeedEvent.id);
-      assert.equal("PutBlob", changeFeedEvent.data.api);
-      assert.equal("f0270546-168e-4398-8fa8-107a1ac214d2", changeFeedEvent.data.clientRequestId);
-      assert.equal("322343e3-8020-0000-00fe-233467000000", changeFeedEvent.data.requestId);
-      assert.equal("0x8D9F2155CBF7928", changeFeedEvent.data.etag);
-      assert.equal("application/octet-stream", changeFeedEvent.data.contentType);
-      assert.equal(128, changeFeedEvent.data.contentLength);
-      assert.equal("BlockBlob", changeFeedEvent.data.blobType);
-      assert.equal("https://www.myurl.com", changeFeedEvent.data.url);
+      assert.equal(changeFeedEvent.id, "322343e3-8020-0000-00fe-233467066726");
+      assert.equal(changeFeedEvent.data.api, "PutBlob");
+      assert.equal(changeFeedEvent.data.clientRequestId, "f0270546-168e-4398-8fa8-107a1ac214d2");
+      assert.equal(changeFeedEvent.data.requestId, "322343e3-8020-0000-00fe-233467000000");
+      assert.equal(changeFeedEvent.data.etag, "0x8D9F2155CBF7928");
+      assert.equal(changeFeedEvent.data.contentType, "application/octet-stream");
+      assert.equal(changeFeedEvent.data.contentLength, 128);
+      assert.equal(changeFeedEvent.data.blobType, "BlockBlob");
+      assert.equal(changeFeedEvent.data.url, "https://www.myurl.com");
       assert.equal(
         "00000000000000010000000000000002000000000000001d",
         changeFeedEvent.data.sequencer,
@@ -280,7 +280,7 @@ describe(
       const eventObject = JSON.parse(eventData);
       const changeFeedEvent = rawEventToBlobChangeFeedEvent(eventObject);
 
-      assert.equal(3, changeFeedEvent.schemaVersion);
+      assert.equal(changeFeedEvent.schemaVersion, 3);
       assert.equal(
         "/subscriptions/dd40261b-437d-43d0-86cf-ef222b78fd15/resourceGroups/haambaga/providers/Microsoft.Storage/storageAccounts/HAAMBAGA-DEV",
         changeFeedEvent.topic,
@@ -289,20 +289,20 @@ describe(
         "/blobServices/default/containers/apitestcontainerver/blobs/20220217_130510699_Blob_oaG6iu7ImEB1cX8M",
         changeFeedEvent.subject,
       );
-      assert.equal("BlobCreated", changeFeedEvent.eventType);
+      assert.equal(changeFeedEvent.eventType, "BlobCreated");
       assert.equal(
         new Date("2022-02-17T13:05:19.6798242Z").valueOf(),
         changeFeedEvent.eventTime.valueOf(),
       );
-      assert.equal("eefe8fc8-8020-0000-00fe-23346706daaa", changeFeedEvent.id);
-      assert.equal("PutBlob", changeFeedEvent.data.api);
-      assert.equal("00c0b6b7-bb67-4748-a3dc-86464863d267", changeFeedEvent.data.clientRequestId);
-      assert.equal("eefe8fc8-8020-0000-00fe-233467000000", changeFeedEvent.data.requestId);
-      assert.equal("0x8D9F216266170DC", changeFeedEvent.data.etag);
-      assert.equal("application/octet-stream", changeFeedEvent.data.contentType);
-      assert.equal(128, changeFeedEvent.data.contentLength);
-      assert.equal("BlockBlob", changeFeedEvent.data.blobType);
-      assert.equal("https://www.myurl.com", changeFeedEvent.data.url);
+      assert.equal(changeFeedEvent.id, "eefe8fc8-8020-0000-00fe-23346706daaa");
+      assert.equal(changeFeedEvent.data.api, "PutBlob");
+      assert.equal(changeFeedEvent.data.clientRequestId, "00c0b6b7-bb67-4748-a3dc-86464863d267");
+      assert.equal(changeFeedEvent.data.requestId, "eefe8fc8-8020-0000-00fe-233467000000");
+      assert.equal(changeFeedEvent.data.etag, "0x8D9F216266170DC");
+      assert.equal(changeFeedEvent.data.contentType, "application/octet-stream");
+      assert.equal(changeFeedEvent.data.contentLength, 128);
+      assert.equal(changeFeedEvent.data.blobType, "BlockBlob");
+      assert.equal(changeFeedEvent.data.url, "https://www.myurl.com");
       assert.equal(
         "00000000000000010000000000000002000000000000001d",
         changeFeedEvent.data.sequencer,
@@ -321,9 +321,9 @@ describe(
         "2022-02-17T16:11:52.0781797Z",
         changeFeedEvent.data.previousInfo?.oldBlobVersion,
       );
-      assert.equal("Hot", changeFeedEvent.data.previousInfo?.previousTier);
+      assert.equal(changeFeedEvent.data.previousInfo?.previousTier, "Hot");
 
-      assert.equal("2022-02-17T16:09:16.7261278Z", changeFeedEvent.data.snapshot);
+      assert.equal(changeFeedEvent.data.snapshot, "2022-02-17T16:09:16.7261278Z");
 
       assert.equal(
         "ContentLanguage",
@@ -359,7 +359,7 @@ describe(
         "gzip, identity",
         changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].newValue,
       );
-      assert.equal("gzip", changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].oldValue);
+      assert.equal(changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].oldValue, "gzip");
 
       assert.equal(
         "ContentMD5",
@@ -382,7 +382,7 @@ describe(
         "attachment",
         changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].newValue,
       );
-      assert.equal("", changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].oldValue);
+      assert.equal(changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].oldValue, "");
 
       assert.equal(
         "ContentType",
@@ -404,7 +404,7 @@ describe(
       const eventObject = JSON.parse(eventData);
       const changeFeedEvent = rawEventToBlobChangeFeedEvent(eventObject);
 
-      assert.equal(4, changeFeedEvent.schemaVersion);
+      assert.equal(changeFeedEvent.schemaVersion, 4);
       assert.equal(
         "/subscriptions/dd40261b-437d-43d0-86cf-ef222b78fd15/resourceGroups/haambaga/providers/Microsoft.Storage/storageAccounts/HAAMBAGA-DEV",
         changeFeedEvent.topic,
@@ -413,23 +413,23 @@ describe(
         "/blobServices/default/containers/apitestcontainerver/blobs/20220217_130833395_Blob_oaG6iu7ImEB1cX8M",
         changeFeedEvent.subject,
       );
-      assert.equal("BlobCreated", changeFeedEvent.eventType);
+      assert.equal(changeFeedEvent.eventType, "BlobCreated");
       assert.equal(
         new Date("2022-02-17T13:08:42.4835902Z").valueOf(),
         changeFeedEvent.eventTime.valueOf(),
       );
-      assert.equal("ca76bce1-8020-0000-00ff-23346706e769", changeFeedEvent.id);
-      assert.equal("PutBlob", changeFeedEvent.data.api);
-      assert.equal("58fbfee9-6cf5-4096-9666-c42980beee65", changeFeedEvent.data.clientRequestId);
-      assert.equal("ca76bce1-8020-0000-00ff-233467000000", changeFeedEvent.data.requestId);
-      assert.equal("0x8D9F2169F42D701", changeFeedEvent.data.etag);
-      assert.equal("application/octet-stream", changeFeedEvent.data.contentType);
-      assert.equal(128, changeFeedEvent.data.contentLength);
-      assert.equal("BlockBlob", changeFeedEvent.data.blobType);
-      assert.equal("2022-02-17T16:11:52.5901564Z", changeFeedEvent.data.blobVersion);
-      assert.equal("0000000000000001", changeFeedEvent.data.containerVersion);
-      assert.equal("Archive", changeFeedEvent.data.blobAccessTier);
-      assert.equal("https://www.myurl.com", changeFeedEvent.data.url);
+      assert.equal(changeFeedEvent.id, "ca76bce1-8020-0000-00ff-23346706e769");
+      assert.equal(changeFeedEvent.data.api, "PutBlob");
+      assert.equal(changeFeedEvent.data.clientRequestId, "58fbfee9-6cf5-4096-9666-c42980beee65");
+      assert.equal(changeFeedEvent.data.requestId, "ca76bce1-8020-0000-00ff-233467000000");
+      assert.equal(changeFeedEvent.data.etag, "0x8D9F2169F42D701");
+      assert.equal(changeFeedEvent.data.contentType, "application/octet-stream");
+      assert.equal(changeFeedEvent.data.contentLength, 128);
+      assert.equal(changeFeedEvent.data.blobType, "BlockBlob");
+      assert.equal(changeFeedEvent.data.blobVersion, "2022-02-17T16:11:52.5901564Z");
+      assert.equal(changeFeedEvent.data.containerVersion, "0000000000000001");
+      assert.equal(changeFeedEvent.data.blobAccessTier, "Archive");
+      assert.equal(changeFeedEvent.data.url, "https://www.myurl.com");
       assert.equal(
         "00000000000000010000000000000002000000000000001d",
         changeFeedEvent.data.sequencer,
@@ -448,9 +448,9 @@ describe(
         "2022-02-17T16:11:52.0781797Z",
         changeFeedEvent.data.previousInfo?.oldBlobVersion,
       );
-      assert.equal("Hot", changeFeedEvent.data.previousInfo?.previousTier);
+      assert.equal(changeFeedEvent.data.previousInfo?.previousTier, "Hot");
 
-      assert.equal("2022-02-17T16:09:16.7261278Z", changeFeedEvent.data.snapshot);
+      assert.equal(changeFeedEvent.data.snapshot, "2022-02-17T16:09:16.7261278Z");
 
       assert.equal(
         "ContentLanguage",
@@ -486,7 +486,7 @@ describe(
         "gzip, identity",
         changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].newValue,
       );
-      assert.equal("gzip", changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].oldValue);
+      assert.equal(changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].oldValue, "gzip");
 
       assert.equal(
         "ContentMD5",
@@ -509,7 +509,7 @@ describe(
         "attachment",
         changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].newValue,
       );
-      assert.equal("", changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].oldValue);
+      assert.equal(changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].oldValue, "");
 
       assert.equal(
         "ContentType",
@@ -524,9 +524,9 @@ describe(
         changeFeedEvent.data.updatedBlobProperties!["ContentType"].oldValue,
       );
 
-      assert.equal("Hot", changeFeedEvent.data.longRunningOperationInfo?.destinationAccessTier);
+      assert.equal(changeFeedEvent.data.longRunningOperationInfo?.destinationAccessTier, "Hot");
       assert.isTrue(changeFeedEvent.data.longRunningOperationInfo?.isAsync);
-      assert.equal("copyId", changeFeedEvent.data.longRunningOperationInfo?.copyId);
+      assert.equal(changeFeedEvent.data.longRunningOperationInfo?.copyId, "copyId");
     });
 
     it("Event schema v5 test", async () => {
@@ -534,7 +534,7 @@ describe(
       const eventData = await streamToString(fs.createReadStream(eventSchemaV5));
       const eventObject = JSON.parse(eventData);
       const changeFeedEvent = rawEventToBlobChangeFeedEvent(eventObject);
-      assert.equal(5, changeFeedEvent.schemaVersion);
+      assert.equal(changeFeedEvent.schemaVersion, 5);
       assert.equal(
         "/subscriptions/dd40261b-437d-43d0-86cf-ef222b78fd15/resourceGroups/haambaga/providers/Microsoft.Storage/storageAccounts/HAAMBAGA-DEV",
         changeFeedEvent.topic,
@@ -543,23 +543,23 @@ describe(
         "/blobServices/default/containers/apitestcontainerver/blobs/20220217_131202494_Blob_oaG6iu7ImEB1cX8M",
         changeFeedEvent.subject,
       );
-      assert.equal("BlobCreated", changeFeedEvent.eventType);
+      assert.equal(changeFeedEvent.eventType, "BlobCreated");
       assert.equal(
         new Date("2022-02-17T13:12:11.5746587Z").valueOf(),
         changeFeedEvent.eventTime.valueOf(),
       );
-      assert.equal("62616073-8020-0000-00ff-233467060cc0", changeFeedEvent.id);
-      assert.equal("PutBlob", changeFeedEvent.data.api);
-      assert.equal("b3f9b39a-ae5a-45ac-afad-95ac9e9f2791", changeFeedEvent.data.clientRequestId);
-      assert.equal("62616073-8020-0000-00ff-233467000000", changeFeedEvent.data.requestId);
-      assert.equal("0x8D9F2171BE32588", changeFeedEvent.data.etag);
-      assert.equal("application/octet-stream", changeFeedEvent.data.contentType);
-      assert.equal(128, changeFeedEvent.data.contentLength);
-      assert.equal("BlockBlob", changeFeedEvent.data.blobType);
-      assert.equal("2022-02-17T16:11:52.5901564Z", changeFeedEvent.data.blobVersion);
-      assert.equal("0000000000000001", changeFeedEvent.data.containerVersion);
-      assert.equal("Archive", changeFeedEvent.data.blobAccessTier);
-      assert.equal("https://www.myurl.com", changeFeedEvent.data.url);
+      assert.equal(changeFeedEvent.id, "62616073-8020-0000-00ff-233467060cc0");
+      assert.equal(changeFeedEvent.data.api, "PutBlob");
+      assert.equal(changeFeedEvent.data.clientRequestId, "b3f9b39a-ae5a-45ac-afad-95ac9e9f2791");
+      assert.equal(changeFeedEvent.data.requestId, "62616073-8020-0000-00ff-233467000000");
+      assert.equal(changeFeedEvent.data.etag, "0x8D9F2171BE32588");
+      assert.equal(changeFeedEvent.data.contentType, "application/octet-stream");
+      assert.equal(changeFeedEvent.data.contentLength, 128);
+      assert.equal(changeFeedEvent.data.blobType, "BlockBlob");
+      assert.equal(changeFeedEvent.data.blobVersion, "2022-02-17T16:11:52.5901564Z");
+      assert.equal(changeFeedEvent.data.containerVersion, "0000000000000001");
+      assert.equal(changeFeedEvent.data.blobAccessTier, "Archive");
+      assert.equal(changeFeedEvent.data.url, "https://www.myurl.com");
       assert.equal(
         "00000000000000010000000000000002000000000000001d",
         changeFeedEvent.data.sequencer,
@@ -578,9 +578,9 @@ describe(
         "2022-02-17T16:11:52.0781797Z",
         changeFeedEvent.data.previousInfo?.oldBlobVersion,
       );
-      assert.equal("Hot", changeFeedEvent.data.previousInfo?.previousTier);
+      assert.equal(changeFeedEvent.data.previousInfo?.previousTier, "Hot");
 
-      assert.equal("2022-02-17T16:09:16.7261278Z", changeFeedEvent.data.snapshot);
+      assert.equal(changeFeedEvent.data.snapshot, "2022-02-17T16:09:16.7261278Z");
 
       assert.equal(
         "ContentLanguage",
@@ -616,7 +616,7 @@ describe(
         "gzip, identity",
         changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].newValue,
       );
-      assert.equal("gzip", changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].oldValue);
+      assert.equal(changeFeedEvent.data.updatedBlobProperties!["ContentEncoding"].oldValue, "gzip");
 
       assert.equal(
         "ContentMD5",
@@ -639,7 +639,7 @@ describe(
         "attachment",
         changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].newValue,
       );
-      assert.equal("", changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].oldValue);
+      assert.equal(changeFeedEvent.data.updatedBlobProperties!["ContentDisposition"].oldValue, "");
 
       assert.equal(
         "ContentType",
@@ -654,15 +654,15 @@ describe(
         changeFeedEvent.data.updatedBlobProperties!["ContentType"].oldValue,
       );
 
-      assert.equal("Hot", changeFeedEvent.data.longRunningOperationInfo?.destinationAccessTier);
+      assert.equal(changeFeedEvent.data.longRunningOperationInfo?.destinationAccessTier, "Hot");
       assert.isTrue(changeFeedEvent.data.longRunningOperationInfo?.isAsync);
-      assert.equal("copyId", changeFeedEvent.data.longRunningOperationInfo?.copyId);
+      assert.equal(changeFeedEvent.data.longRunningOperationInfo?.copyId, "copyId");
 
-      assert.equal("Value1_3", changeFeedEvent.data.updatedBlobTags?.oldTags["Tag1"]);
-      assert.equal("Value2_3", changeFeedEvent.data.updatedBlobTags?.oldTags["Tag2"]);
+      assert.equal(changeFeedEvent.data.updatedBlobTags?.oldTags["Tag1"], "Value1_3");
+      assert.equal(changeFeedEvent.data.updatedBlobTags?.oldTags["Tag2"], "Value2_3");
 
-      assert.equal("Value1_4", changeFeedEvent.data.updatedBlobTags?.newTags["Tag1"]);
-      assert.equal("Value2_4", changeFeedEvent.data.updatedBlobTags?.newTags["Tag2"]);
+      assert.equal(changeFeedEvent.data.updatedBlobTags?.newTags["Tag1"], "Value1_4");
+      assert.equal(changeFeedEvent.data.updatedBlobTags?.newTags["Tag2"], "Value2_4");
     });
   },
 );

--- a/sdk/storage/storage-blob/test/node/avroreader.spec.ts
+++ b/sdk/storage/storage-blob/test/node/avroreader.spec.ts
@@ -20,25 +20,25 @@ class TestCase {
 describe("AvroReader", () => {
   it("test with local avro files", async () => {
     const testCases: TestCase[] = [
-      new TestCase("test_null_0.avro", (o) => assert.strictEqual(null, o)), // null
-      new TestCase("test_null_1.avro", (o) => assert.strictEqual(true, o as any)), // boolean
+      new TestCase("test_null_0.avro", (o) => assert.strictEqual(o, null)), // null
+      new TestCase("test_null_1.avro", (o) => assert.strictEqual(o as any, true)), // boolean
       new TestCase("test_null_2.avro", (o) =>
-        assert.strictEqual("adsfasdf09809dsf-=adsf", o as any),
+        assert.strictEqual(o as any, "adsfasdf09809dsf-=adsf"),
       ), // string
       new TestCase("test_null_3.avro", (o) =>
         assert.isTrue(arraysEqual(new TextEncoder().encode("12345abcd"), o as Uint8Array)),
       ), // byte[]
-      new TestCase("test_null_4.avro", (o) => assert.strictEqual(1234, o as any)), // int
-      new TestCase("test_null_5.avro", (o) => assert.strictEqual(1234, o as any)), // long
-      new TestCase("test_null_6.avro", (o) => assert.strictEqual(1234.0, o as any)), // float
-      new TestCase("test_null_7.avro", (o) => assert.strictEqual(1234.0, o as any)), // double
+      new TestCase("test_null_4.avro", (o) => assert.strictEqual(o as any, 1234)), // int
+      new TestCase("test_null_5.avro", (o) => assert.strictEqual(o as any, 1234)), // long
+      new TestCase("test_null_6.avro", (o) => assert.strictEqual(o as any, 1234.0)), // float
+      new TestCase("test_null_7.avro", (o) => assert.strictEqual(o as any, 1234.0)), // double
       // Not supported today.
       // new TestCase("test_null_8.avro", o => assert.ok(arraysEqual(new TextEncoder().encode("B"), o as Uint8Array))), // fixed
-      new TestCase("test_null_9.avro", (o) => assert.strictEqual("B", o as any)), // enum
+      new TestCase("test_null_9.avro", (o) => assert.strictEqual(o as any, "B")), // enum
       // Not supported today.
       // new TestCase("test_null_10.avro", o => assert.deepStrictEqual([1, 2, 3], o)), // array
-      new TestCase("test_null_11.avro", (o) => assert.deepStrictEqual({ a: 1, b: 3, c: 2 }, o)), // map
-      new TestCase("test_null_12.avro", (o) => assert.strictEqual(null, o)), // union
+      new TestCase("test_null_11.avro", (o) => assert.deepStrictEqual(o, { a: 1, b: 3, c: 2 })), // map
+      new TestCase("test_null_12.avro", (o) => assert.strictEqual(o, null)), // union
       new TestCase("test_null_13.avro", (o) => {
         const expected = { $schema: "Test", f: 5 };
         const expectedEntries = Object.entries(expected);

--- a/sdk/storage/storage-blob/test/node/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/containerclient.spec.ts
@@ -46,7 +46,7 @@ describe("ContainerClient Node.js only", () => {
     );
     configureBlobStorageClient(recorder, containerClientWithOAuthToken);
     const exists = await containerClientWithOAuthToken.exists();
-    assert.strictEqual(true, exists);
+    assert.strictEqual(exists, true);
   });
 
   it("Customized audience should work", async () => {
@@ -59,7 +59,7 @@ describe("ContainerClient Node.js only", () => {
     );
     configureBlobStorageClient(recorder, containerClientWithOAuthToken);
     const exists = await containerClientWithOAuthToken.exists();
-    assert.strictEqual(true, exists);
+    assert.strictEqual(exists, true);
   });
 
   it("Bearer token challenge should work", async () => {
@@ -127,7 +127,7 @@ describe("ContainerClient Node.js only", () => {
     );
     configureBlobStorageClient(recorder, containerClientWithOAuthToken);
     const exists = await containerClientWithOAuthToken.exists();
-    assert.strictEqual(true, exists);
+    assert.strictEqual(exists, true);
 
     const containerAcl = [
       {

--- a/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/pathclient.spec.ts
@@ -1162,10 +1162,10 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       ),
     );
 
-    assert.deepStrictEqual(3, result.counters.changedDirectoriesCount);
-    assert.deepStrictEqual(4, result.counters.changedFilesCount);
-    assert.deepStrictEqual(0, result.counters.failedChangesCount);
-    assert.deepStrictEqual(undefined, result.continuationToken);
+    assert.deepStrictEqual(result.counters.changedDirectoriesCount, 3);
+    assert.deepStrictEqual(result.counters.changedFilesCount, 4);
+    assert.deepStrictEqual(result.counters.failedChangesCount, 0);
+    assert.deepStrictEqual(result.continuationToken, undefined);
   });
 
   it("setAccessControlRecursive should work with options - maxBatches", async () => {
@@ -1208,8 +1208,8 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       },
     );
 
-    assert.deepStrictEqual(1, batchCounter);
-    assert.notDeepEqual(undefined, result.continuationToken);
+    assert.deepStrictEqual(batchCounter, 1);
+    assert.notDeepEqual(result.continuationToken, undefined);
   });
 
   it("setAccessControlRecursive should work with options - batchSize", async () => {
@@ -1280,14 +1280,14 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       },
     );
 
-    assert.deepStrictEqual(3, cumulativeCounters.changedDirectoriesCount);
-    assert.deepStrictEqual(4, cumulativeCounters.changedFilesCount);
-    assert.deepStrictEqual(0, cumulativeCounters.failedChangesCount);
-    assert.deepStrictEqual(3, result.counters.changedDirectoriesCount);
-    assert.deepStrictEqual(4, result.counters.changedFilesCount);
-    assert.deepStrictEqual(0, result.counters.failedChangesCount);
-    assert.deepStrictEqual(undefined, result.continuationToken);
-    assert.deepStrictEqual(true, batchCounter > 3);
+    assert.deepStrictEqual(cumulativeCounters.changedDirectoriesCount, 3);
+    assert.deepStrictEqual(cumulativeCounters.changedFilesCount, 4);
+    assert.deepStrictEqual(cumulativeCounters.failedChangesCount, 0);
+    assert.deepStrictEqual(result.counters.changedDirectoriesCount, 3);
+    assert.deepStrictEqual(result.counters.changedFilesCount, 4);
+    assert.deepStrictEqual(result.counters.failedChangesCount, 0);
+    assert.deepStrictEqual(result.continuationToken, undefined);
+    assert.deepStrictEqual(batchCounter > 3, true);
   });
 
   it("setAccessControlRecursive should work with aborter & resume, ", async () => {
@@ -1365,7 +1365,7 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       0,
       result.counters.failedChangesCount + midProgress!.batchCounters.failedChangesCount,
     );
-    assert.deepStrictEqual(undefined, result.continuationToken);
+    assert.deepStrictEqual(result.continuationToken, undefined);
   });
 
   it("updateAccessControlRecursive should work", async () => {
@@ -1400,10 +1400,10 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       ),
     );
 
-    assert.deepStrictEqual(3, result.counters.changedDirectoriesCount);
-    assert.deepStrictEqual(4, result.counters.changedFilesCount);
-    assert.deepStrictEqual(0, result.counters.failedChangesCount);
-    assert.deepStrictEqual(undefined, result.continuationToken);
+    assert.deepStrictEqual(result.counters.changedDirectoriesCount, 3);
+    assert.deepStrictEqual(result.counters.changedFilesCount, 4);
+    assert.deepStrictEqual(result.counters.failedChangesCount, 0);
+    assert.deepStrictEqual(result.continuationToken, undefined);
   });
 
   it("removeAccessControlRecursive should work", async () => {
@@ -1438,10 +1438,10 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       ),
     );
 
-    assert.deepStrictEqual(3, result.counters.changedDirectoriesCount);
-    assert.deepStrictEqual(4, result.counters.changedFilesCount);
-    assert.deepStrictEqual(0, result.counters.failedChangesCount);
-    assert.deepStrictEqual(undefined, result.continuationToken);
+    assert.deepStrictEqual(result.counters.changedDirectoriesCount, 3);
+    assert.deepStrictEqual(result.counters.changedFilesCount, 4);
+    assert.deepStrictEqual(result.counters.failedChangesCount, 0);
+    assert.deepStrictEqual(result.continuationToken, undefined);
 
     const removeResult = await directoryClient.removeAccessControlRecursive(
       toRemoveAcl(
@@ -1452,10 +1452,10 @@ describe("DataLakePathClient setAccessControlRecursive Node.js only", () => {
       ),
     );
 
-    assert.deepStrictEqual(3, removeResult.counters.changedDirectoriesCount);
-    assert.deepStrictEqual(4, removeResult.counters.changedFilesCount);
-    assert.deepStrictEqual(0, removeResult.counters.failedChangesCount);
-    assert.deepStrictEqual(undefined, removeResult.continuationToken);
+    assert.deepStrictEqual(removeResult.counters.changedDirectoriesCount, 3);
+    assert.deepStrictEqual(removeResult.counters.changedFilesCount, 4);
+    assert.deepStrictEqual(removeResult.counters.failedChangesCount, 0);
+    assert.deepStrictEqual(removeResult.continuationToken, undefined);
   });
 
   it("setAccessControlRecursive should work with progress failures", async () => {

--- a/sdk/storage/storage-internal-avro/test/node/avroreader.spec.ts
+++ b/sdk/storage/storage-internal-avro/test/node/avroreader.spec.ts
@@ -20,25 +20,25 @@ class TestCase {
 describe("AvroReader", () => {
   it("test with local avro files", async () => {
     const testCases: TestCase[] = [
-      new TestCase("test_null_0.avro", (o) => assert.strictEqual(null, o)), // null
-      new TestCase("test_null_1.avro", (o) => assert.strictEqual(true, o as any)), // boolean
+      new TestCase("test_null_0.avro", (o) => assert.strictEqual(o, null)), // null
+      new TestCase("test_null_1.avro", (o) => assert.strictEqual(o as any, true)), // boolean
       new TestCase("test_null_2.avro", (o) =>
-        assert.strictEqual("adsfasdf09809dsf-=adsf", o as any),
+        assert.strictEqual(o as any, "adsfasdf09809dsf-=adsf"),
       ), // string
       new TestCase("test_null_3.avro", (o) =>
         assert.isTrue(arraysEqual(new TextEncoder().encode("12345abcd"), o as Uint8Array)),
       ), // byte[]
-      new TestCase("test_null_4.avro", (o) => assert.strictEqual(1234, o as any)), // int
-      new TestCase("test_null_5.avro", (o) => assert.strictEqual(1234, o as any)), // long
-      new TestCase("test_null_6.avro", (o) => assert.strictEqual(1234.0, o as any)), // float
-      new TestCase("test_null_7.avro", (o) => assert.strictEqual(1234.0, o as any)), // double
+      new TestCase("test_null_4.avro", (o) => assert.strictEqual(o as any, 1234)), // int
+      new TestCase("test_null_5.avro", (o) => assert.strictEqual(o as any, 1234)), // long
+      new TestCase("test_null_6.avro", (o) => assert.strictEqual(o as any, 1234.0)), // float
+      new TestCase("test_null_7.avro", (o) => assert.strictEqual(o as any, 1234.0)), // double
       // Not supported today.
       // new TestCase("test_null_8.avro", o => assert.ok(arraysEqual(new TextEncoder().encode("B"), o as Uint8Array))), // fixed
-      new TestCase("test_null_9.avro", (o) => assert.strictEqual("B", o as any)), // enum
+      new TestCase("test_null_9.avro", (o) => assert.strictEqual(o as any, "B")), // enum
       // Not supported today.
       // new TestCase("test_null_10.avro", o => assert.deepStrictEqual([1, 2, 3], o)), // array
-      new TestCase("test_null_11.avro", (o) => assert.deepStrictEqual({ a: 1, b: 3, c: 2 }, o)), // map
-      new TestCase("test_null_12.avro", (o) => assert.strictEqual(null, o)), // union
+      new TestCase("test_null_11.avro", (o) => assert.deepStrictEqual(o, { a: 1, b: 3, c: 2 })), // map
+      new TestCase("test_null_12.avro", (o) => assert.strictEqual(o, null)), // union
       new TestCase("test_null_13.avro", (o) => {
         const expected = { $schema: "Test", f: 5 };
         const expectedEntries = Object.entries(expected);

--- a/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/public/textAnalyticsClient.spec.ts
@@ -188,8 +188,8 @@ describe.each(["AAD", "APIKey"] as const)(`[%s] TextAnalyticsClient`, (authMetho
         documentSentiment.sentences.map((sentence) =>
           sentence.opinions?.map((opinion) => {
             const Target = opinion.target;
-            assert.equal("design", Target.text);
-            assert.equal("positive", Target.sentiment);
+            assert.equal(Target.text, "design");
+            assert.equal(Target.sentiment, "positive");
             assert.isAtLeast(Target.confidenceScores.positive, 0);
             assert.isAtLeast(Target.confidenceScores.negative, 0);
             assert.equal(Target.offset, 32);
@@ -197,8 +197,8 @@ describe.each(["AAD", "APIKey"] as const)(`[%s] TextAnalyticsClient`, (authMetho
             assert.equal(Target.text.length, Target.length);
 
             const sleekAssessment = opinion.assessments[0];
-            assert.equal("sleek", sleekAssessment.text);
-            assert.equal("positive", sleekAssessment.sentiment);
+            assert.equal(sleekAssessment.text, "sleek");
+            assert.equal(sleekAssessment.sentiment, "positive");
             assert.isAtLeast(sleekAssessment.confidenceScores.positive, 0);
             assert.isAtLeast(sleekAssessment.confidenceScores.positive, 0);
             assert.isFalse(sleekAssessment.isNegated);
@@ -207,8 +207,8 @@ describe.each(["AAD", "APIKey"] as const)(`[%s] TextAnalyticsClient`, (authMetho
             assert.equal(sleekAssessment.text.length, sleekAssessment.length);
 
             const beautifulAssessment = opinion.assessments[1];
-            assert.equal("beautiful", beautifulAssessment.text);
-            assert.equal("positive", beautifulAssessment.sentiment);
+            assert.equal(beautifulAssessment.text, "beautiful");
+            assert.equal(beautifulAssessment.sentiment, "positive");
             assert.isAtLeast(beautifulAssessment.confidenceScores.positive, 0);
             assert.isAtLeast(beautifulAssessment.confidenceScores.positive, 0);
             assert.isFalse(beautifulAssessment.isNegated);
@@ -236,8 +236,8 @@ describe.each(["AAD", "APIKey"] as const)(`[%s] TextAnalyticsClient`, (authMetho
           results[0] as AnalyzeSentimentSuccessResult;
         documentSentiment.sentences.map((sentence) => {
           const foodTarget = sentence.opinions?.[0].target;
-          assert.equal("food", foodTarget?.text);
-          assert.equal("negative", foodTarget?.sentiment);
+          assert.equal(foodTarget?.text, "food");
+          assert.equal(foodTarget?.sentiment, "negative");
 
           const foodTargetPositiveScore = foodTarget ? foodTarget.confidenceScores.positive : 0;
           const foodTargetNegativeScore = foodTarget ? foodTarget.confidenceScores.negative : 0;
@@ -247,8 +247,8 @@ describe.each(["AAD", "APIKey"] as const)(`[%s] TextAnalyticsClient`, (authMetho
           assert.equal(foodTargetPositiveScore + foodTargetNegativeScore, 1);
 
           const serviceTarget = sentence.opinions?.[1].target;
-          assert.equal("service", serviceTarget?.text);
-          assert.equal("negative", serviceTarget?.sentiment);
+          assert.equal(serviceTarget?.text, "service");
+          assert.equal(serviceTarget?.sentiment, "negative");
 
           const serviceTargetPositiveScore = serviceTarget
             ? serviceTarget.confidenceScores.positive
@@ -266,8 +266,8 @@ describe.each(["AAD", "APIKey"] as const)(`[%s] TextAnalyticsClient`, (authMetho
 
           assert.deepEqual(foodAssessment!, serviceAssessment!);
 
-          assert.equal("good", foodAssessment?.text);
-          assert.equal("negative", foodAssessment?.sentiment);
+          assert.equal(foodAssessment?.text, "good");
+          assert.equal(foodAssessment?.sentiment, "negative");
 
           const foodAssessmentPositiveScore = foodAssessment
             ? foodAssessment.confidenceScores.positive

--- a/sdk/translation/ai-translation-document-rest/test/public/node/documentTranslationTest.spec.ts
+++ b/sdk/translation/ai-translation-document-rest/test/public/node/documentTranslationTest.spec.ts
@@ -529,7 +529,7 @@ describe("DocumentTranslation tests", () => {
     }
     assert.notEqual(new Date(), new Date(documentStatusOutput.createdDateTimeUtc));
     assert.notEqual(new Date(), new Date(documentStatusOutput.lastActionDateTimeUtc));
-    assert.equal(1, documentStatusOutput.progress);
+    assert.equal(documentStatusOutput.progress, 1);
 
     return;
   }

--- a/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.lifetime.spec.ts
@@ -241,17 +241,17 @@ describe("WebPubSubClient", function () {
       await client.start();
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn")));
 
-      await spinCheck(() => assert.equal("conn", conn));
+      await spinCheck(() => assert.equal(conn, "conn"));
 
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
       // connected should not happen again
-      await expect(spinCheck(() => assert.equal("conn2", conn), 10, 3)).rejects.toThrowError();
+      await expect(spinCheck(() => assert.equal(conn, "conn2"), 10, 3)).rejects.toThrowError();
 
       // drop connection
       testWs.invokeclose(1006);
       await spinCheck(() => testWs.openTime === 2);
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
-      await spinCheck(() => assert.equal("conn2", conn));
+      await spinCheck(() => assert.equal(conn, "conn2"));
     });
 
     it("recover if using reliable protocol", async () => {
@@ -269,18 +269,18 @@ describe("WebPubSubClient", function () {
       await client.start();
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn", "reconToken")));
 
-      await spinCheck(() => assert.equal("conn", conn));
+      await spinCheck(() => assert.equal(conn, "conn"));
 
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2", "reconToken")));
       // connected should not happen again
-      await expect(spinCheck(() => assert.equal("conn2", conn), 10, 3)).rejects.toThrowError();
+      await expect(spinCheck(() => assert.equal(conn, "conn2"), 10, 3)).rejects.toThrowError();
 
       // drop connection
       testWs.invokeclose(1006);
       await spinCheck(() => testWs.openTime === 2);
 
       // after recover, connected should be emit again
-      await expect(spinCheck(() => assert.equal("conn2", conn), 10, 3)).rejects.toThrowError();
+      await expect(spinCheck(() => assert.equal(conn, "conn2"), 10, 3)).rejects.toThrowError();
     });
 
     it("recover shouldn't work for 1008 close", async () => {
@@ -298,17 +298,17 @@ describe("WebPubSubClient", function () {
       await client.start();
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn")));
 
-      await spinCheck(() => assert.equal("conn", conn));
+      await spinCheck(() => assert.equal(conn, "conn"));
 
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
       // connected should not happen again
-      await expect(spinCheck(() => assert.equal("conn2", conn), 10, 3)).rejects.toThrowError();
+      await expect(spinCheck(() => assert.equal(conn, "conn2"), 10, 3)).rejects.toThrowError();
 
       // drop connection
       testWs.invokeclose(1008);
       await spinCheck(() => testWs.openTime === 2);
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
-      await spinCheck(() => assert.equal("conn2", conn));
+      await spinCheck(() => assert.equal(conn, "conn2"));
     });
 
     it("rejoin group after reconnection", async () => {
@@ -332,7 +332,7 @@ describe("WebPubSubClient", function () {
       await client.start();
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn")));
 
-      await spinCheck(() => assert.equal("conn", conn));
+      await spinCheck(() => assert.equal(conn, "conn"));
 
       // join 2 groups first
       await client.joinGroup("a");
@@ -342,7 +342,7 @@ describe("WebPubSubClient", function () {
       testWs.invokeclose(1006);
       await spinCheck(() => testWs.openTime === 2);
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
-      await spinCheck(() => assert.equal("conn2", conn));
+      await spinCheck(() => assert.equal(conn, "conn2"));
 
       expect(mock).toHaveBeenCalledTimes(4);
     });
@@ -369,7 +369,7 @@ describe("WebPubSubClient", function () {
       await client.start();
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn")));
 
-      await spinCheck(() => assert.equal("conn", conn));
+      await spinCheck(() => assert.equal(conn, "conn"));
 
       // join 2 groups first
       await client.joinGroup("a");
@@ -379,7 +379,7 @@ describe("WebPubSubClient", function () {
       testWs.invokeclose(1006);
       await spinCheck(() => testWs.openTime === 2);
       testWs.invokemessage(JSON.stringify(getConnectedPayload("conn2")));
-      await spinCheck(() => assert.equal("conn2", conn));
+      await spinCheck(() => assert.equal(conn, "conn2"));
 
       expect(mock).toHaveBeenCalledTimes(2);
     });

--- a/sdk/web-pubsub/web-pubsub-client/test/client.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/client.spec.ts
@@ -39,7 +39,7 @@ describe("WebPubSubClient", function () {
           { autoReconnect: false } as WebPubSubClientOptions,
         );
         const protocol = client["_protocol"];
-        assert.equal("json.reliable.webpubsub.azure.v1", protocol.name);
+        assert.equal(protocol.name, "json.reliable.webpubsub.azure.v1");
         const options = client["_options"];
         assert.isFalse(options.autoReconnect);
       });

--- a/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connect.spec.ts
@@ -147,7 +147,7 @@ describe("Can handle connect event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response with 204 when handler is not specified for an mqtt request", async () => {
@@ -158,7 +158,7 @@ describe("Can handle connect event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(204, res.statusCode, "should be 204");
+    assert.equal(res.statusCode, 204, "should be 204");
   });
 
   it("Should response with 200 when handler is not specified", async () => {
@@ -169,7 +169,7 @@ describe("Can handle connect event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response with error when handler returns error", async () => {
@@ -186,7 +186,7 @@ describe("Can handle connect event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(400, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 400, "should be error");
   });
 
   it("Should response with mqtt error when handler returns error and request is mqtt", async () => {
@@ -205,7 +205,7 @@ describe("Can handle connect event", function () {
     expect(endSpy).toBeCalledTimes(1);
     // Verify response body
     expect(endSpy).toBeCalledWith('{"mqtt":{"code":4}}');
-    assert.equal(400, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 400, "should be error");
   });
 
   it("Should response with correct status code and body when handler returns mqtt error", async () => {
@@ -229,7 +229,7 @@ describe("Can handle connect event", function () {
     expect(endSpy).toBeCalledTimes(1);
     // Verify response body
     expect(endSpy).toBeCalledWith('{"mqtt":{"code":4,"reason":"Bad username or password"}}');
-    assert.equal(401, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 401, "should be error");
   });
 
   it("Should respond with correct mqtt response and body when handler returns default error but request is mqtt", async () => {
@@ -248,7 +248,7 @@ describe("Can handle connect event", function () {
     expect(endSpy).toBeCalledTimes(1);
     // Verify response body
     expect(endSpy).toBeCalledWith('{"mqtt":{"code":5,"reason":"Auth failed"}}');
-    assert.equal(401, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 401, "should be error");
   });
 
   it("Should response with success when handler returns success", async () => {
@@ -265,7 +265,7 @@ describe("Can handle connect event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 200, "should be success");
   });
 
   it("Should response with correct body when handler returns success for an mqtt request", async () => {
@@ -295,7 +295,7 @@ describe("Can handle connect event", function () {
     expect(endSpy).toBeCalledWith(
       '{"subprotocol":"mqtt","mqtt":{"userProperties":[{"name":"userId","value":"vic"}]}}',
     );
-    assert.equal(200, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 200, "should be success");
   });
 
   it("Should response with success when handler returns success value", async () => {
@@ -312,7 +312,7 @@ describe("Can handle connect event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 200, "should be success");
   });
 
   it("Should be able to set connection state", async () => {
@@ -354,9 +354,9 @@ describe("Can handle connect event", function () {
     buildRequest(req, "hub1", "conn1", undefined, states);
     const dispatcher = new CloudEventsDispatcher("hub1", {
       handleConnect: (request, response) => {
-        assert.equal("val3", request.context.states["key1"][0]);
-        assert.equal("val2", request.context.states["key2"]);
-        assert.equal("", request.context.states["key3"]);
+        assert.equal(request.context.states["key1"][0], "val3");
+        assert.equal(request.context.states["key2"], "val2");
+        assert.equal(request.context.states["key3"], "");
         response.success();
       },
     });
@@ -365,7 +365,7 @@ describe("Can handle connect event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(204, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 204, "should be success");
   });
 
   it("Invalid state header gets ignored", async () => {
@@ -373,7 +373,7 @@ describe("Can handle connect event", function () {
     buildRequest(req, "hub1", "conn1", undefined, "");
     const dispatcher = new CloudEventsDispatcher("hub1", {
       handleConnect: (request, response) => {
-        assert.deepEqual({}, request.context.states);
+        assert.deepEqual(request.context.states, {});
         response.success();
       },
     });
@@ -382,6 +382,6 @@ describe("Can handle connect event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(204, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 204, "should be success");
   });
 });

--- a/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/connected.spec.ts
@@ -69,7 +69,7 @@ describe("Can handle connected event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async () => {
@@ -80,7 +80,7 @@ describe("Can handle connected event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response 200 even the event handler throws", async () => {
@@ -97,6 +97,6 @@ describe("Can handle connected event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 200, "should be error");
   });
 });

--- a/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/ctor.spec.ts
@@ -7,14 +7,14 @@ import { WebPubSubEventHandler } from "../src/webPubSubEventHandler.js";
 describe("Can create event handler", function () {
   it("Can provide default path", () => {
     const dispatcher = new WebPubSubEventHandler("hub");
-    assert.equal("/api/webpubsub/hubs/hub/", dispatcher.path);
+    assert.equal(dispatcher.path, "/api/webpubsub/hubs/hub/");
   });
 
   it("Supports custom path", () => {
     const dispatcher = new WebPubSubEventHandler("hub", {
       path: "/custom",
     });
-    assert.equal("/custom/", dispatcher.path);
+    assert.equal(dispatcher.path, "/custom/");
   });
 
   it("Throw with invalid endpoints", () => {

--- a/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/disconnected.spec.ts
@@ -69,7 +69,7 @@ describe("Can handle disconnected event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async () => {
@@ -80,7 +80,7 @@ describe("Can handle disconnected event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response 200 even the event handler throws", async () => {
@@ -97,6 +97,6 @@ describe("Can handle disconnected event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 200, "should be error");
   });
 });

--- a/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/user.spec.ts
@@ -73,7 +73,7 @@ describe("Can handle user event", function () {
       handleUserEvent: async (request, response) => {
         assert.equal(request.dataType, "json");
         assert.equal(typeof request.data, "number");
-        assert.strictEqual(1, request.data);
+        assert.strictEqual(request.data, 1);
         response.success();
       },
     });
@@ -82,7 +82,7 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
     expect(endSpy).toBeCalledTimes(1);
   });
 
@@ -94,7 +94,7 @@ describe("Can handle user event", function () {
       handleUserEvent: async (request, response) => {
         assert.equal(request.dataType, "json");
         assert.equal(typeof request.data, "boolean");
-        assert.strictEqual(true, request.data);
+        assert.strictEqual(request.data, true);
         response.success();
       },
     });
@@ -103,7 +103,7 @@ describe("Can handle user event", function () {
     const result = await process;
 
     assert.isTrue(result);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
     expect(endSpy).toBeCalledTimes(1);
   });
 
@@ -223,7 +223,7 @@ describe("Can handle user event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response with 200 when handler is not specified", async () => {
@@ -234,7 +234,7 @@ describe("Can handle user event", function () {
     const result = await dispatcher.handleRequest(req, res);
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be 200");
+    assert.equal(res.statusCode, 200, "should be 200");
   });
 
   it("Should response with error when handler returns error", async () => {
@@ -251,7 +251,7 @@ describe("Can handle user event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(500, res.statusCode, "should be error");
+    assert.equal(res.statusCode, 500, "should be error");
   });
 
   it("Should response with success when handler returns success", async () => {
@@ -268,7 +268,7 @@ describe("Can handle user event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 200, "should be success");
   });
 
   it("Should response with success when returns success binary", async () => {
@@ -285,8 +285,8 @@ describe("Can handle user event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
-    assert.equal("application/octet-stream", res.getHeader("content-type"), "should be binary");
+    assert.equal(res.statusCode, 200, "should be success");
+    assert.equal(res.getHeader("content-type"), "application/octet-stream", "should be binary");
   });
 
   it("Should response with success when returns success text", async () => {
@@ -303,8 +303,8 @@ describe("Can handle user event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
-    assert.equal("text/plain; charset=utf-8", res.getHeader("content-type"), "should be text");
+    assert.equal(res.statusCode, 200, "should be success");
+    assert.equal(res.getHeader("content-type"), "text/plain; charset=utf-8", "should be text");
   });
 
   it("Should response with success when returns success json", async () => {
@@ -321,7 +321,7 @@ describe("Can handle user event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 200, "should be success");
     assert.equal(
       "application/json; charset=utf-8",
       res.getHeader("content-type"),
@@ -347,7 +347,7 @@ describe("Can handle user event", function () {
     const result = await process;
     assert.isTrue(result, "should handle");
     expect(endSpy).toBeCalledTimes(1);
-    assert.equal(200, res.statusCode, "should be success");
+    assert.equal(res.statusCode, 200, "should be success");
 
     assert.equal(
       Buffer.from(

--- a/sdk/web-pubsub/web-pubsub-express/test/validate.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-express/test/validate.spec.ts
@@ -25,7 +25,7 @@ describe("Abuse protection works", function () {
 
     const result = dispatcher.handlePreflight(req, res);
     assert.isTrue(result);
-    assert.equal("*", res.getHeader("webhook-allowed-origin"));
+    assert.equal(res.getHeader("webhook-allowed-origin"), "*");
   });
 
   it("Support valid url in allowed endpoints and return them", () => {

--- a/sdk/web-pubsub/web-pubsub/test/public/odata.spec.ts
+++ b/sdk/web-pubsub/web-pubsub/test/public/odata.spec.ts
@@ -10,6 +10,6 @@ describe("Can parse odata to string", () => {
     const anonymous = null;
     const length = 3;
     const filter = odata`userId eq ${anonymous} or userId eq ${userId} or length(userId) gt ${length}`;
-    assert.equal("userId eq null or userId eq 'vic''s' or length(userId) gt 3", filter);
+    assert.equal(filter, "userId eq null or userId eq 'vic''s' or length(userId) gt 3");
   });
 });


### PR DESCRIPTION
## Description

Fix 303 swapped assertion arguments across 45 test files where a constant literal was incorrectly passed as the first (`actual`) argument instead of the second (`expected`) argument.

For example:
```typescript
// Before (incorrect): constant in actual position
assert.equal(200, res.statusCode);

// After (correct): actual value first, expected constant second
assert.equal(res.statusCode, 200);
```

### Assertion methods fixed
- `assert.equal`
- `assert.strictEqual`
- `assert.deepEqual`
- `assert.deepStrictEqual`
- `assert.notEqual`
- `assert.notDeepEqual`

### Constant types caught
Number literals, string literals, boolean literals (`true`/`false`), `null`, `undefined`, object literals (`{}`), and array literals (`[]`).

### Packages affected
appconfiguration, attestation, core-client, cosmosdb, deviceupdate, easm, eventgrid, healthdataaiservices, keyvault, loadtesting, search, servicebus, storage (blob, datalake, avro, changefeed), textanalytics, translation, and web-pubsub.

This is a test-only change with no functional impact, but correcting argument order ensures assertion failure messages display the actual vs expected values correctly.