### PR TITLE
[ts-http-runtime] set bodyAsText on RestError.response

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 0.3.6 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Set `RestError.response.bodyAsText` when the error response body has `string` type [PR #38059](https://github.com/Azure/azure-sdk-for-js/pull/38059)
+
 ## 0.3.5 (2026-04-07)
 
 ### Bugs Fixed

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/ts-http-runtime",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/ts-http-runtime/src/client/restError.ts
+++ b/sdk/core/ts-http-runtime/src/client/restError.ts
@@ -32,11 +32,12 @@ export function createRestError(
   });
 }
 
-function toPipelineResponse(response: PathUncheckedResponse): PipelineResponse {
+function toPipelineResponse(errorResponse: PathUncheckedResponse): PipelineResponse {
   return {
-    headers: createHttpHeaders(response.headers),
-    request: response.request,
-    status: statusCodeToNumber(response.status) ?? -1,
+    headers: createHttpHeaders(errorResponse.headers),
+    request: errorResponse.request,
+    status: statusCodeToNumber(errorResponse.status) ?? -1,
+    ...(typeof errorResponse.body === "string" ? { bodyAsText: errorResponse.body } : {}),
   };
 }
 

--- a/sdk/core/ts-http-runtime/src/constants.ts
+++ b/sdk/core/ts-http-runtime/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "0.3.5";
+export const SDK_VERSION: string = "0.3.6";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;

--- a/sdk/core/ts-http-runtime/test/public/client/createRestError.spec.ts
+++ b/sdk/core/ts-http-runtime/test/public/client/createRestError.spec.ts
@@ -98,4 +98,18 @@ describe("createRestError", () => {
     assert.equal(error.code, undefined);
     assert.equal(error.message, "Unexpected status code: 400");
   });
+
+  it("should create a rest error with response bodyAsText when response body is a string", () => {
+    const response = {
+      status: "404",
+      headers: {},
+      request: {} as PipelineRequest,
+      body: "error body",
+    };
+    const error = createRestError(response);
+    assert.equal(error.statusCode, 404);
+    assert.equal(error.code, undefined);
+    assert.equal(error.message, "Unexpected status code: 404");
+    assert.equal(error.response?.bodyAsText, "error body");
+  });
 });


### PR DESCRIPTION
when the body type is string. This allows downstream libraries to access error information.

### Packages impacted by this PR

@typespec/ts-http-runtime

### Issues associated with this PR

https://github.com/Azure/azure-sdk-for-js/issues/38057
