### PR TITLE
[KeyVault] Add samples for new certificate SANs (IP/URI) and secret outContentType/previousVersion features

### DIFF
--- a/sdk/keyvault/keyvault-certificates/samples/v4/javascript/helloWorld.js
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/javascript/helloWorld.js
@@ -5,7 +5,7 @@
  * @summary Uses a CertificateClient in various ways to read a certificate as well as update a certificate's tags.
  */
 
-const { CertificateClient, DefaultCertificatePolicy } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 const { DefaultAzureCredential } = require("@azure/identity");
 // Load the .env file if it exists
 require("dotenv/config");
@@ -24,10 +24,20 @@ async function main() {
   const uniqueString = new Date().getTime();
   const certificateName = `hello-world-${uniqueString}`;
 
-  // Creating a self-signed certificate
+  // Creating a self-signed certificate with Subject Alternative Names (SANs)
+  // SANs can include DNS names, IP addresses, URIs, and more.
+  const certificatePolicy = {
+    issuerName: "Self",
+    subject: "cn=MyCert",
+    subjectAlternativeNames: {
+      dnsNames: ["sdk.azure-int.net"],
+      ipAddresses: ["10.0.0.1", "2001:db8::1"],
+      uniformResourceIdentifiers: ["https://mydomain.com"],
+    },
+  };
   const createPoller = await client.beginCreateCertificate(
     certificateName,
-    DefaultCertificatePolicy,
+    certificatePolicy,
   );
 
   // Get the pending certificate before the creation operation is complete

--- a/sdk/keyvault/keyvault-certificates/samples/v4/typescript/src/helloWorld.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/typescript/src/helloWorld.ts
@@ -5,8 +5,8 @@
  * @summary Uses a CertificateClient in various ways to read a certificate as well as update a certificate's tags.
  */
 
-import type { CertificatePolicy, UpdateCertificateOptions } from "@azure/keyvault-certificates";
-import { CertificateClient, DefaultCertificatePolicy } from "@azure/keyvault-certificates";
+import type { CertificatePolicy, SubjectAlternativeNames, UpdateCertificateOptions } from "@azure/keyvault-certificates";
+import { CertificateClient } from "@azure/keyvault-certificates";
 import { DefaultAzureCredential } from "@azure/identity";
 // Load the .env file if it exists
 import "dotenv/config";
@@ -25,10 +25,20 @@ export async function main(): Promise<void> {
   const uniqueString = new Date().getTime();
   const certificateName = `hello-world-${uniqueString}`;
 
-  // Creating a self-signed certificate
+  // Creating a self-signed certificate with Subject Alternative Names (SANs)
+  // SANs can include DNS names, IP addresses, URIs, and more.
+  const certificatePolicy: CertificatePolicy = {
+    issuerName: "Self",
+    subject: "cn=MyCert",
+    subjectAlternativeNames: {
+      dnsNames: ["sdk.azure-int.net"],
+      ipAddresses: ["10.0.0.1", "2001:db8::1"],
+      uniformResourceIdentifiers: ["https://mydomain.com"],
+    },
+  };
   const createPoller = await client.beginCreateCertificate(
     certificateName,
-    DefaultCertificatePolicy,
+    certificatePolicy,
   );
 
   // Get the pending certificate before the creation operation is complete

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/helloWorld.js
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/helloWorld.js
@@ -5,7 +5,7 @@
  * @summary Uses a SecretClient to create, read, and update a secret in various ways.
  */
 
-const { SecretClient } = require("@azure/keyvault-secrets");
+const { SecretClient, KnownContentType } = require("@azure/keyvault-secrets");
 const { DefaultAzureCredential } = require("@azure/identity");
 
 // Load the .env file if it exists
@@ -34,11 +34,24 @@ async function main() {
   const secret = await client.getSecret(secretName);
   console.log("secret: ", secret);
 
+  // For certificate-backed secrets, you can retrieve the value in a different format using outContentType.
+  // For example, to get a PFX-backed secret as PEM:
+  // const pemSecret = await client.getSecret(secretName, { outContentType: KnownContentType.PEM });
+
   // Update the secret with different attributes
   const updatedSecret = await client.updateSecretProperties(secretName, result.properties.version, {
     enabled: false,
   });
   console.log("updated secret: ", updatedSecret);
+
+  // Create a new version to demonstrate previousVersion tracking
+  const newResult = await client.setSecret(secretName, "MyUpdatedSecretValue");
+  console.log("new secret version: ", newResult.properties.version);
+
+  // For secrets created after June 1, 2025, previousVersion tracks version history.
+  if (newResult.properties.previousVersion) {
+    console.log("previous version: ", newResult.properties.previousVersion);
+  }
 
   // Delete the secret
   // If we don't want to purge the secret later, we don't need to wait until this finishes

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/helloWorld.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/helloWorld.ts
@@ -5,7 +5,7 @@
  * @summary Uses a SecretClient to create, read, and update a secret in various ways.
  */
 
-import { SecretClient } from "@azure/keyvault-secrets";
+import { SecretClient, KnownContentType } from "@azure/keyvault-secrets";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
@@ -35,6 +35,10 @@ export async function main(): Promise<void> {
   const secret = await client.getSecret(secretName);
   console.log("secret: ", secret);
 
+  // For certificate-backed secrets, you can retrieve the value in a different format using outContentType.
+  // For example, to get a PFX-backed secret as PEM:
+  // const pemSecret = await client.getSecret(secretName, { outContentType: KnownContentType.PEM });
+
   // Update the secret with different attributes
   const updatedSecret = await client.updateSecretProperties(
     secretName,
@@ -44,6 +48,15 @@ export async function main(): Promise<void> {
     },
   );
   console.log("updated secret: ", updatedSecret);
+
+  // Create a new version to demonstrate previousVersion tracking
+  const newResult = await client.setSecret(secretName, "MyUpdatedSecretValue");
+  console.log("new secret version: ", newResult.properties.version);
+
+  // For secrets created after June 1, 2025, previousVersion tracks version history.
+  if (newResult.properties.previousVersion) {
+    console.log("previous version: ", newResult.properties.previousVersion);
+  }
 
   // Delete the secret
   // If we don't want to purge the secret later, we don't need to wait until this finishes


### PR DESCRIPTION
## Description
This PR adds sample code demonstrating new KeyVault features:

### Certificates
- IP addresses in Subject Alternative Names (SANs)
- URIs in Subject Alternative Names (SANs)

### Secrets
- `outContentType` option for format conversion (PFX/PEM) via `KnownContentType`  
- `previousVersion` property on SecretProperties

## Files Changed
- `sdk/keyvault/keyvault-certificates/samples/v4/typescript/src/helloWorld.ts`  
- `sdk/keyvault/keyvault-certificates/samples/v4/javascript/helloWorld.js`  
- `sdk/keyvault/keyvault-secrets/samples/v4/typescript/src/helloWorld.ts`  
- `sdk/keyvault/keyvault-secrets/samples/v4/javascript/helloWorld.js`