### PR TITLE
chore(core): add per-platform tsconfig files in config/ directories

### DIFF
--- a/sdk/core/abort-controller/config/tsconfig.lint.json
+++ b/sdk/core/abort-controller/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/abort-controller/config/tsconfig.snippets.json
+++ b/sdk/core/abort-controller/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/abort-controller": ["../src/index.ts"],
+      "@azure/abort-controller/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/abort-controller/config/tsconfig.src.cjs.json
+++ b/sdk/core/abort-controller/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/abort-controller/config/tsconfig.src.esm.json
+++ b/sdk/core/abort-controller/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/abort-controller/config/tsconfig.test.node.json
+++ b/sdk/core/abort-controller/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/abort-controller": ["../src/index.ts"],
+      "@azure/abort-controller/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-amqp/config/tsconfig.lint.json
+++ b/sdk/core/core-amqp/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-amqp/config/tsconfig.snippets.json
+++ b/sdk/core/core-amqp/config/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json"
+}

--- a/sdk/core/core-amqp/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-amqp/config/tsconfig.src.esm.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-amqp/config/tsconfig.test.node.json
+++ b/sdk/core/core-amqp/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-amqp": ["../src/index.ts"],
+      "@azure/core-amqp/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-auth/config/tsconfig.lint.json
+++ b/sdk/core/core-auth/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-auth/config/tsconfig.snippets.json
+++ b/sdk/core/core-auth/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-auth": ["../src/index.ts"],
+      "@azure/core-auth/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-auth/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-auth/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-auth/config/tsconfig.src.esm.json
+++ b/sdk/core/core-auth/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-auth/config/tsconfig.test.node.json
+++ b/sdk/core/core-auth/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-auth": ["../src/index.ts"],
+      "@azure/core-auth/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-client-rest/config/tsconfig.lint.json
+++ b/sdk/core/core-client-rest/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-client-rest/config/tsconfig.snippets.json
+++ b/sdk/core/core-client-rest/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-rest/core-client": ["../src/index.ts"],
+      "@azure-rest/core-client/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-client-rest/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-client-rest/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-client-rest/config/tsconfig.src.esm.json
+++ b/sdk/core/core-client-rest/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-client-rest/config/tsconfig.test.node.json
+++ b/sdk/core/core-client-rest/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure-rest/core-client": ["../src/index.ts"],
+      "@azure-rest/core-client/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-client/config/tsconfig.lint.json
+++ b/sdk/core/core-client/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-client/config/tsconfig.snippets.json
+++ b/sdk/core/core-client/config/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json"
+}

--- a/sdk/core/core-client/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-client/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts", "../src/state-cjs.ts"]
+}

--- a/sdk/core/core-client/config/tsconfig.src.esm.json
+++ b/sdk/core/core-client/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts", "../src/state-cjs.ts"]
+}

--- a/sdk/core/core-client/config/tsconfig.test.node.json
+++ b/sdk/core/core-client/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-client": ["../src/index.ts"],
+      "@azure/core-client/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-http-compat/config/tsconfig.lint.json
+++ b/sdk/core/core-http-compat/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-http-compat/config/tsconfig.snippets.json
+++ b/sdk/core/core-http-compat/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-http-compat": ["../src/index.ts"],
+      "@azure/core-http-compat/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-http-compat/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-http-compat/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-http-compat/config/tsconfig.src.esm.json
+++ b/sdk/core/core-http-compat/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-http-compat/config/tsconfig.test.node.json
+++ b/sdk/core/core-http-compat/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-http-compat": ["../src/index.ts"],
+      "@azure/core-http-compat/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-lro/config/tsconfig.lint.json
+++ b/sdk/core/core-lro/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-lro/config/tsconfig.samples.json
+++ b/sdk/core/core-lro/config/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../eng/tsconfigs/samples.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-lro": ["../dist/esm"]
+    }
+  }
+}

--- a/sdk/core/core-lro/config/tsconfig.snippets.json
+++ b/sdk/core/core-lro/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-lro": ["../src/index.ts"],
+      "@azure/core-lro/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-lro/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-lro/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-lro/config/tsconfig.src.esm.json
+++ b/sdk/core/core-lro/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-lro/config/tsconfig.test.node.json
+++ b/sdk/core/core-lro/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-lro": ["../src/index.ts"],
+      "@azure/core-lro/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-paging/config/tsconfig.lint.json
+++ b/sdk/core/core-paging/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-paging/config/tsconfig.samples.json
+++ b/sdk/core/core-paging/config/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../eng/tsconfigs/samples.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-paging": ["../dist/esm"]
+    }
+  }
+}

--- a/sdk/core/core-paging/config/tsconfig.snippets.json
+++ b/sdk/core/core-paging/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-paging": ["../src/index.ts"],
+      "@azure/core-paging/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-paging/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-paging/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-paging/config/tsconfig.src.esm.json
+++ b/sdk/core/core-paging/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-paging/config/tsconfig.test.node.json
+++ b/sdk/core/core-paging/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-paging": ["../src/index.ts"],
+      "@azure/core-paging/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-rest-pipeline/config/tsconfig.lint.json
+++ b/sdk/core/core-rest-pipeline/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-rest-pipeline/config/tsconfig.samples.json
+++ b/sdk/core/core-rest-pipeline/config/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../eng/tsconfigs/samples.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-rest-pipeline": ["../dist/esm"]
+    }
+  }
+}

--- a/sdk/core/core-rest-pipeline/config/tsconfig.snippets.json
+++ b/sdk/core/core-rest-pipeline/config/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json"
+}

