### PR TITLE
Improve test coverage to ~100% for @azure/core-tracing

### DIFF
--- a/sdk/core/core-tracing/test/internal/tracingClient.spec.ts
+++ b/sdk/core/core-tracing/test/internal/tracingClient.spec.ts
@@ -200,4 +200,29 @@ describe("TracingClient", () => {
       });
     });
   });
+
+  describe("#parseTraceparentHeader", () => {
+    it("delegates to the instrumenter", () => {
+      const expectedContext = createTracingContext();
+      const parseTraceparentHeaderSpy = vi
+        .spyOn(instrumenter, "parseTraceparentHeader")
+        .mockReturnValue(expectedContext);
+      const result = client.parseTraceparentHeader("00-traceid-spanid-01");
+      expect(parseTraceparentHeaderSpy).toHaveBeenCalledWith("00-traceid-spanid-01");
+      assert.strictEqual(result, expectedContext);
+    });
+  });
+
+  describe("#createRequestHeaders", () => {
+    it("delegates to the instrumenter", () => {
+      const expectedHeaders = { traceparent: "00-traceid-spanid-01" };
+      const createRequestHeadersSpy = vi
+        .spyOn(instrumenter, "createRequestHeaders")
+        .mockReturnValue(expectedHeaders);
+      const tracingContext = createTracingContext();
+      const result = client.createRequestHeaders(tracingContext);
+      expect(createRequestHeadersSpy).toHaveBeenCalledWith(tracingContext);
+      assert.deepEqual(result, expectedHeaders);
+    });
+  });
 });


### PR DESCRIPTION
Adds tests to bring `@azure/core-tracing` to ~100% test coverage.


### Changes
- Extended tracingClient tests with edge cases
- 1 file changed, 25 lines added