### PR TITLE
fix(core): handle Uint8Array subarrays correctly in createFile and encodeByteArray

### DIFF
--- a/sdk/core/core-client/src/base64.ts
+++ b/sdk/core/core-client/src/base64.ts
@@ -16,10 +16,7 @@ export function encodeString(value: string): string {
  * @internal
  */
 export function encodeByteArray(value: Uint8Array): string {
-  const bufferValue =
-    value instanceof Buffer
-      ? value
-      : Buffer.from(value.buffer as ArrayBufferLike, value.byteOffset, value.byteLength);
+  const bufferValue = Buffer.isBuffer(value) ? value : Buffer.from(value);
   return bufferValue.toString("base64");
 }
 

--- a/sdk/core/core-client/src/base64.ts
+++ b/sdk/core/core-client/src/base64.ts
@@ -16,7 +16,10 @@ export function encodeString(value: string): string {
  * @internal
  */
 export function encodeByteArray(value: Uint8Array): string {
-  const bufferValue = value instanceof Buffer ? value : Buffer.from(value.buffer as ArrayBuffer);
+  const bufferValue =
+    value instanceof Buffer
+      ? value
+      : Buffer.from(value.buffer as ArrayBufferLike, value.byteOffset, value.byteLength);
   return bufferValue.toString("base64");
 }
 

--- a/sdk/core/core-client/test/public/serializer.spec.ts
+++ b/sdk/core/core-client/test/public/serializer.spec.ts
@@ -185,6 +185,19 @@ describe("Serializer", function () {
       assert.equal(serializedObject, base64str);
     });
 
+    it("should correctly serialize a ByteArray subarray", function () {
+      const mapper: Mapper = {
+        type: { name: "ByteArray" },
+        required: false,
+        serializedName: "ByteArray",
+      };
+      const full = stringToByteArray("XXJavascriptYY");
+      const subarray = full.subarray(2, 12);
+      const base64str = "SmF2YXNjcmlwdA==";
+      const serializedObject = Serializer.serialize(mapper, subarray, "stringBody");
+      assert.equal(serializedObject, base64str);
+    });
+
     it("should correctly serialize a Date Object", function () {
       const dateObj = new Date("2015-01-01");
       const dateISO = "2015-01-01";

--- a/sdk/core/core-rest-pipeline/src/util/file.ts
+++ b/sdk/core/core-rest-pipeline/src/util/file.ts
@@ -170,7 +170,7 @@ export function createFile(
       webkitRelativePath: options.webkitRelativePath ?? "",
       size: content.byteLength,
       name,
-      arrayBuffer: async () => content.buffer,
+      arrayBuffer: async () => toArrayBuffer(content).buffer,
       stream: () => new Blob([toArrayBuffer(content)]).stream(),
       [rawContent]: () => content,
     } as File & RawContent;
@@ -181,7 +181,10 @@ export function createFile(
 
 function toArrayBuffer(source: Uint8Array): Uint8Array<ArrayBuffer> {
   if ("resize" in source.buffer) {
-    // ArrayBuffer
+    // ArrayBuffer — return a copy if the view is a subarray of a larger buffer
+    if (source.byteOffset !== 0 || source.byteLength !== source.buffer.byteLength) {
+      return new Uint8Array(source) as Uint8Array<ArrayBuffer>;
+    }
     return source as Uint8Array<ArrayBuffer>;
   }
   // SharedArrayBuffer

--- a/sdk/core/core-rest-pipeline/test/internal/formDataPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/formDataPolicy.spec.ts
@@ -148,4 +148,25 @@ describe("formDataPolicy", function () {
       },
     );
   });
+
+  describe("file uploads", function () {
+    it("handles subarray content correctly in createFile", async function () {
+      const backing = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]);
+      const subarray = backing.subarray(1, 4);
+      const result = await performRequest({
+        file: createFile(subarray, "sub.bin"),
+      });
+
+      const parts = (result.request.multipartBody as MultipartRequestBody).parts;
+      assert.equal(parts.length, 1, "expected 1 part");
+
+      const body = parts[0].body;
+      assert.isTrue(
+        typeof (body as unknown as Record<string, unknown>).arrayBuffer === "function",
+        "expected body to have arrayBuffer method",
+      );
+      const content = new Uint8Array(await (body as Blob).arrayBuffer());
+      assert.deepEqual([...content], [0x01, 0x02, 0x03]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`createFile` and `encodeByteArray` silently corrupt data when given a `Uint8Array` subarray (via `.subarray()`). Both read from the full backing `ArrayBuffer` instead of the subarray range.

## Fix

- **`createFile`** (`core-rest-pipeline`): copy subarrays that do not span the full buffer
- **`encodeByteArray`** (`core-client`): pass `byteOffset`/`byteLength` to `Buffer.from()`

Tests added for both.