### PR TITLE
feat(confidential-ledger): add redirect URL caching for write operations

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 1.1.2-beta.5 (Unreleased)
+
+### Features Added
+
+- Added redirect URL caching for write operations. When the Confidential Ledger load balancer issues a 307/308 redirect, the target (primary node) URL is cached so subsequent write requests skip the load balancer, reducing latency. Read requests (GET/HEAD) continue to always go through the load balancer. The cache is automatically invalidated on server errors (5xx) or transport failures.
+- Added support for HTTP 308 (Permanent Redirect) status code in the redirect policy.
+
 ## 1.1.2-beta.4 (2026-02-18)
 
 ### Bugs Fixed

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
-  "version": "1.1.2-beta.4",
+  "version": "1.1.2-beta.5",
   "keywords": [
     "node",
     "azure",

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
@@ -31,7 +31,7 @@ export default function createClient(
   { apiVersion = "2024-12-09-preview", ...options }: ConfidentialLedgerClientOptions = {},
 ): ConfidentialLedgerClient {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `${ledgerEndpoint}`;
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.1.2-beta.4`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.1.2-beta.5`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
@@ -83,24 +83,111 @@ export default function createClient(
 const allowedRedirect = ["GET", "HEAD"];
 
 /**
- * A custom redirect policy for Confidential Ledger that preserves all headers,
- * including the Authorization header, when following redirects.
+ * HTTP methods that are considered write operations for redirect caching.
+ * Only writes cache and use the redirect target URL.
+ */
+const writeMethods = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Rewrite a URL by replacing its scheme and host with those from the cached base URL,
+ * preserving the original path, query string, and fragment.
  *
- * The default core redirect policy strips the Authorization header on redirect
- * as a general security measure. However, Confidential Ledger may redirect write
- * operations (e.g., POST) from a secondary node to the primary node using a 307
- * redirect. Because the redirect target is the same trusted Confidential Ledger
- * service, the Authorization header must be forwarded to avoid 401 errors.
+ * @param originalUrl - The original request URL.
+ * @param cachedBaseUrl - The cached base URL (scheme + host) from a previous redirect.
+ * @returns The rewritten URL string.
+ */
+function rewriteUrl(originalUrl: string, cachedBaseUrl: string): string {
+  const original = new URL(originalUrl);
+  const cached = new URL(cachedBaseUrl);
+  original.protocol = cached.protocol;
+  original.host = cached.host;
+  return original.toString();
+}
+
+/**
+ * A custom redirect policy for Confidential Ledger that preserves all headers,
+ * including the Authorization header, when following redirects. Additionally,
+ * caches the redirect target URL for write operations so that subsequent writes
+ * skip the load balancer.
+ *
+ * Cache behavior:
+ * - Write requests (POST/PUT/PATCH/DELETE) that receive a 307/308 redirect
+ *   cache the target URL's base (scheme + host).
+ * - Subsequent writes rewrite their URL to the cached primary before sending.
+ * - Read requests (GET/HEAD/OPTIONS) never use or populate the cache.
+ * - 5xx responses or transport errors on writes invalidate the cache.
+ *
+ * NOTE: Python SDK caches on all redirect codes (301/302/307/308). JS only
+ * caches on 307/308 because JS only follows 301/302 for GET/HEAD, so writes
+ * never encounter those status codes. This is an intentional difference.
  *
  * @param maxRetries - The maximum number of redirects to follow. Defaults to 20.
- * @returns A PipelinePolicy that handles redirects while preserving all headers.
+ * @returns A PipelinePolicy that handles redirects with caching.
  */
 function confidentialLedgerRedirectPolicy(maxRetries: number = 20): PipelinePolicy {
+  let cachedBaseUrl: string | null = null;
+
   return {
     name: "confidentialLedgerRedirectPolicy",
     async sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      const response = await next(request);
-      return handleRedirect(next, response, maxRetries);
+      const method = request.method.toUpperCase();
+      const isWrite = writeMethods.has(method);
+
+      // Save the original URL and method so we can restore on errors.
+      // This is critical because the retry policy (upstream) may re-invoke
+      // sendRequest with the same request object after a transport error.
+      // handleRedirect also mutates request.url (and method on 303), so
+      // we must restore in ALL failure paths, not just the top-level catch.
+      const originalUrl = request.url;
+      const originalMethod = request.method;
+
+      // For writes, rewrite URL to cached primary if cache is warm.
+      if (isWrite && cachedBaseUrl) {
+        request.url = rewriteUrl(request.url, cachedBaseUrl);
+      }
+
+      let response: PipelineResponse;
+      try {
+        response = await next(request);
+      } catch (e) {
+        // Restore original URL and method so retry policy can re-send cleanly.
+        request.url = originalUrl;
+        request.method = originalMethod;
+        // Transport error on write: invalidate cache and rethrow.
+        if (isWrite) {
+          cachedBaseUrl = null;
+        }
+        throw e;
+      }
+
+      // Follow redirect chain. This may mutate request.url and method (303).
+      try {
+        response = await handleRedirect(next, response, maxRetries, isWrite, (url: string) => {
+          const parsed = new URL(url);
+          cachedBaseUrl = `${parsed.protocol}//${parsed.host}`;
+        });
+      } catch (e) {
+        // Transport error during redirect follow: restore and invalidate.
+        request.url = originalUrl;
+        request.method = originalMethod;
+        if (isWrite) {
+          cachedBaseUrl = null;
+        }
+        throw e;
+      }
+
+      // Invalidate cache on server errors for writes and restore the original
+      // URL so the upstream retry policy re-enters sendRequest with the LB URL
+      // instead of the rewritten cached-primary URL.
+      // Use the CURRENT request method (not original isWrite) because 303
+      // may have converted POST→GET, and a GET 5xx should not invalidate.
+      if (writeMethods.has(request.method.toUpperCase()) && response.status >= 500) {
+        cachedBaseUrl = null;
+        request.url = originalUrl;
+        request.method = originalMethod;
+      }
+
+      return response;
     },
   };
 }
@@ -109,6 +196,8 @@ async function handleRedirect(
   next: SendRequest,
   response: PipelineResponse,
   maxRetries: number,
+  isWrite: boolean,
+  cacheRedirectUrl: (url: string) => void,
   currentRetries: number = 0,
 ): Promise<PipelineResponse> {
   const { request, status, headers } = response;
@@ -119,11 +208,20 @@ async function handleRedirect(
       (status === 301 && allowedRedirect.includes(request.method)) ||
       (status === 302 && allowedRedirect.includes(request.method)) ||
       (status === 303 && request.method === "POST") ||
-      status === 307) &&
+      status === 307 ||
+      status === 308) &&
     currentRetries < maxRetries
   ) {
     const url = new URL(locationHeader, request.url);
     request.url = url.toString();
+
+    // Cache the redirect target for write methods on 307/308.
+    // We only cache on 307/308 (not 301/302) because those are the only
+    // method-preserving redirects. 301/302 are only followed for GET/HEAD
+    // in this policy, so writes never hit those code paths.
+    if (isWrite && (status === 307 || status === 308)) {
+      cacheRedirectUrl(request.url);
+    }
 
     // POST request with Status code 303 should be converted into a
     // redirected GET request if the redirect url is present in the location header
@@ -133,13 +231,25 @@ async function handleRedirect(
       delete request.body;
     }
 
+    // Recalculate isWrite after potential 303 POST→GET conversion.
+    const isWriteAfterRedirect = writeMethods.has(request.method.toUpperCase());
+
     // NOTE: Unlike the default redirectPolicy, we intentionally do NOT strip the
     // Authorization header here. Confidential Ledger redirects are always within
     // the same trusted service (e.g., secondary to primary node), so credentials
     // must be forwarded for the redirected request to succeed.
 
+    // Transport errors from redirect-follow propagate to sendRequest's
+    // outer try/catch which handles URL restore and cache invalidation.
     const res = await next(request);
-    return handleRedirect(next, res, maxRetries, currentRetries + 1);
+    return handleRedirect(
+      next,
+      res,
+      maxRetries,
+      isWriteAfterRedirect,
+      cacheRedirectUrl,
+      currentRetries + 1,
+    );
   }
 
   return response;

--- a/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
@@ -15,7 +15,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ../generated
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/2024-12-09-preview/confidentialledger.json
-package-version: 1.1.2-beta.4
+package-version: 1.1.2-beta.5
 hide-clients: true
 rest-level-client: true
 security: "AADToken"

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectCaching.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectCaching.spec.ts
@@ -1,0 +1,966 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert, vi } from "vitest";
+import type { PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import createClient from "../../src/confidentialLedger.js";
+
+/**
+ * Helper to extract the custom redirect policy from a client's pipeline.
+ */
+function getRedirectPolicy(ledgerEndpoint: string) {
+  const fakeCredential = {
+    getToken: vi
+      .fn()
+      .mockResolvedValue({ token: "fake-token", expiresOnTimestamp: Date.now() + 3600000 }),
+  };
+  const client = createClient(ledgerEndpoint, fakeCredential);
+  const policies = client.pipeline.getOrderedPolicies();
+  const policy = policies.find((p) => p.name === "confidentialLedgerRedirectPolicy");
+  assert.ok(policy, "confidentialLedgerRedirectPolicy should be present in the pipeline");
+  return policy!;
+}
+
+describe("Confidential Ledger Redirect Caching", () => {
+  const ledgerEndpoint = "https://test-ledger.confidential-ledger.azure.com";
+  const primaryEndpoint = "https://node3.test-ledger.confidential-ledger.azure.com";
+
+  describe("Cache population and usage", () => {
+    it("should cache redirect target on first write 307 and skip LB on subsequent writes", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+
+      // First write: gets 307, follows redirect, caches primary
+      const request1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+        body: JSON.stringify({ contents: "write1" }),
+      });
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/transactions`,
+        }),
+        request: request1,
+        status: 307,
+      };
+      const success1: PipelineResponse = {
+        headers: createHttpHeaders(),
+        request: request1,
+        status: 200,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+      next.mockResolvedValueOnce(success1);
+
+      await policy.sendRequest(request1, next);
+      assert.equal(next.mock.calls.length, 2);
+
+      // Second write: should go directly to cached primary (no redirect)
+      const request2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+        body: JSON.stringify({ contents: "write2" }),
+      });
+      const success2: PipelineResponse = {
+        headers: createHttpHeaders(),
+        request: request2,
+        status: 200,
+      };
+      next.mockResolvedValueOnce(success2);
+
+      await policy.sendRequest(request2, next);
+
+      // Third call should have been sent to cached primary directly
+      const sentUrl = next.mock.calls[2][0].url;
+      assert.ok(
+        sentUrl.startsWith(primaryEndpoint),
+        `Expected ${sentUrl} to start with ${primaryEndpoint}`,
+      );
+      // Only 3 total next() calls (not 4) — no redirect on second write
+      assert.equal(next.mock.calls.length, 3);
+    });
+
+    it("should keep cache warm when cached write returns 200", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm the cache
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // Second write succeeds — cache should stay warm
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      // Third write should still use cache
+      const req3 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "PUT",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req3,
+        status: 200,
+      });
+      await policy.sendRequest(req3, next);
+
+      // req3 should go to cached primary (call index 4: 0=redirect, 1=follow, 2=req2, 3=req3)
+      assert.ok(next.mock.calls[3][0].url.startsWith(primaryEndpoint));
+    });
+
+    it("should treat DELETE as a write method that uses cache", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache with a POST
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // DELETE should use cached URL
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/collections/test`,
+        method: "DELETE",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(next.mock.calls[2][0].url.startsWith(primaryEndpoint));
+    });
+  });
+
+  describe("Read requests bypass cache", () => {
+    it("should not use cached URL for GET requests", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm the cache with a write
+      const writeReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: writeReq,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: writeReq,
+        status: 200,
+      });
+      await policy.sendRequest(writeReq, next);
+
+      // GET should NOT use cache — should go to original LB endpoint
+      const getReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions/latest`,
+        method: "GET",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: getReq,
+        status: 200,
+      });
+      await policy.sendRequest(getReq, next);
+
+      // GET should have been sent to original LB URL, not cached primary
+      const getSentUrl = next.mock.calls[2][0].url;
+      assert.ok(
+        getSentUrl.startsWith(ledgerEndpoint),
+        `Expected GET to go to LB (${ledgerEndpoint}), got ${getSentUrl}`,
+      );
+    });
+
+    it("should not populate cache on GET 300 redirect", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // GET receives a 300 redirect
+      const getReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions/latest`,
+        method: "GET",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/transactions/latest`,
+        }),
+        request: getReq,
+        status: 300,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: getReq,
+        status: 200,
+      });
+      await policy.sendRequest(getReq, next);
+
+      // Subsequent POST should NOT use cache (cache should still be empty)
+      const writeReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: writeReq,
+        status: 200,
+      });
+      await policy.sendRequest(writeReq, next);
+
+      // POST should go to original LB, not the redirect target from the GET
+      assert.ok(
+        next.mock.calls[2][0].url.startsWith(ledgerEndpoint),
+        "Cache should not be populated by GET redirects",
+      );
+    });
+
+    it("should not use cached URL for HEAD requests", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache
+      const writeReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: writeReq,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: writeReq,
+        status: 200,
+      });
+      await policy.sendRequest(writeReq, next);
+
+      // HEAD should go to LB, not cache
+      const headReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "HEAD",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: headReq,
+        status: 200,
+      });
+      await policy.sendRequest(headReq, next);
+
+      assert.ok(next.mock.calls[2][0].url.startsWith(ledgerEndpoint));
+    });
+  });
+
+  describe("Cache invalidation", () => {
+    it("should invalidate cache on 5xx response for write", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // Second write gets 503 — cache should be invalidated
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 503,
+      });
+      await policy.sendRequest(req2, next);
+
+      // Third write should go to LB (cache was invalidated)
+      const req3 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req3,
+        status: 200,
+      });
+      await policy.sendRequest(req3, next);
+
+      assert.ok(
+        next.mock.calls[3][0].url.startsWith(ledgerEndpoint),
+        "After 5xx, cache should be invalidated and write should go to LB",
+      );
+    });
+
+    it("should restore request URL to LB after 5xx so retry policy re-enters cleanly", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache
+      const req = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req,
+        status: 200,
+      });
+      await policy.sendRequest(req, next);
+
+      // Same request object gets 503 from cached primary
+      req.url = `${ledgerEndpoint}/app/transactions`;
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req,
+        status: 503,
+      });
+      await policy.sendRequest(req, next);
+
+      // After 5xx, request.url should be restored to LB URL (not stuck on primary)
+      // so the retry policy can re-enter sendRequest with the correct LB URL
+      assert.strictEqual(
+        req.url,
+        `${ledgerEndpoint}/app/transactions`,
+        "request.url must be restored to LB after 5xx for retry policy correctness",
+      );
+      assert.strictEqual(req.method, "POST", "request.method must be preserved");
+
+      // Simulate retry: re-enter sendRequest with the same request object
+      // It should go to LB (not the stale primary) since cache was invalidated
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req,
+        status: 200,
+      });
+      await policy.sendRequest(req, next);
+
+      assert.ok(
+        next.mock.calls[3][0].url.startsWith(ledgerEndpoint),
+        "Retry after 5xx must go through LB, not the unhealthy primary",
+      );
+    });
+
+    it("should invalidate cache on transport error for write", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // Second write throws transport error
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockRejectedValueOnce(new Error("Connection refused"));
+
+      try {
+        await policy.sendRequest(req2, next);
+        assert.fail("Should have thrown");
+      } catch (e: any) {
+        assert.equal(e.message, "Connection refused");
+      }
+
+      // Third write should go to LB (cache was invalidated)
+      const req3 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req3,
+        status: 200,
+      });
+      await policy.sendRequest(req3, next);
+
+      assert.ok(
+        next.mock.calls[3][0].url.startsWith(ledgerEndpoint),
+        "After transport error, cache should be invalidated",
+      );
+    });
+
+    it("should re-cache after invalidation when new 307 is received", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+      const newPrimary = "https://node5.test-ledger.confidential-ledger.azure.com";
+
+      // Warm cache
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req1, status: 200 });
+      await policy.sendRequest(req1, next);
+
+      // Invalidate with 500 — this write goes to cached primary (call index 2)
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req2, status: 500 });
+      await policy.sendRequest(req2, next);
+
+      // Write again — gets new 307 to different node (call index 3=307, 4=follow)
+      const req3 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${newPrimary}/app/transactions` }),
+        request: req3,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req3, status: 200 });
+      await policy.sendRequest(req3, next);
+
+      // Fourth write should go to NEW cached primary (call index 5)
+      const req4 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req4, status: 200 });
+      await policy.sendRequest(req4, next);
+
+      assert.ok(
+        next.mock.calls[5][0].url.startsWith(newPrimary),
+        `Expected re-cached URL to point to ${newPrimary}`,
+      );
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should keep cache empty when cold-cache write gets transport error", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // First write with empty cache throws transport error
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockRejectedValueOnce(new Error("Connection refused"));
+
+      try {
+        await policy.sendRequest(req1, next);
+        assert.fail("Should have thrown");
+      } catch (e: any) {
+        assert.equal(e.message, "Connection refused");
+      }
+
+      // Second write should still go to LB (cache was never populated)
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[1][0].url.startsWith(ledgerEndpoint),
+        "Cache should remain empty after cold-cache transport error",
+      );
+    });
+
+    it("should rewrite different write paths using same cached base URL", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // POST to /app/transactions gets 307 → cache primary
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions?api-version=2024-12-09-preview`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/transactions?api-version=2024-12-09-preview`,
+        }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // PUT to /app/users/me (different path) should use same cached base
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/users/me?api-version=2024-12-09-preview`,
+        method: "PUT",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      const sentUrl = new URL(next.mock.calls[2][0].url);
+      assert.equal(sentUrl.origin, primaryEndpoint, "Should rewrite to cached primary");
+      assert.equal(sentUrl.pathname, "/app/users/me", "Should preserve different path");
+      assert.equal(
+        sentUrl.searchParams.get("api-version"),
+        "2024-12-09-preview",
+        "Should preserve query params",
+      );
+    });
+
+    it("should follow and cache 308 redirects for write operations", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // POST gets 308 (Permanent Redirect) — should follow AND cache
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+        body: JSON.stringify({ contents: "test" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/transactions`,
+        }),
+        request: req1,
+        status: 308,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // Second write should use cached URL (proving 308 was cached)
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[2][0].url.startsWith(primaryEndpoint),
+        "308 redirect target should be cached and used for subsequent writes",
+      );
+      // Verify method was preserved (308 doesn't convert POST→GET)
+      assert.equal(next.mock.calls[1][0].method, "POST");
+    });
+
+    it("should restore original URL on transport error for clean retry", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // Second write to cached primary throws transport error
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockRejectedValueOnce(new Error("Connection refused"));
+
+      try {
+        await policy.sendRequest(req2, next);
+        assert.fail("Should have thrown");
+      } catch (e: any) {
+        assert.equal(e.message, "Connection refused");
+      }
+
+      // The request URL should have been restored to original (for retry policy)
+      assert.equal(
+        req2.url,
+        `${ledgerEndpoint}/app/transactions`,
+        "Request URL should be restored to original LB URL after transport error",
+      );
+    });
+
+    it("should not cache redirect target after 303 POST-to-GET conversion", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // POST gets 303 → converted to GET → then GET gets 300 redirect
+      // The 300 should NOT populate the cache because the method is now GET
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({
+          Authorization: "Bearer fake-token",
+          "Content-Length": "100",
+        }),
+        body: JSON.stringify({ contents: "test" }),
+      });
+
+      // 303 redirect (POST→GET conversion)
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/result`,
+        }),
+        request: req1,
+        status: 303,
+      });
+      // After 303, method is GET. Now this GET gets a 300 redirect
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `https://other-node.test-ledger.confidential-ledger.azure.com/app/result`,
+        }),
+        request: req1,
+        status: 300,
+      });
+      // Final response
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 200,
+      });
+      await policy.sendRequest(req1, next);
+
+      // Subsequent POST should NOT use cache (303→GET chain should not have cached)
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[3][0].url.startsWith(ledgerEndpoint),
+        "Cache should not be populated after 303 POST→GET conversion",
+      );
+    });
+
+    it("should restore URL and invalidate cache on transport error during redirect follow", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // POST gets 307 redirect, then the follow-up request throws
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+        body: JSON.stringify({ contents: "test" }),
+      });
+
+      // 307 redirect response
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/transactions`,
+        }),
+        request: req1,
+        status: 307,
+      });
+      // Follow-up request to primary throws
+      next.mockRejectedValueOnce(new Error("Primary node down"));
+
+      try {
+        await policy.sendRequest(req1, next);
+        assert.fail("Should have thrown");
+      } catch (e: any) {
+        assert.equal(e.message, "Primary node down");
+      }
+
+      // Request URL should be restored to original LB URL
+      assert.equal(
+        req1.url,
+        `${ledgerEndpoint}/app/transactions`,
+        "URL should be restored after redirect-follow transport error",
+      );
+      // Request method should still be POST
+      assert.equal(req1.method, "POST");
+
+      // Cache should be invalidated — next write goes to LB
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[2][0].url.startsWith(ledgerEndpoint),
+        "Cache should be invalidated after redirect-follow failure",
+      );
+    });
+
+    it("should invalidate cache when redirect-follow returns 5xx for write", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // POST gets 307 redirect, follow-up returns 503
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: `${primaryEndpoint}/app/transactions`,
+        }),
+        request: req1,
+        status: 307,
+      });
+      // Follow-up to primary returns 503
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req1,
+        status: 503,
+      });
+
+      const result = await policy.sendRequest(req1, next);
+      assert.equal(result.status, 503);
+
+      // Cache should be invalidated — next write goes to LB
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[2][0].url.startsWith(ledgerEndpoint),
+        "Cache should be invalidated after redirect-follow 5xx",
+      );
+    });
+
+    it("should NOT invalidate cache when 303 POST→GET conversion results in 5xx", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // First warm the cache with a normal POST→307→200
+      const warm = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: warm,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: warm, status: 200 });
+      await policy.sendRequest(warm, next);
+
+      // POST gets 303 → converted to GET → GET returns 503
+      // The 503 should NOT invalidate cache because the failing request was GET, not POST
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/result` }),
+        request: req1,
+        status: 303,
+      });
+      // After 303 conversion, method is GET. GET returns 503.
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req1, status: 503 });
+      await policy.sendRequest(req1, next);
+
+      // Cache should still be warm — next POST should go to cached primary
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req2, status: 200 });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[4][0].url.startsWith(primaryEndpoint),
+        "Cache should NOT be invalidated by 5xx on a 303-converted GET",
+      );
+    });
+
+    it("should not invalidate cache on read transport error", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm cache
+      const warm = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: warm,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: warm, status: 200 });
+      await policy.sendRequest(warm, next);
+
+      // GET throws transport error — should NOT invalidate write cache
+      const getReq = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions/latest`,
+        method: "GET",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockRejectedValueOnce(new Error("Network error"));
+
+      try {
+        await policy.sendRequest(getReq, next);
+        assert.fail("Should have thrown");
+      } catch (e: any) {
+        assert.equal(e.message, "Network error");
+      }
+
+      // Cache should still be warm — next POST should go to cached primary
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({ headers: createHttpHeaders(), request: req2, status: 200 });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[3][0].url.startsWith(primaryEndpoint),
+        "Read transport error should not invalidate write cache",
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/confidential-ledger`

