### PR TITLE
[KeyVault] Update keyvault-certificates default API version to 2025-07-01

### DIFF
--- a/sdk/keyvault/keyvault-certificates/assets.json
+++ b/sdk/keyvault/keyvault-certificates/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/keyvault/keyvault-certificates",
-  "Tag": "js/keyvault/keyvault-certificates_cb4b7ec7b6"
+  "Tag": "js/keyvault/keyvault-certificates_364ad076be"
 }

--- a/sdk/keyvault/keyvault-certificates/src/api/keyVaultContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/api/keyVaultContext.ts
@@ -43,7 +43,7 @@ export function createKeyVault(
   };
   const clientContext = getClient(endpointUrl, credential, updatedOptions);
   clientContext.pipeline.removePolicy({ name: "ApiVersionPolicy" });
-  const apiVersion = options.apiVersion ?? "7.6";
+  const apiVersion = options.apiVersion ?? KnownVersions.V20250701;
   clientContext.pipeline.addPolicy({
     name: "ClientApiVersionPolicy",
     sendRequest: (req, next) => {

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -15,7 +15,7 @@ import type {
 /**
  * The latest supported KeyVault service API version
  */
-export const LATEST_API_VERSION = "7.6";
+export const LATEST_API_VERSION = "2025-07-01";
 
 /**
  * The optional parameters accepted by the KeyVault's CertificateClient

--- a/sdk/keyvault/keyvault-certificates/src/models/models.ts
+++ b/sdk/keyvault/keyvault-certificates/src/models/models.ts
@@ -1259,4 +1259,6 @@ export enum KnownVersions {
   V76Preview2 = "7.6-preview.2",
   /** The 7.6 API version. */
   V76 = "7.6",
+  /** The 2025-07-01 API version. */
+  V20250701 = "2025-07-01",
 }


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/keyvault-certificates`

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The `keyvault-certificates` package was still defaulting to API version `7.6`, while the `keyvault-secrets` package had already been updated to `2025-07-01`. This PR aligns the certificates package to use the same latest stable API version (`2025-07-01`), which adds support for new features including IP addresses and URIs in Subject Alternative Names (SANs).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This is a straightforward version bump following the same pattern used in the secrets package. The three changes are:
- Update `LATEST_API_VERSION` constant in `certificatesModels.ts` from `"7.6"` to `"2025-07-01"`
- Update the default `apiVersion` fallback in `keyVaultContext.ts` from `"7.6"` to `"2025-07-01"`
- Add `V20250701 = "2025-07-01"` member to the `KnownVersions` enum in `src/models/models.ts`

### Are there test cases added in this PR? _(If not, why?)_

No new tests — this is a version constant update only. Existing tests continue to pass against the new API version, which is backward compatible.

### Provide a list of related PRs _(if any)_

- `keyvault-secrets` default API version update to `2025-07-01` (already merged)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)