### PR TITLE
refactor(ts-http-runtime): consolidate test imports to use public entry point

### DIFF
--- a/sdk/core/ts-http-runtime/test/auth/credential.spec.ts
+++ b/sdk/core/ts-http-runtime/test/auth/credential.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { assert, describe, it } from "vitest";
-import type { ClientCredential } from "../../src/auth/credentials.js";
+import type { ClientCredential } from "../../src/index.js";
 import {
   isApiKeyCredential,
   isBasicCredential,

--- a/sdk/core/ts-http-runtime/test/browser/fetchHttpClient.spec.ts
+++ b/sdk/core/ts-http-runtime/test/browser/fetchHttpClient.spec.ts
@@ -3,10 +3,8 @@
 
 import { describe, it, assert, vi, beforeEach, afterEach } from "vitest";
 import { createFetchHttpClient } from "../../src/fetchHttpClient.js";
-import { createPipelineRequest } from "../../src/pipelineRequest.js";
+import { createPipelineRequest, createHttpHeaders, AbortError } from "../../src/index.js";
 import { png } from "./mocks/encodedPng.js";
-import { createHttpHeaders } from "../../src/httpHeaders.js";
-import { AbortError } from "../../src/abort-controller/AbortError.js";
 import { delay } from "../../src/util/helpers.js";
 import { arrayBufferViewToArrayBuffer } from "../../src/util/arrayBuffer.js";
 

--- a/sdk/core/ts-http-runtime/test/browser/logger.spec.ts
+++ b/sdk/core/ts-http-runtime/test/browser/logger.spec.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import * as Logger from "../../src/logger/logger.js";
+import { createClientLogger, setLogLevel } from "../../src/index.js";
 
-const testLogger = Logger.createClientLogger("test");
+const testLogger = createClientLogger("test");
 
 describe("TypeSpecRuntimeLogger (browser)", function () {
   function expectedTestMessage(namespace: string, message: string): string {
@@ -12,12 +12,12 @@ describe("TypeSpecRuntimeLogger (browser)", function () {
   }
 
   afterEach(() => {
-    Logger.setLogLevel(undefined);
+    setLogLevel(undefined);
     vi.restoreAllMocks();
   });
 
   it("logs to the correct console function", () => {
-    Logger.setLogLevel("verbose");
+    setLogLevel("verbose");
 
     const debugStub = vi.spyOn(console, "debug");
     testLogger.verbose("verbose");

--- a/sdk/core/ts-http-runtime/test/browser/streams.spec.ts
+++ b/sdk/core/ts-http-runtime/test/browser/streams.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, expect, vi, beforeEach, afterEach } from "vitest";
-import { getClient } from "../../src/client/getClient.js";
+import { getClient } from "../../src/index.js";
 
 function createResponse(statusCode: number, body = ""): Response {
   const stream = new ReadableStream({

--- a/sdk/core/ts-http-runtime/test/client/clientHelpers.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/clientHelpers.spec.ts
@@ -7,7 +7,7 @@ import type {
   BearerTokenCredential,
   OAuth2TokenCredential,
   BasicCredential,
-} from "../../src/auth/credentials.js";
+} from "../../src/index.js";
 import { createDefaultPipeline } from "../../src/client/clientHelpers.js";
 import { bearerAuthenticationPolicyName } from "../../src/policies/auth/bearerAuthenticationPolicy.js";
 import { basicAuthenticationPolicyName } from "../../src/policies/auth/basicAuthenticationPolicy.js";

--- a/sdk/core/ts-http-runtime/test/client/createRestError.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/createRestError.spec.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import { createRestError } from "../../src/client/restError.js";
-import type { PipelineRequest } from "../../src/interfaces.js";
+import { createRestError, type PipelineRequest } from "../../src/index.js";
 
 describe("createRestError", () => {
   it("should create a rest error from a PathUnchecked response with standard error", () => {

--- a/sdk/core/ts-http-runtime/test/client/getClient.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/getClient.spec.ts
@@ -3,15 +3,16 @@
 
 import { describe, it, assert, vi, afterEach } from "vitest";
 import { getCachedDefaultHttpsClient } from "../../src/client/clientHelpers.js";
-import { getClient } from "../../src/client/getClient.js";
-import type {
-  HttpClient,
-  PipelineRequest,
-  PipelineResponse,
-  SendRequest,
-} from "../../src/interfaces.js";
-import { createEmptyPipeline, type PipelinePolicy } from "../../src/pipeline.js";
-import { createHttpHeaders } from "../../src/httpHeaders.js";
+import {
+  getClient,
+  type HttpClient,
+  type PipelineRequest,
+  type PipelineResponse,
+  type SendRequest,
+  createEmptyPipeline,
+  type PipelinePolicy,
+  createHttpHeaders,
+} from "../../src/index.js";
 import { isNodeLike } from "../../src/util/checkEnvironment.js";
 
 describe("getClient", () => {

--- a/sdk/core/ts-http-runtime/test/client/sendRequest.spec.ts
+++ b/sdk/core/ts-http-runtime/test/client/sendRequest.spec.ts
@@ -3,11 +3,14 @@
 
 import { describe, it, assert } from "vitest";
 import { sendRequest } from "../../src/client/sendRequest.js";
-import { RestError } from "../../src/restError.js";
-import type { MultipartRequestBody, PipelineResponse } from "../../src/interfaces.js";
-import type { Pipeline } from "../../src/pipeline.js";
-import { createEmptyPipeline } from "../../src/pipeline.js";
-import { createHttpHeaders } from "../../src/httpHeaders.js";
+import {
+  RestError,
+  type MultipartRequestBody,
+  type PipelineResponse,
+  type Pipeline,
+  createEmptyPipeline,
+  createHttpHeaders,
+} from "../../src/index.js";
 import { stringToUint8Array } from "../../src/util/bytesEncoding.js";
 import type { PartDescriptor } from "../../src/client/multipart.js";
 

--- a/sdk/core/ts-http-runtime/test/defaultLogPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/defaultLogPolicy.spec.ts
@@ -3,10 +3,8 @@
 
 import { describe, it, assert, vi } from "vitest";
 import { DEFAULT_RETRY_POLICY_COUNT } from "../src/constants.js";
-import type { PipelinePolicy } from "../src/pipeline.js";
-import { createHttpHeaders } from "../src/httpHeaders.js";
+import { type PipelinePolicy, createHttpHeaders, createPipelineRequest } from "../src/index.js";
 import { createPipelineFromOptions } from "../src/createPipelineFromOptions.js";
-import { createPipelineRequest } from "../src/pipelineRequest.js";
 import { isBrowser, isNodeLike } from "../src/util/checkEnvironment.js";
 
 describe("defaultLogPolicy", function () {

--- a/sdk/core/ts-http-runtime/test/formDataPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/formDataPolicy.spec.ts
@@ -2,10 +2,15 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, vi } from "vitest";
-import type { PipelineResponse, SendRequest } from "../src/index.js";
-import type { BodyPart, FormDataMap, MultipartRequestBody } from "../src/interfaces.js";
-import { createPipelineRequest } from "../src/pipelineRequest.js";
-import { createHttpHeaders } from "../src/httpHeaders.js";
+import {
+  type PipelineResponse,
+  type SendRequest,
+  type BodyPart,
+  type FormDataMap,
+  type MultipartRequestBody,
+  createPipelineRequest,
+  createHttpHeaders,
+} from "../src/index.js";
 import { formDataPolicy } from "../src/policies/formDataPolicy.js";
 import { isBrowser, isNodeLike } from "../src/util/checkEnvironment.js";
 

--- a/sdk/core/ts-http-runtime/test/httpHeaders.spec.ts
+++ b/sdk/core/ts-http-runtime/test/httpHeaders.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import { createHttpHeaders } from "../src/httpHeaders.js";
+import { createHttpHeaders } from "../src/index.js";
 
 describe("HttpHeaders", () => {
   it("toJSON() should use normalized header names", () => {

--- a/sdk/core/ts-http-runtime/test/logger/debug.spec.ts
+++ b/sdk/core/ts-http-runtime/test/logger/debug.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
-import type { Debugger } from "../../src/logger/debug.js";
+import type { Debugger } from "../../src/index.js";
 import debug from "../../src/logger/debug.js";
 
 describe("debug", function () {

--- a/sdk/core/ts-http-runtime/test/logger/logger.spec.ts
+++ b/sdk/core/ts-http-runtime/test/logger/logger.spec.ts
@@ -2,23 +2,23 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import * as Logger from "../../src/logger/logger.js";
+import { createClientLogger, setLogLevel, TypeSpecRuntimeLogger } from "../../src/index.js";
 
-const testLogger = Logger.createClientLogger("test");
+const testLogger = createClientLogger("test");
 
 describe("TypeSpecRuntimeLogger", function () {
   it("is not enabled", () => {
     // TypeSpecRuntimeLogger is only used to enable a way to redirect logs.
     // This test ensures logs aren't redirected to the root logger.
     // Log redirection works because all the client loggers inherit from the root logger.
-    Logger.setLogLevel("verbose");
-    assert.isFalse(Logger.TypeSpecRuntimeLogger.enabled);
+    setLogLevel("verbose");
+    assert.isFalse(TypeSpecRuntimeLogger.enabled);
   });
 });
 
 describe("setLogLevel", () => {
   it("enables all relevant loggers for verbose setting", () => {
-    Logger.setLogLevel("verbose");
+    setLogLevel("verbose");
     assert.isTrue(testLogger.verbose.enabled);
     assert.isTrue(testLogger.info.enabled);
     assert.isTrue(testLogger.warning.enabled);
@@ -26,7 +26,7 @@ describe("setLogLevel", () => {
   });
 
   it("enables all relevant loggers for info setting", () => {
-    Logger.setLogLevel("info");
+    setLogLevel("info");
     assert.isFalse(testLogger.verbose.enabled);
     assert.isTrue(testLogger.info.enabled);
     assert.isTrue(testLogger.warning.enabled);
@@ -34,7 +34,7 @@ describe("setLogLevel", () => {
   });
 
   it("enables all relevant loggers for warning setting", () => {
-    Logger.setLogLevel("warning");
+    setLogLevel("warning");
     assert.isFalse(testLogger.verbose.enabled);
     assert.isFalse(testLogger.info.enabled);
     assert.isTrue(testLogger.warning.enabled);
@@ -42,7 +42,7 @@ describe("setLogLevel", () => {
   });
 
   it("enables all relevant loggers for warning setting", () => {
-    Logger.setLogLevel("error");
+    setLogLevel("error");
     assert.isFalse(testLogger.verbose.enabled);
     assert.isFalse(testLogger.info.enabled);
     assert.isFalse(testLogger.warning.enabled);
@@ -50,13 +50,13 @@ describe("setLogLevel", () => {
   });
 
   it("clears all relevant loggers when undefined", () => {
-    Logger.setLogLevel("verbose");
+    setLogLevel("verbose");
     assert.isTrue(testLogger.verbose.enabled);
     assert.isTrue(testLogger.info.enabled);
     assert.isTrue(testLogger.warning.enabled);
     assert.isTrue(testLogger.error.enabled);
 
-    Logger.setLogLevel(undefined);
+    setLogLevel(undefined);
     assert.isFalse(testLogger.verbose.enabled);
     assert.isFalse(testLogger.info.enabled);
     assert.isFalse(testLogger.warning.enabled);
@@ -65,25 +65,25 @@ describe("setLogLevel", () => {
 
   it("throws when setting to an unknown log level", () => {
     assert.throws(() => {
-      Logger.setLogLevel("debug" as any);
+      setLogLevel("debug" as any);
     }, /Unknown log level/);
   });
 });
 
 describe("ClientLoggers", () => {
   it("logs to parent loggers", () => {
-    Logger.setLogLevel("verbose");
+    setLogLevel("verbose");
 
-    const oldLog = Logger.TypeSpecRuntimeLogger.log.bind(Logger.TypeSpecRuntimeLogger);
+    const oldLog = TypeSpecRuntimeLogger.log.bind(TypeSpecRuntimeLogger);
     let called = false;
 
-    Logger.TypeSpecRuntimeLogger.log = () => {
+    TypeSpecRuntimeLogger.log = () => {
       called = true;
     };
 
     testLogger.info("hello");
     assert.isTrue(called);
 
-    Logger.TypeSpecRuntimeLogger.log = oldLog;
+    TypeSpecRuntimeLogger.log = oldLog;
   });
 });

--- a/sdk/core/ts-http-runtime/test/multipartPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/multipartPolicy.spec.ts
@@ -2,11 +2,15 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, vi, expect } from "vitest";
-import { createHttpHeaders } from "../src/httpHeaders.js";
-import type { PipelineRequest, PipelineResponse, SendRequest } from "../src/interfaces.js";
-import { createPipelineRequest } from "../src/pipelineRequest.js";
+import {
+  createHttpHeaders,
+  type PipelineRequest,
+  type PipelineResponse,
+  type SendRequest,
+  createPipelineRequest,
+  type PipelineRequestOptions,
+} from "../src/index.js";
 import { multipartPolicy } from "../src/policies/multipartPolicy.js";
-import type { PipelineRequestOptions } from "../src/pipelineRequest.js";
 import { stringToUint8Array } from "../src/util/bytesEncoding.js";
 import { assertBodyMatches } from "./util.js";
 

--- a/sdk/core/ts-http-runtime/test/node/nodeHttpClient.spec.ts
+++ b/sdk/core/ts-http-runtime/test/node/nodeHttpClient.spec.ts
@@ -4,7 +4,7 @@
 import { describe, it, assert, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough, Writable } from "node:stream";
 import type { ClientRequest, IncomingHttpHeaders, IncomingMessage } from "http";
-import { createPipelineRequest } from "../../src/index.js";
+import { createPipelineRequest, createDefaultHttpClient } from "../../src/index.js";
 
 vi.mock("node:https", async () => {
   const actual = await vi.importActual("node:https");
@@ -28,7 +28,6 @@ vi.mock("node:http", async () => {
 
 import https from "node:https";
 import http from "node:http";
-import { createDefaultHttpClient } from "../../src/defaultHttpClient.js";
 
 function delay(timeInMs: number): Promise<void> {
   return new Promise((resolve) => {

--- a/sdk/core/ts-http-runtime/test/node/pipeline.spec.ts
+++ b/sdk/core/ts-http-runtime/test/node/pipeline.spec.ts
@@ -4,10 +4,8 @@
 import { describe, it, assert, vi, afterEach } from "vitest";
 import { proxyPolicy, proxyPolicyName } from "../../src/policies/proxyPolicy.js";
 import { tlsPolicy, tlsPolicyName } from "../../src/policies/tlsPolicy.js";
-import type { HttpClient } from "../../src/interfaces.js";
+import { type HttpClient, createEmptyPipeline, createHttpHeaders } from "../../src/index.js";
 import { HttpsProxyAgent } from "https-proxy-agent";
-import { createEmptyPipeline } from "../../src/pipeline.js";
-import { createHttpHeaders } from "../../src/httpHeaders.js";
 import { createNodeHttpClient } from "../../src/nodeHttpClient.js";
 import { createPipelineFromOptions } from "../../src/createPipelineFromOptions.js";
 

--- a/sdk/core/ts-http-runtime/test/pipeline.spec.ts
+++ b/sdk/core/ts-http-runtime/test/pipeline.spec.ts
@@ -2,9 +2,13 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import type { HttpClient, PipelinePolicy } from "../src/index.js";
-import { createHttpHeaders, createPipelineRequest } from "../src/index.js";
-import { createEmptyPipeline } from "../src/pipeline.js";
+import {
+  type HttpClient,
+  type PipelinePolicy,
+  createHttpHeaders,
+  createPipelineRequest,
+  createEmptyPipeline,
+} from "../src/index.js";
 import { createPipelineFromOptions } from "../src/createPipelineFromOptions.js";
 
 describe("HttpsPipeline", function () {

--- a/sdk/core/ts-http-runtime/test/restError.spec.ts
+++ b/sdk/core/ts-http-runtime/test/restError.spec.ts
@@ -2,9 +2,12 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import type { PipelineRequest, PipelineResponse } from "../src/interfaces.js";
-import { createHttpHeaders } from "../src/httpHeaders.js";
-import { RestError } from "../src/restError.js";
+import {
+  type PipelineRequest,
+  type PipelineResponse,
+  createHttpHeaders,
+  RestError,
+} from "../src/index.js";
 
 describe("RestError", function () {
   const request: PipelineRequest = {


### PR DESCRIPTION
## What

Consolidate test imports in `@typespec/ts-http-runtime` to use the public entry point (`src/index.js`) for all publicly exported symbols, instead of importing from deep source paths like `src/httpHeaders.js`, `src/pipeline.js`, etc.

## Why

- Tests should validate the **public API surface**, not internal module structure
- Import paths become resilient to internal refactoring (moving/renaming source files)
- Consistent import style across test files

## What changed

18 test files updated — only import paths, no test logic changes:
- Deep imports like `from "../src/httpHeaders.js"` → consolidated into `from "../src/index.js"`
- `* as Logger` namespace imports → named imports from index (`createClientLogger`, `setLogLevel`, `TypeSpecRuntimeLogger`)
- Imports that **must** use deep paths (non-exported internals) are left unchanged

## Validation

Node tests: 40 files, 390 passed ✅