### PR TITLE
[ContentUnderstanding] Move usage and operationId to AnalysisOperationState

### DIFF
--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0 (2026-04-23)
+## 1.1.0 (2026-04-27)
 
 ### Features Added
 

--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -8,10 +8,9 @@
 - Added `AnalysisOperationMetadata` interface with `usage` and `operationId` fields.
 - Added `usage` on `AnalysisOperationState` to surface billing and token consumption details (`UsageDetails`) after the operation completes. Access via `poller.operationState?.usage`.
 
-### Breaking Changes
+### Deprecations
 
-- `operationId` is no longer a direct property on `AnalysisResultPoller`. Use `poller.operationState?.operationId` instead. The deprecated `poller.operationId` getter is retained for backward compatibility.
-- `usage` is now accessed via `poller.operationState?.usage` instead of `poller.usage`.
+- `poller.operationId` is deprecated. Use `poller.operationState?.operationId` instead.
 
 ## 1.0.0 (2026-02-28)
 

--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ### Features Added
 
-- Added `usage` property on `AnalysisResultPoller` to surface billing and token consumption details (`UsageDetails`) returned by the REST API.
+- Added `AnalysisOperationState` interface that extends `OperationState<AnalysisResult>` with `operationId` and `usage` metadata, following the same pattern used by Form Recognizer (`DocumentAnalysisPollOperationState`) and Storage Blob (`BlobBeginCopyFromUrlPollState`).
+- Added `AnalysisOperationMetadata` interface with `usage` and `operationId` fields.
+- Added `usage` on `AnalysisOperationState` to surface billing and token consumption details (`UsageDetails`) after the operation completes. Access via `poller.operationState?.usage`.
+
+### Breaking Changes
+
+- `operationId` is no longer a direct property on `AnalysisResultPoller`. Use `poller.operationState?.operationId` instead. The deprecated `poller.operationId` getter is retained for backward compatibility.
+- `usage` is now accessed via `poller.operationState?.usage` instead of `poller.usage`.
 
 ## 1.0.0 (2026-02-28)
 

--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Features Added
 
-- Added `AnalysisOperationState` interface that extends `OperationState<AnalysisResult>` with `operationId` and `usage` metadata, following the same pattern used by Form Recognizer (`DocumentAnalysisPollOperationState`) and Storage Blob (`BlobBeginCopyFromUrlPollState`).
-- Added `AnalysisOperationMetadata` interface with `usage` and `operationId` fields.
-- Added `usage` on `AnalysisOperationState` to surface billing and token consumption details (`UsageDetails`) after the operation completes. Access via `poller.operationState?.usage`.
+- Billing and token consumption details are now available after analysis operations complete. Access via `poller.operationState?.usage`.
+- The operation ID is now available on the operation state via `poller.operationState?.operationId`.
 
 ### Deprecations
 

--- a/sdk/contentunderstanding/ai-content-understanding/review/ai-content-understanding-node.api.md
+++ b/sdk/contentunderstanding/ai-content-understanding/review/ai-content-understanding-node.api.md
@@ -40,6 +40,16 @@ export interface AnalysisInput {
 }
 
 // @public
