### PR TITLE
fix(core-client): fix typos in serializer error messages

### DIFF
--- a/sdk/core/core-client/src/serializer.ts
+++ b/sdk/core/core-client/src/serializer.ts
@@ -561,8 +561,8 @@ function serializeSequenceType(
   let elementType = mapper.type.element;
   if (!elementType || typeof elementType !== "object") {
     throw new Error(
-      `element" metadata for an Array must be defined in the ` +
-        `mapper and it must of type "object" in ${objectName}.`,
+      `"element" metadata for an Array must be defined in the ` +
+        `mapper and it must be of type "object" in ${objectName}.`,
     );
   }
   // Quirk: Composite mappers referenced by `element` might
@@ -1101,8 +1101,8 @@ function deserializeSequenceType(
   let element = mapper.type.element;
   if (!element || typeof element !== "object") {
     throw new Error(
-      `element" metadata for an Array must be defined in the ` +
-        `mapper and it must of type "object" in ${objectName}`,
+      `"element" metadata for an Array must be defined in the ` +
+        `mapper and it must be of type "object" in ${objectName}`,
     );
   }
   if (responseBody) {

--- a/sdk/core/core-client/test/public/serializer.spec.ts
+++ b/sdk/core/core-client/test/public/serializer.spec.ts
@@ -2504,7 +2504,7 @@ describe("serializer", () => {
             [1, 2],
             "testObj",
           ),
-        /element" metadata for an Array must be defined/,
+        /"element" metadata for an Array must be defined/,
       );
     });
   });
@@ -2573,7 +2573,7 @@ describe("serializer", () => {
             [1, 2],
             "testObj",
           ),
-        /element" metadata for an Array must be defined/,
+        /"element" metadata for an Array must be defined/,
       );
     });
 


### PR DESCRIPTION
Fix two issues in the Array element metadata error messages in `serializer.ts`:

- Add missing opening quote: `element"` → `"element"`
- Fix grammar: "it must of type" → "it must be of type"

Both occurrences (serialize and deserialize paths) are fixed. Test regexes updated to match.

Fixes feedback from #38176.