### PR TITLE
[Confidential Ledger] Add 406/404 LRO retries and built-in GetLedgerE…

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Release History
 
+## 1.1.2-beta.5 (Unreleased)
+
+### Features Added
+
+- Added `getLedgerEntry(client, transactionId, options?)` helper that polls
+  `GET /app/transactions/{transactionId}` until the entry is in the `Ready`
+  state, mirroring the .NET `ConfidentialLedgerClient.GetLedgerEntry` behavior.
+  Up to `MAX_LOADING_RETRIES` (10) additional attempts are made; non-200
+  responses are returned immediately.
+- Added `waitForLedgerEntryCommit(client, transactionId, options?)` helper that
+  polls `GET /app/transactions/{transactionId}/status` with the same retry
+  semantics as the .NET `PostLedgerEntryOperation`:
+  - HTTP 406 is treated as `Pending` indefinitely and resets the
+    consecutive-404 counter.
+  - HTTP 404 is tolerated for up to `MAX_NOT_FOUND_RETRIES` (3) consecutive
+    responses before being surfaced as a failure.
+  - HTTP 200 resets the consecutive-404 counter and returns once `state` is no
+    longer `Pending`.
+- Both helpers honor an optional `AbortSignalLike` and a configurable
+  `pollingIntervalInMs` (default 500ms; tests can set 0 to skip sleeping).
+
+### Other Changes
+
+- Updated the README `Get a Ledger Entry By Transaction Id` sample to use the
+  new `getLedgerEntry` helper, removing the manual polling loop.
+
 ## 1.1.2-beta.4 (2026-02-18)
 
 ### Bugs Fixed

--- a/sdk/confidentialledger/confidential-ledger-rest/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/README.md
@@ -244,8 +244,16 @@ const result = await client.path("/app/transactions").post(ledgerEntry);
 
 ### Get a Ledger Entry By Transaction Id
 
+The service may take some time to make a previously written entry available
+for read. The `getLedgerEntry` helper polls until the entry is in the `Ready`
+state (or returns the last response if the entry is still loading after the
+built-in retry budget). Callers no longer need to write a manual `while` loop.
+
 ```ts snippet:ReadmeSampleGetLedgerEntry
-import ConfidentialLedger, { getLedgerIdentity } from "@azure-rest/confidential-ledger";
+import ConfidentialLedger, {
+  getLedgerIdentity,
+  getLedgerEntry,
+} from "@azure-rest/confidential-ledger";
 import { DefaultAzureCredential } from "@azure/identity";
 
 const { ledgerIdentityCertificate } = await getLedgerIdentity(
@@ -261,13 +269,16 @@ const client = ConfidentialLedger(
 );
 
 const transactionId = "<TRANSACTION_ID>";
-const status = await client.path("/app/transactions/{transactionId}/status", transactionId).get();
+const response = await getLedgerEntry(client, transactionId);
 ```
 
 ### Get a Ledger Entry By Transaction Id With CollectionId
 
 ```ts snippet:ReadmeSampleGetLedgerEntryWithCollectionIdSample
-import ConfidentialLedger, { getLedgerIdentity } from "@azure-rest/confidential-ledger";
+import ConfidentialLedger, {
+  getLedgerIdentity,
+  getLedgerEntry,
+} from "@azure-rest/confidential-ledger";
 import { DefaultAzureCredential } from "@azure/identity";
 
 const { ledgerIdentityCertificate } = await getLedgerIdentity(
@@ -281,15 +292,14 @@ const client = ConfidentialLedger(
   credential,
 );
 const transactionId = "<TRANSACTION_ID>";
-const getLedgerEntryParams = {
-  queryParameters: { collectionId: "my-collection" },
-};
-const result = await client
-  .path("/app/transactions/{transactionId}", transactionId)
-  .get(getLedgerEntryParams);
+const response = await getLedgerEntry(client, transactionId, {
+  collectionId: "my-collection",
+});
 ```
 
 ### Get a Ledger Entry By Transaction Id With CollectionId and Tag