--- a/sdk/core/core-rest-pipeline/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-rest-pipeline/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-rest-pipeline/config/tsconfig.src.esm.json
+++ b/sdk/core/core-rest-pipeline/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-rest-pipeline/config/tsconfig.test.node.json
+++ b/sdk/core/core-rest-pipeline/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-rest-pipeline": ["../src/index.ts"],
+      "@azure/core-rest-pipeline/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-sse/config/tsconfig.lint.json
+++ b/sdk/core/core-sse/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-sse/config/tsconfig.samples.json
+++ b/sdk/core/core-sse/config/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../eng/tsconfigs/samples.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-sse": ["../dist/esm"]
+    }
+  }
+}

--- a/sdk/core/core-sse/config/tsconfig.snippets.json
+++ b/sdk/core/core-sse/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-sse": ["../src/index.ts"],
+      "@azure/core-sse/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-sse/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-sse/config/tsconfig.src.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "ESNext.Disposable"]
+  },
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-sse/config/tsconfig.src.esm.json
+++ b/sdk/core/core-sse/config/tsconfig.src.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "ESNext.Disposable"]
+  },
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-sse/config/tsconfig.test.node.json
+++ b/sdk/core/core-sse/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-sse": ["../src/index.ts"],
+      "@azure/core-sse/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-tracing/config/tsconfig.lint.json
+++ b/sdk/core/core-tracing/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-tracing/config/tsconfig.samples.json
+++ b/sdk/core/core-tracing/config/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../eng/tsconfigs/samples.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-tracing": ["../dist/esm"]
+    }
+  }
+}

--- a/sdk/core/core-tracing/config/tsconfig.snippets.json
+++ b/sdk/core/core-tracing/config/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json"
+}

--- a/sdk/core/core-tracing/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-tracing/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts", "../src/state-cjs.ts"]
+}

--- a/sdk/core/core-tracing/config/tsconfig.src.esm.json
+++ b/sdk/core/core-tracing/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts", "../src/state-cjs.ts"]
+}

--- a/sdk/core/core-tracing/config/tsconfig.test.node.json
+++ b/sdk/core/core-tracing/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-tracing": ["../src/index.ts"],
+      "@azure/core-tracing/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-util/config/tsconfig.lint.json
+++ b/sdk/core/core-util/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-util/config/tsconfig.snippets.json
+++ b/sdk/core/core-util/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-util": ["../src/index.ts"],
+      "@azure/core-util/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-util/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-util/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-util/config/tsconfig.src.esm.json
+++ b/sdk/core/core-util/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-util/config/tsconfig.test.node.json
+++ b/sdk/core/core-util/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-util": ["../src/index.ts"],
+      "@azure/core-util/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/core-xml/config/tsconfig.lint.json
+++ b/sdk/core/core-xml/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/core-xml/config/tsconfig.samples.json
+++ b/sdk/core/core-xml/config/tsconfig.samples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../eng/tsconfigs/samples.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-xml": ["../dist/esm"]
+    }
+  }
+}

--- a/sdk/core/core-xml/config/tsconfig.snippets.json
+++ b/sdk/core/core-xml/config/tsconfig.snippets.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json"
+}

--- a/sdk/core/core-xml/config/tsconfig.src.cjs.json
+++ b/sdk/core/core-xml/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-xml/config/tsconfig.src.esm.json
+++ b/sdk/core/core-xml/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/core-xml/config/tsconfig.test.node.json
+++ b/sdk/core/core-xml/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/core-xml": ["../src/index.ts"],
+      "@azure/core-xml/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/logger/config/tsconfig.lint.json
+++ b/sdk/core/logger/config/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["../src", "../test"]
+}

--- a/sdk/core/logger/config/tsconfig.snippets.json
+++ b/sdk/core/logger/config/tsconfig.snippets.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../eng/tsconfigs/snippets.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/logger": ["../src/index.ts"],
+      "@azure/logger/*": ["../src/*"]
+    }
+  }
+}

--- a/sdk/core/logger/config/tsconfig.src.cjs.json
+++ b/sdk/core/logger/config/tsconfig.src.cjs.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.cjs.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/logger/config/tsconfig.src.esm.json
+++ b/sdk/core/logger/config/tsconfig.src.esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.esm.json",
+  "include": ["../src/index.ts"]
+}

--- a/sdk/core/logger/config/tsconfig.test.node.json
+++ b/sdk/core/logger/config/tsconfig.test.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../eng/tsconfigs/test.node.json",
+  "compilerOptions": {
+    "paths": {
+      "@azure/logger": ["../src/index.ts"],
+      "@azure/logger/*": ["../src/*"],
+      "$internal/*": ["../src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Add `config/` directories to all 15 core packages with per-package tsconfig files.

## Included configs

- `tsconfig.src.esm.json` — ESM build config
- `tsconfig.src.cjs.json` — CJS build config
- `tsconfig.test.node.json` — Node test config
- `tsconfig.lint.json` — Lint config
- `tsconfig.snippets.json` — Snippets config
- `tsconfig.samples.json` — Samples config (where applicable)

## Deferred to a future PR

The following configs require the `#platform/*` source code migration to land first, since they set `types: []` (no `@types/node`) which breaks `api-extractor` and `warp` when source code still references Node.js types directly:

- `tsconfig.src.browser.json`
- `tsconfig.src.react-native.json`
- `tsconfig.test.browser.json`
- `tsconfig.test.react-native.json`

These are pure additions — no existing files are modified.