### PR TITLE
Fix broken REST API doc link in ai-projects README

### DIFF
--- a/sdk/ai/ai-projects/README.md
+++ b/sdk/ai/ai-projects/README.md
@@ -1355,6 +1355,6 @@ additional questions or comments.
 [azure_sub]: https://azure.microsoft.com/free/
 [evaluators]: https://learn.microsoft.com/azure/ai-studio/how-to/develop/evaluate-sdk
 [evaluator_library]: https://learn.microsoft.com/azure/ai-studio/how-to/evaluate-generative-ai-app#view-and-manage-the-evaluators-in-the-evaluator-library
-[ai_foundry_data_plane_rest_apis]: https://learn.microsoft.com/rest/api/aifoundry/aiprojects/operation-groups?view=rest-aifoundry-aiprojects-v1
+[ai_foundry_data_plane_rest_apis]: https://learn.microsoft.com/rest/api/aifoundry/aiproject/operation-groups?view=rest-aifoundry-aiprojects-v1
 [ai_project_client_endpoint]: https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview?tabs=sync&pivots=programming-language-javascript
 [samples]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-projects/samples

--- a/sdk/ai/ai-projects/README.md
+++ b/sdk/ai/ai-projects/README.md
@@ -1355,6 +1355,6 @@ additional questions or comments.
 [azure_sub]: https://azure.microsoft.com/free/
 [evaluators]: https://learn.microsoft.com/azure/ai-studio/how-to/develop/evaluate-sdk
 [evaluator_library]: https://learn.microsoft.com/azure/ai-studio/how-to/evaluate-generative-ai-app#view-and-manage-the-evaluators-in-the-evaluator-library
-[ai_foundry_data_plane_rest_apis]: https://learn.microsoft.com/rest/api/aifoundry/aiproject/operation-groups?view=rest-aifoundry-aiprojects-v1
+[ai_foundry_data_plane_rest_apis]: https://learn.microsoft.com/rest/api/aifoundry/aiproject
 [ai_project_client_endpoint]: https://learn.microsoft.com/azure/ai-foundry/how-to/develop/sdk-overview?tabs=sync&pivots=programming-language-javascript
 [samples]: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/ai/ai-projects/samples


### PR DESCRIPTION
The `[ai_foundry_data_plane_rest_apis]` reference link at the bottom of the ai-projects README points to `/rest/api/aifoundry/aiprojects/operation-groups` (plural). That URL 404s on Learn.

The correct path is `/rest/api/aifoundry/aiproject/operation-groups` (singular).

**What changed:** One character in the reference link on line 1358.

**How I found it:** A customer reported broken doc links via OCV after migrating to the new Foundry portal. The NPS auto-analysis confirmed the issue came from REST API doc links. I audited all azure-sdk-for-* repos and this was the only one affected. A matching fix for microsoft-foundry/foundry-samples is at https://github.com/microsoft-foundry/foundry-samples/pull/662.