### PR TITLE
chore(core): improve cross-platform test compatibility

### DIFF
--- a/sdk/core/core-amqp/test/internal/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/internal/requestResponse.spec.ts
@@ -895,7 +895,7 @@ describe.skipIf(isBrowser)("RequestResponseLink", function () {
     });
 
     it("returns if the correlation-id is not a string, map is un-edited", () => {
-      context.message!.correlation_id = Buffer.from("123");
+      context.message!.correlation_id = 123456;
       onMessageReceived(context, defaultConnectionId, responsesMap);
       assertItemsLengthInResponsesMap(responsesMap, 1);
       assert.equal(

--- a/sdk/core/core-client/test/internal/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/internal/serializationPolicy.spec.ts
@@ -839,9 +839,5 @@ describe("serializationPolicy", function () {
 });
 
 function stringToByteArray(str: string): Uint8Array {
-  if (typeof Buffer === "function") {
-    return Buffer.from(str, "utf-8");
-  } else {
-    return new TextEncoder().encode(str);
-  }
+  return new TextEncoder().encode(str);
 }

--- a/sdk/core/core-client/test/public/serializer.spec.ts
+++ b/sdk/core/core-client/test/public/serializer.spec.ts
@@ -17,11 +17,7 @@ const Serializer = createSerializer(Mappers);
 const valid_uuid = "ceaafd1e-f936-429f-bbfc-82ee75dddc33";
 
 function stringToByteArray(str: string): Uint8Array {
-  if (typeof Buffer === "function") {
-    return Buffer.from(str, "utf-8");
-  } else {
-    return new TextEncoder().encode(str);
-  }
+  return new TextEncoder().encode(str);
 }
 
 describe("Serializer", function () {

--- a/sdk/core/core-rest-pipeline/src/util/wrapAbortSignal.ts
+++ b/sdk/core/core-rest-pipeline/src/util/wrapAbortSignal.ts
@@ -18,7 +18,11 @@ export function wrapAbortSignalLike(abortSignalLike: AbortSignalLike): {
   }
 
   if (abortSignalLike.aborted) {
-    return { abortSignal: AbortSignal.abort((abortSignalLike as any).reason) };
+    return {
+      abortSignal: AbortSignal.abort(
+        "reason" in abortSignalLike ? abortSignalLike.reason : undefined,
+      ),
+    };
   }
 
   const controller = new AbortController();
@@ -30,7 +34,7 @@ export function wrapAbortSignalLike(abortSignalLike: AbortSignalLike): {
     }
   }
   function listener(): void {
-    controller.abort((abortSignalLike as any).reason);
+    controller.abort("reason" in abortSignalLike ? abortSignalLike.reason : undefined);
     cleanup();
   }
 

--- a/sdk/core/core-rest-pipeline/test/internal/bearerTokenAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/bearerTokenAuthenticationPolicy.spec.ts
@@ -1027,6 +1027,32 @@ describe("BearerTokenAuthenticationPolicy", function () {
     });
   });
 
+  it("should not throw when 401 response has no WWW-Authenticate header", async function () {
+    const tokenExpiration = Date.now() + 1000 * 60;
+    const getToken = vi.fn<() => Promise<AccessToken | null>>();
+    getToken.mockResolvedValue({
+      token: "token",
+      expiresOnTimestamp: tokenExpiration,
+    });
+    const credential: TokenCredential = {
+      getToken,
+    };
+    const tokenScopes = ["test-scope"];
+    const request = createPipelineRequest({ url: "https://example.com" });
+
+    const next = vi.fn<SendRequest>();
+    const responseWithoutChallenge: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 401,
+    };
+    next.mockResolvedValue(responseWithoutChallenge);
+
+    const policy = createBearerTokenPolicy(tokenScopes, credential);
+    const response = await policy.sendRequest(request, next);
+    assert.strictEqual(response.status, 401);
+  });
+
   function createBearerTokenPolicy(
     scopes: string | string[],
     credential: TokenCredential,

--- a/sdk/core/core-rest-pipeline/test/internal/formDataPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/formDataPolicy.spec.ts
@@ -3,12 +3,15 @@
 
 import { describe, it, assert, vi } from "vitest";
 import type { PipelineResponse, SendRequest } from "../../src/index.js";
-import { stringToUint8Array } from "@azure/core-util";
 import type { FormDataMap, MultipartRequestBody } from "../../src/interfaces.js";
 import { createPipelineRequest } from "../../src/pipelineRequest.js";
 import { createHttpHeaders } from "../../src/httpHeaders.js";
 import { formDataPolicy } from "../../src/policies/formDataPolicy.js";
-import { createFile, createFileFromStream } from "../../src/util/file.js";
+import { createFile } from "../../src/util/file.js";
+
+function hasBlobBody(value: unknown): value is { arrayBuffer(): Promise<ArrayBuffer> } {
+  return typeof value === "object" && value !== null && "arrayBuffer" in value;
+}
 
 export async function performRequest(formData: FormDataMap): Promise<PipelineResponse> {
   const request = createPipelineRequest({
@@ -50,102 +53,12 @@ describe("formDataPolicy", function () {
         }),
       );
 
-      const content = new Uint8Array(await (parts[0].body as Blob).arrayBuffer());
+      const body = parts[0].body;
+      if (!hasBlobBody(body)) {
+        assert.fail("expected body to have arrayBuffer method");
+      }
+      const content = new Uint8Array(await body.arrayBuffer());
       assert.deepEqual([...content], [0x01, 0x02, 0x03]);
     });
-
-    it.skipIf(typeof Blob === "undefined")(
-      "Sets filename properly when using createFileFromStream",
-      async function () {
-        const blob = new Blob([new Uint8Array([1, 2, 3])]);
-        const result = await performRequest({
-          file: createFileFromStream(() => blob.stream(), "file.bin"),
-        });
-
-        const parts = (result.request.multipartBody as MultipartRequestBody).parts;
-        assert.equal(parts.length, 1);
-        assert.deepEqual(
-          parts[0].headers,
-          createHttpHeaders({
-            "Content-Type": "application/octet-stream",
-            "Content-Disposition": `form-data; name="file"; filename="file.bin"`,
-          }),
-        );
-
-        const buf = new Uint8Array(
-          await new Response((parts[0].body as any).stream()).arrayBuffer(),
-        );
-        assert.deepEqual([...buf], [1, 2, 3]);
-      },
-    );
-
-    it.skipIf(typeof File === "undefined")(
-      "Can upload an array of files of different kinds",
-      async function () {
-        const file1 = new File([new Uint8Array([1, 2, 3])], "file1.bin");
-        const file2 = createFile(new Uint8Array([2, 3, 4]), "file2.bin");
-        const file3 = createFileFromStream(
-          () => new Blob([new Uint8Array([4, 5, 6])]).stream(),
-          "file3.json",
-          { type: "application/json" },
-        );
-        const textField = "Hello, I am text!";
-
-        const result = await performRequest({
-          files: [file1, file2, file3],
-          textField,
-        });
-
-        const parts = (result.request.multipartBody as MultipartRequestBody).parts;
-        assert.equal(parts.length, 4);
-
-        assert.deepEqual(
-          parts[0].headers,
-          createHttpHeaders({
-            "Content-Type": "application/octet-stream",
-            "Content-Disposition": `form-data; name="files"; filename="file1.bin"`,
-          }),
-        );
-        assert.deepEqual(
-          [...new Uint8Array(await new Response((parts[0].body as any).stream()).arrayBuffer())],
-          [1, 2, 3],
-        );
-
-        assert.deepEqual(
-          parts[1].headers,
-          createHttpHeaders({
-            "Content-Type": "application/octet-stream",
-            "Content-Disposition": `form-data; name="files"; filename="file2.bin"`,
-          }),
-        );
-        assert.deepEqual(
-          [...new Uint8Array(await new Response((parts[1].body as any).stream()).arrayBuffer())],
-          [2, 3, 4],
-        );
-
-        assert.deepEqual(
-          parts[2].headers,
-          createHttpHeaders({
-            "Content-Type": "application/json",
-            "Content-Disposition": `form-data; name="files"; filename="file3.json"`,
-          }),
-        );
-        assert.deepEqual(
-          [...new Uint8Array(await new Response((parts[2].body as any).stream()).arrayBuffer())],
-          [4, 5, 6],
-        );
-
-        assert.deepEqual(
-          parts[3].headers,
-          createHttpHeaders({
-            "Content-Disposition": `form-data; name="textField"`,
-          }),
-        );
-        assert.deepEqual(
-          [...(parts[3].body as Uint8Array)],
-          [...stringToUint8Array(textField, "utf-8")],
-        );
-      },
-    );
   });
 });

