### PR TITLE
fix(warp-ci): use --frozen-lockfile in CI to prevent version drift

### DIFF
--- a/.github/workflows/warp-ci.yml
+++ b/.github/workflows/warp-ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install -g pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm --filter @microsoft/warp... build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23502,7 +23502,7 @@ importers:
         version: 20.19.39
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -23514,7 +23514,7 @@ importers:
         version: 9.39.4
       prettier:
         specifier: 'catalog:'
-        version: 3.8.1
+        version: 3.8.2
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -23523,7 +23523,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:testing
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/browser-playwright@4.1.2)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   sdk/powerbidedicated/arm-powerbidedicated:
     dependencies:


### PR DESCRIPTION
The Warp CI workflow runs `pnpm install` without `--frozen-lockfile`, which resolves semver ranges at install time. When a new version of a dependency (e.g. vitest 4.1.4) is published after the lockfile was generated (pinning 4.1.2), pnpm tries to use the new version but can't find matching peer dependency entries in the lockfile, causing:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'@vitest/coverage-istanbul@4.1.2(vitest@4.1.2)' in pnpm-lock.yaml
```

This is currently breaking CI on the warp PR (#38106) and any other PR touching warp.

Fix: use `--frozen-lockfile` to install exactly what's in the lockfile.