### PR TITLE
Pin Playwright version

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -48,15 +48,23 @@ export const commandInfo = makeCommandInfo(
 );
 
 async function playwrightInstall(): Promise<void> {
+  const downloadHost = process.env.PLAYWRIGHT_DOWNLOAD_HOST;
   const { result } = concurrently([
     {
-      command: "npx playwright install",
+      command: "npx playwright@1.59.1 install",
       name: "playwright install",
+      env : {
+        ...process.env,
+      },
     },
   ]);
 
   await result;
-  log.info("playwright browsers installed");
+  log.info(
+    downloadHost
+      ? `playwright browsers installed from ${downloadHost}`
+      : "playwright browsers installed from default CDN",
+  );
 }
 
 export default leafCommand(commandInfo, async (options) => {


### PR DESCRIPTION
### Packages impacted by this PR
`appnetwork - mgmt`

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
- This pins playwright version to the latest and uses an environment variable to override the download URL for the chrome browser.
- The browser binaries are stored in Azure Blob Storage and will need to be versioned with playwright.