### PR TITLE
fix: repair broken lockfile for arm-powerbidedicated

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23502,7 +23502,7 @@ importers:
         version: 20.19.39
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.1.2(vitest@4.1.2)
+        version: 4.1.4(vitest@4.1.4)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -23514,7 +23514,7 @@ importers:
         version: 9.39.4
       prettier:
         specifier: 'catalog:'
-        version: 3.8.1
+        version: 3.8.2
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -23523,7 +23523,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:testing
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/browser-playwright@4.1.2)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   sdk/powerbidedicated/arm-powerbidedicated:
     dependencies:


### PR DESCRIPTION
## Problem

The automatic pnpm update PR (#38123) updated vitest from 4.1.2 to 4.1.4 across the workspace but missed `sdk/powerbidedicated/arm-powerbidedicated`. This left its lockfile entries pointing to non-existent 4.1.2 snapshot entries, causing `pnpm install` to fail with:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for '@vitest/coverage-istanbul@4.1.2(vitest@4.1.2)' in pnpm-lock.yaml
```

This breaks CI for **every PR** in the repo, not just ones touching warp or vitest.

## Fix

Surgical 3-line fix in `pnpm-lock.yaml` to update the stale entries for `arm-powerbidedicated`:
- `@vitest/coverage-istanbul`: 4.1.2 → 4.1.4
- `vitest`: 4.1.2 → 4.1.4
- `prettier`: 3.8.1 → 3.8.2 (also stale)