### PR TITLE
docs: fix inconsistencies in documentation folder

### DIFF
--- a/documentation/resolve-pnpm-lock-merge-conflict.md
+++ b/documentation/resolve-pnpm-lock-merge-conflict.md
@@ -15,5 +15,5 @@ Here's the recommended process to resolve merge conflicts of `pnpm-lock.yaml` in
 Step 4) to 6) can be combined and enhanced to run under any directory under the repo if you are using a \*NIX environment:
 
 ```shell
-git checkout upstream/main `git rev-parse --show-toplevel`/pnpm-lock.yaml && pnpm install && git add `git rev-parse --show-toplevel`pnpm-lock.yaml
+git checkout upstream/main `git rev-parse --show-toplevel`/pnpm-lock.yaml && pnpm install && git add `git rev-parse --show-toplevel`/pnpm-lock.yaml
 ```

--- a/documentation/steps-after-generations.md
+++ b/documentation/steps-after-generations.md
@@ -67,7 +67,7 @@ See the [Javascript Codegen Quick Start for Test](https://github.com/Azure/azure
     On Windows, you could use `SET`:
 
     ```shell
-    pnpm build --filter=${PACKAGE_NAME}
+    pnpm build --filter=${PACKAGE_NAME}...
     SET TEST_MODE=record&& pnpm test # this will run live test and generate a recordings folder, you will need to submit it in the PR.
     ```
 
@@ -76,13 +76,13 @@ See the [Javascript Codegen Quick Start for Test](https://github.com/Azure/azure
     On Linux, you could use below commands:
 
     ```shell
-      pnpm build --filter=${PACKAGE_NAME}
+      pnpm build --filter=${PACKAGE_NAME}...
     export TEST_MODE=playback && pnpm test # this will run live test and generate a recordings folder, you will need to submit it in the PR.
     ```
     On Windows, you can use:
 
     ```shell
-    pnpm build --filter=${PACKAGE_NAME}
+    pnpm build --filter=${PACKAGE_NAME}...
     SET TEST_MODE=playback&& pnpm test # this will run live test and generate a recordings folder, you will need to submit it in the PR.
     ```
 

--- a/documentation/using-azure-identity.md
+++ b/documentation/using-azure-identity.md
@@ -314,7 +314,13 @@ which tries each of the following credential types in order until one of them
 succeeds:
 
 - `EnvironmentCredential`
+- `WorkloadIdentityCredential`
 - `ManagedIdentityCredential`
+- `VisualStudioCodeCredential`
+- `AzureCliCredential`
+- `AzurePowerShellCredential`
+- `AzureDeveloperCliCredential`
+- `BrokerCredential` (requires `@azure/identity-broker`)
 
 This credential type is ideal when one of the credentials in the chain will work
 in the current environment, whether it's your local development or a production

--- a/documentation/writing-performance-tests.md
+++ b/documentation/writing-performance-tests.md
@@ -65,7 +65,7 @@ To add perf tests for the `sdk/<service>/<service-sdk>` package, follow the step
 
 ```json
 {
-  "extends": "../../../../tsconfig.package",
+  "extends": "../../../../tsconfig.lib.json",
   "compilerOptions": {
     "module": "commonjs",
     "declarationDir": "./types/latest",


### PR DESCRIPTION
Per #38115, the documentation folder has four inconsistencies that the docs-consistency-check workflow flagged but couldn't auto-PR (it lacks PR-creation permission).

## Changes

### `using-azure-identity.md` — DefaultAzureCredential chain was incomplete
Listed only `EnvironmentCredential` and `ManagedIdentityCredential` for the chain. The actual implementation in `sdk/identity/identity/src/credentials/defaultAzureCredential.ts` tries **eight** credentials in order. Added the missing six (`WorkloadIdentityCredential`, `VisualStudioCodeCredential`, `AzureCliCredential`, `AzurePowerShellCredential`, `AzureDeveloperCliCredential`, `BrokerCredential`).

### `writing-performance-tests.md` — non-existent `tsconfig.package` reference
The example `tsconfig.json` for a perf test project extended `tsconfig.package`, which doesn't exist at the repo root. The actual template perf test extends `tsconfig.lib.json`.

### `resolve-pnpm-lock-merge-conflict.md` — missing `/` in the `git add` one-liner
The combined shell command was missing the path separator between the shell-substituted repo root and `pnpm-lock.yaml`.

### `steps-after-generations.md` — missing `...` suffix on three `pnpm build --filter` commands
The Linux record block already had `...` (so dependencies are built); the other three (Windows record, Linux playback, Windows playback) were inconsistent and have been fixed to match.

Closes #38115