### PR TITLE
fix(eng/tsconfigs): add customConditions: ["browser"] to test.browser.json

### DIFF
--- a/eng/tsconfigs/test.browser.json
+++ b/eng/tsconfigs/test.browser.json
@@ -2,7 +2,8 @@
   "extends": "./base.test.json",
   "compilerOptions": {
     "lib": ["DOM", "ESNext"],
-    "types": []
+    "types": [],
+    "customConditions": ["browser"]
   },
   "exclude": [
     "${configDir}/../test/**/node",


### PR DESCRIPTION
Add `customConditions: ["browser"]` to `eng/tsconfigs/test.browser.json` to match `src.browser.json`. Without this, `#platform/*` subpath imports with a `"browser"` condition don't resolve correctly in browser test configs.