### PR TITLE
Add dist and dist-test directories to prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,7 @@
 **/*.yml
 **/*.yaml
 **/*.d.ts
+**/dist/
+**/dist-test/
 .env
 tsdoc-metadata.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,7 @@
 **/*.yml
 **/*.yaml
 **/*.d.ts
-**/dist/
-**/dist-test/
+dist/
+dist-test/
 .env
 tsdoc-metadata.json


### PR DESCRIPTION
There are debugging/testing scenarios where we modify build output files in VS Code. This PR adds `dist/` and `dist-test/` directories into .prettierignore so that those files are not formatted by the prettier VS Code extension.