### PR TITLE
chore(ts-http-runtime): add react-native platform tests

### DIFF
--- a/sdk/core/ts-http-runtime/eslint.config.mjs
+++ b/sdk/core/ts-http-runtime/eslint.config.mjs
@@ -1,11 +1,16 @@
 import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 
-export default azsdkEslint.config([
-  {
-    rules: {
-      "@azure/azure-sdk/ts-package-json-name": "warn",
-      "@azure/azure-sdk/ts-versioning-semver": "warn",
-      "n/no-unsupported-features/node-builtins": "off",
+export default [
+  // React Native test files require a dedicated tsconfig project that will be
+  // added in a follow-up migration PR. Until then, exclude them from linting.
+  { ignores: ["test/**/react-native/**"] },
+  ...azsdkEslint.config([
+    {
+      rules: {
+        "@azure/azure-sdk/ts-package-json-name": "warn",
+        "@azure/azure-sdk/ts-versioning-semver": "warn",
+        "n/no-unsupported-features/node-builtins": "off",
+      },
     },
-  },
-]);
+  ]),
+];

--- a/sdk/core/ts-http-runtime/test/internal/react-native/checkEnvironment.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/react-native/checkEnvironment.spec.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  isBrowser,
+  isBun,
+  isDeno,
+  isNodeLike,
+  isNodeRuntime,
+  isReactNative,
+  isWebWorker,
+} from "../../../src/util/internal.js";
+import { describe, it, assert } from "vitest";
+
+describe("checkEnvironment (react-native)", function () {
+  it("isBrowser should return false", function () {
+    assert.isFalse(isBrowser);
+  });
+
+  it("isBun should return false", function () {
+    assert.isFalse(isBun);
+  });
+
+  it("isDeno should return false", function () {
+    assert.isFalse(isDeno);
+  });
+
+  it("isNodeRuntime should return false", function () {
+    assert.isFalse(isNodeRuntime);
+  });
+
+  it("isNodeLike should return false", function () {
+    assert.isFalse(isNodeLike);
+  });
+
+  it("isReactNative should return true", function () {
+    assert.isTrue(isReactNative);
+  });
+
+  it("isWebWorker should return false", function () {
+    assert.isFalse(isWebWorker);
+  });
+});

