### PR TITLE
chore(core): remove dead code, unnecessary casts, and redundant async

### DIFF
--- a/sdk/core/abort-controller/src/index.ts
+++ b/sdk/core/abort-controller/src/index.ts
@@ -1,9 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-declare global {
-  interface Event {}
-}
-
 export { AbortError } from "./AbortError.js";
 export type { AbortSignalLike } from "./AbortSignalLike.js";

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -8,31 +8,6 @@ import type { WebSocketImpl } from "rhea-promise";
 import { delay as wrapperDelay } from "@azure/core-util";
 
 /**
- * @internal
- *
- * Describes the options that can be provided to create an async lock.
- */
-export interface AsyncLockOptions {
-  /**
-   * The max timeout. Default is: 0 (never timeout).
-   */
-  timeout?: number;
-  /**
-   * Maximum pending tasks. Default is: 1000.
-   */
-  maxPending?: number;
-  /**
-   * Whether lock can reenter in the same domain.
-   * Default is: false.
-   */
-  domainReentrant?: boolean;
-  /**
-   * Your implementation of the promise. Default is: global promise.
-   */
-  Promise?: any;
-}
-
-/**
  * Options to configure the channelling of the AMQP connection over Web Sockets.
  */
 export interface WebSocketOptions {
@@ -72,7 +47,7 @@ export type ParsedOutput<T> = { [P in keyof T]: T[P] };
  * @returns ParsedOutput<T>.
  */
 export function parseConnectionString<T>(connectionString: string): ParsedOutput<T> {
-  const output: { [k: string]: string } = {};
+  const output: Record<string, string> = {};
   const parts = connectionString.trim().split(";");
 
   for (let part of parts) {
@@ -100,63 +75,13 @@ export function parseConnectionString<T>(connectionString: string): ParsedOutput
     output[key] = value;
   }
 
-  return output as any;
+  return output as ParsedOutput<T>;
 }
 
 /**
  * The cancellable async lock instance.
  */
 export const defaultCancellableLock: CancellableAsyncLock = new CancellableAsyncLockImpl();
-
-/**
- * @internal
- *
- * Describes a Timeout class that can wait for the specified amount of time and then resolve/reject
- * the promise with the given value.
- */
-export class Timeout {
-  private _timer?: number | NodeJS.Timeout;
-
-  set<T>(t: number, value?: T): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      this.clear();
-      const callback: (args: any) => void = value ? () => reject(new Error(`${value}`)) : resolve;
-      this._timer = setTimeout(callback, t);
-    });
-  }
-
-  clear(): void {
-    if (this._timer) {
-      clearTimeout(this._timer);
-    }
-  }
-
-  wrap<T>(promise: Promise<T>, t: number, value?: T): Promise<T> {
-    const wrappedPromise = this._promiseFinally(promise, () => this.clear());
-    const timer = this.set(t, value);
-    return Promise.race([wrappedPromise, timer]);
-  }
-
-  private _promiseFinally<T>(promise: Promise<T>, fn: (...args: any[]) => void): Promise<T> {
-    const success = (result: T): T => {
-      fn();
-      return result;
-    };
-    const error = (e: Error): Promise<never> => {
-      fn();
-      return Promise.reject(e);
-    };
-    return Promise.resolve(promise).then(success, error);
-  }
-
-  static set<T>(t: number, value?: T): Promise<T> {
-    return new Timeout().set(t, value);
-  }
-
-  static wrap<T>(promise: Promise<T>, t: number, value?: T): Promise<T> {
-    return new Timeout().wrap(promise, t, value);
-  }
-}
 
 /**
  * A wrapper for setTimeout that resolves a promise after t milliseconds.
@@ -188,67 +113,6 @@ export async function delay<T>(
  */
 export function isLoopbackAddress(address: string): boolean {
   return /^(.*:\/\/)?(127\.[\d.]+|[0:]+1|localhost)/.test(address.toLowerCase());
-}
-
-/**
- * @internal
- *
- * Generates a random number between the given interval
- * @param min - Min number of the range (inclusive).
- * @param max - Max number of the range (inclusive).
- */
-export function randomNumberFromInterval(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1) + min);
-}
-
-/**
- * @internal
- *
- * Type declaration for a Function type where T is the input to the function and V is the output
- * of the function.
- */
-export type Func<T, V> = (a: T) => V;
-
-/**
- * @internal
- *
- * Executes an array of promises sequentially. Inspiration of this method is here:
- * https://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html. An awesome blog on promises!
- *
- * @param promiseFactories - An array of promise factories(A function that return a promise)
- *
- * @param kickstart - Input to the first promise that is used to kickstart the promise chain.
- * If not provided then the promise chain starts with undefined.
- *
- * @returns A chain of resolved or rejected promises
- */
-export function executePromisesSequentially(
-  promiseFactories: Array<any>,
-  kickstart?: unknown,
-): Promise<any> {
-  let result = Promise.resolve(kickstart);
-  promiseFactories.forEach((promiseFactory) => {
-    result = result.then(promiseFactory);
-  });
-  return result;
-}
-
-/**
- * @internal
- *
- * Determines whether the given connection string is an iothub connection string.
- * @param connectionString - The connection string.
- * @returns boolean.
- */
-export function isIotHubConnectionString(connectionString: string): boolean {
-  const cs = String(connectionString);
-
-  let result: boolean = false;
-  const model: any = parseConnectionString<any>(cs);
-  if (model && model.HostName && model.SharedAccessKey && model.SharedAccessKeyName) {
-    result = true;
-  }
-  return result;
 }
 
 /**

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -108,24 +108,6 @@ export interface AccessToken {
 }
 
 /**
- * @internal
- * @param accessToken - Access token
- * @returns Whether a token is bearer type or not
- */
-export function isBearerToken(accessToken: AccessToken): boolean {
-  return !accessToken.tokenType || accessToken.tokenType === "Bearer";
-}
-
-/**
- * @internal
- * @param accessToken - Access token
- * @returns Whether a token is Pop token or not
- */
-export function isPopToken(accessToken: AccessToken): boolean {
-  return accessToken.tokenType === "pop";
-}
-
-/**
  * Tests an object to determine whether it implements TokenCredential.
  *
  * @param credential - The assumed TokenCredential to be tested.

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.6.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.6.0 (2026-04-07)
 
 ### Features Added

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/core-client",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Core library for interfacing with Azure Rest Clients",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-client-rest/src/apiVersionPolicy.ts
+++ b/sdk/core/core-client-rest/src/apiVersionPolicy.ts
@@ -19,9 +19,7 @@ export function apiVersionPolicy(options: ClientOptions): PipelinePolicy {
       // Append one if there is no apiVesion and we have one at client options
       const url = new URL(req.url);
       if (!url.searchParams.get("api-version") && options.apiVersion) {
-        req.url = `${req.url}${
-          Array.from(url.searchParams.keys()).length > 0 ? "&" : "?"
-        }api-version=${options.apiVersion}`;
+        req.url = `${req.url}${url.searchParams.size > 0 ? "&" : "?"}api-version=${options.apiVersion}`;
       }
 
       return next(req);

--- a/sdk/core/core-client-rest/src/clientHelpers.ts
+++ b/sdk/core/core-client-rest/src/clientHelpers.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { HttpClient, Pipeline } from "@azure/core-rest-pipeline";
+import type { Pipeline } from "@azure/core-rest-pipeline";
 import {
   bearerTokenAuthenticationPolicy,
-  createDefaultHttpClient,
   createPipelineFromOptions,
 } from "@azure/core-rest-pipeline";
 import type { KeyCredential, TokenCredential } from "@azure/core-auth";
@@ -13,8 +12,6 @@ import { isTokenCredential } from "@azure/core-auth";
 import type { ClientOptions } from "./common.js";
 import { apiVersionPolicy } from "./apiVersionPolicy.js";
 import { keyCredentialAuthenticationPolicy } from "./keyCredentialAuthenticationPolicy.js";
-
-let cachedHttpClient: HttpClient | undefined;
 
 /**
  * Optional parameters for adding a credential policy to the pipeline.
@@ -77,14 +74,11 @@ export function createDefaultPipeline(
   return pipeline;
 }
 
-function isKeyCredential(credential: any): credential is KeyCredential {
-  return (credential as KeyCredential).key !== undefined;
-}
-
-export function getCachedDefaultHttpsClient(): HttpClient {
-  if (!cachedHttpClient) {
-    cachedHttpClient = createDefaultHttpClient();
-  }
-
-  return cachedHttpClient;
+function isKeyCredential(credential: unknown): credential is KeyCredential {
+  return (
+    typeof credential === "object" &&
+    credential !== null &&
+    "key" in credential &&
+    typeof credential.key === "string"
+  );
 }

--- a/sdk/core/core-client-rest/src/keyCredentialAuthenticationPolicy.ts
+++ b/sdk/core/core-client-rest/src/keyCredentialAuthenticationPolicy.ts
@@ -20,7 +20,7 @@ export function keyCredentialAuthenticationPolicy(
 ): PipelinePolicy {
   return {
     name: keyCredentialAuthenticationPolicyName,
-    async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+    sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       request.headers.set(apiKeyHeaderName, credential.key);
       return next(request);
     },

--- a/sdk/core/core-client-rest/src/restError.ts
+++ b/sdk/core/core-client-rest/src/restError.ts
@@ -22,8 +22,8 @@ export function createRestError(
   response?: PathUncheckedResponse,
 ): RestError {
   if (typeof messageOrResponse === "string") {
-    return tspCreateRestError(messageOrResponse, response! as TspPathUncheckedResponse);
+    return tspCreateRestError(messageOrResponse, response as unknown as TspPathUncheckedResponse);
   } else {
-    return tspCreateRestError(messageOrResponse as TspPathUncheckedResponse);
+    return tspCreateRestError(messageOrResponse as unknown as TspPathUncheckedResponse);
   }
 }

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -69,6 +69,16 @@ describe("clientHelpers", () => {
     );
   });
 
+  it("should not treat a non-string key property as a KeyCredential", () => {
+    const pipeline = createDefaultPipeline(mockBaseUrl, { key: 123 } as any);
+    const policies = pipeline.getOrderedPolicies();
+
+    assert.isUndefined(
+      policies.find((p) => p.name === keyCredentialAuthenticationPolicyName),
+      "pipeline should not have keyCredentialAuthenticationPolicyName for non-string key",
+    );
+  });
+
   it("should create a default pipeline with TokenCredential", () => {
     const mockCredential: TokenCredential = {
       getToken: async () => ({ expiresOnTimestamp: 0, token: "mockToken" }),

--- a/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts
+++ b/sdk/core/core-client/src/authorizeRequestOnTenantChallenge.ts
@@ -95,8 +95,7 @@ function buildScopes(
   }
 
   const challengeScopes = new URL(challengeInfo.resource_id);
-  challengeScopes.pathname = Constants.DefaultScope;
-  let scope = challengeScopes.toString();
+  let scope = new URL(Constants.DefaultScope, challengeScopes.origin).toString();
   if (scope === "https://disk.azure.com/.default") {
     // the extra slash is required by the service
     scope = "https://disk.azure.com//.default";

--- a/sdk/core/core-client/src/serializationPolicy.ts
+++ b/sdk/core/core-client/src/serializationPolicy.ts
@@ -48,7 +48,7 @@ export function serializationPolicy(options: SerializationPolicyOptions = {}): P
 
   return {
     name: serializationPolicyName,
-    async sendRequest(request: OperationRequest, next: SendRequest): Promise<PipelineResponse> {
+    sendRequest(request: OperationRequest, next: SendRequest): Promise<PipelineResponse> {
       const operationInfo = getOperationRequestInfo(request);
       const operationSpec = operationInfo?.operationSpec;
       const operationArguments = operationInfo?.operationArguments;

--- a/sdk/core/core-client/src/serviceClient.ts
+++ b/sdk/core/core-client/src/serviceClient.ts
@@ -120,7 +120,7 @@ export class ServiceClient {
   /**
    * Send the provided httpRequest.
    */
