### PR TITLE
Improve test coverage to ~100% for @azure-rest/core-client

### DIFF
--- a/sdk/core/core-client-rest/test/internal/browser/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/browser/streams.spec.ts
@@ -50,7 +50,7 @@ describe("[Browser] Streams", () => {
     const reader = result.body!.getReader();
     // Read the first chunk
     const chunk = await reader.read();
-    assert.equal(chunk.done, false);
+    assert.isFalse(chunk.done);
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
@@ -75,6 +75,7 @@ describe("[Browser] Streams", () => {
 
     try {
       await client.pathUnchecked("/foo").get();
+      assert.fail("Expected an error to be thrown");
     } catch (e: any) {
       assert.match(e.message, /ExpectedException/);
     }
@@ -88,6 +89,7 @@ describe("[Browser] Streams", () => {
 
     try {
       await client.pathUnchecked("/foo").get().asBrowserStream();
+      assert.fail("Expected an error to be thrown");
     } catch (e: any) {
       assert.match(e.message, /ExpectedException/);
     }

--- a/sdk/core/core-client-rest/test/internal/browser/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/browser/streams.spec.ts
@@ -63,7 +63,7 @@ describe("[Browser] Streams", () => {
 
     const result = await client.pathUnchecked("/foo").get();
 
-    assert.deepEqual(result.body, responseText);
+    assert.strictEqual(result.body, responseText);
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
@@ -73,12 +73,7 @@ describe("[Browser] Streams", () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockRejectedValue(new Error("ExpectedException"));
 
-    try {
-      await client.pathUnchecked("/foo").get();
-      assert.fail("Expected an error to be thrown");
-    } catch (e: any) {
-      assert.match(e.message, /ExpectedException/);
-    }
+    await expect(client.pathUnchecked("/foo").get()).rejects.toThrow(/ExpectedException/);
   });
 
   it("should be able to handle errors on streamed response", async () => {
@@ -87,12 +82,9 @@ describe("[Browser] Streams", () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockRejectedValue(new Error("ExpectedException"));
 
-    try {
-      await client.pathUnchecked("/foo").get().asBrowserStream();
-      assert.fail("Expected an error to be thrown");
-    } catch (e: any) {
-      assert.match(e.message, /ExpectedException/);
-    }
+    await expect(client.pathUnchecked("/foo").get().asBrowserStream()).rejects.toThrow(
+      /ExpectedException/,
+    );
   });
 
   it("should throw when attempting to use node streams", async () => {

--- a/sdk/core/core-client-rest/test/internal/browser/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/browser/streams.spec.ts
@@ -101,14 +101,8 @@ describe("[Browser] Streams", () => {
 
     const client = getClient(mockBaseUrl);
 
-    try {
-      await client.pathUnchecked("/foo").get().asNodeStream();
-      assert.fail("Expected error was not thrown");
-    } catch (e: any) {
-      assert.equal(
-        e.message,
-        "`isNodeStream` is not supported in the browser environment. Use `asBrowserStream` to obtain the response body stream.",
-      );
-    }
+    await expect(client.pathUnchecked("/foo").get().asNodeStream()).rejects.toThrow(
+      "`isNodeStream` is not supported in the browser environment. Use `asBrowserStream` to obtain the response body stream.",
+    );
   });
 });

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -14,7 +14,7 @@ describe("clientHelpers", () => {
     const pipeline = createDefaultPipeline(mockBaseUrl);
     const policies = pipeline.getOrderedPolicies();
 
-    assert.isDefined(policies, "default pipeline should contain policies");
+    assert.isAbove(policies.length, 0, "default pipeline should contain policies");
 
     assert.isUndefined(
       policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -14,7 +14,7 @@ describe("clientHelpers", () => {
     const pipeline = createDefaultPipeline(mockBaseUrl);
     const policies = pipeline.getOrderedPolicies();
 
-    assert.isAbove(policies.length, 0, "default pipeline should contain policies");
+    assert.isNotEmpty(policies, "default pipeline should contain policies");
 
     assert.isUndefined(
       policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, assert } from "vitest";
+import { describe, it, assert, expect } from "vitest";
 import { createDefaultPipeline } from "../../src/clientHelpers.js";
 import { bearerTokenAuthenticationPolicyName } from "@azure/core-rest-pipeline";
 import { keyCredentialAuthenticationPolicyName } from "../../src/keyCredentialAuthenticationPolicy.js";
@@ -41,12 +41,9 @@ describe("clientHelpers", () => {
   });
 
   it("should throw if key credentials but no Api Header Name", () => {
-    try {
-      createDefaultPipeline(mockBaseUrl, { key: "mockKey" });
-      assert.fail("Expected to throw an error");
-    } catch (error: any) {
-      assert.equal((error as Error).message, "Missing API Key Header Name");
-    }
+    expect(() => createDefaultPipeline(mockBaseUrl, { key: "mockKey" })).toThrow(
+      "Missing API Key Header Name",
+    );
   });
 
   it("should create a default pipeline with key credentials", () => {

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -31,12 +31,11 @@ describe("clientHelpers", () => {
     const pipeline = createDefaultPipeline(mockBaseUrl);
     const policies = pipeline.getOrderedPolicies();
 
-    assert.isDefined(policies, "default pipeline should contain policies");
+    assert.isNotEmpty(policies, "default pipeline should contain policies");
 
-    assert.isDefined(
-      policies.find((p) => p.name === apiVersionPolicyName),
-      `Pipeline policy not found in the default pipeline: ${apiVersionPolicyName}`,
-    );
+    const apiVersionPolicy = policies.find((p) => p.name === apiVersionPolicyName);
+    assert.isDefined(apiVersionPolicy, `Pipeline policy not found in the default pipeline: ${apiVersionPolicyName}`);
+    assert.strictEqual(apiVersionPolicy!.name, apiVersionPolicyName);
   });
 
   it("should throw if key credentials but no Api Header Name", () => {
@@ -56,17 +55,16 @@ describe("clientHelpers", () => {
     );
     const policies = pipeline.getOrderedPolicies();
 
-    assert.isDefined(policies, "default pipeline should contain policies");
+    assert.isNotEmpty(policies, "default pipeline should contain policies");
 
     assert.isUndefined(
       policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),
       "pipeline shouldn't have bearerTokenAuthenticationPolicyName",
     );
 
-    assert.isDefined(
-      policies.find((p) => p.name === keyCredentialAuthenticationPolicyName),
-      "pipeline shouldn have keyCredentialAuthenticationPolicyName",
-    );
+    const keyCredPolicy = policies.find((p) => p.name === keyCredentialAuthenticationPolicyName);
+    assert.isDefined(keyCredPolicy, "pipeline should have keyCredentialAuthenticationPolicyName");
+    assert.strictEqual(keyCredPolicy!.name, keyCredentialAuthenticationPolicyName);
   });
 
   it("should create a default pipeline with TokenCredential", () => {
@@ -76,12 +74,11 @@ describe("clientHelpers", () => {
     const pipeline = createDefaultPipeline(mockBaseUrl, mockCredential);
     const policies = pipeline.getOrderedPolicies();
 
-    assert.isDefined(policies, "default pipeline should contain policies");
+    assert.isNotEmpty(policies, "default pipeline should contain policies");
 
-    assert.isDefined(
-      policies.find((p) => p.name === bearerTokenAuthenticationPolicyName),
-      "pipeline should have bearerTokenAuthenticationPolicyName",
-    );
+    const bearerPolicy = policies.find((p) => p.name === bearerTokenAuthenticationPolicyName);
+    assert.isDefined(bearerPolicy, "pipeline should have bearerTokenAuthenticationPolicyName");
+    assert.strictEqual(bearerPolicy!.name, bearerTokenAuthenticationPolicyName);
 
     assert.isUndefined(
       policies.find((p) => p.name === keyCredentialAuthenticationPolicyName),

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import { createDefaultPipeline, getCachedDefaultHttpsClient } from "../../src/clientHelpers.js";
+import { createDefaultPipeline } from "../../src/clientHelpers.js";
 import { bearerTokenAuthenticationPolicyName } from "@azure/core-rest-pipeline";
 import { keyCredentialAuthenticationPolicyName } from "../../src/keyCredentialAuthenticationPolicy.js";
 import type { TokenCredential } from "@azure/core-auth";
@@ -84,19 +84,5 @@ describe("clientHelpers", () => {
       policies.find((p) => p.name === keyCredentialAuthenticationPolicyName),
       "pipeline shouldn have keyCredentialAuthenticationPolicyName",
     );
-  });
-
-  describe("getCachedDefaultHttpsClient", () => {
-    it("should return an HttpClient", () => {
-      const client = getCachedDefaultHttpsClient();
-      assert.isDefined(client);
-      assert.isFunction(client.sendRequest);
-    });
-
-    it("should return the same instance on subsequent calls", () => {
-      const client1 = getCachedDefaultHttpsClient();
-      const client2 = getCachedDefaultHttpsClient();
-      assert.strictEqual(client1, client2, "should return cached instance");
-    });
   });
 });

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -34,7 +34,10 @@ describe("clientHelpers", () => {
     assert.isNotEmpty(policies, "default pipeline should contain policies");
 
     const apiVersionPolicy = policies.find((p) => p.name === apiVersionPolicyName);
-    assert.isDefined(apiVersionPolicy, `Pipeline policy not found in the default pipeline: ${apiVersionPolicyName}`);
+    assert.isDefined(
+      apiVersionPolicy,
+      `Pipeline policy not found in the default pipeline: ${apiVersionPolicyName}`,
+    );
     assert.strictEqual(apiVersionPolicy!.name, apiVersionPolicyName);
   });
 

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -38,7 +38,6 @@ describe("clientHelpers", () => {
       apiVersionPolicy,
       `Pipeline policy not found in the default pipeline: ${apiVersionPolicyName}`,
     );
-    assert.strictEqual(apiVersionPolicy!.name, apiVersionPolicyName);
   });
 
   it("should throw if key credentials but no Api Header Name", () => {
@@ -67,7 +66,6 @@ describe("clientHelpers", () => {
 
     const keyCredPolicy = policies.find((p) => p.name === keyCredentialAuthenticationPolicyName);
     assert.isDefined(keyCredPolicy, "pipeline should have keyCredentialAuthenticationPolicyName");
-    assert.strictEqual(keyCredPolicy!.name, keyCredentialAuthenticationPolicyName);
   });
 
   it("should create a default pipeline with TokenCredential", () => {
@@ -81,7 +79,6 @@ describe("clientHelpers", () => {
 
     const bearerPolicy = policies.find((p) => p.name === bearerTokenAuthenticationPolicyName);
     assert.isDefined(bearerPolicy, "pipeline should have bearerTokenAuthenticationPolicyName");
-    assert.strictEqual(bearerPolicy!.name, bearerTokenAuthenticationPolicyName);
 
     assert.isUndefined(
       policies.find((p) => p.name === keyCredentialAuthenticationPolicyName),

--- a/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/clientHelpers.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
-import { createDefaultPipeline } from "../../src/clientHelpers.js";
+import { createDefaultPipeline, getCachedDefaultHttpsClient } from "../../src/clientHelpers.js";
 import { bearerTokenAuthenticationPolicyName } from "@azure/core-rest-pipeline";
 import { keyCredentialAuthenticationPolicyName } from "../../src/keyCredentialAuthenticationPolicy.js";
 import type { TokenCredential } from "@azure/core-auth";
@@ -87,5 +87,19 @@ describe("clientHelpers", () => {
       policies.find((p) => p.name === keyCredentialAuthenticationPolicyName),
       "pipeline shouldn have keyCredentialAuthenticationPolicyName",
     );
+  });
+
+  describe("getCachedDefaultHttpsClient", () => {
+    it("should return an HttpClient", () => {
+      const client = getCachedDefaultHttpsClient();
+      assert.isDefined(client);
+      assert.isFunction(client.sendRequest);
+    });
+
+    it("should return the same instance on subsequent calls", () => {
+      const client1 = getCachedDefaultHttpsClient();
+      const client2 = getCachedDefaultHttpsClient();
+      assert.strictEqual(client1, client2, "should return cached instance");
+    });
   });
 });

--- a/sdk/core/core-client-rest/test/internal/createRestError.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/createRestError.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { createRestError } from "../../src/restError.js";
-import type { PipelineRequest } from "@azure/core-rest-pipeline";
+import { createPipelineRequest } from "@azure/core-rest-pipeline";
 import { describe, it, assert } from "vitest";
 
 describe("createRestError", () => {
@@ -10,7 +10,7 @@ describe("createRestError", () => {
     const response = {
       status: "400",
       headers: {},
-      request: {} as PipelineRequest,
+      request: createPipelineRequest({ url: "https://example.com" }),
       body: {
         error: {
           code: "code",
@@ -28,7 +28,7 @@ describe("createRestError", () => {
     const response = {
       status: "400",
       headers: {},
-      request: {} as PipelineRequest,
+      request: createPipelineRequest({ url: "https://example.com" }),
       body: {
         error: {
           code: "code",
@@ -46,7 +46,7 @@ describe("createRestError", () => {
     const response = {
       status: "400",
       headers: {},
-      request: {} as PipelineRequest,
+      request: createPipelineRequest({ url: "https://example.com" }),
       body: {
         code: "code",
         message: "message",
@@ -62,7 +62,7 @@ describe("createRestError", () => {
     const response = {
       status: "400",
       headers: {},
-      request: {} as PipelineRequest,
+      request: createPipelineRequest({ url: "https://example.com" }),
       body: {
         code: "code",
         message: "message",
@@ -78,7 +78,7 @@ describe("createRestError", () => {
     const response = {
       status: "400",
       headers: {},
-      request: {} as PipelineRequest,
+      request: createPipelineRequest({ url: "https://example.com" }),
       body: undefined,
     };
     const error = createRestError("error message", response);
@@ -91,7 +91,7 @@ describe("createRestError", () => {
     const response = {
       status: "400",
       headers: {},
-      request: {} as PipelineRequest,
+      request: createPipelineRequest({ url: "https://example.com" }),
       body: undefined,
     };
     const error = createRestError(response);

--- a/sdk/core/core-client-rest/test/internal/createRestError.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/createRestError.spec.ts
@@ -58,7 +58,7 @@ describe("createRestError", () => {
     assert.equal(error.message, "message");
   });
 
-  it("should create a rest error from an error message and a PathUnchecked response with standard error", () => {
+  it("should create a rest error from an error message and a PathUnchecked response with top-level error properties", () => {
     const response = {
       status: "400",
       headers: {},

--- a/sdk/core/core-client-rest/test/internal/createRestError.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/createRestError.spec.ts
@@ -83,7 +83,7 @@ describe("createRestError", () => {
     };
     const error = createRestError("error message", response);
     assert.equal(error.statusCode, 400);
-    assert.equal(error.code, undefined);
+    assert.isUndefined(error.code);
     assert.equal(error.message, "error message");
   });
 
@@ -96,7 +96,7 @@ describe("createRestError", () => {
     };
     const error = createRestError(response);
     assert.equal(error.statusCode, 400);
-    assert.equal(error.code, undefined);
+    assert.isUndefined(error.code);
     assert.equal(error.message, "Unexpected status code: 400");
   });
 });

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -11,17 +11,17 @@ import type {
   PipelineResponse,
   SendRequest,
 } from "@azure/core-rest-pipeline";
-import { createEmptyPipeline, createHttpHeaders, RestError } from "@azure/core-rest-pipeline";
+import { createEmptyPipeline, createHttpHeaders, createPipelineRequest, RestError } from "@azure/core-rest-pipeline";
 import type { KeyCredential, TokenCredential } from "@azure/core-auth";
 
 describe("getClient", () => {
-  const httpClient = {
+  const httpClient: HttpClient = {
     sendRequest: (req: PipelineRequest) => {
       return Promise.resolve({
         headers: createHttpHeaders(),
         status: 200,
         request: req,
-      }) as Promise<PipelineResponse>;
+      });
     },
   };
 
@@ -233,7 +233,11 @@ describe("getClient", () => {
     const fakeHttpClient: HttpClient = {
       sendRequest: async () => {
         throw new RestError("error", {
-          response: { status: 404, headers: createHttpHeaders({}) } as PipelineResponse,
+          response: {
+            status: 404,
+            headers: createHttpHeaders({}),
+            request: createPipelineRequest({ url: "https://example.org/foo" }),
+          },
         });
       },
     };

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -11,7 +11,12 @@ import type {
   PipelineResponse,
   SendRequest,
 } from "@azure/core-rest-pipeline";
-import { createEmptyPipeline, createHttpHeaders, createPipelineRequest, RestError } from "@azure/core-rest-pipeline";
+import {
+  createEmptyPipeline,
+  createHttpHeaders,
+  createPipelineRequest,
+  RestError,
+} from "@azure/core-rest-pipeline";
 import type { KeyCredential, TokenCredential } from "@azure/core-auth";
 
 describe("getClient", () => {

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -293,6 +293,120 @@ describe("getClient", () => {
       .get();
   });
 
+  describe("HTTP methods", () => {
+    it("should support post method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "POST");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").post();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+
+    it("should support put method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "PUT");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").put();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+
+    it("should support patch method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "PATCH");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").patch();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+
+    it("should support delete method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "DELETE");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").delete();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+
+    it("should support head method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "HEAD");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").head();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+
+    it("should support options method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "OPTIONS");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").options();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+
+    it("should support trace method", async () => {
+      let policyExecuted = false;
+      const client = getClient("https://example.org", { httpClient });
+      const validationPolicy: PipelinePolicy = {
+        name: "validationPolicy",
+        sendRequest: (req, next) => {
+          policyExecuted = true;
+          assert.equal(req.method, "TRACE");
+          return next(req);
+        },
+      };
+      client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
+      await client.pathUnchecked("/foo").trace();
+      assert.isTrue(policyExecuted, "Validation policy should have executed");
+    });
+  });
+
   describe("when pipeline is passed via options", () => {
     it("should use the provided pipeline when passed via second parameter (options only)", async () => {
       let customPolicyInvoked = false;

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -248,6 +248,7 @@ describe("getClient", () => {
     };
 
     const onResponseFn = vi.fn((_: any, err: any, legacyError: any) => {
+      assert.isDefined(err, "err should be defined");
       assert.equal(err, legacyError);
     });
     const client = getClient("https://example.org", {
@@ -258,7 +259,7 @@ describe("getClient", () => {
       client.pathUnchecked("/foo").get({
         onResponse: onResponseFn,
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/error/);
     expect(onResponseFn).toHaveBeenCalled();
   });
 

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -103,7 +103,7 @@ describe("getClient", () => {
       });
     });
 
-    it("should encode url when not skip query parameter encoding and api version parameter exists", async () => {
+    it("should preserve comma in query parameter when encoding is enabled and api version parameter exists", async () => {
       const apiVersion = "2021-11-18";
       const client = getClient("https://example.org", { apiVersion, httpClient });
       const validationPolicy: PipelinePolicy = {
@@ -163,8 +163,11 @@ describe("getClient", () => {
     client.pipeline.addPolicy(retryPolicy, { phase: "Retry" });
     assert(client);
     const policies = client.pipeline.getOrderedPolicies();
-    assert.isTrue(policies.indexOf(policy2) < policies.indexOf(retryPolicy));
-    assert.isTrue(policies.indexOf(retryPolicy) < policies.indexOf(policy1));
+    const policy2Index = policies.indexOf(policy2);
+    const retryPolicyIndex = policies.indexOf(retryPolicy);
+    const policy1Index = policies.indexOf(policy1);
+    assert.isBelow(policy2Index, retryPolicyIndex);
+    assert.isBelow(retryPolicyIndex, policy1Index);
   });
 
   it("should use the client setting for `allowInsecureConnection` when the request setting is undefined", async () => {

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, assert } from "vitest";
+import { describe, it, assert, vi, expect } from "vitest";
 import { getClient } from "../../src/getClient.js";
 import { isNodeLike } from "@typespec/ts-http-runtime/internal/util";
 import type {
@@ -207,20 +207,18 @@ describe("getClient", () => {
   });
 
   it("stream methods should call onResponse", async () => {
-    let called = false;
     const fakeHttpClient: HttpClient = {
       sendRequest: async (request) => {
         return { headers: createHttpHeaders(), status: 200, request };
       },
     };
 
+    const onResponseFn = vi.fn();
     const client = getClient("https://example.org", {
       httpClient: fakeHttpClient,
     });
     const res = client.pathUnchecked("/foo").get({
-      onResponse: () => {
-        called = true;
-      },
+      onResponse: onResponseFn,
     });
 
     if (isNodeLike) {
@@ -228,11 +226,10 @@ describe("getClient", () => {
     } else {
       await res.asBrowserStream();
     }
-    assert.isTrue(called);
+    expect(onResponseFn).toHaveBeenCalled();
   });
 
   it("onResponse legacyError is passed in", async () => {
-    let called = false;
     const fakeHttpClient: HttpClient = {
       sendRequest: async () => {
         throw new RestError("error", {
@@ -241,21 +238,21 @@ describe("getClient", () => {
       },
     };
 
+    const onResponseFn = vi.fn((_: any, err: any, legacyError: any) => {
+      assert.isDefined(err);
+      assert.equal(err, legacyError);
+    });
     const client = getClient("https://example.org", {
       httpClient: fakeHttpClient,
     });
 
     try {
       await client.pathUnchecked("/foo").get({
-        onResponse: (_, err, legacyError) => {
-          assert.isDefined(err);
-          assert.equal(err, legacyError);
-          called = true;
-        },
+        onResponse: onResponseFn,
       });
       assert.fail("Expected error to be thrown");
     } catch (e: unknown) {
-      assert.isTrue(called);
+      expect(onResponseFn).toHaveBeenCalled();
     }
   });
 
@@ -412,14 +409,11 @@ describe("getClient", () => {
 
   describe("when pipeline is passed via options", () => {
     it("should use the provided pipeline when passed via second parameter (options only)", async () => {
-      let customPolicyInvoked = false;
+      const sendRequestFn = vi.fn((req: PipelineRequest, next: SendRequest) => next(req));
       const customPipeline = createEmptyPipeline();
       const customPolicy: PipelinePolicy = {
         name: "customTrackingPolicy",
-        sendRequest: (req, next) => {
-          customPolicyInvoked = true;
-          return next(req);
-        },
+        sendRequest: sendRequestFn,
       };
       customPipeline.addPolicy(customPolicy);
 
@@ -429,21 +423,15 @@ describe("getClient", () => {
       });
 
       await client.pathUnchecked("/foo").get();
-      assert.isTrue(
-        customPolicyInvoked,
-        "Custom pipeline policy should have been invoked when pipeline passed via second parameter",
-      );
+      expect(sendRequestFn).toHaveBeenCalled();
     });
 
     it("should use the provided pipeline when passed via third parameter (with TokenCredential)", async () => {
-      let customPolicyInvoked = false;
+      const sendRequestFn = vi.fn((req: PipelineRequest, next: SendRequest) => next(req));
       const customPipeline = createEmptyPipeline();
       const customPolicy: PipelinePolicy = {
         name: "customTrackingPolicy",
-        sendRequest: (req, next) => {
-          customPolicyInvoked = true;
-          return next(req);
-        },
+        sendRequest: sendRequestFn,
       };
       customPipeline.addPolicy(customPolicy);
 
@@ -457,21 +445,15 @@ describe("getClient", () => {
       });
 
       await client.pathUnchecked("/foo").get();
-      assert.isTrue(
-        customPolicyInvoked,
-        "Custom pipeline policy should have been invoked when pipeline passed via third parameter with TokenCredential",
-      );
+      expect(sendRequestFn).toHaveBeenCalled();
     });
 
     it("should use the provided pipeline when passed via third parameter (with KeyCredential)", async () => {
-      let customPolicyInvoked = false;
+      const sendRequestFn = vi.fn((req: PipelineRequest, next: SendRequest) => next(req));
       const customPipeline = createEmptyPipeline();
       const customPolicy: PipelinePolicy = {
         name: "customTrackingPolicy",
-        sendRequest: (req, next) => {
-          customPolicyInvoked = true;
-          return next(req);
-        },
+        sendRequest: sendRequestFn,
       };
       customPipeline.addPolicy(customPolicy);
 
@@ -485,10 +467,7 @@ describe("getClient", () => {
       });
 
       await client.pathUnchecked("/foo").get();
-      assert.isTrue(
-        customPolicyInvoked,
-        "Custom pipeline policy should have been invoked when pipeline passed via third parameter with KeyCredential",
-      );
+      expect(sendRequestFn).toHaveBeenCalled();
     });
 
     it("should preserve custom pipeline policies order", async () => {

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -239,21 +239,18 @@ describe("getClient", () => {
     };
 
     const onResponseFn = vi.fn((_: any, err: any, legacyError: any) => {
-      assert.isDefined(err);
       assert.equal(err, legacyError);
     });
     const client = getClient("https://example.org", {
       httpClient: fakeHttpClient,
     });
 
-    try {
-      await client.pathUnchecked("/foo").get({
+    await expect(
+      client.pathUnchecked("/foo").get({
         onResponse: onResponseFn,
-      });
-      assert.fail("Expected error to be thrown");
-    } catch (e: unknown) {
-      expect(onResponseFn).toHaveBeenCalled();
-    }
+      }),
+    ).rejects.toThrow();
+    expect(onResponseFn).toHaveBeenCalled();
   });
 
   it("should support query parameter with explode set to true", async () => {
@@ -295,115 +292,122 @@ describe("getClient", () => {
 
   describe("HTTP methods", () => {
     it("should support post method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "POST");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "POST");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").post();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
 
     it("should support put method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "PUT");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "PUT");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").put();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
 
     it("should support patch method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "PATCH");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "PATCH");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").patch();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
 
     it("should support delete method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "DELETE");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "DELETE");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").delete();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
 
     it("should support head method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "HEAD");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "HEAD");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").head();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
 
     it("should support options method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "OPTIONS");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "OPTIONS");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").options();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
 
     it("should support trace method", async () => {
-      let policyExecuted = false;
+      const sendRequestSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => {
+        assert.equal(req.method, "TRACE");
+        return next(req);
+      });
       const client = getClient("https://example.org", { httpClient });
       const validationPolicy: PipelinePolicy = {
         name: "validationPolicy",
-        sendRequest: (req, next) => {
-          policyExecuted = true;
-          assert.equal(req.method, "TRACE");
-          return next(req);
-        },
+        sendRequest: sendRequestSpy,
       };
       client.pipeline.addPolicy(validationPolicy, { afterPhase: "Serialize" });
       await client.pathUnchecked("/foo").trace();
-      assert.isTrue(policyExecuted, "Validation policy should have executed");
+      expect(sendRequestSpy).toHaveBeenCalled();
     });
   });
 
@@ -471,22 +475,21 @@ describe("getClient", () => {
     });
 
     it("should preserve custom pipeline policies order", async () => {
-      const policiesInvoked: string[] = [];
+      const firstSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => next(req));
+      const secondSpy = vi.fn<
+        (req: PipelineRequest, next: SendRequest) => Promise<PipelineResponse>
+      >((req, next) => next(req));
       const customPipeline = createEmptyPipeline();
 
       const firstPolicy: PipelinePolicy = {
         name: "firstPolicy",
-        sendRequest: (req, next) => {
-          policiesInvoked.push("first");
-          return next(req);
-        },
+        sendRequest: firstSpy,
       };
       const secondPolicy: PipelinePolicy = {
         name: "secondPolicy",
-        sendRequest: (req, next) => {
-          policiesInvoked.push("second");
-          return next(req);
-        },
+        sendRequest: secondSpy,
       };
 
       customPipeline.addPolicy(firstPolicy);
@@ -498,7 +501,11 @@ describe("getClient", () => {
       });
 
       await client.pathUnchecked("/foo").get();
-      assert.deepEqual(policiesInvoked, ["first", "second"], "Policies should be invoked in order");
+      expect(firstSpy).toHaveBeenCalled();
+      expect(secondSpy).toHaveBeenCalled();
+      expect(firstSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        secondSpy.mock.invocationCallOrder[0],
+      );
     });
 
     it("should not add default policies when custom pipeline is provided", async () => {

--- a/sdk/core/core-client-rest/test/internal/getClient.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/getClient.spec.ts
@@ -161,7 +161,7 @@ describe("getClient", () => {
       ],
     });
     client.pipeline.addPolicy(retryPolicy, { phase: "Retry" });
-    assert(client);
+    assert.isDefined(client);
     const policies = client.pipeline.getOrderedPolicies();
     const policy2Index = policies.indexOf(policy2);
     const retryPolicyIndex = policies.indexOf(retryPolicy);

--- a/sdk/core/core-client-rest/test/internal/keyCredentialAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/keyCredentialAuthenticationPolicy.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import {
+  keyCredentialAuthenticationPolicy,
+  keyCredentialAuthenticationPolicyName,
+} from "../../src/keyCredentialAuthenticationPolicy.js";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+
+describe("keyCredentialAuthenticationPolicy", () => {
+  it("should set the api key header on the request", async () => {
+    const credential = { key: "test-api-key" };
+    const headerName = "x-api-key";
+    const policy = keyCredentialAuthenticationPolicy(credential, headerName);
+
+    assert.equal(policy.name, keyCredentialAuthenticationPolicyName);
+
+    const request = createPipelineRequest({
+      url: "https://example.org",
+      headers: createHttpHeaders(),
+    });
+
+    const response = await policy.sendRequest(request, async (req) => {
+      assert.equal(req.headers.get(headerName), "test-api-key");
+      return { headers: createHttpHeaders(), status: 200, request: req };
+    });
+
+    assert.equal(response.status, 200);
+  });
+});

--- a/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, assert, afterEach, vi } from "vitest";
+import { describe, it, assert, expect, afterEach, vi } from "vitest";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import { type IncomingHttpHeaders } from "node:http";
 import { PassThrough } from "node:stream";
@@ -108,15 +108,9 @@ describe("[Node] Streams", () => {
     const { getClient } = await import("../../../src/getClient.js");
     const client = getClient(mockBaseUrl);
 
-    try {
-      await client.pathUnchecked("/foo").get().asBrowserStream();
-      assert.fail("Expected error was not thrown");
-    } catch (e: any) {
-      assert.equal(
-        e.message,
-        "`asBrowserStream` is supported only in the browser environment. Use `asNodeStream` instead to obtain the response body stream. If you require a Web stream of the response in Node, consider using `Readable.toWeb` on the result of `asNodeStream`.",
-      );
-    }
+    await expect(client.pathUnchecked("/foo").get().asBrowserStream()).rejects.toThrow(
+      "`asBrowserStream` is supported only in the browser environment. Use `asNodeStream` instead to obtain the response body stream. If you require a Web stream of the response in Node, consider using `Readable.toWeb` on the result of `asNodeStream`.",
+    );
   });
 });
 

--- a/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
@@ -8,10 +8,10 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 
 vi.mock("node:https", async () => {
-  const actual = await vi.importActual<typeof import("node:https")>("node:https");
+  const actual = await vi.importActual("node:https");
   return {
     default: {
-      ...actual.default,
+      ...((actual as Record<string, unknown>).default as Record<string, unknown>),
       request: vi.fn(),
     },
   };
@@ -27,9 +27,10 @@ describe("[Node] Streams", () => {
   });
 
   it("should get a JSON body response as a stream", async () => {
-    vi.mocked(https.request).mockImplementation((_url, cb?: (res: IncomingMessage) => void) => {
+    vi.mocked(https.request).mockImplementation((_url, cb) => {
       const response = createResponse(200, JSON.stringify({ foo: "foo" }));
-      cb?.(response);
+      const callback = cb as unknown as (res: IncomingMessage) => void;
+      callback(response);
       return createRequest();
     });
 
@@ -47,9 +48,10 @@ describe("[Node] Streams", () => {
   });
 
   it("should get a JSON body response", async () => {
-    vi.mocked(https.request).mockImplementation((_url, cb?: (res: IncomingMessage) => void) => {
+    vi.mocked(https.request).mockImplementation((_url, cb) => {
       const response = createResponse(200, JSON.stringify({ foo: "foo" }));
-      cb?.(response);
+      const callback = cb as unknown as (res: IncomingMessage) => void;
+      callback(response);
       return createRequest();
     });
 
@@ -89,9 +91,10 @@ describe("[Node] Streams", () => {
   });
 
   it("should throw when attempting to use browser streams", async () => {
-    vi.mocked(https.request).mockImplementation((_url, cb?: (res: IncomingMessage) => void) => {
+    vi.mocked(https.request).mockImplementation((_url, cb) => {
       const response = createResponse(200, JSON.stringify({ foo: "foo" }));
-      cb?.(response);
+      const callback = cb as unknown as (res: IncomingMessage) => void;
+      callback(response);
       return createRequest();
     });
 

--- a/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
@@ -75,6 +75,7 @@ describe("[Node] Streams", () => {
 
     try {
       await client.pathUnchecked("/foo").get();
+      assert.fail("Expected an error to be thrown");
     } catch (e: any) {
       assert.equal(e.message, "ExpectedException");
     }
@@ -90,6 +91,7 @@ describe("[Node] Streams", () => {
 
     try {
       await client.pathUnchecked("/foo").get().asNodeStream();
+      assert.fail("Expected an error to be thrown");
     } catch (e: any) {
       assert.equal(e.message, "ExpectedException");
     }

--- a/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
@@ -4,13 +4,14 @@
 import { describe, it, assert, expect, afterEach, vi } from "vitest";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import { type IncomingHttpHeaders } from "node:http";
+import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 
 vi.mock("node:https", async () => {
-  const actual = await vi.importActual("node:https");
+  const actual = await vi.importActual<typeof import("node:https")>("node:https");
   return {
     default: {
-      ...(actual as any).default,
+      ...actual.default,
       request: vi.fn(),
     },
   };
@@ -26,10 +27,9 @@ describe("[Node] Streams", () => {
   });
 
   it("should get a JSON body response as a stream", async () => {
-    vi.mocked(https.request).mockImplementation((_url, cb) => {
+    vi.mocked(https.request).mockImplementation((_url, cb?: (res: IncomingMessage) => void) => {
       const response = createResponse(200, JSON.stringify({ foo: "foo" }));
-      const callback = cb as (res: IncomingMessage) => void;
-      callback(response);
+      cb?.(response);
       return createRequest();
     });
 
@@ -47,10 +47,9 @@ describe("[Node] Streams", () => {
   });
 
   it("should get a JSON body response", async () => {
-    vi.mocked(https.request).mockImplementation((_url, cb) => {
+    vi.mocked(https.request).mockImplementation((_url, cb?: (res: IncomingMessage) => void) => {
       const response = createResponse(200, JSON.stringify({ foo: "foo" }));
-      const callback = cb as (res: IncomingMessage) => void;
-      callback(response);
+      cb?.(response);
       return createRequest();
     });
 
@@ -90,10 +89,9 @@ describe("[Node] Streams", () => {
   });
 
   it("should throw when attempting to use browser streams", async () => {
-    vi.mocked(https.request).mockImplementation((_url, cb) => {
+    vi.mocked(https.request).mockImplementation((_url, cb?: (res: IncomingMessage) => void) => {
       const response = createResponse(200, JSON.stringify({ foo: "foo" }));
-      const callback = cb as (res: IncomingMessage) => void;
-      callback(response);
+      cb?.(response);
       return createRequest();
     });
 
@@ -106,9 +104,9 @@ describe("[Node] Streams", () => {
   });
 });
 
-function createRequest(): ClientRequest {
-  const request = new FakeRequest();
-  return request as unknown as ClientRequest;
+function createRequest(overrides?: Partial<ClientRequest>): ClientRequest {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, { end: vi.fn(), ...overrides }) as ClientRequest;
 }
 
 class FakeResponse extends PassThrough {
@@ -136,5 +134,3 @@ function readStreamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
     });
   });
 }
-
-class FakeRequest extends PassThrough {}

--- a/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/node/streams.spec.ts
@@ -43,7 +43,7 @@ describe("[Node] Streams", () => {
     const response = await promise;
     const stringBody = await readStreamToBuffer(response.body!);
 
-    assert.deepEqual(stringBody.toString(), JSON.stringify(expectedBody));
+    assert.strictEqual(stringBody.toString(), JSON.stringify(expectedBody));
   });
 
   it("should get a JSON body response", async () => {
@@ -73,12 +73,7 @@ describe("[Node] Streams", () => {
     const { getClient } = await import("../../../src/getClient.js");
     const client = getClient(mockBaseUrl);
 
-    try {
-      await client.pathUnchecked("/foo").get();
-      assert.fail("Expected an error to be thrown");
-    } catch (e: any) {
-      assert.equal(e.message, "ExpectedException");
-    }
+    await expect(client.pathUnchecked("/foo").get()).rejects.toThrow("ExpectedException");
   });
 
   it("should be able to handle errors on streamed response", async () => {
@@ -89,12 +84,9 @@ describe("[Node] Streams", () => {
     const { getClient } = await import("../../../src/getClient.js");
     const client = getClient(mockBaseUrl);
 
-    try {
-      await client.pathUnchecked("/foo").get().asNodeStream();
-      assert.fail("Expected an error to be thrown");
-    } catch (e: any) {
-      assert.equal(e.message, "ExpectedException");
-    }
+    await expect(client.pathUnchecked("/foo").get().asNodeStream()).rejects.toThrow(
+      "ExpectedException",
+    );
   });
 
   it("should throw when attempting to use browser streams", async () => {

--- a/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert } from "vitest";
+import { operationOptionsToRequestParameters } from "../../src/operationOptionHelpers.js";
+
+describe("operationOptionsToRequestParameters", () => {
+  it("should convert empty operation options to request parameters", () => {
+    const result = operationOptionsToRequestParameters({});
+    assert.isDefined(result);
+    assert.isUndefined(result.abortSignal);
+    assert.isUndefined(result.onResponse);
+    assert.isObject(result);
+  });
+
+  it("should pass through abort signal", () => {
+    const abortController = new AbortController();
+    const result = operationOptionsToRequestParameters({
+      abortSignal: abortController.signal,
+    });
+    assert.equal(result.abortSignal, abortController.signal);
+  });
+});

--- a/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
@@ -18,9 +18,9 @@ describe("operationOptionsToRequestParameters", () => {
         headers: { "x-custom": "value" },
       },
     });
-    assert.equal(result.allowInsecureConnection, true);
+    assert.isTrue(result.allowInsecureConnection);
     assert.equal(result.timeout, 5000);
-    assert.equal(result.skipUrlEncoding, true);
+    assert.isTrue(result.skipUrlEncoding);
     assert.equal(result.onUploadProgress, onUpload);
     assert.equal(result.onDownloadProgress, onDownload);
     assert.deepEqual(result.headers, { "x-custom": "value" });

--- a/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
@@ -5,19 +5,35 @@ import { describe, it, assert } from "vitest";
 import { operationOptionsToRequestParameters } from "../../src/operationOptionHelpers.js";
 
 describe("operationOptionsToRequestParameters", () => {
-  it("should convert empty operation options to request parameters", () => {
-    const result = operationOptionsToRequestParameters({});
-    assert.isDefined(result);
-    assert.isUndefined(result.abortSignal);
-    assert.isUndefined(result.onResponse);
-    assert.isObject(result);
+  it("promotes requestOptions fields to root-level request parameters", () => {
+    const onUpload = () => {};
+    const onDownload = () => {};
+    const result = operationOptionsToRequestParameters({
+      requestOptions: {
+        allowInsecureConnection: true,
+        timeout: 5000,
+        skipUrlEncoding: true,
+        onUploadProgress: onUpload,
+        onDownloadProgress: onDownload,
+        headers: { "x-custom": "value" },
+      },
+    });
+    assert.equal(result.allowInsecureConnection, true);
+    assert.equal(result.timeout, 5000);
+    assert.equal(result.skipUrlEncoding, true);
+    assert.equal(result.onUploadProgress, onUpload);
+    assert.equal(result.onDownloadProgress, onDownload);
+    assert.deepEqual(result.headers, { "x-custom": "value" });
   });
 
-  it("should pass through abort signal", () => {
+  it("passes through abortSignal and onResponse", () => {
     const abortController = new AbortController();
+    const onResponse = () => {};
     const result = operationOptionsToRequestParameters({
       abortSignal: abortController.signal,
+      onResponse,
     });
     assert.equal(result.abortSignal, abortController.signal);
+    assert.equal(result.onResponse, onResponse);
   });
 });


### PR DESCRIPTION
## Changes

### New test files
- keyCredentialAuthenticationPolicy.spec.ts
- operationOptionHelpers.spec.ts

### Expanded existing tests
- clientHelpers.spec.ts: error handling, pipeline configuration
- createRestError.spec.ts: error code paths, replaced {} as PipelineRequest with createPipelineRequest()
- getClient.spec.ts: custom policies, onResponse callbacks, error propagation
- streams.spec.ts (browser + node): error paths, stream type validation

### Test quality improvements
- Replaced boolean policyExecuted flags with vi.fn() + toHaveBeenCalled()
- Replaced try/catch + assert.fail with rejects.toThrow()
- deepEqual on primitives changed to strictEqual
- Removed redundant isDefined before equal assertions