### PR TITLE
[engsys] Add `no-console` eslint rule to eslint plugin

### DIFF
--- a/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/azure-sdk-customized.ts
@@ -225,4 +225,10 @@ export default (parser: FlatConfig.Parser): FlatConfig.ConfigArray => [
       "@azure/azure-sdk/ts-use-cjs-polyfill": "error",
     },
   },
+  {
+    files: ["**/src/**/*.{ts,cts,mts,tsx}"],
+    rules: {
+      "no-console": "error",
+    },
+  },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1289,6 +1289,9 @@ importers:
       '@azure/identity':
         specifier: ^4.0.1
         version: 4.13.0
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       '@azure/storage-blob':
         specifier: ^12.17.0
         version: 12.31.0
@@ -8627,6 +8630,9 @@ importers:
 
   sdk/core/core-xml:
     dependencies:
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../logger
       fast-xml-parser:
         specifier: ^5.5.9
         version: 5.5.11
@@ -13545,6 +13551,9 @@ importers:
       '@azure/abort-controller':
         specifier: ^2.1.2
         version: link:../../core/abort-controller
+      '@azure/logger':
+        specifier: ^1.1.4
+        version: link:../../core/logger
       rhea:
         specifier: ^3.0.2
         version: 3.0.4

--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@azure-rest/core-client": "^1.3.1",
     "@azure/identity": "^4.0.1",
+    "@azure/logger": "^1.1.4",
     "@azure/storage-blob": "^12.17.0",
     "mime": "^4.0.1",
     "tslib": "^2.6.2"

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/logger.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/logger.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createClientLogger } from "@azure/logger";
+
+/**
+ * The \@azure/logger configuration for this package.
+ */
+export const logger = createClientLogger("api-management-custom-widgets-tools");

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/utils.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/utils.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "./logger.js";
+
 /**
  * Key for a search param, from which editor data will be loaded from.
  */
