### PR TITLE
Add warp PRLabel to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1685,6 +1685,9 @@ sdk/servicegroups/arm-servicegroups/ @qiaozha @MaryGao @JialinHuang803
 # PRLabel: %eslint plugin
 /common/tools/eslint-plugin-azure-sdk*/ @deyaaeldeen @jeremymeng
 
+# PRLabel: %warp
+/common/tools/warp/ @Azure/azure-sdk-for-js-core
+
 /tsconfig*.json @mikeharder @Azure/azure-sdk-for-js-core
 /sdk/*/*/tsconfig*.json @Azure/azure-sdk-for-js-core
 


### PR DESCRIPTION
Adds a `# PRLabel: %warp` entry in CODEOWNERS so the `github-event-processor` bot automatically adds the `warp` label to PRs that modify files under `common/tools/warp/`.