### PR TITLE
[docs] Fix documentation inconsistencies across documentation/ folder

### DIFF
--- a/documentation/Generate-code-from-TypeSpec.md
+++ b/documentation/Generate-code-from-TypeSpec.md
@@ -49,7 +49,7 @@ SDK module would be generated under the SDK project folder at `sdk/<service>/<mo
 Install dependencies to use code-gen-pipeline,  
 ```ps
 npm --prefix eng/common/tsp-client ci
-npm install -g @pnpm
+npm install -g pnpm
 npm --prefix eng/tools/js-sdk-release-tools ci
 ```
 

--- a/documentation/Quickstart-on-how-to-write-tests.md
+++ b/documentation/Quickstart-on-how-to-write-tests.md
@@ -370,9 +370,9 @@ This simple test creates a resource and checks that the service handles it corre
 
 ```typescript
 import { Recorder } from "@azure-tools/test-recorder";
-import { assert } from "chai";
-import { PurviewDataMapClient } from "../../src";
-import { createClient, createRecorder } from "./utils/recordedClient";
+import { describe, it, assert, beforeEach, afterEach } from "vitest";
+import type { PurviewDataMapClient } from "../../src/index.js";
+import { createClient, createRecorder } from "./utils/recordedClient.js";
 
 describe("My test", () => {
   let recorder: Recorder;
@@ -380,14 +380,14 @@ describe("My test", () => {
   let client: PurviewDataMapClient;
   let glossaryName: string;
 
-  beforeEach(async function () {
-    recorder = await createRecorder(this);
+  beforeEach(async (ctx) => {
+    recorder = await createRecorder(ctx);
     // Step 3: Create your client
     client = await createClient(recorder);
     glossaryName = "js-testing";
   });
 
-  afterEach(async function () {
+  afterEach(async () => {
     await recorder.stop();
   });
 
@@ -415,11 +415,11 @@ describe("My test", () => {
 ### `utils/recordedClient.ts`
 
 ```typescript
-import { Context } from "mocha";
+import type { TestInfo } from "@azure-tools/test-recorder";
 import { Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
-import PurviewDataMap, { PurviewDataMapClient } from "../../../src";
+import PurviewDataMap, { PurviewDataMapClient } from "../../../src/index.js";
 import { createTestCredential } from "@azure-tools/test-credential";
-import { ClientOptions } from "@azure-rest/core-client";
+import type { ClientOptions } from "@azure-rest/core-client";
 
 const envSetupForPlayback: Record<string, string> = {
   ENDPOINT: "https://endpoint",
@@ -439,8 +439,8 @@ const recorderEnvSetup: RecorderStartOptions = {
  * Should be called first in the test suite to make sure environment variables are
  * read before they are being used.
  */
-export async function createRecorder(context: Context): Promise<Recorder> {
-  const recorder = new Recorder(context.currentTest);
+export async function createRecorder(context: TestInfo): Promise<Recorder> {
+  const recorder = new Recorder(context);
   await recorder.start(recorderEnvSetup);
   return recorder;
 }
@@ -484,9 +484,8 @@ Next, we'll take the package `@azure/arm-monitor` as an example to guide you how
 
 import { env, Recorder, RecorderStartOptions } from "@azure-tools/test-recorder";
 import { createTestCredential } from "@azure-tools/test-credential";
-import { assert } from "chai";
-import { Context } from "mocha";
-import { MonitorClient } from "../src/monitorClient";
+import { describe, it, assert, beforeEach, afterEach } from "vitest";
+import { MonitorClient } from "../src/monitorClient.js";
 
 // Step 4: Add environment variables you'd like to mask the values in recordings
 const replaceableVariables: Record<string, string> = {
@@ -508,8 +507,8 @@ describe("Monitor client", () => {
   let client: MonitorClient;
   let diagnosticName: string;
 
-  beforeEach(async function (this: Context) {
-    recorder = new Recorder(this.currentTest);
+  beforeEach(async (ctx) => {
+    recorder = new Recorder(ctx);
     await recorder.start(recorderOptions);
     // Step 3: create clients
     subscriptionId = env.SUBSCRIPTION_ID || "";

--- a/documentation/RLC-Swagger-quickstart.md
+++ b/documentation/RLC-Swagger-quickstart.md
@@ -227,7 +227,6 @@ And the errors may come from two kinds, the codegen issue or swagger example iss
 Now, you can generate both JavaScript and TypeScript workable samples with the following commands.
 
 ```shell
-npm install -g common/tools/dev-tool # make sure you are in the azure-sdk-for-js repo root directory
 cd ${PROJECT_ROOT}
 npx dev-tool samples publish -f
 ```

--- a/documentation/migrating-to-typespec.md
+++ b/documentation/migrating-to-typespec.md
@@ -243,13 +243,13 @@ Delete the following files that are no longer needed:
 2. **Build the package:**
 
    ```bash
-   npm run build
+   pnpm build
    ```
 
 3. **Run tests:**
 
    ```bash
-   npm run test
+   pnpm test
    ```
 
 4. **Validate the API surface:** Use API Extractor to ensure your public API hasn't changed unexpectedly.
@@ -269,7 +269,7 @@ After migration, your development workflow becomes:
 
 1. **Update TypeSpec definitions** in azure-rest-api-specs
 2. **Generate new code:** `npm run generate:client`
-3. **Build and test:** `npm run build && npm run test`
+3. **Build and test:** `pnpm build && pnpm test`
 
 ### Version Management
 

--- a/documentation/steps-after-generations.md
+++ b/documentation/steps-after-generations.md
@@ -124,7 +124,6 @@ You will need to add a sample configuration section in your `package.json` file 
 Now, you can generate both JavaScript and TypeScript workable samples with the following commands.
 
 ```shell
-npm install -g common/tools/dev-tool # make sure you are in the azure-sdk-for-js repo root directory
 cd ${PROJECT_ROOT}
 npx dev-tool samples publish -f
 ```

--- a/documentation/writing-performance-tests.md
+++ b/documentation/writing-performance-tests.md
@@ -34,16 +34,16 @@ To add perf tests for the `sdk/<service>/<service-sdk>` package, follow the step
 3.  Tests will live under `sdk/<service>/perf-tests/<service-sdk>/src`
 4.  Add a `package.json` such as [example-perf-package.json](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-file-datalake-perf-tests/package.json) at `sdk/<service>/perf-tests/<service-sdk>` folder.
 
-    Make sure to import your `<service-sdk>` and the `test-utils-perf` project.
+    Make sure to import your `<service-sdk>` and the `test-perf` project.
 
     ```json
       "dependencies": {
          "@azure/<service-sdk>": "^<version-in-master-branch>",
-         "@azure/test-utils-perf": "^1.0.0"
+         "@azure-tools/test-perf": "^1.0.0"
        }
     ```
 
-    _Note: `"@azure/test-utils-perf"` is not a published npm package._
+    _Note: `"@azure-tools/test-perf"` is not a published npm package._
 
     Set the name of the package and mark it as private.
 
@@ -87,12 +87,12 @@ To add perf tests for the `sdk/<service>/<service-sdk>` package, follow the step
 
 3. Add a `package.json` such as [example-track-1-perf-package.json](https://github.com/Azure/azure-sdk-for-js/blob/fe9b1e5a50946f53b6491d7f67b2420d8ee1b229/sdk/storage/perf-tests/storage-blob-track-1/package.json) at `sdk/<service>/perf-tests/<service-sdk>` folder.
 
-   Make sure to import your `<service-sdk>` and the `test-utils-perf` project.
+   Make sure to import your `<service-sdk>` and the `test-perf` project.
 
    ```json
      "dependencies": {
         "@azure/<service-sdk>": "^<latest-track-1-version>",
-        "@azure/test-utils-perf": "file:../../../test-utils/perf/azure-test-utils-perf-1.0.0.tgz",
+        "@azure-tools/test-perf": "file:../../../test-utils/perf/azure-test-utils-perf-1.0.0.tgz",
       }
    ```
 
@@ -125,7 +125,7 @@ To add perf tests for the `sdk/<service>/<service-sdk>` package, follow the step
 Add an `index.spec.ts` at `sdk/<service>/perf-tests/<service-sdk>/src/`.
 
 ```js
-import { createPerfProgram } from "@azure/test-utils-perf";
+import { createPerfProgram } from "@azure-tools/test-perf";
 import { `ServiceNameAPI1Name`Test } from "./api1-name.spec";
 import { `ServiceNameAPI2Name`Test } from "./api2-name.spec";
 
@@ -147,7 +147,7 @@ Base class would have all the common code that would be repeated for each of the
 Create a new file such as `serviceName.spec.ts` at `sdk/<service>/perf-tests/<service-sdk>/src/`.
 
 ```js
-import { PerfTest, getEnvVar } from "@azure/test-utils-perf";
+import { PerfTest, getEnvVar } from "@azure-tools/test-perf";
 import {
   ServiceNameClient
 } from "@azure/<service-sdk>";
@@ -176,7 +176,7 @@ Following code shows how the individual perf test files would look like.
 
 ```js
 import { ServiceNameClient } from "@azure/<service-sdk>";
-import { PerfOptionDictionary, drainStream } from "@azure/test-utils-perf";
+import { PerfOptionDictionary, drainStream } from "@azure-tools/test-perf";
 import { `ServiceName`Test } from "./serviceNameTest.spec";
 
 export class `ServiceNameAPIName`Test extends ServiceNameTest {


### PR DESCRIPTION
I reviewed and these mostly look good IMO. From the Agentic Workflow's issue #38215.

- Fix incorrect pnpm install command (@pnpm → pnpm) in Generate-code-from-TypeSpec.md
- Remove invalid 'npm install -g common/tools/dev-tool' from RLC-Swagger-quickstart.md and steps-after-generations.md
- Update @azure/test-utils-perf references to correct @azure-tools/test-perf package name in writing-performance-tests.md
- Update Mocha/Chai patterns to Vitest patterns in Quickstart-on-how-to-write-tests.md (import from vitest, use TestInfo instead of mocha Context, arrow functions instead of function expressions)
- Update npm run build/test to pnpm build/test in migrating-to-typespec.md


Fixes #38215