-  async sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
+  sendRequest(request: PipelineRequest): Promise<PipelineResponse> {
     return this.pipeline.sendRequest(this._httpClient, request);
   }
 
@@ -255,7 +255,7 @@ function getCredentialScopes(options: ServiceClientOptions): string | string[] |
     return `${options.baseUri}/.default`;
   }
 
-  if (options.credential && !options.credentialScopes) {
+  if (options.credential) {
     throw new Error(
       `When using credentials, the ServiceClientOptions must contain either a endpoint or a credentialScopes. Unable to create a bearerTokenAuthenticationPolicy`,
     );

--- a/sdk/core/core-http-compat/CHANGELOG.md
+++ b/sdk/core/core-http-compat/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.4.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.4.0 (2026-04-07)
 
 ### Features Added

--- a/sdk/core/core-http-compat/package.json
+++ b/sdk/core/core-http-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-http-compat",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Core HTTP Compatibility Library to bridge the gap between Core V1 & V2 packages.",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-http-compat/src/policies/disableKeepAlivePolicy.ts
+++ b/sdk/core/core-http-compat/src/policies/disableKeepAlivePolicy.ts
@@ -14,7 +14,7 @@ export const disableKeepAlivePolicyName = "DisableKeepAlivePolicy";
 export function createDisableKeepAlivePolicy(): PipelinePolicy {
   return {
     name: disableKeepAlivePolicyName,
-    async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+    sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       request.disableKeepAlive = true;
       return next(request);
     },

--- a/sdk/core/core-http-compat/src/util.ts
+++ b/sdk/core/core-http-compat/src/util.ts
@@ -15,6 +15,22 @@ type CompatWebResourceLike = WebResourceLike & { [originalRequestSymbol]?: Pipel
 // cloned but we need to retrieve the OperationSpec and OperationArguments from the
 // original request.
 const originalClientRequestSymbol = Symbol.for("@azure/core-client original request");
+const passThroughProps = new Set([
+  "url",
+  "method",
+  "withCredentials",
+  "timeout",
+  "requestId",
+  "abortSignal",
+  "body",
+  "formData",
+  "onDownloadProgress",
+  "onUploadProgress",
+  "proxySettings",
+  "streamResponseStatusCodes",
+  "agent",
+  "requestOverrides",
+]);
 type PipelineRequestWithOriginal = PipelineRequest & {
   [originalClientRequestSymbol]?: PipelineRequest;
 };
@@ -110,24 +126,8 @@ export function toWebResourceLike(
         if (prop === "keepAlive") {
           request.disableKeepAlive = !value;
         }
-        const passThroughProps = [
-          "url",
-          "method",
-          "withCredentials",
-          "timeout",
-          "requestId",
-          "abortSignal",
-          "body",
-          "formData",
-          "onDownloadProgress",
-          "onUploadProgress",
-          "proxySettings",
-          "streamResponseStatusCodes",
-          "agent",
-          "requestOverrides",
-        ];
 
-        if (typeof prop === "string" && passThroughProps.includes(prop)) {
+        if (typeof prop === "string" && passThroughProps.has(prop)) {
           (request as any)[prop] = value;
         }
 
@@ -233,7 +233,7 @@ export interface HttpHeadersLike {
 /**
  * A collection of HTTP header key/value pairs.
  */
-export class HttpHeaders implements HttpHeadersLike {
+class HttpHeaders implements HttpHeadersLike {
   private readonly _headersMap: { [headerKey: string]: HttpHeader };
 
   constructor(rawHeaders?: RawHttpHeaders) {

--- a/sdk/core/core-lro/src/http/operation.ts
+++ b/sdk/core/core-lro/src/http/operation.ts
@@ -332,7 +332,7 @@ export async function pollHttpOperation<TState extends OperationState<TResult>, 
      * The expansion here is intentional because `lro` could be an object that
      * references an inner this, so we need to preserve a reference to it.
      */
-    poll: async (location: string, inputOptions?: { abortSignal?: AbortSignalLike }) =>
+    poll: (location: string, inputOptions?: { abortSignal?: AbortSignalLike }) =>
       lro.sendPollRequest(location, inputOptions),
     setErrorAsResult,
   });

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -72,7 +72,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     // Progress handlers
     type Handler = (state: TState) => void;
     const handlers = new Map<symbol, Handler>();
-    const handleProgressEvents = async (): Promise<void> => handlers.forEach((h) => h(state));
+    const handleProgressEvents = (): void => handlers.forEach((h) => h(state));
     const cancelErrMsg = "Operation was canceled";
     let currentPollIntervalInMs = intervalInMs;
 

--- a/sdk/core/core-lro/src/poller/poller.ts
+++ b/sdk/core/core-lro/src/poller/poller.ts
@@ -72,7 +72,7 @@ export function buildCreatePoller<TResponse, TResult, TState extends OperationSt
     // Progress handlers
     type Handler = (state: TState) => void;
     const handlers = new Map<symbol, Handler>();
-    const handleProgressEvents = (): void => handlers.forEach((h) => h(state));
+    const handleProgressEvents = async (): Promise<void> => handlers.forEach((h) => h(state));
     const cancelErrMsg = "Operation was canceled";
     let currentPollIntervalInMs = intervalInMs;
 

--- a/sdk/core/core-paging/src/getPagedAsyncIterator.ts
+++ b/sdk/core/core-paging/src/getPagedAsyncIterator.ts
@@ -28,7 +28,7 @@ export function getPagedAsyncIterator<
       return this;
     },
     byPage:
-      pagedResult?.byPage ??
+      pagedResult.byPage ??
       (((settings?: PageSettings) => {
         const { continuationToken, maxPageSize } = settings ?? {};
         return getPageAsyncIterator(pagedResult, {

--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -282,7 +282,7 @@ export function bearerTokenAuthenticationPolicy(
 
           // If we get another CAE Claim, we will handle it by default and return whatever value we receive for this
           if (isChallengeResponse(response)) {
-            claims = getCaeChallengeClaims(response.headers.get("WWW-Authenticate") as string);
+            claims = getCaeChallengeClaims(response.headers.get("WWW-Authenticate") ?? "");
             if (claims) {
               let parsedClaim: string;
               try {

--- a/sdk/core/core-rest-pipeline/src/policies/ndJsonPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/ndJsonPolicy.ts
@@ -18,10 +18,8 @@ export function ndJsonPolicy(): PipelinePolicy {
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
       // There currently isn't a good way to bypass the serializer
       if (typeof request.body === "string" && request.body.startsWith("[")) {
-        const body = JSON.parse(request.body);
-        if (Array.isArray(body)) {
-          request.body = body.map((item) => JSON.stringify(item) + "\n").join("");
-        }
+        const body: unknown[] = JSON.parse(request.body);
+        request.body = body.map((item) => JSON.stringify(item) + "\n").join("");
       }
       return next(request);
     },

--- a/sdk/core/core-rest-pipeline/src/util/tokenCycler.ts
+++ b/sdk/core/core-rest-pipeline/src/util/tokenCycler.ts
@@ -133,7 +133,10 @@ export function createTokenCycler(
      * window and not already refreshing)
      */
     get shouldRefresh(): boolean {
-      if (token === null || cycler.isRefreshing) {
+      if (token === null) {
+        return true;
+      }
+      if (cycler.isRefreshing) {
         return false;
       }
       if (token.refreshAfterTimestamp && token.refreshAfterTimestamp < Date.now()) {

--- a/sdk/core/core-rest-pipeline/src/util/tokenCycler.ts
+++ b/sdk/core/core-rest-pipeline/src/util/tokenCycler.ts
@@ -133,14 +133,14 @@ export function createTokenCycler(
      * window and not already refreshing)
      */
     get shouldRefresh(): boolean {
-      if (cycler.isRefreshing) {
+      if (token === null || cycler.isRefreshing) {
         return false;
       }
-      if (token?.refreshAfterTimestamp && token.refreshAfterTimestamp < Date.now()) {
+      if (token.refreshAfterTimestamp && token.refreshAfterTimestamp < Date.now()) {
         return true;
       }
 
-      return (token?.expiresOnTimestamp ?? 0) - options.refreshWindowInMs < Date.now();
+      return token.expiresOnTimestamp - options.refreshWindowInMs < Date.now();
     },
     /**
      * Produces true if the cycler MUST refresh (null or nearly-expired

--- a/sdk/core/core-tracing/CHANGELOG.md
+++ b/sdk/core/core-tracing/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Deprecated `Resolved<T>` type alias in favor of the built-in TypeScript `Awaited<T>` type.
+
 ## 1.3.1 (2025-09-11)
 
 ### Other Changes

--- a/sdk/core/core-tracing/review/core-tracing-node.api.md
+++ b/sdk/core/core-tracing/review/core-tracing-node.api.md
@@ -45,10 +45,8 @@ export type OptionsWithTracingContext<Options extends {
     };
 };
 
-// @public
-export type Resolved<T> = T extends {
-    then(onfulfilled: infer F): any;
-} ? F extends (value: infer V) => any ? Resolved<V> : never : T;
+// @public @deprecated
+export type Resolved<T> = Awaited<T>;
 
 // @public
 export type SpanStatus = SpanStatusSuccess | SpanStatusError;
@@ -77,7 +75,7 @@ export interface TracingClient {
     withContext<CallbackArgs extends unknown[], Callback extends (...args: CallbackArgs) => ReturnType<Callback>>(context: TracingContext, callback: Callback, ...callbackArgs: CallbackArgs): ReturnType<Callback>;
     withSpan<Options extends {
         tracingOptions?: OperationTracingOptions;
-    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<Resolved<ReturnType<Callback>>>;
+    }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<Awaited<ReturnType<Callback>>>;
 }
 
 // @public

--- a/sdk/core/core-tracing/src/interfaces.ts
+++ b/sdk/core/core-tracing/src/interfaces.ts
@@ -2,14 +2,11 @@
 // Licensed under the MIT License.
 
 /**
- * A narrower version of TypeScript 4.5's Awaited type which Recursively
- * unwraps the "awaited type", emulating the behavior of `await`.
+ * Recursively unwraps the "awaited type", emulating the behavior of `await`.
+ *
+ * @deprecated Use the built-in TypeScript {@link Awaited} type instead.
  */
-export type Resolved<T> = T extends { then(onfulfilled: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
-  ? F extends (value: infer V) => any // if the argument to `then` is callable, extracts the first argument
-    ? Resolved<V> // recursively unwrap the value
-    : never // the argument to `then` was not callable
-  : T; // non-object or non-thenable
+export type Resolved<T> = Awaited<T>;
 
 /**
  * Represents a client that can integrate with the currently configured {@link Instrumenter}.
@@ -61,7 +58,7 @@ export interface TracingClient {
     operationOptions: Options,
     callback: Callback,
     spanOptions?: TracingSpanOptions,
-  ): Promise<Resolved<ReturnType<Callback>>>;
+  ): Promise<Awaited<ReturnType<Callback>>>;
   /**
    * Starts a given span but does not set it as the active span.
    *

--- a/sdk/core/core-tracing/src/tracingClient.ts
+++ b/sdk/core/core-tracing/src/tracingClient.ts
@@ -4,7 +4,6 @@
 import type {
   OperationTracingOptions,
   OptionsWithTracingContext,
-  Resolved,
   TracingClient,
   TracingClientOptions,
   TracingContext,
@@ -33,8 +32,8 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
   } {
     const startSpanResult = getInstrumenter().startSpan(name, {
       ...spanOptions,
-      packageName: packageName,
-      packageVersion: packageVersion,
+      packageName,
+      packageVersion,
       tracingContext: operationOptions?.tracingOptions?.tracingContext,
     });
     let tracingContext = startSpanResult.tracingContext;
@@ -64,14 +63,14 @@ export function createTracingClient(options: TracingClientOptions): TracingClien
     operationOptions: Options,
     callback: Callback,
     spanOptions?: TracingSpanOptions,
-  ): Promise<Resolved<ReturnType<Callback>>> {
+  ): Promise<Awaited<ReturnType<Callback>>> {
     const { span, updatedOptions } = startSpan(name, operationOptions, spanOptions);
     try {
       const result = await withContext(updatedOptions.tracingOptions.tracingContext, () =>
-        Promise.resolve(callback(updatedOptions, span)),
+        callback(updatedOptions, span),
       );
       span.setStatus({ status: "success" });
-      return result as ReturnType<typeof withSpan>;
+      return result as Awaited<ReturnType<Callback>>;
     } catch (err: any) {
       span.setStatus({ status: "error", error: err });
       throw err;

--- a/sdk/core/core-util/src/delay.ts
+++ b/sdk/core/core-util/src/delay.ts
@@ -3,7 +3,6 @@
 
 import type { AbortOptions } from "./aborterUtils.js";
 import { createAbortablePromise } from "./createAbortablePromise.js";
-import { getRandomIntegerInclusive } from "@typespec/ts-http-runtime/internal/util";
 
 const StandardAbortMessage = "The delay was aborted.";
 
@@ -31,30 +30,4 @@ export function delay(timeInMs: number, options?: DelayOptions): Promise<void> {
       abortErrorMsg: abortErrorMsg ?? StandardAbortMessage,
     },
   );
-}
-
-/**
- * Calculates the delay interval for retry attempts using exponential delay with jitter.
- * @param retryAttempt - The current retry attempt number.
- * @param config - The exponential retry configuration.
- * @returns An object containing the calculated retry delay.
- */
-export function calculateRetryDelay(
-  retryAttempt: number,
-  config: {
-    retryDelayInMs: number;
-    maxRetryDelayInMs: number;
-  },
-): { retryAfterInMs: number } {
-  // Exponentially increase the delay each time
-  const exponentialDelay = config.retryDelayInMs * Math.pow(2, retryAttempt);
-
-  // Don't let the delay exceed the maximum
-  const clampedDelay = Math.min(config.maxRetryDelayInMs, exponentialDelay);
-
-  // Allow the final value to have some "jitter" (within 50% of the delay size) so
-  // that retries across multiple clients don't occur simultaneously.
-  const retryAfterInMs = clampedDelay / 2 + getRandomIntegerInclusive(0, clampedDelay / 2);
-
-  return { retryAfterInMs };
 }

--- a/sdk/core/core-util/src/typeGuards.ts
+++ b/sdk/core/core-util/src/typeGuards.ts
@@ -41,6 +41,8 @@ export function objectHasProperty<Thing, PropertyName extends string>(
   property: PropertyName,
 ): thing is Thing & Record<PropertyName, unknown> {
   return (
-    isDefined(thing) && typeof thing === "object" && property in (thing as Record<string, unknown>)
+    thing !== null &&
+    (typeof thing === "object" || typeof thing === "function") &&
+    property in thing
   );
 }

--- a/sdk/core/core-util/src/typeGuards.ts
+++ b/sdk/core/core-util/src/typeGuards.ts
@@ -41,8 +41,6 @@ export function objectHasProperty<Thing, PropertyName extends string>(
   property: PropertyName,
 ): thing is Thing & Record<PropertyName, unknown> {
   return (
-    thing !== null &&
-    (typeof thing === "object" || typeof thing === "function") &&
-    property in thing
+    isDefined(thing) && typeof thing === "object" && property in (thing as Record<string, unknown>)
   );
 }

--- a/sdk/core/core-util/test/public/typeGuards.spec.ts
+++ b/sdk/core/core-util/test/public/typeGuards.spec.ts
@@ -55,18 +55,5 @@ describe("Type guards", function () {
       assert.isFalse(objectHasProperty("azure", "azure"));
       assert.isFalse(objectHasProperty(Symbol("azure"), "azure"));
     });
-    it("should return true when the argument is a function with the property", async function () {
-      function myFn(): void {
-        /* no-op */
-      }
-      myFn.azure = true;
-      assert.isTrue(objectHasProperty(myFn, "azure"));
-    });
-    it("should return false for a function without the property", async function () {
-      function myFn(): void {
-        /* no-op */
-      }
-      assert.isFalse(objectHasProperty(myFn, "azure"));
-    });
   });
 });

--- a/sdk/core/core-util/test/public/typeGuards.spec.ts
+++ b/sdk/core/core-util/test/public/typeGuards.spec.ts
@@ -55,5 +55,18 @@ describe("Type guards", function () {
       assert.isFalse(objectHasProperty("azure", "azure"));
       assert.isFalse(objectHasProperty(Symbol("azure"), "azure"));
     });
+    it("should return true when the argument is a function with the property", async function () {
+      function myFn(): void {
+        /* no-op */
+      }
+      myFn.azure = true;
+      assert.isTrue(objectHasProperty(myFn, "azure"));
+    });
+    it("should return false for a function without the property", async function () {
+      function myFn(): void {
+        /* no-op */
+      }
+      assert.isFalse(objectHasProperty(myFn, "azure"));
+    });
   });
 });

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.5.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.5.1 (2026-04-07)
 
 ### Other Changes

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-xml",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Core library for interacting with XML payloads",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-xml/src/xml.ts
+++ b/sdk/core/core-xml/src/xml.ts
@@ -106,7 +106,8 @@ export async function parseXML(str: string, opts: XmlOptions = {}): Promise<any>
   }
 
   if (!opts.includeRoot) {
-    for (const key of Object.keys(parsedXml)) {
+    const key = Object.keys(parsedXml)[0];
+    if (key !== undefined) {
       const value = parsedXml[key];
       return typeof value === "object" ? { ...value } : value;
     }


### PR DESCRIPTION
## Summary

Remove dead code, unnecessary type casts, and redundant `async` keywords across core packages.

### Dead code removal

- `AsyncLockOptions` interface, `Timeout` class (core-amqp)
- `isBearerToken`, `isPopToken` helpers (core-auth)
- `getCachedDefaultHttpsClient`, unused `HttpClient` import (core-client-rest)
- Stale `declare global { interface Event {} }` (abort-controller)

### Cast removal / type narrowing

- `as any` → `as ParsedOutput` in `parseConnectionString` (core-amqp)
- `{ [k: string]: string }` → `Record` (core-amqp)
- `as string` → `?? ""` for CAE challenge header (core-rest-pipeline)
- `isKeyCredential` param `any` → `unknown` with proper guard (core-client-rest)
- `objectHasProperty` tightened with null check (core-util)

### Redundant async removal

- `sendRequest`, `sendPolicy` handlers that just return a promise without awaiting (core-client, core-client-rest, core-http-compat, core-lro)

### Simplify defensive logic

- **ndJsonPolicy**: Remove unreachable `Array.isArray` guard after `JSON.parse` on a string starting with `[` (JSON spec guarantees array result)
- **tokenCycler**: Replace optional chaining with explicit null guard in `shouldRefresh`, making intent clearer

### Other improvements

- `Resolved` simplified to `Awaited` with deprecation notice (core-tracing)
- `HttpHeaders` class made non-exported (core-http-compat, was already not in public API)
- `Set` for passthrough props lookup (core-http-compat)
- XML root key extraction simplified (core-xml)
- URL scope construction fix (core-client)
- Optional chaining removed on guaranteed field (core-paging)