### PR TITLE
Use publlic devOps registry since we publish packages to both public …

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -101,9 +101,13 @@ stages:
                             - sdk/**/*.md
                             - .github/CODEOWNERS
                       - download: current
+                      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+                        parameters:
+                          npmrcPath: $(Agent.TempDirectory)/doc-ms/.npmrc
+                          registryUrl: '$(PublicDevOpsRegistry)'
                       - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
                         parameters:
-                          NpmConfigRegistry: $(PublicNpmRegistry)
+                          NpmConfigUserConfig: $(Agent.TempDirectory)/doc-ms/.npmrc
                       - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
                         parameters:
                           PackageInfoLocations:
@@ -118,7 +122,7 @@ stages:
                             - metadata/
                             - ci-configs/packages-latest.json
                             - ci-configs/packages-preview.json
-                          NpmConfigRegistry: $(PublicNpmRegistry)
+                          NpmConfigUserConfig: $(Agent.TempDirectory)/doc-ms/.npmrc
 
               - ${{ if ne(artifact.skipPublishDocGithubIo, 'true') }}:
                   - job: PublishDocsGitHubIO


### PR DESCRIPTION
### Packages impacted by this PR
All

### Issues associated with this PR
NA

### Describe the problem that is addressed by this PR
Use publlic devOps registry since we publish packages to both public feed this should now be fine.
Test Run https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6140585&view=results