### Issues associated with this PR

Related to [ADO Task #37485929](https://msazure.visualstudio.com/One/_workitems/edit/37485929) (parent Feature #37442109)

### Describe the problem that is addressed by this PR

When writing to Azure Confidential Ledger, the load balancer redirects write requests (POST/PUT/PATCH/DELETE) to the primary node via a 307 redirect. Every write pays this redirect cost, adding 3-10 seconds of latency per request. This is especially painful for batch workloads that do many sequential writes.

This PR caches the redirect target URL after the first 307/308 redirect so that subsequent writes go directly to the primary node, bringing write latency down to around 230ms.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The design mirrors Ryan Zhang's Python SDK implementation (PR #46254 in azure-sdk-for-python). A closure-based cache variable holds the redirect target URL within the existing confidentialLedgerRedirectPolicy. This was chosen because:

- It keeps cache state per-client (no shared global state between clients)
- It builds on the existing custom redirect policy added in PR #37249
- It matches the behavior of the Python SDK so users get a consistent experience across languages

Cache behavior:
- Write requests (POST/PUT/PATCH/DELETE) that receive a 307/308 cache the target and reuse it on subsequent writes
- Read requests (GET/HEAD) never use or populate the cache
- Server errors (5xx) or transport errors on writes invalidate the cache so the next write goes back through the load balancer
- 303 POST-to-GET conversions do not cache (the method changed, so the target is not guaranteed to be the primary)

### Are there test cases added in this PR?

Yes. 18 new unit tests covering cache population, cache bypass for reads, cache invalidation on errors, and edge cases (308 support, URL restore on transport errors, 303 conversion handling, redirect-follow failures). All 30 tests pass (12 existing + 18 new).

Also live tested against a real ledger (ryan-sdk-acl). Round 1 showed the expected 307 redirect on the first write, and Round 2 showed 0 redirects with 5 direct writes at around 230ms each.

### Provide a list of related PRs

- Ryan Zhang's auth-preservation PR (merged): #37249
- Ryan Zhang's Python SDK caching (reference implementation): [azure-sdk-for-python#46254](https://github.com/Azure/azure-sdk-for-python/pull/46254)

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator? No
- [x] Added a changelog (if necessary)