### PR TITLE
Handle AggregateError in core-amqp translate() for Node.js 20+ Happy Eyeballs

### DIFF
--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -685,6 +685,14 @@ export function translate(err: unknown): MessagingError | Error {
     return errObj;
   }
 
+  // Node.js 20+ enables Happy Eyeballs (autoSelectFamily) by default, which races IPv4 and IPv6
+  // connection attempts. When all attempts fail (e.g. DNS lookup for a non-existent host), Node.js
+  // throws an AggregateError bundling the individual failures. Translate by recursing on the first
+  // inner error, which carries the original system error details (e.g. ENOTFOUND, EAI_AGAIN).
+  if (errObj instanceof AggregateError && errObj.errors.length > 0) {
+    return translate(errObj.errors[0]);
+  }
+
   if (isAmqpError(errObj)) {
     // translate
     const condition = errObj.condition;

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -687,10 +687,20 @@ export function translate(err: unknown): MessagingError | Error {
 
   // Node.js 20+ enables Happy Eyeballs (autoSelectFamily) by default, which races IPv4 and IPv6
   // connection attempts. When all attempts fail (e.g. DNS lookup for a non-existent host), Node.js
-  // throws an AggregateError bundling the individual failures. Translate by recursing on the first
-  // inner error, which carries the original system error details (e.g. ENOTFOUND, EAI_AGAIN).
+  // throws an AggregateError bundling the individual failures. Translate all inner errors and
+  // return a single representative MessagingError so retry logic can inspect `retryable`. Prefer
+  // a retryable MessagingError if any inner error is retryable; otherwise use the first result.
+  // The full set of translated errors is attached as `info.innerErrors` for diagnostics.
   if (errObj instanceof AggregateError && errObj.errors.length > 0) {
-    return translate(errObj.errors[0]);
+    const translatedErrors = errObj.errors.map((e) => translate(e));
+    const representative =
+      translatedErrors.find(
+        (e): e is MessagingError => e instanceof MessagingError && e.retryable === true,
+      ) ?? translatedErrors[0];
+    if (representative instanceof MessagingError) {
+      representative.info = { ...representative.info, innerErrors: translatedErrors };
+    }
+    return representative;
   }
 
   if (isAmqpError(errObj)) {

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -688,19 +688,17 @@ export function translate(err: unknown): MessagingError | Error {
   // Node.js 20+ enables Happy Eyeballs (autoSelectFamily) by default, which races IPv4 and IPv6
   // connection attempts. When all attempts fail (e.g. DNS lookup for a non-existent host), Node.js
   // throws an AggregateError bundling the individual failures. Translate all inner errors and
-  // return a single representative MessagingError so retry logic can inspect `retryable`. Prefer
-  // a retryable MessagingError if any inner error is retryable; otherwise use the first result.
-  // The full set of translated errors is attached as `info.innerErrors` for diagnostics.
+  // return a new AggregateError containing the translated MessagingErrors. The `retryable` property
+  // is set on the AggregateError itself so the retry loop can inspect it directly — it is true if
+  // any inner error is retryable.
   if (errObj instanceof AggregateError && errObj.errors.length > 0) {
     const translatedErrors = errObj.errors.map((e) => translate(e));
-    const representative =
-      translatedErrors.find(
-        (e): e is MessagingError => e instanceof MessagingError && e.retryable === true,
-      ) ?? translatedErrors[0];
-    if (representative instanceof MessagingError) {
-      representative.info = { ...representative.info, innerErrors: translatedErrors };
-    }
-    return representative;
+    const retryable = translatedErrors.some(
+      (e) => e instanceof MessagingError && e.retryable === true,
+    );
+    const result = new AggregateError(translatedErrors, errObj.message);
+    (result as AggregateError & { retryable: boolean }).retryable = retryable;
+    return result;
   }
 
   if (isAmqpError(errObj)) {

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -688,15 +688,14 @@ export function translate(err: unknown): MessagingError | Error {
   // Node.js 20+ enables Happy Eyeballs (autoSelectFamily) by default, which races IPv4 and IPv6
   // connection attempts. When all attempts fail (e.g. DNS lookup for a non-existent host), Node.js
   // throws an AggregateError bundling the individual failures. Translate all inner errors and
-  // return a new AggregateError containing the translated MessagingErrors. The `retryable` property
-  // is set on the AggregateError itself so the retry loop can inspect it directly — it is true if
-  // any inner error is retryable.
+  // return a new AggregateError containing the translated errors. The `retryable` property is set
+  // on the AggregateError itself so the retry loop can inspect it directly — it is true if any
+  // inner translated error is retryable (including nested AggregateErrors).
   if (errObj instanceof AggregateError && errObj.errors.length > 0) {
     const translatedErrors = errObj.errors.map((e) => translate(e));
-    const retryable = translatedErrors.some(
-      (e) => e instanceof MessagingError && e.retryable === true,
-    );
-    const result = new AggregateError(translatedErrors, errObj.message);
+    const retryable = translatedErrors.some((e) => (e as any).retryable === true);
+    const result = new AggregateError(translatedErrors, errObj.message, { cause: errObj });
+    result.stack = errObj.stack;
     (result as AggregateError & { retryable: boolean }).retryable = retryable;
     return result;
   }

--- a/sdk/core/core-amqp/test/internal/errors.spec.ts
+++ b/sdk/core/core-amqp/test/internal/errors.spec.ts
@@ -308,22 +308,38 @@ describe("Errors", function () {
         assert.isFalse(aggResult.retryable);
       });
 
-      it("handles nested AggregateError recursively", function () {
+      it("handles nested AggregateError recursively and propagates retryable", function () {
+        const innerError = {
+          code: "EAI_AGAIN",
+          errno: "EAI_AGAIN",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo EAI_AGAIN example.invalid",
+        };
+        const innerAggregate = new AggregateError([innerError]);
+        const outerAggregate = new AggregateError([innerAggregate]);
+        const result = Errors.translate(outerAggregate);
+        assert.instanceOf(result, AggregateError);
+        const aggResult = result as AggregateError & { retryable: boolean };
+        // retryable must propagate through nested AggregateErrors
+        assert.isTrue(aggResult.retryable);
+        // The inner AggregateError was also translated
+        const innerResult = aggResult.errors[0] as AggregateError & { retryable: boolean };
+        assert.instanceOf(innerResult, AggregateError);
+        assert.isTrue(innerResult.retryable);
+      });
+
+      it("preserves the original stack trace", function () {
         const innerError = {
           code: "ENOTFOUND",
           errno: "ENOTFOUND",
           syscall: "getaddrinfo",
           message: "getaddrinfo ENOTFOUND example.invalid",
         };
-        const innerAggregate = new AggregateError([innerError]);
-        const outerAggregate = new AggregateError([innerAggregate]);
-        const result = Errors.translate(outerAggregate);
-        assert.instanceOf(result, AggregateError);
-        // The outer translates its single inner (which is itself an AggregateError)
-        const aggResult = result as AggregateError & { retryable: boolean };
-        assert.isFalse(aggResult.retryable);
-        // The inner AggregateError was also translated
-        assert.instanceOf(aggResult.errors[0], AggregateError);
+        const aggregateError = new AggregateError([innerError], "DNS failure");
+        const originalStack = aggregateError.stack;
+        const result = Errors.translate(aggregateError);
+        assert.equal(result.stack, originalStack);
+        assert.equal(result.cause, aggregateError);
       });
 
       it("returns the original AggregateError for an empty errors array", function () {

--- a/sdk/core/core-amqp/test/internal/errors.spec.ts
+++ b/sdk/core/core-amqp/test/internal/errors.spec.ts
@@ -223,7 +223,7 @@ describe("Errors", function () {
     });
 
     describe("AggregateError handling (Node.js 20+ Happy Eyeballs)", function () {
-      it("translates AggregateError containing ENOTFOUND system error into a non-retryable MessagingError", function () {
+      it("translates AggregateError containing ENOTFOUND into an AggregateError of MessagingErrors", function () {
         const innerError = {
           code: "ENOTFOUND",
           errno: "ENOTFOUND",
@@ -234,13 +234,18 @@ describe("Errors", function () {
           [innerError],
           "getaddrinfo ENOTFOUND example.invalid",
         );
-        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
-        assert.equal(translatedError.name, "MessagingError");
-        assert.equal(translatedError.code, "ENOTFOUND");
-        assert.isFalse(translatedError.retryable);
+        const result = Errors.translate(aggregateError);
+        assert.instanceOf(result, AggregateError);
+        const aggResult = result as AggregateError & { retryable: boolean };
+        assert.isFalse(aggResult.retryable);
+        assert.equal(aggResult.errors.length, 1);
+        const inner = aggResult.errors[0] as Errors.MessagingError;
+        assert.equal(inner.name, "MessagingError");
+        assert.equal(inner.code, "ENOTFOUND");
+        assert.isFalse(inner.retryable);
       });
 
-      it("translates AggregateError containing EAI_AGAIN system error into a retryable MessagingError", function () {
+      it("translates AggregateError containing EAI_AGAIN with retryable=true", function () {
         const innerError = {
           code: "EAI_AGAIN",
           errno: "EAI_AGAIN",
@@ -251,13 +256,17 @@ describe("Errors", function () {
           [innerError],
           "getaddrinfo EAI_AGAIN example.invalid",
         );
-        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
-        assert.equal(translatedError.name, "MessagingError");
-        assert.equal(translatedError.code, "EAI_AGAIN");
-        assert.isTrue(translatedError.retryable);
+        const result = Errors.translate(aggregateError);
+        assert.instanceOf(result, AggregateError);
+        const aggResult = result as AggregateError & { retryable: boolean };
+        assert.isTrue(aggResult.retryable);
+        const inner = aggResult.errors[0] as Errors.MessagingError;
+        assert.equal(inner.name, "MessagingError");
+        assert.equal(inner.code, "EAI_AGAIN");
+        assert.isTrue(inner.retryable);
       });
 
-      it("translates all inner errors and attaches them as info.innerErrors", function () {
+      it("translates all inner errors and sets retryable=true if any inner error is retryable", function () {
         const enotfound = {
           code: "ENOTFOUND",
           errno: "ENOTFOUND",
@@ -270,18 +279,19 @@ describe("Errors", function () {
           syscall: "connect",
           message: "connect ECONNREFUSED 127.0.0.1:5671",
         };
-        const aggregateError = new AggregateError([enotfound, econnrefused]);
-        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
-        assert.equal(translatedError.name, "MessagingError");
-        // ECONNREFUSED is retryable, so it should be preferred as the representative
-        assert.equal(translatedError.code, "ECONNREFUSED");
-        assert.isTrue(translatedError.retryable);
-        // All translated errors should be attached for diagnostics
-        assert.isArray(translatedError.info?.innerErrors);
-        assert.equal(translatedError.info!.innerErrors.length, 2);
+        const result = Errors.translate(
+          new AggregateError([enotfound, econnrefused]),
+        );
+        assert.instanceOf(result, AggregateError);
+        const aggResult = result as AggregateError & { retryable: boolean };
+        // ECONNREFUSED is retryable, so the aggregate should be retryable
+        assert.isTrue(aggResult.retryable);
+        assert.equal(aggResult.errors.length, 2);
+        assert.equal((aggResult.errors[0] as Errors.MessagingError).code, "ENOTFOUND");
+        assert.equal((aggResult.errors[1] as Errors.MessagingError).code, "ECONNREFUSED");
       });
 
-      it("uses the first translated error when none are retryable", function () {
+      it("sets retryable=false when no inner error is retryable", function () {
         const enotfound1 = {
           code: "ENOTFOUND",
           errno: "ENOTFOUND",
@@ -294,15 +304,13 @@ describe("Errors", function () {
           syscall: "getaddrinfo",
           message: "getaddrinfo ENOTFOUND example.invalid (IPv4)",
         };
-        const aggregateError = new AggregateError([enotfound1, enotfound2]);
-        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
-        assert.equal(translatedError.name, "MessagingError");
-        assert.equal(translatedError.code, "ENOTFOUND");
-        assert.isFalse(translatedError.retryable);
-        assert.equal(translatedError.message, enotfound1.message);
+        const result = Errors.translate(new AggregateError([enotfound1, enotfound2]));
+        assert.instanceOf(result, AggregateError);
+        const aggResult = result as AggregateError & { retryable: boolean };
+        assert.isFalse(aggResult.retryable);
       });
 
-      it("translates nested AggregateError recursively", function () {
+      it("handles nested AggregateError recursively", function () {
         const innerError = {
           code: "ENOTFOUND",
           errno: "ENOTFOUND",
@@ -311,16 +319,19 @@ describe("Errors", function () {
         };
         const innerAggregate = new AggregateError([innerError]);
         const outerAggregate = new AggregateError([innerAggregate]);
-        const translatedError = Errors.translate(outerAggregate) as Errors.MessagingError;
-        assert.equal(translatedError.name, "MessagingError");
-        assert.equal(translatedError.code, "ENOTFOUND");
-        assert.isFalse(translatedError.retryable);
+        const result = Errors.translate(outerAggregate);
+        assert.instanceOf(result, AggregateError);
+        // The outer translates its single inner (which is itself an AggregateError)
+        const aggResult = result as AggregateError & { retryable: boolean };
+        assert.isFalse(aggResult.retryable);
+        // The inner AggregateError was also translated
+        assert.instanceOf(aggResult.errors[0], AggregateError);
       });
 
-      it("returns a generic Error for an empty AggregateError", function () {
+      it("returns the original AggregateError for an empty errors array", function () {
         const aggregateError = new AggregateError([]);
-        const translatedError = Errors.translate(aggregateError);
-        assert.equal(translatedError, aggregateError);
+        const result = Errors.translate(aggregateError);
+        assert.equal(result, aggregateError);
       });
     });
   });

--- a/sdk/core/core-amqp/test/internal/errors.spec.ts
+++ b/sdk/core/core-amqp/test/internal/errors.spec.ts
@@ -221,5 +221,82 @@ describe("Errors", function () {
         },
       );
     });
+
+    describe("AggregateError handling (Node.js 20+ Happy Eyeballs)", function () {
+      it("translates AggregateError containing ENOTFOUND system error into a non-retryable MessagingError", function () {
+        const innerError = {
+          code: "ENOTFOUND",
+          errno: "ENOTFOUND",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo ENOTFOUND example.invalid",
+        };
+        const aggregateError = new AggregateError(
+          [innerError],
+          "getaddrinfo ENOTFOUND example.invalid",
+        );
+        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
+        assert.equal(translatedError.name, "MessagingError");
+        assert.equal(translatedError.code, "ENOTFOUND");
+        assert.isFalse(translatedError.retryable);
+      });
+
+      it("translates AggregateError containing EAI_AGAIN system error into a retryable MessagingError", function () {
+        const innerError = {
+          code: "EAI_AGAIN",
+          errno: "EAI_AGAIN",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo EAI_AGAIN example.invalid",
+        };
+        const aggregateError = new AggregateError(
+          [innerError],
+          "getaddrinfo EAI_AGAIN example.invalid",
+        );
+        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
+        assert.equal(translatedError.name, "MessagingError");
+        assert.equal(translatedError.code, "EAI_AGAIN");
+        assert.isTrue(translatedError.retryable);
+      });
+
+      it("translates AggregateError with multiple inner errors using the first one", function () {
+        const enotfound = {
+          code: "ENOTFOUND",
+          errno: "ENOTFOUND",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo ENOTFOUND example.invalid",
+        };
+        const econnrefused = {
+          code: "ECONNREFUSED",
+          errno: "ECONNREFUSED",
+          syscall: "connect",
+          message: "connect ECONNREFUSED 127.0.0.1:5671",
+        };
+        const aggregateError = new AggregateError([enotfound, econnrefused]);
+        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
+        assert.equal(translatedError.name, "MessagingError");
+        assert.equal(translatedError.code, "ENOTFOUND");
+        assert.isFalse(translatedError.retryable);
+      });
+
+      it("translates nested AggregateError recursively", function () {
+        const innerError = {
+          code: "ENOTFOUND",
+          errno: "ENOTFOUND",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo ENOTFOUND example.invalid",
+        };
+        const innerAggregate = new AggregateError([innerError]);
+        const outerAggregate = new AggregateError([innerAggregate]);
+        const translatedError = Errors.translate(outerAggregate) as Errors.MessagingError;
+        assert.equal(translatedError.name, "MessagingError");
+        assert.equal(translatedError.code, "ENOTFOUND");
+        assert.isFalse(translatedError.retryable);
+      });
+
+      it("returns a generic Error for an empty AggregateError", function () {
+        const aggregateError = new AggregateError([]);
+        const translatedError = Errors.translate(aggregateError);
+        assert.equal(translatedError, aggregateError);
+      });
+    });
   });
 });

--- a/sdk/core/core-amqp/test/internal/errors.spec.ts
+++ b/sdk/core/core-amqp/test/internal/errors.spec.ts
@@ -279,9 +279,7 @@ describe("Errors", function () {
           syscall: "connect",
           message: "connect ECONNREFUSED 127.0.0.1:5671",
         };
-        const result = Errors.translate(
-          new AggregateError([enotfound, econnrefused]),
-        );
+        const result = Errors.translate(new AggregateError([enotfound, econnrefused]));
         assert.instanceOf(result, AggregateError);
         const aggResult = result as AggregateError & { retryable: boolean };
         // ECONNREFUSED is retryable, so the aggregate should be retryable

--- a/sdk/core/core-amqp/test/internal/errors.spec.ts
+++ b/sdk/core/core-amqp/test/internal/errors.spec.ts
@@ -257,7 +257,7 @@ describe("Errors", function () {
         assert.isTrue(translatedError.retryable);
       });
 
-      it("translates AggregateError with multiple inner errors using the first one", function () {
+      it("translates all inner errors and attaches them as info.innerErrors", function () {
         const enotfound = {
           code: "ENOTFOUND",
           errno: "ENOTFOUND",
@@ -273,8 +273,33 @@ describe("Errors", function () {
         const aggregateError = new AggregateError([enotfound, econnrefused]);
         const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
         assert.equal(translatedError.name, "MessagingError");
+        // ECONNREFUSED is retryable, so it should be preferred as the representative
+        assert.equal(translatedError.code, "ECONNREFUSED");
+        assert.isTrue(translatedError.retryable);
+        // All translated errors should be attached for diagnostics
+        assert.isArray(translatedError.info?.innerErrors);
+        assert.equal(translatedError.info!.innerErrors.length, 2);
+      });
+
+      it("uses the first translated error when none are retryable", function () {
+        const enotfound1 = {
+          code: "ENOTFOUND",
+          errno: "ENOTFOUND",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo ENOTFOUND example.invalid (IPv6)",
+        };
+        const enotfound2 = {
+          code: "ENOTFOUND",
+          errno: "ENOTFOUND",
+          syscall: "getaddrinfo",
+          message: "getaddrinfo ENOTFOUND example.invalid (IPv4)",
+        };
+        const aggregateError = new AggregateError([enotfound1, enotfound2]);
+        const translatedError = Errors.translate(aggregateError) as Errors.MessagingError;
+        assert.equal(translatedError.name, "MessagingError");
         assert.equal(translatedError.code, "ENOTFOUND");
         assert.isFalse(translatedError.retryable);
+        assert.equal(translatedError.message, enotfound1.message);
       });
 
       it("translates nested AggregateError recursively", function () {

--- a/sdk/eventhub/event-hubs/test/internal/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/client.spec.ts
@@ -19,11 +19,39 @@ function createNoOpCred(): NoOpCredential {
 
 async function validateConnectionError(promise: Promise<unknown>): Promise<void> {
   await expect(promise).to.be.rejected.then((err) => {
-    expect(err)
-      .to.be.an.instanceOf(MessagingError)
-      .and.has.property("code", isNodeLike ? "ENOTFOUND" : "ServiceCommunicationError");
+    // On Node.js 20+, Happy Eyeballs (autoSelectFamily) races IPv4/IPv6 connections,
+    // producing AggregateError on failure. The retry loop may wrap these further.
+    // Unwrap to find the underlying MessagingError(s).
+    const messagingError = findMessagingError(err);
+    if (!messagingError) {
+      assert.fail(
+        `Expected a MessagingError (possibly inside AggregateError), got: ${err}`,
+      );
+    }
+    expect(messagingError).to.be.an.instanceOf(MessagingError);
+    if (isNodeLike) {
+      expect(["ENOTFOUND", "EAI_AGAIN"]).to.include(messagingError.code);
+    } else {
+      expect(messagingError).to.have.property("code", "ServiceCommunicationError");
+    }
     return err;
   });
+}
+
+/**
+ * Recursively searches for a MessagingError inside potentially nested AggregateErrors.
+ */
+function findMessagingError(err: unknown): MessagingError | undefined {
+  if (err instanceof MessagingError) {
+    return err;
+  }
+  if (err instanceof AggregateError) {
+    for (const inner of err.errors) {
+      const found = findMessagingError(inner);
+      if (found) return found;
+    }
+  }
+  return undefined;
 }
 
 async function validateNotFoundError(promise: Promise<unknown>): Promise<void> {

--- a/sdk/eventhub/event-hubs/test/internal/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/client.spec.ts
@@ -24,9 +24,7 @@ async function validateConnectionError(promise: Promise<unknown>): Promise<void>
     // Unwrap to find the underlying MessagingError(s).
     const messagingError = findMessagingError(err);
     if (!messagingError) {
-      assert.fail(
-        `Expected a MessagingError (possibly inside AggregateError), got: ${err}`,
-      );
+      assert.fail(`Expected a MessagingError (possibly inside AggregateError), got: ${err}`);
     }
     expect(messagingError).to.be.an.instanceOf(MessagingError);
     if (isNodeLike) {


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/core-amqp`
- `@azure/event-hubs` (tests only)

### Issues associated with this PR

- Fixes #38231
- Supersedes #38190

### Describe the problem that is addressed by this PR

Node.js 20+ defaults to Happy Eyeballs (RFC 8305), racing IPv4/IPv6 connections. DNS failures now throw `AggregateError` instead of a single system error. `translate()` in core-amqp didn't handle this, returning raw untranslated errors — breaking `instanceof MessagingError` checks, `.retryable` logic, and error code handling for all consumers.

### Fix

`translate()` now maps `AggregateError` → new `AggregateError` with all inner errors translated to `MessagingError`, with `.retryable` stamped on the aggregate (true if any inner is retryable).

### Are there test cases added in this PR?

Yes — 6 new tests in `core-amqp` covering ENOTFOUND, EAI_AGAIN, mixed retryability, nested aggregates, and empty aggregates. Event Hubs test helper updated to unwrap `AggregateError`.