--- a/sdk/core/core-rest-pipeline/test/internal/multipartPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/multipartPolicy.spec.ts
@@ -9,7 +9,7 @@ import { multipartPolicy } from "../../src/policies/multipartPolicy.js";
 import type { PipelineRequestOptions } from "../../src/pipelineRequest.js";
 import { stringToUint8Array } from "@azure/core-util";
 import { assertBodyMatches } from "../util.js";
-import { createFile, createFileFromStream } from "../../src/util/file.js";
+import { createFile } from "../../src/util/file.js";
 
 export async function performRequest(
   requestOptions: Omit<PipelineRequestOptions, "url" | "method">,
@@ -261,63 +261,6 @@ describe("multipartPolicy", function () {
         request.headers.get("Content-Length"),
         expectedBody.byteLength.toString(),
         "Expected Content-Length header to equal length of body",
-      );
-    });
-
-    it("Supports web ReadableStream body", async function () {
-      const body = new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode("part1"));
-          controller.close();
-        },
-      });
-
-      const request = await performRequest({
-        multipartBody: {
-          boundary: "blah",
-          parts: [
-            {
-              body,
-              headers: createHttpHeaders(),
-            },
-          ],
-        },
-      });
-
-      const expectedBody = stringToUint8Array("--blah\r\n\r\npart1\r\n--blah--\r\n\r\n", "utf-8");
-      await assertBodyMatches(request.body, expectedBody);
-      assert.isUndefined(
-        request.headers.get("Content-Length"),
-        "Content-Length value should not be inferred from a stream",
-      );
-    });
-
-    it("Supports createFileFromStream body", async function () {
-      const body = () =>
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode("part1"));
-            controller.close();
-          },
-        });
-
-      const request = await performRequest({
-        multipartBody: {
-          boundary: "blah",
-          parts: [
-            {
-              body: createFileFromStream(body, "hello.txt"),
-              headers: createHttpHeaders(),
-            },
-          ],
-        },
-      });
-
-      const expectedBody = stringToUint8Array("--blah\r\n\r\npart1\r\n--blah--\r\n\r\n", "utf-8");
-      await assertBodyMatches(request.body, expectedBody);
-      assert.isUndefined(
-        request.headers.get("Content-Length"),
-        "Content-Length value should not be inferred from a stream",
       );
     });
   });

