### PR TITLE
[ContentUnderstanding] Fix 1.1.0 user agent version string

### DIFF
--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0 (2026-04-22)
+## 1.1.0 (2026-04-23)
 
 ### Features Added
 

--- a/sdk/contentunderstanding/ai-content-understanding/src/api/contentUnderstandingContext.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/src/api/contentUnderstandingContext.ts
@@ -29,7 +29,7 @@ export function createContentUnderstanding(
 ): ContentUnderstandingContext {
   const endpointUrl = options.endpoint ?? `${endpoint}/contentunderstanding`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-ai-content-understanding/1.0.1`;
+  const userAgentInfo = `azsdk-js-ai-content-understanding/1.1.0`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/ai-content-understanding

### Issues associated with this PR
None

### Describe the problem that is addressed by this PR
The custom user agent string in contentUnderstandingContext.ts was hardcoded as azsdk-js-ai-content-understanding/1.0.1 incorrectly. It should 1.1.0.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Updated the hardcoded version string to 1.1.0 to match package.json.

### Are there test cases added in this PR? _(If not, why?)_
No. This is a one-line string literal change. The existing test suite covers client creation and pipeline behavior.

### Provide a list of related PRs _(if any)_
None

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
None

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