+
+Use the path-based client for advanced query parameters such as `tag`.
 
 ```ts snippet:ReadmeSampleGetLedgerEntryWithCollectionIdAndTagSample
 import ConfidentialLedger, { getLedgerIdentity } from "@azure-rest/confidential-ledger";

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
-  "version": "1.1.2-beta.4",
+  "version": "1.1.2-beta.5",
   "keywords": [
     "node",
     "azure",

--- a/sdk/confidentialledger/confidential-ledger-rest/review/confidential-ledger-node.api.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/review/confidential-ledger-node.api.md
@@ -14,6 +14,16 @@ import type { StreamableMethod } from '@azure-rest/core-client';
 import type { TokenCredential } from '@azure/core-auth';
 
 // @public
+export interface AbortSignalLike {
+    // (undocumented)
+    readonly aborted: boolean;
+    // (undocumented)
+    addEventListener(type: "abort", listener: (this: AbortSignalLike, ev: any) => any): void;
+    // (undocumented)
+    removeEventListener(type: "abort", listener: (this: AbortSignalLike, ev: any) => any): void;
+}
+
+// @public
 export interface ApplicationClaimOutput {
     digest?: ClaimDigestOutput;
     kind: "LedgerEntry" | "ClaimDigest";
@@ -310,6 +320,9 @@ export interface CreateUserDefinedRoleMediaTypesParam {
 // @public (undocumented)
 export type CreateUserDefinedRoleParameters = CreateUserDefinedRoleMediaTypesParam & CreateUserDefinedRoleBodyParam & RequestParameters;
 
+// @public
+export const DEFAULT_POLLING_INTERVAL_IN_MS = 500;
+
 // @public (undocumented)
 export interface DeleteLedgerUser {
     delete(options?: DeleteLedgerUserParameters): StreamableMethod<DeleteLedgerUser204Response | DeleteLedgerUserDefaultResponse>;
@@ -586,6 +599,9 @@ export interface GetLedgerEntry {
 }
 
 // @public
+export function getLedgerEntry(client: ConfidentialLedgerClient, transactionId: string, options?: GetLedgerEntryOptions): Promise<GetLedgerEntryResponse>;
+
+// @public
 export interface GetLedgerEntry200Response extends HttpResponse {
     // (undocumented)
     body: LedgerQueryResultOutput;
@@ -601,6 +617,11 @@ export interface GetLedgerEntryDefaultResponse extends HttpResponse {
     status: string;
 }
 
+// @public
+export interface GetLedgerEntryOptions extends LedgerPollingOptions {
+    collectionId?: string;
+}
+
 // @public (undocumented)
 export type GetLedgerEntryParameters = GetLedgerEntryQueryParam & RequestParameters;
 
@@ -614,6 +635,9 @@ export interface GetLedgerEntryQueryParam {
 export interface GetLedgerEntryQueryParamProperties {
     collectionId?: string;
 }
+
+// @public
+export type GetLedgerEntryResponse = GetLedgerEntry200Response | GetLedgerEntryDefaultResponse;
 
 // @public (undocumented)
 export function getLedgerIdentity(ledgerId: string, identityServiceBaseUrl?: string): Promise<LedgerIdentity>;
@@ -864,6 +888,9 @@ export interface InterpreterReusePolicyOutput {
     key: string;
 }
 
+// @public
+export function isLoadingResponse(response: GetLedgerEntryResponse): boolean;
+
 // @public (undocumented)
 export function isUnexpected(response: GetConstitution200Response | GetConstitutionDefaultResponse): response is GetConstitutionDefaultResponse;
 
@@ -1023,6 +1050,12 @@ export interface LedgerIdentity {
     ledgerId: string;
     // (undocumented)
     ledgerIdentityCertificate: string;
+}
+
+// @public
+export interface LedgerPollingOptions {
+    abortSignal?: AbortSignalLike;
+    pollingIntervalInMs?: number;
 }
 
 // @public
@@ -1223,6 +1256,12 @@ export interface ListUsersDefaultResponse extends HttpResponse {
 
 // @public (undocumented)
 export type ListUsersParameters = RequestParameters;
+
+// @public
+export const MAX_LOADING_RETRIES = 10;
+
+// @public
+export const MAX_NOT_FOUND_RETRIES = 3;
 
 // @public (undocumented)
 export interface Metadata {
@@ -1548,6 +1587,12 @@ export interface UserDefinedFunctionOutput {
     code: string;
     readonly id?: string;
 }
+
+// @public
+export function waitForLedgerEntryCommit(client: ConfidentialLedgerClient, transactionId: string, options?: LedgerPollingOptions): Promise<WaitForLedgerEntryCommitResponse>;
+
+// @public
+export type WaitForLedgerEntryCommitResponse = GetTransactionStatus200Response | GetTransactionStatusDefaultResponse;
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/confidentialledger/confidential-ledger-rest/src/index.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/index.ts
@@ -11,4 +11,17 @@ export * from "./isUnexpected.js";
 export type * from "./outputModels.js";
 export * from "./paginateHelper.js";
 export { type LedgerIdentity, getLedgerIdentity } from "./getLedgerIdentity.js";
+export {
+  getLedgerEntry,
+  waitForLedgerEntryCommit,
+  isLoadingResponse,
+  DEFAULT_POLLING_INTERVAL_IN_MS,
+  MAX_LOADING_RETRIES,
+  MAX_NOT_FOUND_RETRIES,
+  type AbortSignalLike,
+  type GetLedgerEntryOptions,
+  type GetLedgerEntryResponse,
+  type LedgerPollingOptions,
+  type WaitForLedgerEntryCommitResponse,
+} from "./pollingHelpers.js";
 export default ConfidentialLedger;

--- a/sdk/confidentialledger/confidential-ledger-rest/src/pollingHelpers.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/pollingHelpers.ts
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ConfidentialLedgerClient } from "./clientDefinitions.js";
+import type {
+  GetLedgerEntry200Response,
+  GetLedgerEntryDefaultResponse,
+  GetTransactionStatus200Response,
+  GetTransactionStatusDefaultResponse,
+} from "./responses.js";
+
+/**
+ * Minimal structural type compatible with both the global `AbortSignal` and
+ * `@azure/abort-controller`'s `AbortSignalLike`. Defined locally to avoid a
+ * direct dependency on `@azure/abort-controller`.
+ */
+export interface AbortSignalLike {
+  readonly aborted: boolean;
+  addEventListener(type: "abort", listener: (this: AbortSignalLike, ev: any) => any): void;
+  removeEventListener(type: "abort", listener: (this: AbortSignalLike, ev: any) => any): void;
+}
+
+/**
+ * Error thrown when polling is aborted via an {@link AbortSignalLike}.
+ */
+class AbortError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AbortError";
+  }
+}
+
+/**
+ * Default interval, in milliseconds, between polling attempts.
+ */
+export const DEFAULT_POLLING_INTERVAL_IN_MS = 500;
+
+/**
+ * Maximum number of additional attempts that {@link getLedgerEntry} will make
+ * after the initial request when the entry is still in the `Loading` state.
+ *
+ * Mirrors the .NET `MaxLoadingRetries` constant used by
+ * `Azure.Security.ConfidentialLedger.ConfidentialLedgerClient`.
+ */
+export const MAX_LOADING_RETRIES = 10;
+
+/**
+ * Maximum number of consecutive HTTP 404 responses tolerated by
+ * {@link waitForLedgerEntryCommit} before the operation surfaces as failed.
+ *
+ * Mirrors the .NET `MaxNotFoundRetries` constant used by
+ * `Azure.Security.ConfidentialLedger.PostLedgerEntryOperation`.
+ */
+export const MAX_NOT_FOUND_RETRIES = 3;
+
+/**
+ * Options that control polling helpers exposed by this package.
+ */
+export interface LedgerPollingOptions {
+  /**
+   * Interval, in milliseconds, between polling attempts. Defaults to
+   * {@link DEFAULT_POLLING_INTERVAL_IN_MS}. Tests may set this to `0` to avoid
+   * sleeping between attempts.
+   */
+  pollingIntervalInMs?: number;
+  /**
+   * An {@link AbortSignalLike} used to cancel the polling loop between
+   * attempts. The currently in-flight request is also passed this signal.
+   */
+  abortSignal?: AbortSignalLike;
+}
+
+/**
+ * Possible terminal responses for {@link waitForLedgerEntryCommit}. Mirrors the
+ * `GET /transactions/{transactionId}/status` response set.
+ */
+export type WaitForLedgerEntryCommitResponse =
+  | GetTransactionStatus200Response
+  | GetTransactionStatusDefaultResponse;
+
+/**
+ * Possible terminal responses for {@link getLedgerEntry}. Mirrors the
+ * `GET /transactions/{transactionId}` response set.
+ */
+export type GetLedgerEntryResponse = GetLedgerEntry200Response | GetLedgerEntryDefaultResponse;
+
+/**
+ * Options accepted by {@link getLedgerEntry}.
+ */
+export interface GetLedgerEntryOptions extends LedgerPollingOptions {
+  /**
+   * Optional collection identifier. When omitted the service-default collection
+   * is used.
+   */
+  collectionId?: string;
+}
+
+/**
+ * Polls `GET /app/transactions/{transactionId}` until the response represents
+ * a `Ready` ledger entry (HTTP 200 with an `entry` property in the body), the
+ * server returns a terminal non-200 response, the abort signal is triggered,
+ * or {@link MAX_LOADING_RETRIES} additional attempts have been made.
+ *
+ * Mirrors the behavior of `ConfidentialLedgerClient.GetLedgerEntry` in the .NET
+ * Azure.Security.ConfidentialLedger client.
+ *
+ * @param client - The {@link ConfidentialLedgerClient} to poll with.
+ * @param transactionId - Identifier of the transaction whose entry should be
+ *   fetched. Must be a non-empty string.
+ * @param options - Optional polling configuration.
+ * @returns The final response, which may be a `Ready` entry, a terminal
+ *   non-success response, or — if the entry never becomes ready within the
+ *   retry budget — the last `Loading` response.
+ */
+export async function getLedgerEntry(
+  client: ConfidentialLedgerClient,
+  transactionId: string,
+  options: GetLedgerEntryOptions = {},
+): Promise<GetLedgerEntryResponse> {
+  if (!transactionId) {
+    throw new Error("transactionId must be a non-empty string.");
+  }
+
+  const {
+    pollingIntervalInMs = DEFAULT_POLLING_INTERVAL_IN_MS,
+    abortSignal,
+    collectionId,
+  } = options;
+
+  const requestOptions: {
+    abortSignal?: AbortSignalLike;
+    queryParameters?: { collectionId: string };
+  } = {};
+  if (abortSignal) {
+    requestOptions.abortSignal = abortSignal;
+  }
+  if (collectionId) {
+    requestOptions.queryParameters = { collectionId };
+  }
+
+  let response = (await client
+    .path("/app/transactions/{transactionId}", transactionId)
+    .get(requestOptions)) as GetLedgerEntryResponse;
+
+  for (let attempt = 0; attempt < MAX_LOADING_RETRIES; attempt++) {
+    if (!isLoadingResponse(response)) {
+      return response;
+    }
+
+    await delay(pollingIntervalInMs, abortSignal);
+
+    response = (await client
+      .path("/app/transactions/{transactionId}", transactionId)
+      .get(requestOptions)) as GetLedgerEntryResponse;
+  }
+
+  return response;
+}
+
+/**
+ * Polls `GET /app/transactions/{transactionId}/status` until the entry reaches
+ * a terminal state. Mirrors the LRO state machine implemented by
+ * `Azure.Security.ConfidentialLedger.PostLedgerEntryOperation`:
+ *
+ * - HTTP 200 → reset the consecutive-404 counter and continue with normal state
+ *   parsing (returns once `state` is no longer `"Pending"`).
+ * - HTTP 406 → treat as `Pending` indefinitely (no retry cap), reset the
+ *   consecutive-404 counter and continue polling.
+ * - HTTP 404 → increment the consecutive-404 counter; while
+ *   `counter <= {@link MAX_NOT_FOUND_RETRIES}` keep polling, otherwise surface
+ *   the response as the terminal failure.
+ * - Any other status → terminal, returned to the caller.
+ *
+ * @param client - The {@link ConfidentialLedgerClient} to poll with.
+ * @param transactionId - Identifier of the transaction whose commit status
+ *   should be awaited. Must be a non-empty string.
+ * @param options - Optional polling configuration.
+ * @returns The terminal response. Callers should inspect `status` and
+ *   `body.state` to determine whether the operation succeeded.
+ */
+export async function waitForLedgerEntryCommit(
+  client: ConfidentialLedgerClient,
+  transactionId: string,
+  options: LedgerPollingOptions = {},
+): Promise<WaitForLedgerEntryCommitResponse> {
+  if (!transactionId) {
+    throw new Error("transactionId must be a non-empty string.");
+  }
+
+  const { pollingIntervalInMs = DEFAULT_POLLING_INTERVAL_IN_MS, abortSignal } = options;
+  const requestOptions: { abortSignal?: AbortSignalLike } = {};
+  if (abortSignal) {
+    requestOptions.abortSignal = abortSignal;
+  }
+
+  let consecutiveNotFound = 0;
+  let attempt = 0;
+
+  while (true) {
+    if (attempt > 0) {
+      await delay(pollingIntervalInMs, abortSignal);
+    }
+    attempt++;
+
+    const response = (await client
+      .path("/app/transactions/{transactionId}/status", transactionId)
+      .get(requestOptions)) as WaitForLedgerEntryCommitResponse;
+
+    if (response.status === "200") {
+      consecutiveNotFound = 0;
+      const state = (response as GetTransactionStatus200Response).body?.state;
+      if (state !== "Pending") {
+        return response;
+      }
+      continue;
+    }
+
+    if (response.status === "406") {
+      // The node knows the transaction but consensus is still in progress.
+      // Treat as Pending indefinitely.
+      consecutiveNotFound = 0;
+      continue;
+    }
+
+    if (response.status === "404") {
+      consecutiveNotFound++;
+      if (consecutiveNotFound <= MAX_NOT_FOUND_RETRIES) {
+        continue;
+      }
+      return response;
+    }
+
+    return response;
+  }
+}
+
+/**
+ * Returns `true` when the supplied response is an HTTP 200 whose JSON body
+ * does not yet contain an `entry` property — i.e. the service is still loading
+ * the requested historical entry. Non-200 responses, or 200 responses whose
+ * body is not a JSON object, are considered terminal.
+ */
+export function isLoadingResponse(response: GetLedgerEntryResponse): boolean {
+  if (response.status !== "200") {
+    return false;
+  }
+  const body = (response as GetLedgerEntry200Response).body as unknown;
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+  return !("entry" in (body as Record<string, unknown>));
+}
+
+/**
+ * Promise-based delay that honors an optional {@link AbortSignalLike}.
+ *
+ * @internal
+ */
+function delay(timeInMs: number, abortSignal?: AbortSignalLike): Promise<void> {
+  if (timeInMs <= 0) {
+    if (abortSignal?.aborted) {
+      return Promise.reject(new AbortError("The operation was aborted."));
+    }
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const handle: { token: ReturnType<typeof setTimeout> | undefined } = { token: undefined };
+    const onAbort = (): void => {
+      if (handle.token !== undefined) {
+        clearTimeout(handle.token);
+      }
+      abortSignal?.removeEventListener("abort", onAbort);
+      reject(new AbortError("The delay was aborted."));
+    };
+
+    handle.token = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, timeInMs);
+
+    if (abortSignal) {
+      if (abortSignal.aborted) {
+        onAbort();
+        return;
+      }
+      abortSignal.addEventListener("abort", onAbort);
+    }
+  });
+}

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/pollingHelpers.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/pollingHelpers.spec.ts
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert, vi } from "vitest";
+import type { ConfidentialLedgerClient } from "../../src/clientDefinitions.js";
+import {
+  getLedgerEntry,
+  isLoadingResponse,
+  MAX_LOADING_RETRIES,
+  MAX_NOT_FOUND_RETRIES,
+  waitForLedgerEntryCommit,
+} from "../../src/pollingHelpers.js";
+
+interface FakeResponse {
+  status: string;
+  body?: unknown;
+}
+
+/**
+ * Builds a minimal fake {@link ConfidentialLedgerClient} whose `.path(...).get()`
+ * dispatches to a per-path queue of pre-canned responses. Each path is keyed by
+ * its template (e.g. `/app/transactions/{transactionId}`).
+ */
+function createFakeClient(responsesByPath: Record<string, FakeResponse[]>): {
+  client: ConfidentialLedgerClient;
+  callsByPath: Record<string, number>;
+} {
+  const callsByPath: Record<string, number> = {};
+
+  const client = {
+    path: (pathTemplate: string, ..._args: unknown[]) => {
+      return {
+        get: async (_options?: unknown) => {
+          callsByPath[pathTemplate] = (callsByPath[pathTemplate] ?? 0) + 1;
+          const queue = responsesByPath[pathTemplate];
+          if (!queue || queue.length === 0) {
+            throw new Error(`No more mock responses queued for path ${pathTemplate}`);
+          }
+          // Replay the last response if the queue is exhausted but still has items.
+          const next = queue.length === 1 ? queue[0] : queue.shift()!;
+          return next;
+        },
+      };
+    },
+  } as unknown as ConfidentialLedgerClient;
+
+  return { client, callsByPath };
+}
+
+async function assertThrowsAsync(fn: () => Promise<unknown>, expected: RegExp): Promise<void> {
+  let error: unknown;
+  try {
+    await fn();
+  } catch (err) {
+    error = err;
+  }
+  assert.ok(error, "Expected promise to reject but it resolved");
+  assert.match((error as Error).message, expected);
+}
+
+describe("pollingHelpers / isLoadingResponse", () => {
+  it("returns true for HTTP 200 with no entry property", () => {
+    assert.isTrue(isLoadingResponse({ status: "200", body: { state: "Loading" } } as never));
+  });
+
+  it("returns false for HTTP 200 with an entry property", () => {
+    assert.isFalse(
+      isLoadingResponse({
+        status: "200",
+        body: { state: "Ready", entry: { contents: "hi" } },
+      } as never),
+    );
+  });
+
+  it("returns false for non-200 responses", () => {
+    assert.isFalse(isLoadingResponse({ status: "404", body: {} } as never));
+  });
+
+  it("returns false for responses whose body is not a JSON object", () => {
+    assert.isFalse(isLoadingResponse({ status: "200", body: "not-json" } as never));
+    assert.isFalse(isLoadingResponse({ status: "200", body: undefined } as never));
+  });
+});
+
+describe("pollingHelpers / getLedgerEntry", () => {
+  const PATH = "/app/transactions/{transactionId}";
+
+  it("returns immediately on first call when the entry is Ready", async () => {
+    const ready: FakeResponse = {
+      status: "200",
+      body: { state: "Ready", entry: { contents: "hello", transactionId: "1.1" } },
+    };
+    const { client, callsByPath } = createFakeClient({ [PATH]: [ready] });
+
+    const result = await getLedgerEntry(client, "1.1", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.deepEqual(result.body, ready.body);
+    assert.equal(callsByPath[PATH], 1);
+  });
+
+  it("polls multiple times while the body is Loading, then returns Ready", async () => {
+    const loading: FakeResponse = { status: "200", body: { state: "Loading" } };
+    const ready: FakeResponse = {
+      status: "200",
+      body: { state: "Ready", entry: { contents: "value", transactionId: "2.2" } },
+    };
+    const { client, callsByPath } = createFakeClient({
+      [PATH]: [loading, loading, loading, ready],
+    });
+
+    const result = await getLedgerEntry(client, "2.2", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.deepEqual(result.body, ready.body);
+    // 1 initial + 3 polls
+    assert.equal(callsByPath[PATH], 4);
+  });
+
+  it("stops after MaxLoadingRetries + 1 calls when the entry never becomes Ready", async () => {
+    const loading: FakeResponse = { status: "200", body: { state: "Loading" } };
+    // Single-element queues are replayed indefinitely by the fake client.
+    const { client, callsByPath } = createFakeClient({ [PATH]: [loading] });
+
+    const result = await getLedgerEntry(client, "3.3", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.deepEqual(result.body, loading.body);
+    assert.equal(callsByPath[PATH], MAX_LOADING_RETRIES + 1);
+  });
+
+  it("does not retry on a non-200 response", async () => {
+    const notFound: FakeResponse = { status: "404", body: { error: { message: "missing" } } };
+    const { client, callsByPath } = createFakeClient({ [PATH]: [notFound] });
+
+    const result = await getLedgerEntry(client, "4.4", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "404");
+    assert.equal(callsByPath[PATH], 1);
+  });
+
+  it("throws on a null/empty transactionId", async () => {
+    const { client } = createFakeClient({});
+    await assertThrowsAsync(
+      () => getLedgerEntry(client, "", { pollingIntervalInMs: 0 }),
+      /transactionId/,
+    );
+    await assertThrowsAsync(
+      () => getLedgerEntry(client, undefined as unknown as string, { pollingIntervalInMs: 0 }),
+      /transactionId/,
+    );
+  });
+
+  it("forwards collectionId as a query parameter when provided", async () => {
+    const ready: FakeResponse = {
+      status: "200",
+      body: { state: "Ready", entry: { contents: "hi", transactionId: "5.5" } },
+    };
+    const get = vi.fn().mockResolvedValue(ready);
+    const client = {
+      path: vi.fn().mockReturnValue({ get }),
+    } as unknown as ConfidentialLedgerClient;
+
+    await getLedgerEntry(client, "5.5", {
+      pollingIntervalInMs: 0,
+      collectionId: "my-collection",
+    });
+
+    assert.deepEqual(get.mock.calls[0][0], {
+      queryParameters: { collectionId: "my-collection" },
+    });
+  });
+});
+
+describe("pollingHelpers / waitForLedgerEntryCommit (PostLedgerEntry LRO)", () => {
+  const STATUS_PATH = "/app/transactions/{transactionId}/status";
+
+  it("returns immediately when the very first response is Committed", async () => {
+    const committed: FakeResponse = {
+      status: "200",
+      body: { state: "Committed", transactionId: "1.1" },
+    };
+    const { client, callsByPath } = createFakeClient({ [STATUS_PATH]: [committed] });
+
+    const result = await waitForLedgerEntryCommit(client, "1.1", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.equal(callsByPath[STATUS_PATH], 1);
+  });
+
+  it("treats HTTP 406 as Pending and keeps polling indefinitely", async () => {
+    const pending406: FakeResponse = { status: "406", body: { error: { message: "no quorum" } } };
+    const committed: FakeResponse = {
+      status: "200",
+      body: { state: "Committed", transactionId: "2.2" },
+    };
+    const { client, callsByPath } = createFakeClient({
+      // > 3 consecutive 406s should be tolerated (no retry cap).
+      [STATUS_PATH]: [pending406, pending406, pending406, pending406, pending406, committed],
+    });
+
+    const result = await waitForLedgerEntryCommit(client, "2.2", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.equal((result as { body: { state: string } }).body.state, "Committed");
+    assert.equal(callsByPath[STATUS_PATH], 6);
+  });
+
+  it("tolerates up to MAX_NOT_FOUND_RETRIES consecutive 404s and then succeeds", async () => {
+    const notFound: FakeResponse = { status: "404", body: { error: { message: "unknown txn" } } };
+    const committed: FakeResponse = {
+      status: "200",
+      body: { state: "Committed", transactionId: "3.3" },
+    };
+    const { client, callsByPath } = createFakeClient({
+      [STATUS_PATH]: [notFound, notFound, notFound, committed],
+    });
+
+    const result = await waitForLedgerEntryCommit(client, "3.3", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.equal(callsByPath[STATUS_PATH], 4);
+  });
+
+  it("surfaces failure after MAX_NOT_FOUND_RETRIES + 1 consecutive 404s", async () => {
+    const notFound: FakeResponse = { status: "404", body: { error: { message: "unknown txn" } } };
+    const { client, callsByPath } = createFakeClient({ [STATUS_PATH]: [notFound] });
+
+    const result = await waitForLedgerEntryCommit(client, "4.4", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "404");
+    // 1 initial + MAX_NOT_FOUND_RETRIES additional polls before surfacing failure.
+    assert.equal(callsByPath[STATUS_PATH], MAX_NOT_FOUND_RETRIES + 1);
+  });
+
+  it("resets the consecutive-404 counter on a 200 response", async () => {
+    const notFound: FakeResponse = { status: "404", body: { error: { message: "unknown" } } };
+    const pending: FakeResponse = {
+      status: "200",
+      body: { state: "Pending", transactionId: "5.5" },
+    };
+    const committed: FakeResponse = {
+      status: "200",
+      body: { state: "Committed", transactionId: "5.5" },
+    };
+    // 3x 404 (counter -> 3), 200 Pending (counter reset), 3x 404 again (counter -> 3),
+    // then Committed. Without the reset this would exceed MAX_NOT_FOUND_RETRIES.
+    const { client, callsByPath } = createFakeClient({
+      [STATUS_PATH]: [
+        notFound,
+        notFound,
+        notFound,
+        pending,
+        notFound,
+        notFound,
+        notFound,
+        committed,
+      ],
+    });
+
+    const result = await waitForLedgerEntryCommit(client, "5.5", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "200");
+    assert.equal((result as { body: { state: string } }).body.state, "Committed");
+    assert.equal(callsByPath[STATUS_PATH], 8);
+  });
+
+  it("resets the consecutive-404 counter on a 406 response", async () => {
+    const notFound: FakeResponse = { status: "404", body: { error: { message: "unknown" } } };
+    const pending406: FakeResponse = { status: "406", body: { error: { message: "no quorum" } } };
+    const committed: FakeResponse = {
+      status: "200",
+      body: { state: "Committed", transactionId: "6.6" },
+    };
+    const { client } = createFakeClient({
+      [STATUS_PATH]: [
+        notFound,
+        notFound,
+        notFound,
+        pending406,
+        notFound,
+        notFound,
+        notFound,
+        committed,
+      ],
+    });
+
+    const result = await waitForLedgerEntryCommit(client, "6.6", { pollingIntervalInMs: 0 });
+    assert.equal(result.status, "200");
+  });
+
+  it("returns terminal non-200/404/406 responses unchanged", async () => {
+    const serverError: FakeResponse = { status: "500", body: { error: { message: "boom" } } };
+    const { client, callsByPath } = createFakeClient({ [STATUS_PATH]: [serverError] });
+
+    const result = await waitForLedgerEntryCommit(client, "7.7", { pollingIntervalInMs: 0 });
+
+    assert.equal(result.status, "500");
+    assert.equal(callsByPath[STATUS_PATH], 1);
+  });
+
+  it("throws on a null/empty transactionId", async () => {
+    const { client } = createFakeClient({});
+    await assertThrowsAsync(
+      () => waitForLedgerEntryCommit(client, "", { pollingIntervalInMs: 0 }),
+      /transactionId/,
+    );
+  });
+});

--- a/sdk/confidentialledger/confidential-ledger-rest/test/snippets.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/snippets.spec.ts
@@ -4,6 +4,7 @@
 import ConfidentialLedger, {
   CreateLedgerEntryParameters,
   LedgerEntry,
+  getLedgerEntry,
   getLedgerIdentity,
   isUnexpected,
 } from "../src/index.js";
@@ -137,9 +138,7 @@ describe("snippets", () => {
     );
     // @ts-preserve-whitespace
     const transactionId = "<TRANSACTION_ID>";
-    const status = await client
-      .path("/app/transactions/{transactionId}/status", transactionId)
-      .get();
+    const response = await getLedgerEntry(client, transactionId);
   });
 
   it("ReadmeSampleGetLedgerEntryWithCollectionIdSample", async () => {
@@ -154,12 +153,9 @@ describe("snippets", () => {
       credential,
     );
     const transactionId = "<TRANSACTION_ID>";
-    const getLedgerEntryParams = {
-      queryParameters: { collectionId: "my-collection" },
-    };
-    const result = await client
-      .path("/app/transactions/{transactionId}", transactionId)
-      .get(getLedgerEntryParams);
+    const response = await getLedgerEntry(client, transactionId, {
+      collectionId: "my-collection",
+    });
   });
 
   it("ReadmeSampleGetLedgerEntryWithCollectionIdAndTagSample", async () => {


### PR DESCRIPTION
…ntry polling

Mirrors the .NET Azure.Security.ConfidentialLedger client behavior:

- Adds `getLedgerEntry(client, transactionId, options?)` that polls GET /app/transactions/{transactionId} until the response carries a Ready entry (or up to MAX_LOADING_RETRIES = 10 additional attempts). Non-200 responses are returned immediately.

- Adds `waitForLedgerEntryCommit(client, transactionId, options?)`, the post-ledger-entry LRO state machine. It treats HTTP 406 as Pending indefinitely (resetting the consecutive-404 counter), tolerates up to MAX_NOT_FOUND_RETRIES = 3 consecutive 404s, surfaces failure on the 4th, and resets the 404 counter on every 200/406 response.

- Both helpers honor an AbortSignalLike and a configurable pollingIntervalInMs (default 500ms; tests use 0).

- Adds mock-transport unit tests covering all scenarios from the prompt: immediate Ready, repeated Loading then Ready, exhausted retry budget, non-200 short-circuit, argument validation, 406 indefinite retry, 3 then 1 success 404 streak, 4 consecutive 404 failure, 200/406 counter reset, terminal 500.

- Updates the README "Get a Ledger Entry By Transaction Id" sample to use the new helper, removing the manual polling loop.


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