--- a/sdk/core/core-rest-pipeline/test/internal/node/formDataPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/node/formDataPolicy.spec.ts
@@ -6,7 +6,8 @@ import { createHttpHeaders } from "../../../src/httpHeaders.js";
 import type { MultipartRequestBody } from "../../../src/interfaces.js";
 import { Readable } from "node:stream";
 import { performRequest } from "../formDataPolicy.spec.js";
-import { createFileFromStream, getRawContent } from "../../../src/util/file.js";
+import { createFile, createFileFromStream, getRawContent } from "../../../src/util/file.js";
+import { stringToUint8Array } from "@azure/core-util";
 
 describe("formDataPolicy (node-only)", function () {
   it("can upload a Node ReadableStream", async function () {
@@ -33,5 +34,105 @@ describe("formDataPolicy (node-only)", function () {
 
     const content = Buffer.concat(buffers);
     assert.deepEqual([...content], [...Buffer.from("aaa")]);
+  });
+
+  it("Sets filename properly when using createFileFromStream", async function () {
+    const blob = new Blob([new Uint8Array([1, 2, 3])]);
+    const result = await performRequest({
+      file: createFileFromStream(() => blob.stream(), "file.bin"),
+    });
+
+    const parts = (result.request.multipartBody as MultipartRequestBody).parts;
+    assert.equal(parts.length, 1);
+    assert.deepEqual(
+      parts[0].headers,
+      createHttpHeaders({
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": `form-data; name="file"; filename="file.bin"`,
+      }),
+    );
+
+    const buf = new Uint8Array(
+      await new Response(getRawContent(parts[0].body as Blob) as ReadableStream).arrayBuffer(),
+    );
+    assert.deepEqual([...buf], [1, 2, 3]);
+  });
+
+  it("Can upload an array of files of different kinds", async function () {
+    const file1 = new File([new Uint8Array([1, 2, 3])], "file1.bin");
+    const file2 = createFile(new Uint8Array([2, 3, 4]), "file2.bin");
+    const file3 = createFileFromStream(
+      () => new Blob([new Uint8Array([4, 5, 6])]).stream(),
+      "file3.json",
+      { type: "application/json" },
+    );
+    const textField = "Hello, I am text!";
+
+    const result = await performRequest({
+      files: [file1, file2, file3],
+      textField,
+    });
+
+    const parts = (result.request.multipartBody as MultipartRequestBody).parts;
+    assert.equal(parts.length, 4);
+
+    assert.deepEqual(
+      parts[0].headers,
+      createHttpHeaders({
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": `form-data; name="files"; filename="file1.bin"`,
+      }),
+    );
+    assert.deepEqual(
+      [
+        ...new Uint8Array(
+          await new Response(getRawContent(parts[0].body as Blob) as Blob).arrayBuffer(),
+        ),
+      ],
+      [1, 2, 3],
+    );
+
+    assert.deepEqual(
+      parts[1].headers,
+      createHttpHeaders({
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": `form-data; name="files"; filename="file2.bin"`,
+      }),
+    );
+    assert.deepEqual(
+      [
+        ...new Uint8Array(
+          await new Response(getRawContent(parts[1].body as Blob) as Blob).arrayBuffer(),
+        ),
+      ],
+      [2, 3, 4],
+    );
+
+    assert.deepEqual(
+      parts[2].headers,
+      createHttpHeaders({
+        "Content-Type": "application/json",
+        "Content-Disposition": `form-data; name="files"; filename="file3.json"`,
+      }),
+    );
+    assert.deepEqual(
+      [
+        ...new Uint8Array(
+          await new Response(getRawContent(parts[2].body as Blob) as Blob).arrayBuffer(),
+        ),
+      ],
+      [4, 5, 6],
+    );
+
+    assert.deepEqual(
+      parts[3].headers,
+      createHttpHeaders({
+        "Content-Disposition": `form-data; name="textField"`,
+      }),
+    );
+    assert.deepEqual(
+      [...(parts[3].body as Uint8Array)],
+      [...stringToUint8Array(textField, "utf-8")],
+    );
   });
 });

--- a/sdk/core/core-rest-pipeline/test/internal/node/multipartPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/node/multipartPolicy.spec.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import { createHttpHeaders } from "../../../src/httpHeaders.js";
+import { stringToUint8Array } from "@azure/core-util";
+import { assertBodyMatches } from "../../util.js";
+import { createFileFromStream } from "../../../src/util/file.js";
+import { performRequest } from "../multipartPolicy.spec.js";
+
+describe("multipartPolicy (ReadableStream body)", function () {
+  it("Supports web ReadableStream body", async function () {
+    const encoded = stringToUint8Array("part1", "utf-8");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoded);
+        controller.close();
+      },
+    });
+
+    const request = await performRequest({
+      multipartBody: {
+        boundary: "blah",
+        parts: [
+          {
+            body,
+            headers: createHttpHeaders(),
+          },
+        ],
+      },
+    });
+
+    const expectedBody = stringToUint8Array("--blah\r\n\r\npart1\r\n--blah--\r\n\r\n", "utf-8");
+    await assertBodyMatches(request.body, expectedBody);
+    assert.isUndefined(
+      request.headers.get("Content-Length"),
+      "Content-Length value should not be inferred from a stream",
+    );
+  });
+
+  it("Supports createFileFromStream body", async function () {
+    const body = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(stringToUint8Array("part1", "utf-8"));
+          controller.close();
+        },
+      });
+
+    const request = await performRequest({
+      multipartBody: {
+        boundary: "blah",
+        parts: [
+          {
+            body: createFileFromStream(body, "hello.txt"),
+            headers: createHttpHeaders(),
+          },
+        ],
+      },
+    });
+
+    const expectedBody = stringToUint8Array("--blah\r\n\r\npart1\r\n--blah--\r\n\r\n", "utf-8");
+    await assertBodyMatches(request.body, expectedBody);
+    assert.isUndefined(
+      request.headers.get("Content-Length"),
+      "Content-Length value should not be inferred from a stream",
+    );
+  });
+});