@@ -56,7 +58,7 @@ function parseWidgetData<Values extends ValuesCommon>(
     // }
     return urlEditorParams;
   } catch (e) {
-    console.error(
+    logger.error(
       `Could not get '${APIM_EDITOR_DATA_KEY}' from the search params of the URL:\n` + g.location,
       e,
     );

--- a/sdk/communication/communication-call-automation/src/callMedia.ts
+++ b/sdk/communication/communication-call-automation/src/callMedia.ts
@@ -55,6 +55,7 @@ import type {
 import type { KeyCredential, TokenCredential } from "@azure/core-auth";
 import type { SendDtmfTonesResult } from "./models/responses.js";
 import { randomUUID } from "@azure/core-util";
+import { logger } from "./models/logger.js";
 /**
  * CallMedia class represents call media related APIs.
  */
@@ -357,7 +358,7 @@ export class CallMedia {
   ): Promise<void> {
     if (typeof maxTonesOrOptions === "number" && options) {
       // Old function signature logic
-      console.warn(
+      logger.warning(
         "Deprecated function signature used. Please use the new signature with targetParticipant and options params instead, and set maxTonesToCollect in options.",
       );
       options.maxTonesToCollect = maxTonesOrOptions;

--- a/sdk/confidentialledger/confidential-ledger-rest/src/getLedgerIdentity.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/getLedgerIdentity.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { getClient } from "@azure-rest/core-client";
+import { logger } from "./logger.js";
 
 export interface LedgerIdentity {
   ledgerIdentityCertificate: string;
@@ -13,7 +14,7 @@ export async function getLedgerIdentity(
   identityServiceBaseUrl: string = "https://identity.confidential-ledger.core.azure.com",
 ): Promise<LedgerIdentity> {
   const client = getClient(identityServiceBaseUrl);
-  console.log(ledgerId);
+  logger.verbose(ledgerId);
   const cert = await client.pathUnchecked("/ledgerIdentity/{ledgerId}", ledgerId).get();
 
   const updatedCert = {

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -68,6 +68,7 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
+    "@azure/logger": "^1.1.4",
     "fast-xml-parser": "^5.5.9",
     "tslib": "^2.8.1"
   },

--- a/sdk/core/core-xml/src/logger.ts
+++ b/sdk/core/core-xml/src/logger.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createClientLogger } from "@azure/logger";
+
+/**
+ * The \@azure/logger configuration for this package.
+ */
+export const logger = createClientLogger("core-xml");

--- a/sdk/core/core-xml/src/xml-browser.mts
+++ b/sdk/core/core-xml/src/xml-browser.mts
@@ -3,6 +3,7 @@
 
 import type { XmlOptions } from "./xml.common.js";
 import { XML_ATTRKEY, XML_CHARKEY } from "./xml.common.js";
+import { logger } from "./logger.js";
 
 if (!document || !DOMParser || !Node || !XMLSerializer) {
   throw new Error(
@@ -24,7 +25,7 @@ try {
     });
   }
 } catch (e: any) {
-  console.warn('Could not create trusted types policy "@azure/core-xml#xml.browser"');
+  logger.warning('Could not create trusted types policy "@azure/core-xml#xml.browser"');
 }
 
 const doc = document.implementation.createDocument(null, null, null);

--- a/sdk/cosmosdb/cosmos/src/CosmosClient.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClient.ts
@@ -23,6 +23,7 @@ import { ResourceResponse } from "./request/index.js";
 import { checkURL } from "./utils/checkURL.js";
 import { getEmptyCosmosDiagnostics, withDiagnostics } from "./utils/diagnostics.js";
 import { GlobalPartitionEndpointManager } from "./globalPartitionEndpointManager.js";
+import { defaultLogger } from "./common/logger.js";
 
 /**
  * Provides a client-side logical representation of the Azure Cosmos DB database account.
@@ -371,7 +372,7 @@ export class CosmosClient {
           DiagnosticNodeType.BACKGROUND_REFRESH_THREAD,
         );
       } catch (e: any) {
-        console.warn("Failed to refresh endpoints", e);
+        defaultLogger.warning("Failed to refresh endpoints", e);
       }
     }, refreshRate);
     if (this.endpointRefresher.unref && typeof this.endpointRefresher.unref === "function") {

--- a/sdk/cosmosdb/cosmos/src/bulk/Limiter.ts
+++ b/sdk/cosmosdb/cosmos/src/bulk/Limiter.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { StatusCodes } from "../common/statusCodes.js";
+import { defaultLogger } from "../common/logger.js";
 import type { DiagnosticNodeInternal } from "../diagnostics/DiagnosticNodeInternal.js";
 import type { RetryCallback } from "../utils/batch.js";
 import type { Batcher } from "./Batcher.js";
@@ -228,7 +229,7 @@ export class LimiterQueue {
           });
       }
     } catch (err) {
-      console.error("Unexpected error in task queue processing:", err);
+      defaultLogger.error("Unexpected error in task queue processing:", err);
     } finally {
       this.processing = false;
     }

--- a/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
+++ b/sdk/cosmosdb/cosmos/src/diagnostics/index.ts
@@ -5,6 +5,7 @@ import { Constants } from "../common/index.js";
 import { isNonEmptyString } from "../utils/strings.js";
 import { CosmosDbDiagnosticLevel } from "./CosmosDbDiagnosticLevel.js";
 import { diagnosticLevelFromEnv } from "../utils/envUtils.js";
+import { defaultLogger } from "../common/logger.js";
 
 export * from "./DiagnosticWriter.js";
 export * from "./DiagnosticFormatter.js";
@@ -22,7 +23,7 @@ if (isNonEmptyString(diagnosticLevelFromEnv)) {
   if (isCosmosDiagnosticLevel(diagnosticLevelFromEnv)) {
     setDiagnosticLevel(diagnosticLevelFromEnv as CosmosDbDiagnosticLevel);
   } else {
-    console.error(
+    defaultLogger.error(
       `${
         Constants.CosmosDbDiagnosticLevelEnvVarName
       } set to unknown diagnostic level '${diagnosticLevelFromEnv}'; Setting Cosmos Db diagnostic level to info. Acceptable values: ${acceptableDiagnosticLevelValues.join(

--- a/sdk/cosmosdb/cosmos/src/globalPartitionEndpointManager.ts
+++ b/sdk/cosmosdb/cosmos/src/globalPartitionEndpointManager.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import { OperationType, ResourceType, isReadRequest } from "./common/index.js";
+import { defaultLogger } from "./common/logger.js";
 import type { DiagnosticNodeInternal } from "./index.js";
 import {
   Constants,
@@ -380,7 +381,7 @@ export class GlobalPartitionEndpointManager {
       try {
         await this.openConnectionToUnhealthyEndpointsWithFailback();
       } catch (err) {
-        console.error("Failed to open connection to unhealthy endpoints: ", err);
+        defaultLogger.error("Failed to open connection to unhealthy endpoints: ", err);
       }
     }, Constants.StalePartitionUnavailabilityRefreshIntervalInMs);
   }

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/headerUtils.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/headerUtils.ts
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import { Constants } from "../common/index.js";
+import { defaultLogger } from "../common/logger.js";
 import { QueryMetrics } from "../queryMetrics/queryMetrics.js";
 
 export interface CosmosHeaders {
@@ -99,6 +100,6 @@ export function decodeAndParseJSONString(inputString: string): string {
     const indexMetrics = JSON.stringify(parsedString);
     return indexMetrics;
   } catch (e) {
-    console.error("Error parsing JSON file:", e.message);
+    defaultLogger.error("Error parsing JSON file:", e.message);
   }
 }

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/src/helpers/serializerHelpers.ts
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/src/helpers/serializerHelpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "../logger.js";
+
 export function serializeRecord<T extends string | number | boolean | Date | null, R>(
   item: Record<string, T>,
 ): Record<string, R>;
@@ -22,7 +24,7 @@ export function serializeRecord<T, R>(
           acc[key] = serializer(value);
         }
       } else {
-        console.warn(`Don't know how to serialize ${item[key]}`);
+        logger.warning(`Don't know how to serialize ${item[key]}`);
         acc[key] = item[key] as any;
       }
       return acc;

--- a/sdk/edgezones/arm-edgezones/src/helpers/serializerHelpers.ts
+++ b/sdk/edgezones/arm-edgezones/src/helpers/serializerHelpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "../logger.js";
+
 export function serializeRecord<T extends string | number | boolean | Date | null, R>(
   item: Record<string, T>,
 ): Record<string, R>;
@@ -22,7 +24,7 @@ export function serializeRecord<T, R>(
           acc[key] = serializer(value);
         }
       } else {
-        console.warn(`Don't know how to serialize ${item[key]}`);
+        logger.warning(`Don't know how to serialize ${item[key]}`);
         acc[key] = item[key] as any;
       }
       return acc;

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^2.1.2",
+    "@azure/logger": "^1.1.4",
     "rhea": "^3.0.2",
     "tslib": "^2.6.3"
   },

--- a/sdk/eventhub/mock-hub/src/logger.ts
+++ b/sdk/eventhub/mock-hub/src/logger.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createClientLogger } from "@azure/logger";
+
+/**
+ * The \@azure/logger configuration for this package.
+ */
+export const logger = createClientLogger("mock-hub");

--- a/sdk/eventhub/mock-hub/src/sender/streamingPartitionSender.ts
+++ b/sdk/eventhub/mock-hub/src/sender/streamingPartitionSender.ts
@@ -5,6 +5,7 @@ import { AbortError } from "@azure/abort-controller";
 import rhea from "rhea";
 import type { MessageRecord, MessageStore } from "../storage/messageStore.js";
 import type { EventPosition } from "../utils/eventPosition.js";
+import { logger } from "../logger.js";
 
 /**
  * The StreamingPartitionSender is responsible for sending stored events to a client
@@ -46,7 +47,7 @@ export class StreamingPartitionSender {
    */
   start(): void {
     this._sendMessages().catch((err) => {
-      console.error(`Unexpected error while sending messages`, err);
+      logger.error("Unexpected error while sending messages", err);
     });
   }
 
@@ -111,7 +112,7 @@ export class StreamingPartitionSender {
         sender.send(outgoingMessage);
       } catch (err: unknown) {
         if (err instanceof Error && err.name !== "AbortError") {
-          console.error(`Unexpected error while streaming events: `, err);
+          logger.error("Unexpected error while streaming events", err);
         }
       }
     } while (!abortSignal.aborted && !nextResult?.done);

--- a/sdk/eventhub/mock-hub/src/server/mockServer.ts
+++ b/sdk/eventhub/mock-hub/src/server/mockServer.ts
@@ -5,6 +5,7 @@ import rhea from "rhea";
 import { EventEmitter } from "events";
 import type { ListenOptions } from "net";
 import { convertBufferToMessages } from "../utils/convertBufferToMessage.js";
+import { logger } from "../logger.js";
 
 export interface MockServerOptions {
   /**
@@ -270,7 +271,7 @@ export class MockServer extends EventEmitter {
     });
     this._container.on(rhea.ConnectionEvents.connectionOpen, (context: rhea.EventContext) => {
       context.connection.on("error", function (this: typeof context.connection, err: Error) {
-        console.log(`Error occurred on connection:`, err?.message);
+        logger.error("Error occurred on connection:", err);
       });
       this.emit("connectionOpen", {
         context,
@@ -330,7 +331,7 @@ export class MockServer extends EventEmitter {
       }
     });
     this._container.on("error", function (err) {
-      console.log("Unexpected error encountered:", err);
+      logger.error("Unexpected error encountered:", err);
     });
   }
 

--- a/sdk/fabric/arm-fabric/src/helpers/serializerHelpers.ts
+++ b/sdk/fabric/arm-fabric/src/helpers/serializerHelpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "../logger.js";
+
 export function serializeRecord<T extends string | number | boolean | Date | null, R>(
   item: Record<string, T>,
 ): Record<string, R>;
@@ -22,7 +24,7 @@ export function serializeRecord<T, R>(
           acc[key] = serializer(value);
         }
       } else {
-        console.warn(`Don't know how to serialize ${item[key]}`);
+        logger.warning(`Don't know how to serialize ${item[key]}`);
         acc[key] = item[key] as any;
       }
       return acc;

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/src/helpers/serializerHelpers.ts
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/src/helpers/serializerHelpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "../logger.js";
+
 export function serializeRecord<T extends string | number | boolean | Date | null, R>(
   item: Record<string, T>,
 ): Record<string, R>;
@@ -22,7 +24,7 @@ export function serializeRecord<T, R>(
           acc[key] = serializer(value);
         }
       } else {
-        console.warn(`Don't know how to serialize ${item[key]}`);
+        logger.warning(`Don't know how to serialize ${item[key]}`);
         acc[key] = item[key] as any;
       }
       return acc;

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/src/helpers/serializerHelpers.ts
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/src/helpers/serializerHelpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "../logger.js";
+
 export function serializeRecord<T extends string | number | boolean | Date | null, R>(
   item: Record<string, T>,
 ): Record<string, R>;
@@ -22,7 +24,7 @@ export function serializeRecord<T, R>(
           acc[key] = serializer(value);
         }
       } else {
-        console.warn(`Don't know how to serialize ${item[key]}`);
+        logger.warning(`Don't know how to serialize ${item[key]}`);
         acc[key] = item[key] as any;
       }
       return acc;

--- a/sdk/terraform/arm-terraform/src/helpers/serializerHelpers.ts
+++ b/sdk/terraform/arm-terraform/src/helpers/serializerHelpers.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { logger } from "../logger.js";
+
 export function serializeRecord<T extends string | number | boolean | Date | null, R>(
   item: Record<string, T>,
 ): Record<string, R>;
@@ -22,7 +24,7 @@ export function serializeRecord<T, R>(
           acc[key] = serializer(value);
         }
       } else {
-        console.warn(`Don't know how to serialize ${item[key]}`);
+        logger.warning(`Don't know how to serialize ${item[key]}`);
         acc[key] = item[key] as any;
       }
       return acc;

--- a/sdk/web-pubsub/web-pubsub-express/src/utils.ts
+++ b/sdk/web-pubsub/web-pubsub-express/src/utils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import type { IncomingMessage } from "node:http";
+import { logger } from "./logger.js";
 
 function isJsonObject(obj: any): boolean {
   return obj && typeof obj === "object" && !Array.isArray(obj);
@@ -21,7 +22,7 @@ export function fromBase64JsonString(base64String: string | undefined): Record<s
     const parsed = JSON.parse(buf);
     return isJsonObject(parsed) ? parsed : {};
   } catch (e: any) {
-    console.warn("Unexpected state format:" + e);
+    logger.warning("Unexpected state format:", e);
     return {};
   }
 }


### PR DESCRIPTION
### Issues associated with this PR

#25876 
### Describe the problem that is addressed by this PR

ESLint now marks `console` invocations as an error. `console` calls aren't sanitized, so this change enforces sanitization on logs. User-facing output that doesn't need sanitization is addressed in #38252.
