### PR TITLE
Prepare release: @azure/core-amqp 4.4.2 and @azure/event-hubs 6.0.4

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugs Fixed
 
 - Handle `AggregateError` in `translate()` for Node.js 20+ Happy Eyeballs (RFC 8305). When DNS resolution fails over dual-stack connections, Node.js now throws an `AggregateError` bundling IPv4 and IPv6 errors. The `translate()` function now translates all inner errors and returns a properly annotated `AggregateError` with correct `retryable` semantics. [#38233](https://github.com/Azure/azure-sdk-for-js/pull/38233)
-- Fixed `TimeoutNegativeWarning` on Node.js v24+ when timeout budget is exceeded during CBS authentication by clamping `setTimeout` values to a minimum of 0. [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
+- Clamp negative timeout values passed to `setTimeout` to a minimum of 0 when timeout budgets are exceeded in shared request/locking paths, preventing `TimeoutNegativeWarning` on Node.js v24+ (for example, during CBS authentication). [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
 
 ## 4.4.1 (2025-09-11)
 

--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Release History
 
-## 4.4.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.4.2 (2026-04-22)
 
 ### Bugs Fixed
 
+- Handle `AggregateError` in `translate()` for Node.js 20+ Happy Eyeballs (RFC 8305). When DNS resolution fails over dual-stack connections, Node.js now throws an `AggregateError` bundling IPv4 and IPv6 errors. The `translate()` function now translates all inner errors and returns a properly annotated `AggregateError` with correct `retryable` semantics. [#38233](https://github.com/Azure/azure-sdk-for-js/pull/38233)
 - Fixed `TimeoutNegativeWarning` on Node.js v24+ when timeout budget is exceeded during CBS authentication by clamping `setTimeout` values to a minimum of 0. [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
-
-### Other Changes
 
 ## 4.4.1 (2025-09-11)
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 6.0.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 6.0.4 (2026-04-22)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
## Release Preparation

Sets release date to **2026-04-22** for both packages and finalizes changelogs.

### @azure/core-amqp 4.4.2
- **Bug fix**: Handle `AggregateError` in `translate()` for Node.js 20+ Happy Eyeballs (#38233)
- **Bug fix**: Clamp negative `setTimeout` values to 0 for Node.js v24+ (#38166)

### @azure/event-hubs 6.0.4
- **Bug fix**: Clamp negative timeout computations to 0 for Node.js v24+ (#38166)
- **Perf**: Event-driven queue signals, simplified serialization, optimized cloning (#37882)