### PR TITLE
Add ADO CI pipeline for warp build tool

### DIFF
--- a/common/tools/warp/ci.yml
+++ b/common/tools/warp/ci.yml
@@ -1,0 +1,59 @@
+trigger:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+  paths:
+    include:
+      - common/tools/warp/
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+
+  paths:
+    include:
+      - common/tools/warp/
+
+jobs:
+  - job: 'Warp'
+    displayName: 'Warp validation'
+
+    variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+      - template: /eng/pipelines/templates/variables/image.yml
+
+    pool:
+      name: $(LINUXPOOL)
+      demands: ImageOverride -equals $(LINUXVMIMAGE)
+
+    steps:
+      - template: /eng/pipelines/templates/steps/common.yml
+
+      - script: |
+          npm install -g pnpm
+        displayName: "Install Pnpm"
+
+      - script: |
+          pnpm install
+        displayName: "Install library dependencies"
+
+      - script: |
+          pnpm --filter @microsoft/warp... build
+        displayName: "Build warp"
+
+      - script: |
+          pnpm --filter @microsoft/warp... check-format
+        displayName: "Check format for warp"
+
+      - script: |
+          pnpm --filter @microsoft/warp... lint
+        displayName: "Lint warp"
+
+      - script: |
+          pnpm --filter @microsoft/warp test
+        displayName: "Run warp unit tests"


### PR DESCRIPTION
Adds an Azure DevOps CI pipeline for `@microsoft/warp` at `common/tools/warp/ci.yml`, following the same pattern as `common/tools/dev-tool/ci.yml`.

This replaces the GitHub Actions workflow from #37961 (reverted in #37975) which failed because GitHub Actions runners lack credentials for the Azure DevOps npm feed (`pkgs.dev.azure.com`).

The ADO pipeline uses `eng/pipelines/templates/steps/common.yml` which configures authenticated npm via `create-authenticated-npmrc.yml`, solving the auth issue.

**Steps**: build → check-format → lint → test

> **Note**: This pipeline YAML needs to be registered in Azure DevOps to take effect.