### PR TITLE
[event-hubs] Fix 'occured' -> 'occurred' typos in pumpManager logs and consumer model doc

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -154,7 +154,7 @@ export interface SubscriptionEventHandlers {
    * instances of your application running and have passed the `CheckpointStore` to the client to load balance.
    *
    * If the `CloseReason` is `Shutdown`, this indicates that either `subscription.close()` was called, or an
-   * error occured. Unless the subscription was explicitly closed via `subscription.close()`, the subscription
+   * error occurred. Unless the subscription was explicitly closed via `subscription.close()`, the subscription
    * will attempt to resume reading events from the last checkpoint for the partition.
    */
   processClose?: ProcessCloseHandler;

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -131,7 +131,7 @@ export class PumpManagerImpl implements PumpManager {
       await pump.start();
     } catch (err: any) {
       logger.verbose(
-        `[${this._eventProcessorName}] [${partitionId}] An error occured while adding/updating a pump: ${err}`,
+        `[${this._eventProcessorName}] [${partitionId}] An error occurred while adding/updating a pump: ${err}`,
       );
       logErrorStackTrace(err);
     }
@@ -156,7 +156,7 @@ export class PumpManagerImpl implements PumpManager {
       }
     } catch (err: any) {
       logger.verbose(
-        `[${this._eventProcessorName}] [${partitionId}] An error occured while removing a pump: ${err}`,
+        `[${this._eventProcessorName}] [${partitionId}] An error occurred while removing a pump: ${err}`,
       );
       logErrorStackTrace(err);
     }
@@ -183,7 +183,7 @@ export class PumpManagerImpl implements PumpManager {
       await Promise.all(tasks);
     } catch (err: any) {
       logger.verbose(
-        `[${this._eventProcessorName}] An error occured while removing all pumps: ${err}`,
+        `[${this._eventProcessorName}] An error occurred while removing all pumps: ${err}`,
       );
       logErrorStackTrace(err);
     } finally {


### PR DESCRIPTION
Three template-literal log messages in `sdk/eventhub/event-hubs/src/pumpManager.ts` and one doc comment in `sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts` used `An error occured` / `error occured`:

- `pumpManager.ts:134` — `An error occured while adding/updating a pump`
- `pumpManager.ts:159` — `An error occured while removing a pump`
- `pumpManager.ts:186` — `An error occured while removing all pumps`
- `eventHubConsumerClientModels.ts:157` — JSDoc on the subscription error doc

The pumpManager messages are emitted via `logger.warning` when a pump fails to add/update/remove, so the spelling is user-visible in eventhub processor logs. String/comment-only changes.