+export interface AnalysisOperationMetadata {
+    readonly operationId?: string;
+    readonly usage?: UsageDetails;
+}
+
+// @public
+export interface AnalysisOperationState extends OperationState_2<AnalysisResult>, AnalysisOperationMetadata {
+}
+
+// @public
 export interface AnalysisResult {
     analyzerId?: string;
     apiVersion?: string;
@@ -49,10 +59,10 @@ export interface AnalysisResult {
     warnings?: ErrorModel[];
 }
 
-// @public (undocumented)
-export interface AnalysisResultPoller extends PollerLike<OperationState_2<AnalysisResult>, AnalysisResult> {
-    operationId?: string;
-    usage?: UsageDetails;
+// @public
+export interface AnalysisResultPoller extends PollerLike<AnalysisOperationState, AnalysisResult> {
+    // @deprecated
+    readonly operationId?: string;
 }
 
 // @public

--- a/sdk/contentunderstanding/ai-content-understanding/samples-dev/analyzeInvoice.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/samples-dev/analyzeInvoice.ts
@@ -190,7 +190,7 @@ export async function main(): Promise<void> {
   //
   // For full pricing details, see:
   // https://learn.microsoft.com/azure/ai-services/content-understanding/pricing-explainer
-  const usage = poller.usage;
+  const usage = poller.operationState?.usage;
   if (usage) {
     console.log("\nUsage Details:");
     if (usage.documentPagesStandard !== undefined) {

--- a/sdk/contentunderstanding/ai-content-understanding/samples-dev/deleteResult.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/samples-dev/deleteResult.ts
@@ -56,10 +56,10 @@ export async function main(): Promise<void> {
   console.log("\nStep 1: Starting document analysis...");
   const poller = client.analyze("prebuilt-invoice", [{ url: documentUrl }]);
 
-  // Get the operation ID from the poller state
+  // Get the operation ID from the operation state
   // We need to wait for at least one poll to get the operation location
   const result = await poller.pollUntilDone();
-  const operationId = poller.operationId;
+  const operationId = poller.operationState?.operationId;
 
   if (!operationId) {
     console.error("Error: Could not extract operation ID from response");

--- a/sdk/contentunderstanding/ai-content-understanding/samples-dev/getResultFile.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/samples-dev/getResultFile.ts
@@ -54,10 +54,10 @@ export async function main(): Promise<void> {
   // Start the analysis operation
   const poller = client.analyze("prebuilt-videoSearch", [{ url: videoUrl }]);
 
-  // Get the operation ID from the poller state
+  // Get the operation ID from the operation state
   // We need to wait for at least one poll to get the operation location
   const result = await poller.pollUntilDone();
-  const operationId = poller.operationId;
+  const operationId = poller.operationState?.operationId;
 
   console.log(`  Operation ID: ${operationId ?? "(unknown)"}`);
   console.log("  Analysis completed!");

--- a/sdk/contentunderstanding/ai-content-understanding/samples/v1/javascript/analyzeInvoice.js
+++ b/sdk/contentunderstanding/ai-content-understanding/samples/v1/javascript/analyzeInvoice.js
@@ -183,7 +183,7 @@ async function main() {
   //
   // For full pricing details, see:
   // https://learn.microsoft.com/azure/ai-services/content-understanding/pricing-explainer
-  const usage = poller.usage;
+  const usage = poller.operationState?.usage;
   if (usage) {
     console.log("\nUsage Details:");
     if (usage.documentPagesStandard !== undefined) {

--- a/sdk/contentunderstanding/ai-content-understanding/samples/v1/javascript/deleteResult.js
+++ b/sdk/contentunderstanding/ai-content-understanding/samples/v1/javascript/deleteResult.js
@@ -52,10 +52,10 @@ async function main() {
   console.log("\nStep 1: Starting document analysis...");
   const poller = client.analyze("prebuilt-invoice", [{ url: documentUrl }]);
 
-  // Get the operation ID from the poller state
+  // Get the operation ID from the operation state
   // We need to wait for at least one poll to get the operation location
   const result = await poller.pollUntilDone();
-  const operationId = poller.operationId;
+  const operationId = poller.operationState?.operationId;
 
   if (!operationId) {
     console.error("Error: Could not extract operation ID from response");

--- a/sdk/contentunderstanding/ai-content-understanding/samples/v1/javascript/getResultFile.js
+++ b/sdk/contentunderstanding/ai-content-understanding/samples/v1/javascript/getResultFile.js
@@ -50,10 +50,10 @@ async function main() {
   // Start the analysis operation
   const poller = client.analyze("prebuilt-videoSearch", [{ url: videoUrl }]);
 
-  // Get the operation ID from the poller state
+  // Get the operation ID from the operation state
   // We need to wait for at least one poll to get the operation location
   const result = await poller.pollUntilDone();
-  const operationId = poller.operationId;
+  const operationId = poller.operationState?.operationId;
 
   console.log(`  Operation ID: ${operationId ?? "(unknown)"}`);
   console.log("  Analysis completed!");

--- a/sdk/contentunderstanding/ai-content-understanding/samples/v1/typescript/src/analyzeInvoice.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/samples/v1/typescript/src/analyzeInvoice.ts
@@ -188,7 +188,7 @@ export async function main(): Promise<void> {
   //
   // For full pricing details, see:
   // https://learn.microsoft.com/azure/ai-services/content-understanding/pricing-explainer
-  const usage = poller.usage;
+  const usage = poller.operationState?.usage;
   if (usage) {
     console.log("\nUsage Details:");
     if (usage.documentPagesStandard !== undefined) {

--- a/sdk/contentunderstanding/ai-content-understanding/samples/v1/typescript/src/deleteResult.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/samples/v1/typescript/src/deleteResult.ts
@@ -54,10 +54,10 @@ export async function main(): Promise<void> {
   console.log("\nStep 1: Starting document analysis...");
   const poller = client.analyze("prebuilt-invoice", [{ url: documentUrl }]);
 
-  // Get the operation ID from the poller state
+  // Get the operation ID from the operation state
   // We need to wait for at least one poll to get the operation location
   const result = await poller.pollUntilDone();
-  const operationId = poller.operationId;
+  const operationId = poller.operationState?.operationId;
 
   if (!operationId) {
     console.error("Error: Could not extract operation ID from response");

--- a/sdk/contentunderstanding/ai-content-understanding/samples/v1/typescript/src/getResultFile.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/samples/v1/typescript/src/getResultFile.ts
@@ -52,10 +52,10 @@ export async function main(): Promise<void> {
   // Start the analysis operation
   const poller = client.analyze("prebuilt-videoSearch", [{ url: videoUrl }]);
 
-  // Get the operation ID from the poller state
+  // Get the operation ID from the operation state
   // We need to wait for at least one poll to get the operation location
   const result = await poller.pollUntilDone();
-  const operationId = poller.operationId;
+  const operationId = poller.operationState?.operationId;
 
   console.log(`  Operation ID: ${operationId ?? "(unknown)"}`);
   console.log("  Analysis completed!");

--- a/sdk/contentunderstanding/ai-content-understanding/src/contentUnderstandingClient.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/src/contentUnderstandingClient.ts
@@ -93,16 +93,31 @@ export interface AnalyzeBinaryOptionalParams extends OperationOptions {
   processingLocation?: ProcessingLocation;
 }
 
-// CUSTOMIZATION: SDK-IMPROVEMENT: Custom poller type that exposes `operationId` for users to call
-// `getResult`, `getResultFile`, and `deleteResult` methods, and `usage` for billing/metering details.
-export interface AnalysisResultPoller extends PollerLike<
-  OperationState<AnalysisResult>,
-  AnalysisResult
-> {
-  /** The operation ID */
-  operationId?: string;
-  /** Usage details of the analyze operation. Available after the operation completes. */
-  usage?: UsageDetails;
+// CUSTOMIZATION: SDK-IMPROVEMENT: Custom operation state and poller types.
+// AnalysisOperationState extends the standard OperationState with operation metadata
+// (operationId for result retrieval, usage for billing/metering details).
+// This follows the same pattern as Form Recognizer's DocumentAnalysisPollOperationState
+// and Storage Blob's BlobBeginCopyFromUrlPollState.
+
+/** Metadata from an analysis operation, available after the operation completes. */
+export interface AnalysisOperationMetadata {
+  /** Usage details of the analyze operation. */
+  readonly usage?: UsageDetails;
+  /** The operation ID, used with `getResultFile` and `deleteResult`. */
+  readonly operationId?: string;
+}
+
+/** The state of an analysis operation, extending the standard OperationState with analysis metadata. */
+export interface AnalysisOperationState
+  extends OperationState<AnalysisResult>, AnalysisOperationMetadata {}
+
+/** A poller for an analysis operation. */
+export interface AnalysisResultPoller extends PollerLike<AnalysisOperationState, AnalysisResult> {
+  /**
+   * The operation ID.
+   * @deprecated Use `operationState?.operationId` instead.
+   */
+  readonly operationId?: string;
 }
 
 export class ContentUnderstandingClient {
@@ -289,16 +304,29 @@ export class ContentUnderstandingClient {
       abortSignal: options?.abortSignal,
       getInitialResponse,
       resourceLocationConfig: "operation-location",
-    }) as AnalysisResultPoller;
+    }) as unknown as AnalysisResultPoller;
 
-    Object.defineProperty(poller, "operationId", {
-      get: () => operationId,
+    // CUSTOMIZATION: SDK-IMPROVEMENT: Override operationState getter to augment the base
+    // OperationState with operationId and usage metadata, following the pattern used by
+    // Form Recognizer (DocumentAnalysisPollOperationState) and Storage Blob (BlobBeginCopyFromUrlPollState).
+    const baseOperationStateDescriptor = Object.getOwnPropertyDescriptor(poller, "operationState");
+    Object.defineProperty(poller, "operationState", {
+      get(): AnalysisOperationState | undefined {
+        const baseState = baseOperationStateDescriptor?.get?.call(poller);
+        if (!baseState) return undefined;
+        return {
+          ...baseState,
+          operationId,
+          usage,
+        };
+      },
       enumerable: true,
-      configurable: false,
+      configurable: true,
     });
 
-    Object.defineProperty(poller, "usage", {
-      get: () => usage,
+    // Backward compatibility: keep operationId directly on the poller (deprecated).
+    Object.defineProperty(poller, "operationId", {
+      get: () => operationId,
       enumerable: true,
       configurable: false,
     });
@@ -352,16 +380,28 @@ export class ContentUnderstandingClient {
       abortSignal: options?.abortSignal,
       getInitialResponse,
       resourceLocationConfig: "operation-location",
-    }) as AnalysisResultPoller;
+    }) as unknown as AnalysisResultPoller;
 
-    Object.defineProperty(poller, "operationId", {
-      get: () => operationId,
+    // CUSTOMIZATION: SDK-IMPROVEMENT: Override operationState getter to augment the base
+    // OperationState with operationId and usage metadata.
+    const baseOperationStateDescriptor = Object.getOwnPropertyDescriptor(poller, "operationState");
+    Object.defineProperty(poller, "operationState", {
+      get(): AnalysisOperationState | undefined {
+        const baseState = baseOperationStateDescriptor?.get?.call(poller);
+        if (!baseState) return undefined;
+        return {
+          ...baseState,
+          operationId,
+          usage,
+        };
+      },
       enumerable: true,
-      configurable: false,
+      configurable: true,
     });
 
-    Object.defineProperty(poller, "usage", {
-      get: () => usage,
+    // Backward compatibility: keep operationId directly on the poller (deprecated).
+    Object.defineProperty(poller, "operationId", {
+      get: () => operationId,
       enumerable: true,
       configurable: false,
     });

--- a/sdk/contentunderstanding/ai-content-understanding/src/contentUnderstandingClient.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/src/contentUnderstandingClient.ts
@@ -321,7 +321,7 @@ export class ContentUnderstandingClient {
         };
       },
       enumerable: true,
-      configurable: true,
+      configurable: false,
     });
 
     // Backward compatibility: keep operationId directly on the poller (deprecated).
@@ -396,7 +396,7 @@ export class ContentUnderstandingClient {
         };
       },
       enumerable: true,
-      configurable: true,
+      configurable: false,
     });
 
     // Backward compatibility: keep operationId directly on the poller (deprecated).

--- a/sdk/contentunderstanding/ai-content-understanding/src/index.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/src/index.ts
@@ -13,6 +13,8 @@ import type {
 export {
   ContentUnderstandingClient,
   type AnalysisResultPoller,
+  type AnalysisOperationMetadata,
+  type AnalysisOperationState,
   type AnalyzeOptionalParams,
   type AnalyzeBinaryOptionalParams,
 } from "./contentUnderstandingClient.js";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/analysis.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/analysis.spec.ts
@@ -55,8 +55,8 @@ describe("ContentUnderstandingClient - Analysis", () => {
     const poller = client.analyzeBinary(testAnalyzerId, pdfBytes);
 
     const analyzeResult = await poller.pollUntilDone();
-    const operationId = poller.operationId!;
-    assert.ok(operationId, "Poller should have operationId");
+    const operationId = poller.operationState?.operationId!;
+    assert.ok(operationId, "operationState should have operationId");
     assert.ok(analyzeResult, "Expected analyzeResult in response");
 
     const contents = analyzeResult?.contents;
@@ -71,8 +71,8 @@ describe("ContentUnderstandingClient - Analysis", () => {
     const poller = client.analyze(testAnalyzerId, [{ url: testUrl }]);
 
     const analyzeResult = await poller.pollUntilDone();
-    const operationId = poller.operationId!;
-    assert.ok(operationId, "Poller should have operationId");
+    const operationId = poller.operationState?.operationId!;
+    assert.ok(operationId, "operationState should have operationId");
     assert.ok(analyzeResult, "Expected analyzeResult in response");
 
     const contents = analyzeResult?.contents;
@@ -86,8 +86,8 @@ describe("ContentUnderstandingClient - Analysis", () => {
     const poller = client.analyze(testAnalyzerId, [{ url: testUrl }]);
 
     const analyzeResult = await poller.pollUntilDone();
-    const operationId = poller.operationId!;
-    assert.ok(operationId, "Poller should have operationId");
+    const operationId = poller.operationState?.operationId!;
+    assert.ok(operationId, "operationState should have operationId");
     assert.ok(analyzeResult, "Expected analyzeResult in response");
 
     const contents = analyzeResult?.contents;

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/analysis.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/analysis.spec.ts
@@ -55,7 +55,7 @@ describe("ContentUnderstandingClient - Analysis", () => {
     const poller = client.analyzeBinary(testAnalyzerId, pdfBytes);
 
     const analyzeResult = await poller.pollUntilDone();
-    const operationId = poller.operationState?.operationId!;
+    const operationId = poller.operationState!.operationId;
     assert.ok(operationId, "operationState should have operationId");
     assert.ok(analyzeResult, "Expected analyzeResult in response");
 
@@ -71,7 +71,7 @@ describe("ContentUnderstandingClient - Analysis", () => {
     const poller = client.analyze(testAnalyzerId, [{ url: testUrl }]);
 
     const analyzeResult = await poller.pollUntilDone();
-    const operationId = poller.operationState?.operationId!;
+    const operationId = poller.operationState!.operationId;
     assert.ok(operationId, "operationState should have operationId");
     assert.ok(analyzeResult, "Expected analyzeResult in response");
 
@@ -86,7 +86,7 @@ describe("ContentUnderstandingClient - Analysis", () => {
     const poller = client.analyze(testAnalyzerId, [{ url: testUrl }]);
 
     const analyzeResult = await poller.pollUntilDone();
-    const operationId = poller.operationState?.operationId!;
+    const operationId = poller.operationState!.operationId;
     assert.ok(operationId, "operationState should have operationId");
     assert.ok(analyzeResult, "Expected analyzeResult in response");
 

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/operationId.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/operationId.spec.ts
@@ -64,6 +64,7 @@ describe("AnalysisResultPoller operationId", () => {
     await poller.poll();
 
     assert.equal(poller.operationId, expectedOperationId);
+    assert.equal(poller.operationState?.operationId, expectedOperationId);
   });
 
   it("should populate operationId from analyze (URL) response header", async () => {
@@ -86,5 +87,6 @@ describe("AnalysisResultPoller operationId", () => {
     await poller.poll();
 
     assert.equal(poller.operationId, expectedOperationId);
+    assert.equal(poller.operationState?.operationId, expectedOperationId);
   });
 });

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeBinary.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeBinary.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for analyzeBinary.ts - Analyze a PDF file from disk.
+ * Sample test for analyzeBinary.ts - Analyze a PDF file from disk.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeConfigs.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeConfigs.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for analyzeConfigs.ts - Extract additional features like charts, formulas.
+ * Sample test for analyzeConfigs.ts - Extract additional features like charts, formulas.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeInvoice.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeInvoice.spec.ts
@@ -84,9 +84,9 @@ describe("Sample: analyzeInvoice", () => {
       console.log(`Pages: ${documentContent.startPageNumber} to ${documentContent.endPageNumber}`);
     }
 
-    // Verify usage details from the poller (available after pollUntilDone completes)
-    const usage = poller.usage;
-    assert.ok(usage, "Poller should have usage after completion");
+    // Verify usage details from operationState (available after pollUntilDone completes)
+    const usage = poller.operationState?.usage;
+    assert.ok(usage, "operationState should have usage after completion");
     assert.isDefined(usage!.contextualizationTokens, "Should have contextualization tokens");
     assert.isDefined(usage!.tokens, "Should have tokens dictionary");
     console.log("\nUsage Details:");

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeInvoice.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeInvoice.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for analyzeInvoice.ts - Analyze an invoice and extract structured fields.
+ * Sample test for analyzeInvoice.ts - Analyze an invoice and extract structured fields.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeReturnRawJson.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeReturnRawJson.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for analyzeReturnRawJson.ts - Return raw JSON from analysis using pipeline policy.
+ * Sample test for analyzeReturnRawJson.ts - Return raw JSON from analysis using pipeline policy.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeUrl.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/analyzeUrl.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for analyzeUrl.ts - Analyze a document from a URL.
+ * Sample test for analyzeUrl.ts - Analyze a document from a URL.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/copyAnalyzer.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/copyAnalyzer.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for copyAnalyzer.ts - Copy an analyzer within the same resource.
+ * Sample test for copyAnalyzer.ts - Copy an analyzer within the same resource.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/createAnalyzer.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/createAnalyzer.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for createAnalyzer.ts - Create a custom analyzer with field schema.
+ * Sample test for createAnalyzer.ts - Create a custom analyzer with field schema.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/createAnalyzerWithLabels.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/createAnalyzerWithLabels.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for createAnalyzerWithLabels.ts - Create a custom analyzer with labeled
+ * Sample test for createAnalyzerWithLabels.ts - Create a custom analyzer with labeled
  * training data.
  */
 

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/createClassifier.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/createClassifier.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for createClassifier.ts - Create a classifier analyzer.
+ * Sample test for createClassifier.ts - Create a classifier analyzer.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/deleteAnalyzer.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/deleteAnalyzer.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for deleteAnalyzer.ts - Delete a custom analyzer.
+ * Sample test for deleteAnalyzer.ts - Delete a custom analyzer.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/deleteResult.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/deleteResult.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for deleteResult.ts - Delete analysis results.
+ * Sample test for deleteResult.ts - Delete analysis results.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/deleteResult.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/deleteResult.spec.ts
@@ -41,7 +41,7 @@ describe("Sample: deleteResult", () => {
 
     // Get the operation ID
 
-    const operationId = poller.operationId;
+    const operationId = poller.operationState?.operationId;
 
     assert.ok(operationId, "Should have operation ID");
     console.log(`Operation ID: ${operationId}`);

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/getAnalyzer.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/getAnalyzer.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for getAnalyzer.ts - Retrieve information about analyzers.
+ * Sample test for getAnalyzer.ts - Retrieve information about analyzers.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/getResultFile.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/getResultFile.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for getResultFile.ts - Retrieve result files from video analysis.
+ * Sample test for getResultFile.ts - Retrieve result files from video analysis.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/getResultFile.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/getResultFile.spec.ts
@@ -50,7 +50,7 @@ describe("Sample: getResultFile", () => {
 
     // Get the operation ID
 
-    const operationId = poller.operationId;
+    const operationId = poller.operationState?.operationId;
 
     console.log(`Operation ID: ${operationId ?? "(unknown)"}`);
     console.log("Analysis completed!");

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/grantCopyAuth.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/grantCopyAuth.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for grantCopyAuth.ts - Grant copy authorization for cross-resource copy.
+ * Sample test for grantCopyAuth.ts - Grant copy authorization for cross-resource copy.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/listAnalyzers.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/listAnalyzers.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for listAnalyzers.ts - List all available analyzers.
+ * Sample test for listAnalyzers.ts - List all available analyzers.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/sampleTestUtils.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/sampleTestUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Shared utilities for sample tests.
+ * Shared utilities for sample tests.
  */
 
 import type { Recorder, TestInfo } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/updateAnalyzer.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/updateAnalyzer.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for updateAnalyzer.ts - Update an existing custom analyzer.
+ * Sample test for updateAnalyzer.ts - Update an existing custom analyzer.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/updateDefaults.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/samples/updateDefaults.spec.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 /**
- * @summary Sample test for updateDefaults.ts - Configure and retrieve default model deployments.
+ * Sample test for updateDefaults.ts - Configure and retrieve default model deployments.
  */
 
 import type { Recorder } from "@azure-tools/test-recorder";

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/usage.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/usage.spec.ts
@@ -187,7 +187,7 @@ describe("AnalysisResultPoller usage", () => {
     const poller = client.analyze("analyzer1", [{ url: "https://test.com/video.mp4" }]);
     await poller.poll();
 
-    const usage = poller.operationState?.usage!;
+    const usage = poller.operationState!.usage!;
     assert.equal(usage.documentPagesMinimal, 2);
     assert.equal(usage.documentPagesBasic, 3);
     assert.equal(usage.documentPagesStandard, 1);

--- a/sdk/contentunderstanding/ai-content-understanding/test/public/node/usage.spec.ts
+++ b/sdk/contentunderstanding/ai-content-understanding/test/public/node/usage.spec.ts
@@ -79,8 +79,8 @@ describe("AnalysisResultPoller usage", () => {
     const poller = client.analyzeBinary("analyzer1", new Uint8Array([1, 2, 3]));
     await poller.poll();
 
-    const usage: UsageDetails | undefined = poller.usage;
-    assert.ok(usage, "Poller should have usage after poll");
+    const usage: UsageDetails | undefined = poller.operationState?.usage;
+    assert.ok(usage, "operationState should have usage after poll");
     assert.equal(usage!.documentPagesBasic, 1);
     assert.equal(usage!.contextualizationTokens, 1234);
     assert.deepEqual(usage!.tokens, {
@@ -110,8 +110,8 @@ describe("AnalysisResultPoller usage", () => {
     const poller = client.analyze("analyzer1", [{ url: "https://test.com/doc.pdf" }]);
     await poller.poll();
 
-    const usage: UsageDetails | undefined = poller.usage;
-    assert.ok(usage, "Poller should have usage after poll");
+    const usage: UsageDetails | undefined = poller.operationState?.usage;
+    assert.ok(usage, "operationState should have usage after poll");
     assert.equal(usage!.documentPagesBasic, 1);
     assert.equal(usage!.audioHours, 0);
     assert.equal(usage!.videoHours, 0);
@@ -128,7 +128,7 @@ describe("AnalysisResultPoller usage", () => {
     (operationsMock._analyzeBinarySend as any).mockResolvedValue(mockResponse);
 
     const poller = client.analyzeBinary("analyzer1", new Uint8Array([1]));
-    assert.isUndefined(poller.usage, "Usage should be undefined before polling");
+    assert.isUndefined(poller.operationState?.usage, "Usage should be undefined before polling");
   });
 
   it("should handle response with no usage field", async () => {
@@ -151,7 +151,10 @@ describe("AnalysisResultPoller usage", () => {
     const poller = client.analyzeBinary("analyzer1", new Uint8Array([1]));
     await poller.poll();
 
-    assert.isUndefined(poller.usage, "Usage should be undefined when not in response");
+    assert.isUndefined(
+      poller.operationState?.usage,
+      "Usage should be undefined when not in response",
+    );
   });
 
   it("should deserialize all usage fields correctly", async () => {
@@ -184,7 +187,7 @@ describe("AnalysisResultPoller usage", () => {
     const poller = client.analyze("analyzer1", [{ url: "https://test.com/video.mp4" }]);
     await poller.poll();
 
-    const usage = poller.usage!;
+    const usage = poller.operationState?.usage!;
     assert.equal(usage.documentPagesMinimal, 2);
     assert.equal(usage.documentPagesBasic, 3);
     assert.equal(usage.documentPagesStandard, 1);
@@ -216,7 +219,7 @@ describe("AnalysisResultPoller usage", () => {
     await poller.poll();
 
     // Deserializer produces a UsageDetails with empty/undefined fields (JS is lenient)
-    const usage = poller.usage;
+    const usage = poller.operationState?.usage;
     assert.ok(usage, "Usage should be populated even with malformed data");
     assert.deepEqual(usage!.tokens, {}, "Malformed tokens should produce empty object");
     assert.isUndefined(usage!.documentPagesBasic, "Non-existent fields should be undefined");


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/ai-content-understanding`

### Issues associated with this PR

Follow-up to PR #38159 API review feedback — reviewer requested that `usage` and `operationId` be surfaced through `operationState` rather than as side-channel properties on the poller.

### Describe the problem that is addressed by this PR

In 1.0.0 and the initial 1.1.0 PR, `operationId` and `usage` were exposed as direct properties on the `AnalysisResultPoller` via `Object.defineProperty`. This is inconsistent with how other Azure SDK JS packages surface LRO metadata — Form Recognizer uses `DocumentAnalysisPollOperationState` and Storage Blob uses `BlobBeginCopyFromUrlPollState`, both extending `OperationState` with additional metadata fields.

This PR moves `usage` and `operationId` to a custom `AnalysisOperationState` that extends `OperationState<AnalysisResult>`, accessed via `poller.operationState?.usage` and `poller.operationState?.operationId`.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

1. **Put `usage` on `AnalysisResult`** — simpler for consumption, but semantically incorrect since `usage` is operation metadata, not part of the analysis result (it's a sibling to `result` in the service response envelope).
2. **Put `usage` on a custom `OperationState`** (chosen) — follows the established pattern from Form Recognizer (`DocumentAnalysisPollOperationState`) and Storage Blob (`BlobBeginCopyFromUrlPollState`). Keeps operation metadata separate from the result type.

### Are there test cases added in this PR? _(If not, why?)_

Yes. Existing unit tests for `usage` (6 tests) and `operationId` (2 tests) updated to use the new `poller.operationState?.usage` and `poller.operationState?.operationId` access pattern. The `operationId` tests also verify the deprecated `poller.operationId` backward-compat getter still works.

### Provide a list of related PRs _(if any)_

- #38159 — Original 1.1.0 PR with `usage` as poller property (API review feedback led to this follow-up)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A — manual customization changes

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)