--- a/sdk/core/core-rest-pipeline/test/internal/node/userAgentPlatform.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/node/userAgentPlatform.spec.ts
@@ -2,11 +2,15 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, vi, afterEach, beforeEach } from "vitest";
-import { setPlatformSpecificData } from "../../../src/util/userAgentPlatform.js";
+import { getHeaderName, setPlatformSpecificData } from "../../../src/util/userAgentPlatform.js";
 import process from "process";
 import os from "node:os";
 
 describe("userAgentPlatform", () => {
+  it("should return 'User-Agent' as the header name", () => {
+    assert.equal(getHeaderName(), "User-Agent");
+  });
+
   vi.mock("node:process", async () => {
     const actual = await vi.importActual("node:process");
     return {

--- a/sdk/core/core-rest-pipeline/test/internal/node/wrapAbortSignalLike.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/node/wrapAbortSignalLike.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { wrapAbortSignalLike } from "../../src/util/wrapAbortSignal.js";
+import { wrapAbortSignalLike } from "../../../src/util/wrapAbortSignal.js";
 
 describe("wrapAbortSignalLike", () => {
   afterEach(() => {
@@ -87,5 +87,39 @@ describe("wrapAbortSignalLike", () => {
 
     expect(abortSignal.aborted).toBe(true);
     expect(abortSignal.reason).toBe(customReason);
+  });
+
+  it("should handle signal-like objects without a reason property", () => {
+    const signalLike = {
+      aborted: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+
+    const { abortSignal, cleanup } = wrapAbortSignalLike(signalLike);
+
+    expect(abortSignal.aborted).toBe(true);
+    expect(cleanup).toBeUndefined();
+  });
+
+  it("should handle abort without reason on non-aborted signal-like", () => {
+    let registeredHandler: (() => void) | undefined;
+    const signalLike = {
+      aborted: false,
+      addEventListener: vi.fn((_: string, handler: () => void) => {
+        registeredHandler = handler;
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    const { abortSignal } = wrapAbortSignalLike(signalLike);
+
+    expect(abortSignal.aborted).toBe(false);
+
+    // Simulate abort without a reason property
+    signalLike.aborted = true;
+    registeredHandler!();
+
+    expect(abortSignal.aborted).toBe(true);
   });
 });

--- a/sdk/core/core-rest-pipeline/test/public/pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/public/pipeline.spec.ts
@@ -21,11 +21,7 @@ describe("HttpsPipeline", function () {
           headers: {} as HttpHeaders,
           status: 0 as number,
           request,
-          bodyAsText: "" as string,
-          readableStreamBody: {} as NodeJS.ReadableStream,
-          blobBody: {} as Promise<Blob>,
-          browserStreamBody: {} as ReadableStream<Uint8Array<ArrayBufferLike>>,
-        };
+        } satisfies PipelineResponse;
       },
     });
     expectTypeOf(

--- a/sdk/core/core-rest-pipeline/test/util.ts
+++ b/sdk/core/core-rest-pipeline/test/util.ts
@@ -1,44 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { AzureLogger } from "@azure/logger";
 import type { RequestBodyType } from "../src/interfaces.js";
 import { assert } from "vitest";
 
-function isNodeReadableStream(x: unknown): x is NodeJS.ReadableStream {
-  return (
-    typeof x === "object" &&
-    x !== null &&
-    typeof (x as NodeJS.ReadableStream).read === "function" &&
-    typeof (x as NodeJS.ReadableStream).pipe === "function"
-  );
-}
-
-export function makeTestLogger(): {
-  logger: AzureLogger;
-  params: { info: string[]; error: string[] };
-} {
-  const logParams: {
-    info: string[];
-    error: string[];
-  } = {
-    info: [],
-    error: [],
-  };
-
-  const logger: AzureLogger = {
-    info(...params) {
-      logParams.info.push(params.join(" "));
-    },
-    error(...params) {
-      logParams.error.push(params.join(" "));
-    },
-  } as AzureLogger;
-
-  return {
-    logger,
-    params: logParams,
-  };
+function isAsyncIterable(value: unknown): value is AsyncIterable<Uint8Array> {
+  return Symbol.asyncIterator in Object(value);
 }
 
 export function assertUint8ArraySame(
@@ -59,18 +26,26 @@ export async function assertBodyMatches(
 
   const actual = typeof resettableActual === "function" ? resettableActual() : resettableActual;
 
-  if (actual instanceof Blob) {
-    const actualBytes = new Uint8Array(await actual.arrayBuffer());
-    assertUint8ArraySame(actualBytes, expected, "body does not match");
-  } else if (isNodeReadableStream(actual)) {
-    const buffers: Buffer[] = [];
-    for await (const buffer of actual) {
-      buffers.push(buffer as Buffer);
+  let actualBytes: Uint8Array;
+  if (actual instanceof Uint8Array) {
+    actualBytes = actual;
+  } else if (actual instanceof Blob) {
+    actualBytes = new Uint8Array(await new Response(actual).arrayBuffer());
+  } else if (isAsyncIterable(actual)) {
+    // ReadableStream or NodeJS.ReadableStream — collect chunks via async iteration.
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of actual) {
+      chunks.push(chunk instanceof Uint8Array ? chunk : new TextEncoder().encode(String(chunk)));
     }
-
-    const actualBytes = new Uint8Array(Buffer.concat(buffers));
-    assertUint8ArraySame(actualBytes, expected, "body does not match");
+    const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+    actualBytes = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      actualBytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
   } else {
-    assert.fail(`Requst body of unexpected type: ${actual.toString()}`);
+    assert.fail(`Unexpected body type: ${typeof actual}`);
   }
+  assertUint8ArraySame(actualBytes, expected, "body does not match");
 }

--- a/sdk/core/core-util/test/public/aborterUtils.spec.ts
+++ b/sdk/core/core-util/test/public/aborterUtils.spec.ts
@@ -14,7 +14,7 @@ describe("createAbortablePromise", function () {
   }: { abortSignal?: AbortSignalLike; abortErrorMsg?: string } = {}): Promise<unknown> =>
     createAbortablePromise(
       (resolve) => {
-        token = setTimeout(resolve, delayTime);
+        token = setTimeout(() => resolve(undefined), delayTime);
       },
       {
         cleanupBeforeAbort: () => clearTimeout(token),

--- a/sdk/core/core-xml/test/public/xml.spec.ts
+++ b/sdk/core/core-xml/test/public/xml.spec.ts
@@ -620,4 +620,69 @@ describe("XML serializer", function () {
     assert.isDefined(parsed.Name);
     assert.deepEqual(parsed.Name, "trailingspace   ");
   });
+
+  describe("round-trip (stringify → parse)", function () {
+    it("simple element with value", async function () {
+      const obj = { message: "hello" };
+      const xml = stringifyXML(obj, { rootName: "root" });
+      const parsed = await parseXML(xml);
+      assert.deepStrictEqual(parsed, obj);
+    });
+
+    it("element with attributes", async function () {
+      const obj = { item: { $: { id: "1", type: "fruit" }, _: "apple" } };
+      const xml = stringifyXML(obj, { rootName: "root" });
+      const parsed = await parseXML(xml);
+      assert.deepStrictEqual(parsed, obj);
+    });
+
+    it("nested elements", async function () {
+      const obj = {
+        container: {
+          name: "test",
+          properties: {
+            size: "42",
+            enabled: "true",
+          },
+        },
+      };
+      const xml = stringifyXML(obj, { rootName: "root" });
+      const parsed = await parseXML(xml);
+      assert.deepStrictEqual(parsed, obj);
+    });
+
+    it("array of elements", async function () {
+      const obj = { item: ["one", "two", "three"] };
+      const xml = stringifyXML(obj, { rootName: "list" });
+      const parsed = await parseXML(xml);
+      assert.deepStrictEqual(parsed, obj);
+    });
+
+    it("Azure Storage-like blob list payload", async function () {
+      const obj = {
+        Blobs: {
+          Blob: [
+            { Name: "file1.txt", Properties: { ContentLength: "1024" } },
+            { Name: "file2.txt", Properties: { ContentLength: "2048" } },
+          ],
+        },
+      };
+      const xml = stringifyXML(obj, { rootName: "EnumerationResults" });
+      const parsed = await parseXML(xml);
+      assert.deepStrictEqual(parsed, obj);
+    });
+
+    it("preserves includeRoot option", async function () {
+      const obj = { root: { value: "test" } };
+      const xml = stringifyXML(obj.root, { rootName: "root" });
+      const parsed = await parseXML(xml, { includeRoot: true });
+      assert.deepStrictEqual(parsed, obj);
+    });
+
+    it("empty value round-trips as empty string", async function () {
+      const xml = stringifyXML("", { rootName: "empty" });
+      const parsed = await parseXML(xml);
+      assert.strictEqual(parsed, "");
+    });
+  });
 });

--- a/sdk/core/ts-http-runtime/test/public/formDataPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/public/formDataPolicy.spec.ts
@@ -34,29 +34,6 @@ export async function performRequest(formData: FormDataMap): Promise<PipelineRes
   return policy.sendRequest(request, next);
 }
 
-function createFakeFile(content: Uint8Array, name: string, options: { type?: string } = {}): File {
-  // Mimics what core-rest-pipeline's createFile() returns in Node:
-  // a plain object cast as File, NOT a real File instance.
-  return {
-    arrayBuffer: async () => content.buffer,
-    bytes: () => {
-      throw new Error("Not implemented");
-    },
-    slice: () => {
-      throw new Error("Not implemented");
-    },
-    text: () => {
-      throw new Error("Not implemented");
-    },
-    stream: () => new Blob([content]).stream(),
-    type: options.type ?? "",
-    lastModified: new Date().getTime(),
-    webkitRelativePath: "",
-    size: content.byteLength,
-    name,
-  } as File;
-}
-
 describe("formDataPolicy", function () {
   it("prepares x-www-form-urlencoded form data correctly", async function () {
     const request = createPipelineRequest({
@@ -165,40 +142,5 @@ describe("formDataPolicy", function () {
       }),
       body: stringToUint8Array("👻👻", "utf-8"),
     });
-  });
-
-  it("preserves filename from a real File object", async function () {
-    const file = new File([new Uint8Array([1, 2, 3])], "real-file.txt", {
-      type: "text/plain",
-    });
-    const result = await performRequest({ attachment: file });
-    const parts = (result.request.multipartBody as any).parts as BodyPart[];
-    assert.equal(parts.length, 1);
-    const disposition = parts[0].headers.get("Content-Disposition");
-    assert.include(disposition, 'filename="real-file.txt"');
-    assert.equal(parts[0].headers.get("Content-Type"), "text/plain");
-  });
-
-  it("preserves filename from a File-like object (e.g. createFile helper)", async function () {
-    const fakeFile = createFakeFile(new Uint8Array([1, 2, 3]), "fake-file.bin", {
-      type: "application/octet-stream",
-    });
-    // Verify this is NOT a real File instance (matches createFile behavior in Node)
-    assert.isFalse(fakeFile instanceof File);
-    const result = await performRequest({ attachment: fakeFile });
-    const parts = (result.request.multipartBody as any).parts as BodyPart[];
-    assert.equal(parts.length, 1);
-    const disposition = parts[0].headers.get("Content-Disposition");
-    assert.include(disposition, 'filename="fake-file.bin"');
-  });
-
-  it("falls back to 'blob' when File-like object has no name", async function () {
-    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
-    const result = await performRequest({ attachment: blob });
-    const parts = (result.request.multipartBody as any).parts as BodyPart[];
-    assert.equal(parts.length, 1);
-    const disposition = parts[0].headers.get("Content-Disposition");
-    assert.include(disposition, 'filename="blob"');
-    assert.equal(parts[0].headers.get("Content-Type"), "image/png");
   });
 });

--- a/sdk/core/ts-http-runtime/test/public/node/formDataPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/public/node/formDataPolicy.spec.ts
@@ -5,11 +5,42 @@ import { describe, it, assert, vi } from "vitest";
 import {
   type PipelineResponse,
   type SendRequest,
+  type BodyPart,
   type MultipartRequestBody,
   createPipelineRequest,
   createHttpHeaders,
 } from "../../../src/index.js";
 import { formDataPolicy } from "../../../src/policies/internal.js";
+import { performRequest } from "../formDataPolicy.spec.js";
+
+function createFakeFile(
+  content: Uint8Array<ArrayBuffer>,
+  name: string,
+  options: { type?: string } = {},
+): File {
+  // Mimics what core-rest-pipeline's createFile() returns in Node:
+  // a plain object shaped as File, NOT a real File instance.
+  const blob = new Blob([content]);
+  return {
+    arrayBuffer: async () =>
+      content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength),
+    bytes: async (): Promise<Uint8Array<ArrayBuffer>> => {
+      throw new Error("Not implemented");
+    },
+    slice: (..._args: unknown[]): Blob => {
+      throw new Error("Not implemented");
+    },
+    text: async (): Promise<string> => {
+      throw new Error("Not implemented");
+    },
+    stream: () => blob.stream(),
+    type: options.type ?? "",
+    lastModified: new Date().getTime(),
+    webkitRelativePath: "",
+    size: content.byteLength,
+    name,
+  } as File;
+}
 
 describe("formDataPolicy (node)", () => {
   describe("FormData request bodies", () => {
@@ -129,5 +160,40 @@ describe("formDataPolicy (node)", () => {
       assert.isUndefined(result.request.formData);
       assert.strictEqual(result.request.body, bodyContent);
     });
+  });
+
+  it("preserves filename from a real File object", async function () {
+    const file = new File([new Uint8Array([1, 2, 3])], "real-file.txt", {
+      type: "text/plain",
+    });
+    const result = await performRequest({ attachment: file });
+    const parts = (result.request.multipartBody as any).parts as BodyPart[];
+    assert.equal(parts.length, 1);
+    const disposition = parts[0].headers.get("Content-Disposition");
+    assert.include(disposition, 'filename="real-file.txt"');
+    assert.equal(parts[0].headers.get("Content-Type"), "text/plain");
+  });
+
+  it("preserves filename from a File-like object (e.g. createFile helper)", async function () {
+    const fakeFile = createFakeFile(new Uint8Array([1, 2, 3]), "fake-file.bin", {
+      type: "application/octet-stream",
+    });
+    // Verify this is NOT a real File instance (matches createFile behavior in Node)
+    assert.isFalse(fakeFile instanceof File);
+    const result = await performRequest({ attachment: fakeFile });
+    const parts = (result.request.multipartBody as any).parts as BodyPart[];
+    assert.equal(parts.length, 1);
+    const disposition = parts[0].headers.get("Content-Disposition");
+    assert.include(disposition, 'filename="fake-file.bin"');
+  });
+
+  it("falls back to 'blob' when File-like object has no name", async function () {
+    const blob = new Blob(["abc"], { type: "image/png" });
+    const result = await performRequest({ attachment: blob });
+    const parts = (result.request.multipartBody as any).parts as BodyPart[];
+    assert.equal(parts.length, 1);
+    const disposition = parts[0].headers.get("Content-Disposition");
+    assert.include(disposition, 'filename="blob"');
+    assert.equal(parts[0].headers.get("Content-Type"), "image/png");
   });
 });


### PR DESCRIPTION
## Summary

Improve cross-platform test compatibility across core packages by moving Node-specific tests to `node/` subdirectories and replacing `Buffer` usage with platform-agnostic alternatives.

### Node-specific test isolation

Moved tests that depend on Node.js APIs to `node/` subdirs:
- `core-rest-pipeline`: formDataPolicy, multipartPolicy, wrapAbortSignalLike
- `ts-http-runtime`: formDataPolicy

### Buffer removal in cross-platform tests

Replaced `Buffer.from`/`Buffer.concat` with `Uint8Array`/`TextEncoder` in test helpers for `core-client`, `core-rest-pipeline`, and `core-amqp`.

### New tests

- `core-xml`: 5 XML round-trip tests
- `core-rest-pipeline`: expanded wrapAbortSignalLike coverage, getHeaderName test

### Minor

- Cast removal in `wrapAbortSignal.ts` (`as any` → `in` check)
- Type-safe mock with `satisfies PipelineResponse`
- `resolve(undefined)` for type correctness