--- a/sdk/core/ts-http-runtime/test/internal/react-native/formDataPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/react-native/formDataPolicy.spec.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert, vi } from "vitest";
+import {
+  type PipelineResponse,
+  type SendRequest,
+  createPipelineRequest,
+  createHttpHeaders,
+} from "../../../src/index.js";
+import { formDataPolicy } from "../../../src/policies/internal.js";
+
+describe("formDataPolicy (react-native)", () => {
+  describe("FormData request bodies", () => {
+    it("should be passed through in react-native", async () => {
+      const request = createPipelineRequest({
+        url: "https://bing.com",
+        headers: createHttpHeaders({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
+      });
+      const formData = new FormData();
+      formData.append("service", "registry.azurecr.io");
+      formData.append("scope", "repository:library/hello-world:metadata_read");
+      request.body = formData;
+
+      const successResponse: PipelineResponse = {
+        headers: createHttpHeaders(),
+        request,
+        status: 200,
+      };
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValue(successResponse);
+
+      const policy = formDataPolicy();
+
+      const result = await policy.sendRequest(request, next);
+
+      assert.isUndefined(result.request.formData);
+      assert.strictEqual(result.request.body, formData);
+    });
+  });
+});

--- a/sdk/core/ts-http-runtime/test/internal/react-native/proxyPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/react-native/proxyPolicy.spec.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import { proxyPolicy } from "../../../src/policies/internal.js";
+
+describe("proxyPolicy (react-native)", function () {
+  it("Throws on creation", function () {
+    assert.throws(() => {
+      proxyPolicy();
+    }, /proxyPolicy is not supported in browser environment/);
+  });
+});

--- a/sdk/core/ts-http-runtime/test/internal/react-native/userAgentPlatform.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/react-native/userAgentPlatform.spec.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import { setPlatformSpecificData } from "../../../src/util/userAgent.js";
+
+describe("userAgentPlatform (react-native)", () => {
+  it("should set react-native platform data from Platform.constants", async () => {
+    const map = new Map<string, string>();
+
+    await setPlatformSpecificData(map);
+
+    // The stub provides Platform = { OS: "test", Version: "0.0.0", constants: { reactNativeVersion: { major: 0, minor: 0, patch: 0 } } }
+    assert.strictEqual(map.get("react-native"), "0.0.0 (test 0.0.0)");
+  });
+});

--- a/sdk/core/ts-http-runtime/test/public/react-native/logger.spec.ts
+++ b/sdk/core/ts-http-runtime/test/public/react-native/logger.spec.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createClientLogger, setLogLevel } from "../../../src/index.js";
+
+const testLogger = createClientLogger("test");
+
+describe("TypeSpecRuntimeLogger (react-native)", function () {
+  function expectedTestMessage(namespace: string, message: string): string {
+    return `${namespace} ${message}`;
+  }
+
+  afterEach(() => {
+    setLogLevel(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("logs to the correct console function", () => {
+    setLogLevel("verbose");
+
+    const debugStub = vi.spyOn(console, "debug");
+    testLogger.verbose("verbose");
+    expect(debugStub).toHaveBeenCalledOnce();
+    expect(debugStub).toHaveBeenCalledWith(
+      expectedTestMessage("typeSpecRuntime:test:verbose", "verbose"),
+    );
+    debugStub.mockClear();
+
+    const infoStub = vi.spyOn(console, "info");
+    testLogger.info("info");
+    expect(infoStub).toHaveBeenCalledOnce();
+    expect(infoStub).toHaveBeenCalledWith(expectedTestMessage("typeSpecRuntime:test:info", "info"));
+    infoStub.mockClear();
+
+    const warningStub = vi.spyOn(console, "warn");
+    testLogger.warning("warning");
+    expect(warningStub).toHaveBeenCalledOnce();
+    expect(warningStub).toHaveBeenCalledWith(
+      expectedTestMessage("typeSpecRuntime:test:warning", "warning"),
+    );
+    warningStub.mockClear();
+
+    const errorStub = vi.spyOn(console, "error");
+    testLogger.error("error");
+    expect(errorStub).toHaveBeenCalledOnce();
+    expect(errorStub).toHaveBeenCalledWith(
+      expectedTestMessage("typeSpecRuntime:test:error", "error"),
+    );
+    errorStub.mockClear();
+  });
+});

--- a/sdk/core/ts-http-runtime/tsconfig.test.node.json
+++ b/sdk/core/ts-http-runtime/tsconfig.test.node.json
@@ -13,6 +13,7 @@
     "./**/*-browser.mts",
     "./**/*-react-native.mts",
     "./test/snippets.spec.ts",
-    "./test/**/browser"
+    "./test/**/browser",
+    "./test/**/react-native"
   ]
 }

--- a/tsconfig.browser.base.json
+++ b/tsconfig.browser.base.json
@@ -16,6 +16,7 @@
   "include": ["${configDir}/src", "${configDir}/test"],
   "exclude": [
     "${configDir}/test/**/node",
+    "${configDir}/test/**/react-native",
     "${configDir}/test/stress",
     "${configDir}/test/snippets.spec.ts"
   ]


### PR DESCRIPTION
Adds react-native specific tests for `ts-http-runtime`:

- `checkEnvironment` — verifies platform detection flags under react-native conditions
- `formDataPolicy` — tests form data handling for react-native
- `proxyPolicy` — verifies proxy policy throws on react-native (unsupported)
- `userAgentPlatform` — tests RN-specific user agent platform data
- `logger` — tests logger behavior under react-native conditions

These tests are not wired up to run yet — vitest config and test scripts will be added in a follow-up PR once the platform migration lands.