### PR TITLE
[engsys] Migrate user output to stdio helpers

### DIFF
--- a/common/tools/dev-tool/src/commands/about.ts
+++ b/common/tools/dev-tool/src/commands/about.ts
@@ -8,6 +8,7 @@ import { createPrinter } from "../util/printer";
 import { leafCommand, makeCommandInfo } from "../framework/command";
 import { printCommandUsage } from "../framework/printCommandUsage";
 import * as pwsh from "../util/pwsh";
+import { writeStdout } from "../util/stdio.js";
 
 const log = createPrinter("about");
 
@@ -24,13 +25,13 @@ Developer quality-of-life command for the Azure SDK for JS
 export const commandInfo = makeCommandInfo("about", "display command help and information");
 
 export default leafCommand(commandInfo, async (options) => {
-  console.log(chalk.blueBright(banner));
+  writeStdout(chalk.blueBright(banner));
 
   try {
     const packageInfo = await resolveProject(__dirname);
-    console.log(chalk.blueBright(`  Name/Version:\t${packageInfo.name}@${packageInfo.version}`));
-    console.log(chalk.blueBright(`  Location:\t${packageInfo.path}`));
-    console.log();
+    writeStdout(chalk.blueBright(`  Name/Version:\t${packageInfo.name}@${packageInfo.version}`));
+    writeStdout(chalk.blueBright(`  Location:\t${packageInfo.path}`));
+    writeStdout("");
   } catch (error: unknown) {
     log.error("Could not locate dev-tool package.");
     log.error("Unable to display dev-tool version information.");
@@ -39,22 +40,22 @@ export default leafCommand(commandInfo, async (options) => {
   const hasPowerShell = await pwsh.hasPowerShell();
 
   if (hasPowerShell) {
-    console.log(chalk.blueBright("  PowerShell: Found"));
+    writeStdout(chalk.blueBright("  PowerShell: Found"));
   } else {
-    console.log(chalk.yellow("  PowerShell: Not found"));
+    writeStdout(chalk.yellow("  PowerShell: Not found"));
   }
-  console.log();
+  writeStdout("");
 
   if (options.args.length || options["--"]?.length) {
-    console.log();
+    writeStdout("");
     log.warn("Warning, unused options:", JSON.stringify(options, null, 2));
   }
 
   await printCommandUsage(baseCommandInfo, baseCommands);
 
-  console.log("For more information about a given command, try `dev-tool COMMAND --help`");
+  writeStdout("For more information about a given command, try `dev-tool COMMAND --help`");
 
-  console.log();
+  writeStdout("");
 
   return true;
 });

--- a/common/tools/dev-tool/src/commands/admin/list/packages.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/packages.ts
@@ -5,6 +5,7 @@ import { leafCommand, makeCommandInfo } from "../../../framework/command";
 import path from "node:path";
 import { resolveRoot } from "../../../util/resolveProject";
 import { getRushJson, type RushJsonProject } from "../../../util/synthesizedRushJson";
+import { writeStdout } from "../../../util/stdio.js";
 
 export const commandInfo = makeCommandInfo("packages", "list packages defined in the monorepo", {
   paths: {
@@ -38,9 +39,9 @@ export async function getProjects(service?: string): Promise<RushJsonProject[]> 
 
 async function echoPackage(project: RushJsonProject, paths: boolean, cwd: string, root: string) {
   if (paths) {
-    console.log(path.relative(cwd, path.resolve(root, project.projectFolder)) || ".");
+    writeStdout(path.relative(cwd, path.resolve(root, project.projectFolder)) || ".");
   } else {
-    console.log(project.packageName);
+    writeStdout(project.packageName);
   }
 }
 

--- a/common/tools/dev-tool/src/commands/admin/list/service-folders.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/service-folders.ts
@@ -5,6 +5,7 @@ import { leafCommand, makeCommandInfo } from "../../../framework/command";
 import path from "node:path";
 import { resolveRoot } from "../../../util/resolveProject";
 import { readdir } from "node:fs/promises";
+import { writeStdout } from "../../../util/stdio.js";
 
 export const commandInfo = makeCommandInfo("packages", "list service folders in the monorepo", {
   relative: {
@@ -38,9 +39,9 @@ export default leafCommand(commandInfo, async ({ relative }) => {
 
   for (const dir of sdkDirs) {
     if (relative) {
-      console.log(path.join(sdkRelativePath, dir) || ".");
+      writeStdout(path.join(sdkRelativePath, dir) || ".");
     } else {
-      console.log(`sdk/${dir}`);
+      writeStdout(`sdk/${dir}`);
     }
   }
 

--- a/common/tools/dev-tool/src/commands/admin/list/typespec-migrations.ts
+++ b/common/tools/dev-tool/src/commands/admin/list/typespec-migrations.ts
@@ -6,6 +6,7 @@ import { readdir } from "node:fs/promises";
 import { resolveRoot } from "../../../util/resolveProject";
 import path from "node:path";
 import { getRushJson, type RushJsonProject } from "../../../util/synthesizedRushJson";
+import { writeStdout, writeStderr } from "../../../util/stdio.js";
 
 export const commandInfo = makeCommandInfo(
   "typespec-migrations",
@@ -84,7 +85,7 @@ export default leafCommand(commandInfo, async (options) => {
 
   if (clientTypeFilter) {
     if (clientTypeFilter !== "RLC" && clientTypeFilter !== "HLC") {
-      console.error("Error: client-type must be either 'RLC' or 'HLC'");
+      writeStderr("Error: client-type must be either 'RLC' or 'HLC'");
       return false;
     }
 
@@ -143,32 +144,32 @@ export default leafCommand(commandInfo, async (options) => {
   const completionPercentage =
     totalFiltered > 0 ? ((completedCount / totalFiltered) * 100).toFixed(2) : "0.00";
 
-  console.log("# TypeSpec Migration Report");
-  console.log();
-  console.log(`Total projects: ${projects.length}`);
-  console.log(`Client projects: ${clientProjects.length}`);
+  writeStdout("# TypeSpec Migration Report");
+  writeStdout();
+  writeStdout(`Total projects: ${projects.length}`);
+  writeStdout(`Client projects: ${clientProjects.length}`);
   if (clientTypeFilter) {
-    console.log(`Filtered by client type (${clientTypeFilter}): ${filteredProjects.length}`);
+    writeStdout(`Filtered by client type (${clientTypeFilter}): ${filteredProjects.length}`);
   }
-  console.log();
+  writeStdout();
 
   // Add summary section
-  console.log("## Summary");
-  console.log();
-  console.log(`- ✅ Migrated: ${migratedCount}`);
-  console.log(`- N/A (no migration needed): ${naCount}`);
-  console.log(`- Total Completed (Migrated + N/A): ${migratedCount + naCount}`);
-  console.log(`- ❌ Not Migrated: ${notMigratedCount}`);
-  console.log(`- **Completion percentage: ${completionPercentage}%**`);
-  console.log();
+  writeStdout("## Summary");
+  writeStdout();
+  writeStdout(`- ✅ Migrated: ${migratedCount}`);
+  writeStdout(`- N/A (no migration needed): ${naCount}`);
+  writeStdout(`- Total Completed (Migrated + N/A): ${migratedCount + naCount}`);
+  writeStdout(`- ❌ Not Migrated: ${notMigratedCount}`);
+  writeStdout(`- **Completion percentage: ${completionPercentage}%**`);
+  writeStdout();
 
   // Generate markdown table header
-  console.log("| Package Name | Project Folder | Version Policy | Client Type | TypeSpec Status |");
-  console.log("| --- | --- | --- | --- | --- |");
+  writeStdout("| Package Name | Project Folder | Version Policy | Client Type | TypeSpec Status |");
+  writeStdout("| --- | --- | --- | --- | --- |");
 
   // Output the table using pre-calculated data
   for (const { project, clientType, typespecStatus } of projectStatuses) {
-    console.log(
+    writeStdout(
       `| ${project.packageName} | ${project.projectFolder} | ${project.versionPolicyName} | ${clientType} | ${typespecStatus} |`,
     );
   }

--- a/common/tools/dev-tool/src/commands/package/resolve.ts
+++ b/common/tools/dev-tool/src/commands/package/resolve.ts
@@ -6,6 +6,7 @@ import { resolveProject } from "../../util/resolveProject";
 import { createPrinter } from "../../util/printer";
 import { leafCommand } from "../../framework/command";
 import { makeCommandInfo } from "../../framework/command";
+import { writeStdout } from "../../util/stdio.js";
 
 const log = createPrinter("resolve-package");
 
@@ -34,7 +35,7 @@ export default leafCommand(commandInfo, async (options) => {
     try {
       const currentPackage = await resolveProject(dir);
       if (options.quiet) {
-        console.log(currentPackage.path);
+        writeStdout(currentPackage.path);
       } else {
         log.success("== Detected package:", currentPackage.name);
         log.info(`Version specifier: ${currentPackage.name}@${currentPackage.version}`);

--- a/common/tools/dev-tool/src/commands/run/check-api.ts
+++ b/common/tools/dev-tool/src/commands/run/check-api.ts
@@ -8,6 +8,7 @@ import { createPrinter } from "../../util/printer";
 import { resolveProject } from "../../util/resolveProject";
 import path from "node:path";
 import semver from "semver";
+import { writeStdout } from "../../util/stdio.js";
 
 export const commandInfo = makeCommandInfo(
   "check-api",
@@ -44,7 +45,7 @@ function testTsMax(filePaths: string[]): boolean {
   ];
 
   if (diagnostics.length > 0) {
-    console.log(tsMax.formatDiagnosticsWithColorAndContext(diagnostics, host));
+    writeStdout(tsMax.formatDiagnosticsWithColorAndContext(diagnostics, host));
   }
 
   const hadError = diagnostics.some(
@@ -80,8 +81,8 @@ function testTsMin(filePaths: string[]): boolean {
   ];
 
   if (diagnostics.length > 0) {
-    // No special logging here, just dump the diagnostics to the console as they are already formatted.
-    console.log(tsMin.formatDiagnosticsWithColorAndContext(diagnostics, host));
+    // No special logging here, just dump the diagnostics to stdout as they are already formatted.
+    writeStdout(tsMin.formatDiagnosticsWithColorAndContext(diagnostics, host));
   }
 
   const hadError = diagnostics.some(

--- a/common/tools/dev-tool/src/framework/command.ts
+++ b/common/tools/dev-tool/src/framework/command.ts
@@ -4,6 +4,7 @@
 import { CommandLoader } from "./CommandModule";
 import { createPrinter } from "../util/printer";
 import { printCommandUsage, commandStack } from "./printCommandUsage";
+import { writeStderr } from "../util/stdio.js";
 import { ParsedOptions, parseOptions } from "./parseOptions";
 import { CommandInfo, CommandOptions } from "./CommandInfo";
 
@@ -92,7 +93,7 @@ export function subCommand<Info extends CommandInfo<CommandOptions>>(
 
     if (commandName === undefined) {
       log.error("No sub-command provided.");
-      await printCommandUsage(info, commands, console.error);
+      await printCommandUsage(info, commands, writeStderr);
       process.exit(1);
     }
 
@@ -110,7 +111,7 @@ export function subCommand<Info extends CommandInfo<CommandOptions>>(
       return await commandModule.default(...fullArgs);
     } else {
       log.error("No such sub-command:", commandName);
-      await printCommandUsage(info, commands, console.error);
+      await printCommandUsage(info, commands, writeStderr);
       process.exit(1);
     }
   };

--- a/common/tools/dev-tool/src/framework/printCommandUsage.ts
+++ b/common/tools/dev-tool/src/framework/printCommandUsage.ts
@@ -3,6 +3,7 @@
 
 import { CommandLoader } from "./CommandModule";
 import { CommandInfo, CommandOptions } from "./CommandInfo";
+import { writeStdout } from "../util/stdio.js";
 
 /**
  * The stack of subcommands executed so far
@@ -21,7 +22,7 @@ export const commandStack: string[] = [];
 export async function printCommandUsage(
   info: CommandInfo<CommandOptions>,
   subCommands?: CommandLoader,
-  println: (...values: string[]) => void = console.log,
+  println: (message?: string) => void = writeStdout,
 ): Promise<void> {
   println(`${info.name} - ${info.description}\n`);
   println(

--- a/common/tools/dev-tool/src/index.ts
+++ b/common/tools/dev-tool/src/index.ts
@@ -4,14 +4,15 @@
 import chalk from "chalk";
 
 import { baseCommand } from "./commands";
+import { writeStderr } from "./util/stdio.js";
 
 // The main command is implemented using the same `subCommand` method.
 baseCommand(...process.argv.slice(2)).catch((err) => {
-  console.error(chalk.red("[Internal Error]", err.message));
-  console.trace(chalk.red("[Internal Error]", err.stack));
+  writeStderr(chalk.red("[Internal Error]", err.message));
+  writeStderr(chalk.red("[Internal Error]", err.stack));
   if (err.cause) {
-    console.error(chalk.red("[Internal Error Cause]", err.cause.message));
-    console.trace(chalk.red("[Internal Error Cause]", err.cause.stack));
+    writeStderr(chalk.red("[Internal Error Cause]", err.cause.message));
+    writeStderr(chalk.red("[Internal Error Cause]", err.cause.stack));
   }
   process.exit(255);
 });

--- a/common/tools/dev-tool/src/util/assert.ts
+++ b/common/tools/dev-tool/src/util/assert.ts
@@ -6,6 +6,7 @@
  */
 
 import chalk from "chalk";
+import { writeStderr } from "./stdio.js";
 
 /**
  * Asserts that this expression is unreachable. This function will panic if it is called.
@@ -49,16 +50,16 @@ export function unimplemented(message: string): never {
  * @param message - the error message to print
  */
 export function panic(message: string): never {
-  console.error(chalk.red("[PANIC] " + message));
+  writeStderr(chalk.red("[PANIC] " + message));
 
-  console.trace(
+  writeStderr(
     chalk.red(
       "This is a bug in the tool. Please file an issue at https://github.com/azure/azure-sdk-for-js/issues.",
       "Include the stack trace below.",
     ),
   );
 
-  console.error(
+  writeStderr(
     chalk.red(
       "The package state may be damaged or corrupted. Please reset your working directory to a known-good state.",
     ),

--- a/common/tools/dev-tool/src/util/printer.ts
+++ b/common/tools/dev-tool/src/util/printer.ts
@@ -5,6 +5,7 @@
 
 import chalk from "chalk";
 import path from "node:path";
+import { writeStderr, writeStdout } from "./stdio.js";
 
 const printModes = ["info", "warn", "error", "success", "debug"] as const;
 
@@ -45,11 +46,11 @@ export interface PrinterBackend {
  * The object that is used to write output.
  */
 let backend: PrinterBackend = {
-  error: console.error,
-  log: console.log,
-  info: console.info,
-  warn: console.warn,
-  trace: console.trace,
+  error: (...args: any[]) => writeStderr(args.join(" ")),
+  log: (...args: any[]) => writeStdout(args.join(" ")),
+  info: (...args: any[]) => writeStdout(args.join(" ")),
+  warn: (...args: any[]) => writeStderr(args.join(" ")),
+  trace: (...args: any[]) => writeStderr(args.join(" ")),
 };
 
 /**
@@ -121,7 +122,7 @@ const finalLogger: ModeMap<Fn> = {
       backend.error(values[0], colors.debug(callerInfo), ...values.slice(1));
     }
   },
-  success: console.info,
+  success: (...values) => backend.info(...values),
 };
 
 /**
@@ -149,7 +150,7 @@ const finalLogger: ModeMap<Fn> = {
 export function createPrinter(name: string): Printer {
   const prefix = "[" + name + "]";
   const base = ((...values: string[]) => {
-    console.log(chalk.reset(prefix, ...values));
+    writeStdout(chalk.reset(prefix, ...values));
   }) as Printer;
 
   for (const mode of printModes) {

--- a/common/tools/dev-tool/src/util/stdio.ts
+++ b/common/tools/dev-tool/src/util/stdio.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  if (error instanceof Error) {
+    writeStderr(error.stack ?? error.message);
+    return;
+  }
+  writeStderr(String(error));
+}

--- a/common/tools/dev-tool/src/util/typescript/diagnostic.ts
+++ b/common/tools/dev-tool/src/util/typescript/diagnostic.ts
@@ -3,6 +3,7 @@
 
 import ts from "typescript";
 import { EOL } from "node:os";
+import { writeStderr } from "../stdio.js";
 
 /**
  * The type of the emitter function.
@@ -52,7 +53,7 @@ export function createDiagnosticEmitter(
 
     const formatted = ts.formatDiagnosticsWithColorAndContext([diagnostic], diagnosticHost);
 
-    console.error(formatted);
+    writeStderr(formatted);
 
     onError?.(formatted);
   };

--- a/common/tools/warp/src/cli.ts
+++ b/common/tools/warp/src/cli.ts
@@ -6,6 +6,7 @@ import { parseArgs } from "node:util";
 import { build } from "./build.ts";
 import { setLogLevel } from "./logger.ts";
 import { WarpError } from "./types.ts";
+import { writeStdout, writeStderr, writeUnknownError } from "./stdio.js";
 
 async function main(): Promise<void> {
   const { values, positionals } = parseArgs({
@@ -67,7 +68,7 @@ async function main(): Promise<void> {
   }
 
   if (command !== "build") {
-    console.error(`[warp] Unknown command: ${command}`);
+    writeStderr(`[warp] Unknown command: ${command}`);
     printUsage();
     process.exit(1);
   }
@@ -99,7 +100,7 @@ async function main(): Promise<void> {
     if (result.sizeReport) {
       jsonOutput.sizeReport = result.sizeReport;
     }
-    console.log(JSON.stringify(jsonOutput, null, 2));
+    writeStdout(JSON.stringify(jsonOutput, null, 2));
   }
 
   if (!result.success) {
@@ -113,7 +114,7 @@ function printUsage(): void {
   const supportsLink = process.env.TERM_PROGRAM !== undefined || (process.stderr.isTTY ?? false);
   const docsLink = supportsLink ? `\x1b]8;;${docsUrl}\x1b\\${docsUrl}\x1b]8;;\x1b\\` : docsUrl;
 
-  console.log(`
+  writeStdout(`
 Usage: warp <command> [options]
 
 Commands:
@@ -141,7 +142,7 @@ main().catch((err) => {
   const error = err as unknown;
 
   if (err instanceof WarpError) {
-    console.error(err.message);
+    writeStderr(err.message);
     if (err.cause) {
       const causeText =
         err.cause instanceof Error
@@ -149,7 +150,7 @@ main().catch((err) => {
           : typeof err.cause === "string"
             ? err.cause
             : JSON.stringify(err.cause);
-      console.error(`  cause: ${causeText}`);
+      writeStderr(`  cause: ${causeText}`);
     }
     process.exit(1);
   }
@@ -159,8 +160,8 @@ main().catch((err) => {
     error instanceof Error &&
     (error as { code?: string }).code === "ERR_PARSE_ARGS_UNKNOWN_OPTION"
   ) {
-    console.error(`[warp] ${error.message}`);
-    console.error(`[warp] Run "warp --help" for usage information.`);
+    writeStderr(`[warp] ${error.message}`);
+    writeStderr(`[warp] Run "warp --help" for usage information.`);
     process.exit(1);
   }
 
@@ -168,12 +169,12 @@ main().catch((err) => {
     error instanceof Error &&
     (error as { code?: string }).code === "ERR_PARSE_ARGS_INVALID_OPTION_VALUE"
   ) {
-    console.error(`[warp] ${error.message}`);
-    console.error(`[warp] Run "warp --help" for usage information.`);
+    writeStderr(`[warp] ${error.message}`);
+    writeStderr(`[warp] Run "warp --help" for usage information.`);
     process.exit(1);
   }
 
   // Unexpected errors — show full stack for debugging
-  console.error(error);
+  writeUnknownError(error);
   process.exit(2);
 });

--- a/common/tools/warp/src/logger.ts
+++ b/common/tools/warp/src/logger.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { writeStdout, writeStderr } from "./stdio.js";
+
 /**
  * Structured logger with configurable verbosity and optional buffering.
  *
@@ -33,20 +35,20 @@ export class Logger {
 
   /** Always printed (unless piped to /dev/null). */
   error(msg: string): void {
-    console.error(msg);
+    writeStderr(msg);
   }
 
   /** Printed at "info" and "verbose". Suppressed at "quiet". */
   warn(msg: string): void {
     if (this.level !== "quiet") {
-      console.warn(msg);
+      writeStderr(msg);
     }
   }
 
   /** Printed at "info" and "verbose". Suppressed at "quiet". */
   info(msg: string): void {
     if (this.level !== "quiet") {
-      console.log(msg);
+      writeStdout(msg);
     } else {
       // Suppressed — buffer for potential replay on failure
       this.buffer.push(msg);
@@ -56,7 +58,7 @@ export class Logger {
   /** Printed only at "verbose". Buffered at lower levels for failure replay. */
   verbose(msg: string): void {
     if (this.level === "verbose") {
-      console.log(msg);
+      writeStdout(msg);
     } else {
       // Suppressed — buffer for potential replay on failure
       this.buffer.push(msg);
@@ -77,9 +79,9 @@ export class Logger {
     }
     if (this.buffer.length === 0) return;
 
-    console.error("\n[warp] Diagnostic trail (use --verbose to see this in real-time):");
+    writeStderr("\n[warp] Diagnostic trail (use --verbose to see this in real-time):");
     for (const msg of this.buffer) {
-      console.error(msg);
+      writeStderr(msg);
     }
     this.buffer.length = 0;
   }

--- a/common/tools/warp/src/stdio.ts
+++ b/common/tools/warp/src/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/execute.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/execute.ts
@@ -16,12 +16,12 @@ import {
 } from "./execute-configs.js";
 import chalk from "chalk";
 import { generateProject } from "../generateProject.js";
+import { writeStdout, writeUnknownError } from "./stdio.js";
 
-const log = console.log;
-const white: Log = (msg) => log(chalk.white(msg));
-const green: Log = (msg) => log(chalk.green(msg));
-const red: Log = (msg) => log(chalk.red(msg));
-const gray: Log = (msg) => log(chalk.gray(msg));
+const white: Log = (msg) => writeStdout(chalk.white(msg));
+const green: Log = (msg) => writeStdout(chalk.green(msg));
+const red: Log = (msg) => writeStdout(chalk.red(msg));
+const gray: Log = (msg) => writeStdout(chalk.gray(msg));
 
 async function main(): Promise<void> {
   green(
@@ -57,12 +57,12 @@ async function main(): Promise<void> {
 
   return generateProject(widgetConfig, serviceInformation, miscConfig)
     .then(() => green("\nThe custom widget’s code scaffold has been successfully generated.\n"))
-    .catch(console.error);
+    .catch(writeUnknownError);
 }
 
 main()
   .then(() => process.exit(0))
   .catch((err) => {
-    console.error(err);
+    writeUnknownError(err);
     process.exit(1);
   });

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/stdio.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/src/bin/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/node/deploy.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/node/deploy.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import getStorageSasUrl from "./getStorageSasUrl.js";
 import readdir from "./readdir.js";
 import type { DeployConfig, ServiceInformation } from "./types.js";
+import { writeStdout } from "./stdio.js";
 
 /**
  * Deploys everything from /dist folder to the API Management DevPortals' blob storage.
@@ -26,9 +27,9 @@ async function deploy(
     interactiveBrowserCredentialOptions = { redirectUri: "http://localhost:1337" },
   }: DeployConfig = {},
 ): Promise<void> {
-  console.log("\n\n");
-  console.log("Starting deploy process of custom widget: " + name);
-  console.log("Please, sign in to your Azure account when prompted\n");
+  writeStdout("\n\n");
+  writeStdout("Starting deploy process of custom widget: " + name);
+  writeStdout("Please, sign in to your Azure account when prompted\n");
 
   const blobStorageUrl = await getStorageSasUrl(
     serviceInformation,
@@ -38,24 +39,24 @@ async function deploy(
 
   let config: Config | undefined;
   try {
-    console.log("Looking for config file in the Azure blob storage");
+    writeStdout("Looking for config file in the Azure blob storage");
     config = await customWidgetBlobService.getConfig();
   } catch (e) {
-    console.log("Config not found.");
+    writeStdout("Config not found.");
   }
   if (!config) {
-    console.log("Looking for a local config file in: " + fallbackConfigPath);
+    writeStdout("Looking for a local config file in: " + fallbackConfigPath);
     config = JSON.parse(fs.readFileSync(fallbackConfigPath).toString());
   }
   if (!config) {
     throw new Error("Config file could not be loaded.");
   }
 
-  console.log("Config file loaded\n");
+  writeStdout("Config file loaded\n");
 
   const files = readdir("", rootLocal);
 
-  console.log("Starting upload of data files from the '" + rootLocal + "' folder\n");
+  writeStdout("Starting upload of data files from the '" + rootLocal + "' folder\n");
 
   await customWidgetBlobService.cleanDataDir();
 
@@ -64,16 +65,16 @@ async function deploy(
     const content = fs.readFileSync(rootLocal + file);
     const promise = customWidgetBlobService
       .uploadWidgetDataFile(file, content)
-      .then(() => console.log("Uploaded file: " + file));
+      .then(() => writeStdout("Uploaded file: " + file));
     promises.push(promise);
   });
   await Promise.all(promises);
 
-  console.log(files.length + " files has been uploaded\n");
+  writeStdout(files.length + " files has been uploaded\n");
 
   config.deployedOn = new Date();
   await customWidgetBlobService.uploadConfig(config);
-  console.log("Uploaded updated config");
+  writeStdout("Uploaded updated config");
 }
 
 export default deploy;

--- a/sdk/apimanagement/api-management-custom-widgets-tools/src/node/stdio.ts
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/src/node/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/core/core-rest-pipeline-perf-tests/src/baseHttpTest.ts
+++ b/sdk/core/core-rest-pipeline-perf-tests/src/baseHttpTest.ts
@@ -6,6 +6,7 @@ import type { PerfOptionDictionary } from "@azure-tools/test-perf";
 import { PerfTest } from "@azure-tools/test-perf";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import { writeStdout } from "./stdio.js";
 
 let app: express.Application;
 let server: Server;
@@ -37,7 +38,7 @@ export abstract class BaseHttpTest extends PerfTest<BaseHttpTestOptions> {
       });
 
       server = app.listen(0, () => {
-        console.log("Listening on port:", (server.address() as AddressInfo).port);
+        writeStdout(`Listening on port: ${(server.address() as AddressInfo).port}`);
       });
 
       this.url = `http://localhost:${(server.address() as AddressInfo).port}`;

--- a/sdk/core/core-rest-pipeline-perf-tests/src/core-rest-pipeline.spec.ts
+++ b/sdk/core/core-rest-pipeline-perf-tests/src/core-rest-pipeline.spec.ts
@@ -4,6 +4,7 @@
 import type { HttpClient, PipelineRequest } from "@azure/core-rest-pipeline";
 import { createDefaultHttpClient, createPipelineRequest } from "@azure/core-rest-pipeline";
 import { BaseHttpTest } from "./baseHttpTest.js";
+import { writeStdout } from "./stdio.js";
 
 export class CoreRestPipelineTest extends BaseHttpTest {
   client: HttpClient;
@@ -24,6 +25,6 @@ export class CoreRestPipelineTest extends BaseHttpTest {
   async run(): Promise<void> {
     const response = await this.client.sendRequest(this.request);
 
-    console.log(response.bodyAsText); // Hello World!
+    writeStdout(response.bodyAsText ?? ""); // Hello World!
   }
 }

--- a/sdk/core/core-rest-pipeline-perf-tests/src/fetch.spec.ts
+++ b/sdk/core/core-rest-pipeline-perf-tests/src/fetch.spec.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import { BaseHttpTest } from "./baseHttpTest.js";
+import { writeStdout } from "./stdio.js";
 
 export class FetchTest extends BaseHttpTest {
   async run(): Promise<void> {
     const response = await fetch(this.url, { keepalive: true });
-    console.log(await response.text()); // Hello World!
+    writeStdout(await response.text()); // Hello World!
   }
 }

--- a/sdk/core/core-rest-pipeline-perf-tests/src/stdio.ts
+++ b/sdk/core/core-rest-pipeline-perf-tests/src/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/core/core-rest-pipeline-perf-tests/src/undici-request.spec.ts
+++ b/sdk/core/core-rest-pipeline-perf-tests/src/undici-request.spec.ts
@@ -3,10 +3,11 @@
 
 import { BaseHttpTest } from "./baseHttpTest.js";
 import { request } from "undici";
+import { writeStdout } from "./stdio.js";
 
 export class UndiciRequestTest extends BaseHttpTest {
   async run(): Promise<void> {
     const { body } = await request(this.url);
-    console.log(await body.text()); // Hello World!
+    writeStdout(await body.text()); // Hello World!
   }
 }

--- a/sdk/eventhub/event-hubs-perf-tests/src/receive.spec.ts
+++ b/sdk/eventhub/event-hubs-perf-tests/src/receive.spec.ts
@@ -24,6 +24,7 @@ import { getEnvVar } from "@azure-tools/test-perf";
 import moment from "moment";
 import { delay } from "@azure/core-amqp";
 import "dotenv/config";
+import { writeStdout, writeStderr } from "./stdio.js";
 
 const _start = moment();
 
@@ -88,7 +89,7 @@ async function RunTest(maxBatchSize: number, messages: number): Promise<void> {
     }
   };
   const processError = async (err: Error, context: PartitionContext): Promise<void> => {
-    console.log(`Error on partition "${context.partitionId}": ${err}`);
+    writeStderr(`Error on partition "${context.partitionId}": ${err}`);
   };
 
   consumerClient.subscribe(
@@ -153,7 +154,7 @@ function WriteResult(
 }
 
 function log(message: string): void {
-  console.log(`[${moment().format("hh:mm:ss.SSS")}] ${message}`);
+  writeStdout(`[${moment().format("hh:mm:ss.SSS")}] ${message}`);
 }
 
 main().catch((err) => {

--- a/sdk/eventhub/event-hubs-perf-tests/src/stdio.ts
+++ b/sdk/eventhub/event-hubs-perf-tests/src/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/eventhub/event-hubs-perf-tests/src/subscribe.spec.ts
+++ b/sdk/eventhub/event-hubs-perf-tests/src/subscribe.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "@azure/event-hubs";
 import type { PerfOptionDictionary } from "@azure-tools/test-perf";
 import { EventPerfTest, getEnvVar } from "@azure-tools/test-perf";
+import { writeStdout } from "./stdio.js";
 
 interface ReceiverOptions {
   "number-of-events": number;
@@ -121,13 +122,13 @@ export class SubscribeTest extends EventPerfTest<ReceiverOptions> {
     await consumer.close();
     // The following might just be noise if we don't think there are related changes to the code
     if (this.parsedOptions["log-median-batch-size"].value) {
-      console.log(
+      writeStdout(
         `\tBatch count: ${this.callbackCallsCount}, Batch count per sec: ${
           this.callbackCallsCount / this.parsedOptions.duration.value
         }`,
       );
-      console.log(`\tmessagesPerBatch: ${this.messagesPerBatch}`);
-      console.log(
+      writeStdout(`\tmessagesPerBatch: ${this.messagesPerBatch}`);
+      writeStdout(
         `\tmessagesPerBatch... median: ${median(this.messagesPerBatch)}, avg: ${
           this.messagesPerBatch.reduce((a, b) => a + b, 0) / this.messagesPerBatch.length
         }, max: ${Math.max(...this.messagesPerBatch)}, min: ${Math.min(...this.messagesPerBatch)}`,

--- a/sdk/formrecognizer/ai-form-recognizer-perf-tests/src/custom.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer-perf-tests/src/custom.spec.ts
@@ -12,6 +12,7 @@ import {
 import type { TokenCredential } from "@azure/identity";
 import { DefaultAzureCredential } from "@azure/identity";
 import { randomUUID } from "node:crypto";
+import { writeStdout, writeUnknownError } from "./stdio.js";
 
 function unreachable(message?: string): never {
   throw new Error(message ?? "Unreachable Exception.");
@@ -74,9 +75,9 @@ export class CustomModelRecognitionTest extends PerfTest<CustomModelRecognitionT
 
       CustomModelRecognitionTest.sessionModel = await poller.pollUntilDone();
 
-      console.log(`Trained custom model: ${CustomModelRecognitionTest.sessionModel.modelId}`);
+      writeStdout(`Trained custom model: ${CustomModelRecognitionTest.sessionModel.modelId}`);
     } catch (ex) {
-      console.trace(ex);
+      writeUnknownError(ex);
       throw ex;
     }
   }
@@ -84,7 +85,7 @@ export class CustomModelRecognitionTest extends PerfTest<CustomModelRecognitionT
   public async globalCleanup(): Promise<void> {
     const modelId = CustomModelRecognitionTest.sessionModel?.modelId;
     if (modelId) {
-      console.log(`Deleting ${modelId}`);
+      writeStdout(`Deleting ${modelId}`);
       await this.trainingClient.deleteDocumentModel(modelId);
     }
   }

--- a/sdk/formrecognizer/ai-form-recognizer-perf-tests/src/stdio.ts
+++ b/sdk/formrecognizer/ai-form-recognizer-perf-tests/src/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/formrecognizer/ai-form-recognizer/src/bin/gen-model.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/bin/gen-model.ts
@@ -9,6 +9,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { writeFile } from "node:fs/promises";
 import { DocumentModelAdministrationClient } from "../documentModelAdministrationClient.js";
 import { writeModelCode } from "./writeModelCode.js";
+import { writeStderr, writeUnknownError } from "./stdio.js";
 import { format } from "prettier";
 
 /**
@@ -16,7 +17,7 @@ import { format } from "prettier";
  * Prints a help message for the gen-model command.
  */
 function printHelp(): void {
-  console.error(`
+  writeStderr(`
 Usage:
  gen-model [options] <model-id>
  
@@ -53,7 +54,7 @@ async function main(): Promise<void> {
   let output: string | undefined = undefined;
   let test: boolean = false;
 
-  console.error("gen-model - create strong TypeScript types for models");
+  writeStderr("gen-model - create strong TypeScript types for models");
 
   if (args.some((arg) => arg === "--help" || arg === "-h")) {
     printHelp();
@@ -81,7 +82,7 @@ async function main(): Promise<void> {
   }
 
   if (idx + 1 <= args.length) {
-    console.error("warning: unused arguments:", args.slice(idx + 1).join(" "));
+    writeStderr("warning: unused arguments: " + args.slice(idx + 1).join(" "));
   }
 
   if (!modelId) {
@@ -96,7 +97,7 @@ async function main(): Promise<void> {
 
   const modelInfo = await client.getDocumentModel(modelId);
 
-  console.error("Generating model code for:", modelInfo.modelId);
+  writeStderr("Generating model code for: " + modelInfo.modelId);
 
   const file = await writeModelCode(modelInfo, test);
 
@@ -113,7 +114,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((e) => {
-  console.error(e);
-  console.error("see `gen-model --help` for more information");
+  writeUnknownError(e);
+  writeStderr("see `gen-model --help` for more information");
   process.exit(1);
 });

--- a/sdk/formrecognizer/ai-form-recognizer/src/bin/stdio.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/bin/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/loadtesting/create-playwright/src/bin/init.ts
+++ b/sdk/loadtesting/create-playwright/src/bin/init.ts
@@ -8,6 +8,7 @@ import {
   getLanguageAndConfigInfoFromDirectory,
   parseCLIArguments,
 } from "../utils.js";
+import { writeStdout } from "../stdio.js";
 
 export const init = async (): Promise<void> => {
   const options = parseCLIArguments();
@@ -24,7 +25,7 @@ export const init = async (): Promise<void> => {
     };
   }
 
-  console.log("");
+  writeStdout("");
   const playwrightServiceInitialize = new PlaywrightServiceInitialize(playwrightServiceInitConfig);
   await playwrightServiceInitialize.addServiceSupportToTestSuite();
 };

--- a/sdk/loadtesting/create-playwright/src/index.ts
+++ b/sdk/loadtesting/create-playwright/src/index.ts
@@ -4,10 +4,11 @@
 // Licensed under the MIT License.
 
 import { init } from "./bin/init.js";
+import { writeUnknownError } from "./stdio.js";
 
 (async () => {
   await init();
 })().catch((err) => {
-  console.error(err);
+  writeUnknownError(err);
   process.exit(1);
 });

--- a/sdk/loadtesting/create-playwright/src/initialize.ts
+++ b/sdk/loadtesting/create-playwright/src/initialize.ts
@@ -12,6 +12,7 @@ import type {
 } from "./types.js";
 import { executeCommand, getFileReferenceForImport } from "./utils.js";
 import { getPackageManager } from "./packageManager.js";
+import { writeStdout } from "./stdio.js";
 
 const questions: PromptObject[] = [
   {
@@ -53,7 +54,7 @@ export class PlaywrightServiceInitialize {
     if (response.canOverride) return true;
     if (!response.confirmationForExit) return this.checkIfServiceConfigCanBeAdded();
 
-    console.log(`\n${Messages.SETUP_PROCESS_EXIT_MESSAGE}`);
+    writeStdout(`\n${Messages.SETUP_PROCESS_EXIT_MESSAGE}`);
     return false;
   };
 
@@ -71,12 +72,12 @@ export class PlaywrightServiceInitialize {
       `test -c ${this.createAzurePlaywrightConfigFileName()} --workers=20`,
     );
 
-    console.log(`\n\nTo run playwrights tests using Playwright Workspaces\n`);
-    console.log(`\t${runCommandParallelWorkers}\n`);
+    writeStdout(`\n\nTo run playwrights tests using Playwright Workspaces\n`);
+    writeStdout(`\t${runCommandParallelWorkers}\n`);
 
-    console.log("Getting Started - https://aka.ms/pww/docs/quickstart\n");
+    writeStdout("Getting Started - https://aka.ms/pww/docs/quickstart\n");
 
-    console.log(
+    writeStdout(
       "If you're already using the Playwright Workspaces, please review the quickstart guide [https://aka.ms/pww/docs/quickstart] to ensure your tests continue running smoothly.",
     );
   };
@@ -85,7 +86,7 @@ export class PlaywrightServiceInitialize {
     const command = this._packageManager.installDevDependencyCommand(
       "@azure/playwright @azure/identity",
     );
-    console.log(`Installing Service package (${command})`);
+    writeStdout(`Installing Service package (${command})`);
     await executeCommand(command);
   };
 
@@ -93,7 +94,7 @@ export class PlaywrightServiceInitialize {
     const serviceConfigFile = this.createAzurePlaywrightConfigFileName();
     const serviceConfigFileContent = this.createAzurePlaywrightConfigContent();
     await fs.promises.writeFile(serviceConfigFile, serviceConfigFileContent);
-    console.log(`Success! Created service configuration file - ${serviceConfigFile}`);
+    writeStdout(`Success! Created service configuration file - ${serviceConfigFile}`);
   };
 
   private createAzurePlaywrightConfigContent = (): string => {

--- a/sdk/loadtesting/create-playwright/src/stdio.ts
+++ b/sdk/loadtesting/create-playwright/src/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/loadtesting/create-playwright/src/utils.ts
+++ b/sdk/loadtesting/create-playwright/src/utils.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path, { extname } from "node:path";
 import type { CLIArguments, PlaywrightServiceInitConfig } from "./types.js";
 import { ErrorMessages, Extensions, Languages } from "./constants.js";
+import { writeStdout } from "./stdio.js";
 
 export const executeCommand = (command: string): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
@@ -86,7 +87,7 @@ export const parseCLIArguments = (): CLIArguments => {
     if (args[i] === "-c" || args[i] === "--config") {
       cliArguments.config = args[i + 1];
     } else if (args[i] === "-h" || args[i] === "--help") {
-      console.log(showHelpForCLI());
+      writeStdout(showHelpForCLI());
       process.exit(0);
     }
   }

--- a/sdk/loadtesting/playwright/src/common/stdio.ts
+++ b/sdk/loadtesting/playwright/src/common/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/loadtesting/playwright/src/core/playwrightService.ts
+++ b/sdk/loadtesting/playwright/src/core/playwrightService.ts
@@ -27,6 +27,7 @@ import {
 import { ServiceErrorMessageConstants } from "../common/messages.js";
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { globalPaths } from "./playwrightServiceUtils.js";
+import { writeStdout } from "../common/stdio.js";
 
 const performOneTimeOperation = (options?: PlaywrightServiceAdditionalOptions): void => {
   const oneTimeOperationFlag =
@@ -157,14 +158,14 @@ const createAzurePlaywrightConfig = (
   }
   performOneTimeOperation(options);
   if (options?.useCloudHostedBrowsers === false) {
-    console.log("\nRunning tests using local browsers.");
+    writeStdout("\nRunning tests using local browsers.");
     return {
       ...globalFunctions,
     };
   }
   if (!process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED]) {
     process.env[InternalEnvironmentVariables.MPT_CLOUD_HOSTED_BROWSER_USED] = "true";
-    console.log("\nRunning tests using Playwright workspaces.");
+    writeStdout("\nRunning tests using Playwright workspaces.");
   }
 
   return {

--- a/sdk/loadtesting/playwright/src/reporter/playwrightReporter.ts
+++ b/sdk/loadtesting/playwright/src/reporter/playwrightReporter.ts
@@ -8,6 +8,7 @@ import {
   getVersionInfo,
 } from "../utils/utils.js";
 import { coreLogger } from "../common/logger.js";
+import { writeStdout, writeStderr } from "../common/stdio.js";
 import { PlaywrightServiceConfig } from "../common/playwrightServiceConfig.js";
 import { ServiceAuth, InternalEnvironmentVariables } from "../common/constants.js";
 import { ServiceErrorMessageConstants } from "../common/messages.js";
@@ -46,7 +47,7 @@ export default class PlaywrightReporter implements Reporter {
         (playwrightVersionInfo.major === 1 && playwrightVersionInfo.minor >= 57);
 
       if (!isReportingSupportedVersion) {
-        console.error(
+        writeStderr(
           ServiceErrorMessageConstants.PLAYWRIGHT_VERSION_TOO_OLD_FOR_REPORTING.message,
         );
         this.isReportingEnabled = false;
@@ -54,7 +55,7 @@ export default class PlaywrightReporter implements Reporter {
       }
     } catch (error) {
       coreLogger.error(`Failed to get Playwright version: ${error}`);
-      console.error(ServiceErrorMessageConstants.PLAYWRIGHT_VERSION_TOO_OLD_FOR_REPORTING.message);
+      writeStderr(ServiceErrorMessageConstants.PLAYWRIGHT_VERSION_TOO_OLD_FOR_REPORTING.message);
       this.isReportingEnabled = false;
       return;
     }
@@ -64,7 +65,7 @@ export default class PlaywrightReporter implements Reporter {
       process.env[InternalEnvironmentVariables.USING_SERVICE_CONFIG] === "true";
     coreLogger.info(`Using service config: ${usingServiceConfig}`);
     if (!usingServiceConfig) {
-      console.error(ServiceErrorMessageConstants.REPORTER_REQUIRES_SERVICE_CONFIG.message);
+      writeStderr(ServiceErrorMessageConstants.REPORTER_REQUIRES_SERVICE_CONFIG.message);
       this.isReportingEnabled = false;
       return;
     }
@@ -73,8 +74,8 @@ export default class PlaywrightReporter implements Reporter {
     const testRunCreationSuccess =
       process.env[InternalEnvironmentVariables.TEST_RUN_CREATION_SUCCESS] === "true";
     if (!testRunCreationSuccess) {
-      console.error(ServiceErrorMessageConstants.REPORTING_STATUS_FAILED.message);
-      console.error(ServiceErrorMessageConstants.REPORTING_TEST_RUN_FAILED.message);
+      writeStderr(ServiceErrorMessageConstants.REPORTING_STATUS_FAILED.message);
+      writeStderr(ServiceErrorMessageConstants.REPORTING_TEST_RUN_FAILED.message);
       this.isReportingEnabled = false;
       return;
     }
@@ -84,7 +85,7 @@ export default class PlaywrightReporter implements Reporter {
     coreLogger.info(`Current authentication type: ${playwrightServiceConfig.serviceAuthType}`);
     const isUsingAccessToken = playwrightServiceConfig.serviceAuthType === ServiceAuth.ACCESS_TOKEN;
     if (isUsingAccessToken) {
-      console.error(ServiceErrorMessageConstants.REPORTER_REQUIRES_ENTRA_AUTH.message);
+      writeStderr(ServiceErrorMessageConstants.REPORTER_REQUIRES_ENTRA_AUTH.message);
       this.isReportingEnabled = false;
       return;
     }
@@ -108,10 +109,10 @@ export default class PlaywrightReporter implements Reporter {
       }
 
       this.isReportingEnabled = true;
-      console.log(ServiceErrorMessageConstants.REPORTING_ENABLED.message);
+      writeStdout(ServiceErrorMessageConstants.REPORTING_ENABLED.message);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error(
+      writeStderr(
         `${ServiceErrorMessageConstants.WORKSPACE_METADATA_FETCH_FAILED.message}Error: ${errorMessage} `,
       );
     }
@@ -123,7 +124,7 @@ export default class PlaywrightReporter implements Reporter {
 
   async onEnd(): Promise<void> {
     if (this.isReportingEnabled) {
-      console.log(ServiceErrorMessageConstants.COLLECTING_ARTIFACTS.message);
+      writeStdout(ServiceErrorMessageConstants.COLLECTING_ARTIFACTS.message);
       const uploadResult = await this.uploadHtmlReport();
 
       if (uploadResult.success) {
@@ -132,23 +133,23 @@ export default class PlaywrightReporter implements Reporter {
           uploadResult.failedFileDetails &&
           uploadResult.failedFileDetails.length > 0
         ) {
-          console.log("Warning: Failed to upload the following files:");
+          writeStdout("Warning: Failed to upload the following files:");
           uploadResult.failedFileDetails.forEach((fileDetail) => {
-            console.log(`  - ${fileDetail.fileName}, ERROR: ${fileDetail.error}`);
+            writeStdout(`  - ${fileDetail.fileName}, ERROR: ${fileDetail.error}`);
           });
-          console.log(ServiceErrorMessageConstants.REPORTING_STATUS_PARTIAL.message);
+          writeStdout(ServiceErrorMessageConstants.REPORTING_STATUS_PARTIAL.message);
         } else {
-          console.log(ServiceErrorMessageConstants.REPORTING_STATUS_SUCCESS.message);
+          writeStdout(ServiceErrorMessageConstants.REPORTING_STATUS_SUCCESS.message);
         }
         // Display portal URL for both full and partial success
         if (this.workspaceMetadata?.resourceId) {
           const portalUrl = getPortalTestRunUrl(this.workspaceMetadata.resourceId);
-          console.log(ServiceErrorMessageConstants.TEST_REPORT_VIEW_URL.formatWithUrl(portalUrl));
+          writeStdout(ServiceErrorMessageConstants.TEST_REPORT_VIEW_URL.formatWithUrl(portalUrl));
         }
       } else {
-        console.error(ServiceErrorMessageConstants.REPORTING_STATUS_FAILED.message);
+        writeStderr(ServiceErrorMessageConstants.REPORTING_STATUS_FAILED.message);
         if (uploadResult.errorMessage) {
-          console.error(`Error: ${uploadResult.errorMessage}`);
+          writeStderr(`Error: ${uploadResult.errorMessage}`);
         }
       }
     }
@@ -178,7 +179,7 @@ export default class PlaywrightReporter implements Reporter {
 
   private validateHtmlReporterConfiguration(config: FullConfig): boolean {
     if (!config.reporter || !Array.isArray(config.reporter)) {
-      console.error(ServiceErrorMessageConstants.HTML_REPORTER_REQUIRED.message);
+      writeStderr(ServiceErrorMessageConstants.HTML_REPORTER_REQUIRED.message);
       return false;
     }
 
@@ -198,13 +199,13 @@ export default class PlaywrightReporter implements Reporter {
 
     // Validate HTML reporter exists
     if (htmlReporterIndex === -1) {
-      console.error(ServiceErrorMessageConstants.HTML_REPORTER_REQUIRED.message);
+      writeStderr(ServiceErrorMessageConstants.HTML_REPORTER_REQUIRED.message);
       return false;
     }
 
     // Validate HTML reporter comes before Azure reporter (if Azure reporter exists)
     if (azureReporterIndex !== -1 && htmlReporterIndex > azureReporterIndex) {
-      console.error(ServiceErrorMessageConstants.HTML_REPORTER_REQUIRED.message);
+      writeStderr(ServiceErrorMessageConstants.HTML_REPORTER_REQUIRED.message);
       return false;
     }
 
@@ -221,7 +222,7 @@ export default class PlaywrightReporter implements Reporter {
    */
   private isReportingAllowed(workspaceMetadata: WorkspaceMetaData | null): boolean {
     if (!workspaceMetadata) {
-      console.error(ServiceErrorMessageConstants.FAILED_TO_GET_WORKSPACE_METADATA.message);
+      writeStderr(ServiceErrorMessageConstants.FAILED_TO_GET_WORKSPACE_METADATA.message);
       return false;
     }
 
@@ -233,14 +234,14 @@ export default class PlaywrightReporter implements Reporter {
         typeof reporting === "string" ? reporting.toLowerCase() : reporting;
 
       if (normalizedReporting === "disabled") {
-        console.error(ServiceErrorMessageConstants.WORKSPACE_REPORTING_DISABLED.message);
+        writeStderr(ServiceErrorMessageConstants.WORKSPACE_REPORTING_DISABLED.message);
         coreLogger.info("Reporting disabled via workspace metadata configuration");
         return false;
       }
 
       if (normalizedReporting === "enabled") {
         if (!storageUri) {
-          console.error(
+          writeStderr(
             ServiceErrorMessageConstants.WORKSPACE_REPORTING_STORAGE_NOT_LINKED.message,
           );
           coreLogger.info("Reporting enabled in metadata but storage URI not configured");
@@ -258,7 +259,7 @@ export default class PlaywrightReporter implements Reporter {
 
     // Fallback to current logic: check only storageUri (when reporting field is not present or has unexpected value)
     if (!storageUri) {
-      console.error(ServiceErrorMessageConstants.WORKSPACE_REPORTING_DISABLED.message);
+      writeStderr(ServiceErrorMessageConstants.WORKSPACE_REPORTING_DISABLED.message);
       coreLogger.info("Storage URI not configured in workspace metadata");
       return false;
     }

--- a/sdk/loadtesting/playwright/src/utils/PlaywrightServiceClient.ts
+++ b/sdk/loadtesting/playwright/src/utils/PlaywrightServiceClient.ts
@@ -10,6 +10,7 @@ import { ServiceErrorMessageConstants } from "../common/messages.js";
 import { HttpService } from "../common/httpService.js";
 import type { TestRunCreatePayload, WorkspaceMetaData } from "../common/types.js";
 import { Constants, InternalEnvironmentVariables } from "../common/constants.js";
+import { writeStdout, writeStderr } from "../common/stdio.js";
 
 export class PlaywrightServiceClient {
   private httpService: HttpService;
@@ -44,7 +45,7 @@ export class PlaywrightServiceClient {
       if (response.status !== 200) {
         const errorMessage = extractErrorMessage(response?.bodyAsText ?? "");
         process.env[InternalEnvironmentVariables.TEST_RUN_CREATION_SUCCESS] = "false";
-        console.error(
+        writeStderr(
           ServiceErrorMessageConstants.TEST_RUN_CREATION_FAILED.formatWithErrorDetails(
             errorMessage || "Unknown error",
           ),
@@ -52,13 +53,13 @@ export class PlaywrightServiceClient {
         return;
       }
 
-      console.log("Test run created successfully.");
+      writeStdout("Test run created successfully.");
       process.env[InternalEnvironmentVariables.TEST_RUN_CREATION_SUCCESS] = "true";
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error occurred during test run creation";
       process.env[InternalEnvironmentVariables.TEST_RUN_CREATION_SUCCESS] = "false";
-      console.error(
+      writeStderr(
         ServiceErrorMessageConstants.TEST_RUN_CREATION_FAILED.formatWithErrorDetails(errorMessage),
       );
     }

--- a/sdk/loadtesting/playwright/src/utils/playwrightReporterStorageManager.ts
+++ b/sdk/loadtesting/playwright/src/utils/playwrightReporterStorageManager.ts
@@ -5,6 +5,7 @@ import type { ContainerClient, BlockBlobClient } from "@azure/storage-blob";
 import { BlobServiceClient } from "@azure/storage-blob";
 import type { TokenCredential } from "@azure/core-auth";
 import { coreLogger } from "../common/logger.js";
+import { writeStdout } from "../common/stdio.js";
 import { readFileSync, writeFileSync, existsSync, createReadStream } from "fs";
 import { join } from "path";
 import { UploadConstants } from "../common/constants.js";
@@ -65,7 +66,7 @@ export class PlaywrightReporterStorageManager {
       }
 
       const folderName = runId;
-      console.log(
+      writeStdout(
         ServiceErrorMessageConstants.UPLOADING_ARTIFACTS.formatWithDetails(
           storageAccountName,
           containerName,

--- a/sdk/loadtesting/playwright/src/utils/utils.ts
+++ b/sdk/loadtesting/playwright/src/utils/utils.ts
@@ -14,6 +14,7 @@ import {
 } from "../common/constants.js";
 import { ServiceErrorMessageConstants } from "../common/messages.js";
 import { coreLogger } from "../common/logger.js";
+import { writeStdout, writeStderr } from "../common/stdio.js";
 import type { TokenCredential } from "@azure/core-auth";
 import process from "node:process";
 import { randomUUID } from "node:crypto";
@@ -55,12 +56,12 @@ export const exitWithFailureMessage = (
   },
   errorDetails?: string,
 ): never => {
-  console.log();
+  writeStdout();
 
   if (error.formatWithErrorDetails && errorDetails) {
-    console.error(error.formatWithErrorDetails(errorDetails));
+    writeStderr(error.formatWithErrorDetails(errorDetails));
   } else {
-    console.error(error.message);
+    writeStderr(error.message);
   }
   // eslint-disable-next-line n/no-process-exit
   process.exit(1);
@@ -74,7 +75,7 @@ export const throwErrorWithFailureMessage = (
   },
   errorDetails?: string,
 ): never => {
-  console.log();
+  writeStdout();
 
   const finalMessage =
     error.formatWithErrorDetails && errorDetails
@@ -178,7 +179,7 @@ const warnAboutTokenExpiry = (expirationTime: number, currentTime: number): void
   const daysToExpiration = Math.ceil((expirationTime * 1000 - currentTime) / Constants.OneDayInMS);
   const expirationDate = new Date(expirationTime * 1000).toLocaleDateString();
   const expirationWarning = `Warning: The access token used for this test run will expire in ${daysToExpiration} days on ${expirationDate}. Generate a new token from the portal to avoid failures. For a simpler, more secure solution, switch to Microsoft Entra ID and eliminate token management. https://learn.microsoft.com/entra/identity/`;
-  console.warn(expirationWarning);
+  writeStderr(expirationWarning);
 };
 
 export const warnIfAccessTokenCloseToExpiry = (): void => {
@@ -500,7 +501,7 @@ export const getStorageAccountNameFromUri = (storageUri: string): string | null 
 
     return null;
   } catch (error) {
-    console.warn("Failed to extract storage account name from URI:", storageUri, error);
+    coreLogger.warning(`Failed to extract storage account name from URI: ${storageUri} ${error}`);
     return null;
   }
 };

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/src/logExport.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/src/logExport.spec.ts
@@ -4,6 +4,7 @@
 import type { PerfOptionDictionary } from "@azure-tools/test-perf";
 import { MonitorOpenTelemetryTest } from "./monitorOpenTelemetry.spec.js";
 import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import { writeStderr } from "./stdio.js";
 
 type MonitorOpenTelemetryTestOptions = Record<string, unknown>;
 
@@ -20,7 +21,7 @@ export class LogExportTest extends MonitorOpenTelemetryTest<MonitorOpenTelemetry
         attributes: { key: "value" },
       });
     } catch (error) {
-      console.error("Error running logs perf test:", error);
+      writeStderr(`Error running logs perf test: ${error}`);
       process.exit(1);
     }
   }

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/src/spanExport.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/src/spanExport.spec.ts
@@ -5,6 +5,7 @@ import type { PerfOptionDictionary } from "@azure-tools/test-perf";
 import { MonitorOpenTelemetryTest } from "./monitorOpenTelemetry.spec.js";
 import type { Span, Tracer } from "@opentelemetry/api";
 import { trace, context } from "@opentelemetry/api";
+import { writeStderr } from "./stdio.js";
 
 type MonitorOpenTelemetryTestOptions = Record<string, unknown>;
 
@@ -31,7 +32,7 @@ export class SpanExportTest extends MonitorOpenTelemetryTest<MonitorOpenTelemetr
     }
 
     main().catch((error) => {
-      console.error("Error running perf test:", error.message);
+      writeStderr(`Error running perf test: ${error.message}`);
       process.exit(1);
     });
   }

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/src/stdio.ts
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/src/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}

--- a/sdk/test-utils/perf/src/eventPerfTest.ts
+++ b/sdk/test-utils/perf/src/eventPerfTest.ts
@@ -4,6 +4,7 @@
 import { AbortSignalLike } from "@azure/abort-controller";
 import { PerfTestBase } from "./perfTestBase.js";
 import { isDefined } from "@azure/core-util";
+import { writeStderr, writeUnknownError } from "./utils/stdio.js";
 
 /**
  * Extends PerfTestBase, enables writing perf tests for the APIs that receive events as a stream
@@ -44,7 +45,7 @@ export abstract class EventPerfTest<
     try {
       await delay(this.testDuration, this.abortController.signal);
     } catch (error: unknown) {
-      console.warn(error);
+      writeUnknownError(error);
     }
   }
 
@@ -57,7 +58,7 @@ export abstract class EventPerfTest<
   }
 
   public errorRaised(error: Error) {
-    console.warn(`Error occurred:\n ${error}`);
+    writeStderr(`Error occurred:\n ${error}`);
     if (!this.abortController?.signal.aborted) {
       this.abortController?.abort();
     }

--- a/sdk/test-utils/perf/src/managerProgram.ts
+++ b/sdk/test-utils/perf/src/managerProgram.ts
@@ -15,6 +15,7 @@ import { Snapshot } from "./snapshot.js";
 import { PerfTestBase, PerfTestConstructor } from "./perfTestBase.js";
 import { PerfProgram } from "./program.js";
 import { formatDuration, formatNumber } from "./utils/utils.js";
+import { writeStdout } from "./utils/stdio.js";
 
 /**
  * The manager program which is responsible for spawning workers which run the actual perf test.
@@ -94,7 +95,7 @@ export class ManagerPerfProgram implements PerfProgram {
     const operationsPerSecond = this.getOperationsPerSecond(parallels);
     const secondsPerOperation = 1 / operationsPerSecond;
     const weightedAverage = totalOperations / operationsPerSecond;
-    console.log(
+    writeStdout(
       `Completed ${totalOperations.toLocaleString(undefined, {
         maximumFractionDigits: 0,
       })} ` +
@@ -113,7 +114,7 @@ export class ManagerPerfProgram implements PerfProgram {
 
     this.lastCompleted = totalCompleted;
 
-    console.log(
+    writeStdout(
       `${elapsedTime}\t\t${currentCompleted}\t\t${totalCompleted}\t\t${averageCompleted.toFixed(
         2,
       )}`,
@@ -126,7 +127,7 @@ export class ManagerPerfProgram implements PerfProgram {
     let cpus: number;
     if (cpuOption === 0) {
       cpus = os.cpus().length;
-      console.log(`Setting number of CPUs to number of CPUs detected on machine (${cpus}).`);
+      writeStdout(`Setting number of CPUs to number of CPUs detected on machine (${cpus}).`);
     } else {
       cpus = cpuOption;
     }
@@ -152,7 +153,7 @@ export class ManagerPerfProgram implements PerfProgram {
   }
 
   private async runTests(iterationIndex: number, title: "warmup" | "test"): Promise<void> {
-    console.log("=== Starting the perf test ===");
+    writeStdout("=== Starting the perf test ===");
 
     const stage = performStage(title);
 
@@ -163,12 +164,12 @@ export class ManagerPerfProgram implements PerfProgram {
     // We don't enforce this inside of runLoop, so it might never be executed, depending on the number
     // of operations running.
     const millisecondsToLog = Number(this.parsedOptions["milliseconds-to-log"].value);
-    console.log(
+    writeStdout(
       `\n=== ${title} mode, iteration ${iterationIndex + 1}. Logs every ${
         millisecondsToLog / 1000
       }s ===`,
     );
-    console.log(`ElapsedTime\tCurrent\t\tTotal\t\tAverage`);
+    writeStdout(`ElapsedTime\tCurrent\t\tTotal\t\tAverage`);
 
     let done = false;
 
@@ -190,7 +191,7 @@ export class ManagerPerfProgram implements PerfProgram {
 
     const results = resultMessages.map((m) => m.snapshots).flat();
 
-    console.log(`=== ${title} mode, results of iteration ${iterationIndex + 1} ===`);
+    writeStdout(`=== ${title} mode, results of iteration ${iterationIndex + 1} ===`);
     this.logResults(results);
 
     await stage;
@@ -198,10 +199,10 @@ export class ManagerPerfProgram implements PerfProgram {
 
   private async logPackageVersions(listTransitiveDeps: boolean): Promise<void> {
     return new Promise((resolve) => {
-      console.log("=== Versions ===");
+      writeStdout("=== Versions ===");
       exec(`npm list --prod ${listTransitiveDeps ? "" : "--depth=0"}`, (_error, stdout) => {
         for (const dependency of stdout.split("\n").filter((line) => line.includes("@azure"))) {
-          console.log(dependency);
+          writeStdout(dependency);
         }
         resolve();
       });
@@ -231,7 +232,7 @@ export class ManagerPerfProgram implements PerfProgram {
     // There should be no test execution if the help option is passed.
     // --help, or -h
     if (this.parsedOptions.help.value) {
-      console.log(`=== Help: Options that can be sent to ${this.testName} ===`);
+      writeStdout(`=== Help: Options that can be sent to ${this.testName} ===`);
       console.table(this.dummyTestInstance.parsedOptions);
       return;
     }
@@ -241,17 +242,17 @@ export class ManagerPerfProgram implements PerfProgram {
     );
 
     const options = this.dummyTestInstance.parsedOptions;
-    console.log("=== Parsed options ===");
+    writeStdout("=== Parsed options ===");
     console.table(options);
 
     this.createWorkers();
 
-    console.log(
+    writeStdout(
       `=== Calling globalSetup() once per CPU for (all) the instance(s) of ${this.testName} ===`,
     );
     await performStage("globalSetup");
 
-    console.log(
+    writeStdout(
       `=== Calling setup() for the ${this.parallelNumber} instantiated ${this.testName} tests ===`,
     );
 
@@ -271,11 +272,11 @@ export class ManagerPerfProgram implements PerfProgram {
     await performStage("preCleanup");
 
     if (!options["no-cleanup"].value) {
-      console.log(
+      writeStdout(
         `=== Calling cleanup() for the ${this.parallelNumber} instantiated ${this.testName} tests ===`,
       );
       await performStage("cleanup");
-      console.log(
+      writeStdout(
         `=== Calling globalCleanup() once per CPU for (all) the instance(s) of ${this.testName} ===`,
       );
       await performStage("globalCleanup");

--- a/sdk/test-utils/perf/src/utils/profiling.ts
+++ b/sdk/test-utils/perf/src/utils/profiling.ts
@@ -3,6 +3,7 @@
 
 import { Session } from "node:inspector";
 import { mkdirSync, writeFileSync } from "node:fs";
+import { writeStdout, writeUnknownError } from "./stdio.js";
 
 export async function runWithCpuProfile(
   functionToProfile: () => Promise<void>,
@@ -22,9 +23,9 @@ export async function runWithCpuProfile(
             recursive: true,
           });
           writeFileSync(profileFilePath, JSON.stringify(profile));
-          console.log(`...CPUProfile saved to ${profileFilePath}...`);
+          writeStdout(`...CPUProfile saved to ${profileFilePath}...`);
         } else {
-          console.log(err);
+          writeUnknownError(err);
         }
       });
     });

--- a/sdk/test-utils/perf/src/utils/stdio.ts
+++ b/sdk/test-utils/perf/src/utils/stdio.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function writeStdout(message = ""): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function writeStderr(message = ""): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function writeUnknownError(error: unknown): void {
+  writeStderr(error instanceof Error ? (error.stack ?? error.message) : String(error));
+}


### PR DESCRIPTION
### Describe the problem that is addressed by this PR

Some packages use `console` instead of Azure logger, which doesn't sanitize credentials. This followup PR addresses cases where `console` is being used, but Azure logger is inappropriate due to the output being user-facing.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This approach avoids suppressing linter errors. 

This helper might fit better in `core-util`.

### Provide a list of related PRs _(if any)_

Followup to #38251 