### PR TITLE
[engsys] Add create-package-skill

### DIFF
--- a/.github/skills/create-package-skill/SKILL.md
+++ b/.github/skills/create-package-skill/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-package-skill
+description: 'Interactive wizard that walks service teams through creating a package-specific skill for their Azure SDK package. Scans the package, detects customization patterns, scaffolds a SKILL.md with references, validates with vally lint, and registers in find-package-skill. WHEN: create package skill; add service skill; bootstrap skill for package; new package skill; skill for my SDK package; write skill for search; write skill for cosmos.'
+---
+
+# Create Package Skill Wizard
+
+> **Minimal beats comprehensive. Human-written beats auto-generated. Scaffold and iterate.**
+
+> Skills encode tribal knowledge — the "I wish someone had told me" stuff that's hard to learn from just reading code. Focus on what's non-obvious and package-specific.
+
+## Interaction Protocols
+
+**CONFIRM Protocol** (asset-producing steps — creating files):
+1. PRESENT the proposed assets and explain why.
+2. ASK exactly one question: "Create now (recommended), edit first, or skip?"
+3. ACT immediately. Create → write files this turn. Edit → refine, re-ask. Skip → move on.
+
+**DECIDE Protocol** (informational/correction steps — no files created):
+1. PRESENT the information or findings.
+2. ASK one specific question appropriate to the decision.
+3. PROCEED based on the answer.
+
+One question at a time. Respect "skip" — never re-ask or defer.
+
+## Wizard Flow
+
+Run each phase in order. **Progressive loading:** Read only the current phase file.
+
+| Phase | Description | Instructions |
+|---|---|---|
+| **Phase 0** | 🧭 Scan Package — detect architecture, customizations, key files | [phases/00-scan-package.md](phases/00-scan-package.md) |
+| **Phase 1** | 📝 Scaffold SKILL.md — generate skill with common pitfalls, architecture, workflow | [phases/01-scaffold-skill.md](phases/01-scaffold-skill.md) |
+| **Phase 2** | 📚 Generate References — create architecture.md and customization.md | [phases/02-generate-references.md](phases/02-generate-references.md) |
+| **Phase 3** | ✅ Validate — run vally lint | [phases/03-validate.md](phases/03-validate.md) |
+| **Phase 4** | 📋 Register — add to find-package-skill table | [phases/04-register.md](phases/04-register.md) |
+
+## Guardrails
+
+**Content:**
+- Every line must be non-obvious and package-specific. No generic TypeScript/SDK patterns.
+- SKILL.md should be under 500 tokens (soft limit). Move details to references/.
+- References under 1000 tokens each. Split if larger.
+- Never duplicate what's already in `.github/copilot-instructions.md` or shared skills.
+
+**Relationship to existing SDK tools:**
+- Package skills **complement** the Azure SDK MCP tools (`azsdk_package_generate_code`, `azsdk_package_build_code`, etc.) and the `sdk-workflow` shared skill — they do NOT replace them.
+- MCP tools handle deterministic operations (generate, build, test). Package skills provide the reasoning context an agent needs to use those tools correctly for a specific package.
+- Never redefine how generation, building, or testing works — reference the existing tools instead (e.g., "Run `npm run generate:client`", not custom generation steps).
+- If a workflow step is already handled by an MCP tool or shared skill, just reference it — don't re-document it.
+
+**Structure:**
+- Skill directory: `sdk/<service>/<package>/.github/skills/<skill-name>/`
+- Directory name MUST match `name` field in frontmatter (vally lint enforces this).
+- Use semicolons to separate trigger phrases in description (YAML-safe).
+
+**Security:**
+- Never embed secrets or credentials in skill content.
+- Never instruct agents to bypass CI, linters, or eslint rules.
+- Never instruct agents to edit files in `generated/` directly — always route through the customization workflow or TypeSpec decorators.
+
+## Key Principles (from eval data)
+
+Our eval showed that skill **structure** matters more than **volume**:
+
+| Pattern | Impact |
+|---|---|
+| "Common Pitfalls" section at the TOP | Agent reads pitfalls before analyzing errors → correct diagnosis |
+| "Check X FIRST" directives | Changes agent default from "fix the error location" to "check the customization layer" |
+| Error categorization tables | Gives agent a decision framework, not just procedures |
+| `generated/` vs `src/` distinction | Agent knows which files are safe to edit and which will be overwritten |
+
+## References (load on demand)
+
+- [references/skill-template.md](references/skill-template.md) — SKILL.md template with required sections
+- [references/validation-tools.md](references/validation-tools.md) — vally lint, CI workflow setup

--- a/.github/skills/create-package-skill/phases/00-scan-package.md
+++ b/.github/skills/create-package-skill/phases/00-scan-package.md
@@ -1,0 +1,77 @@
+# Phase 0: Scan Package 🧭
+
+> 📍 **Phase 0 — Scan Package** | Detect the package's architecture, customization patterns, and key files.
+
+## Step 1 — Identify the Package
+
+Ask the user: "Which SDK package should I create a skill for?"
+
+The user should provide either:
+- A package name (e.g., `@azure/search-documents`, `@azure/cosmos`, `@azure-rest/purview-catalog`)
+- A path (e.g., `sdk/search/search-documents`, `sdk/cosmos/cosmos`)
+
+Resolve to the package root directory. Verify it exists and contains `package.json` or `tsp-location.yaml`.
+
+## Step 2 — Scan the Package
+
+Scan the package using the checklist below. Use glob/grep/view tools.
+
+### Scan Checklist
+
+1. **Code generation**: Check for `tsp-location.yaml` → TypeSpec-generated package. If present, note the spec directory and commit SHA.
+
+2. **Customization layout**: Check for a `generated/` directory → customization workflow is set up (via `dev-tool customization init`). If present, the package uses the two-directory layout:
+   - `generated/` — auto-generated from TypeSpec. Never hand-edit.
+   - `src/` — mirrors `generated/` structure plus hand-authored convenience layer.
+
+3. **Source layout**: Glob `src/**/*.{ts,mts,cts}` and `generated/**/*.{ts,mts,cts}` → count files. Identify modules (clients, models, api, helpers, etc.).
+
+4. **Hand-written vs generated**: Files in `generated/` are auto-generated. Files in `src/` that have a counterpart in `generated/` are merged copies. Files in `src/` with NO counterpart in `generated/` are purely hand-authored. List the hand-authored files.
+
+5. **Barrel export and entrypoints**: Check `src/index.ts` for the barrel export. Check `package.json` `exports` field for subpath entrypoints. If the generation script uses `--skip index.ts`, note that the barrel export must be manually maintained.
+
+6. **Generation script**: Check `package.json` scripts for generation-related commands. Common patterns:
+   - `generate:client` — runs TypeSpec generation + formatting + customization apply
+   - `customize` — runs customization apply separately
+   - `echo skipped` — generation is disabled for this package
+   - Note the exact script content and flags (e.g., `--skip index.ts`, `customization apply` vs `customization apply-v2`, emitter options). Do NOT assume the script shape — read the actual value.
+
+7. **Key hand-written files**: Look for non-generated utility files in `src/` (e.g., custom clients, type converters, serializers, helper utilities, custom models).
+
+8. **Tests**: Check `test/` structure. Look for `assets.json` (recorded tests), test config files (`vitest.config.ts`), and test patterns (`*.spec.ts`). Note if there are separate node/browser test configs.
+
+9. **Package metadata**: Read `package.json` for package name (may be `@azure/*` or `@azure-rest/*`), dependencies (especially `@azure/core-*` packages), and any notable scripts.
+
+10. **Package shape classification**: Based on the scan, classify the package:
+    - **TypeSpec + modular customization** — has `tsp-location.yaml`, `generated/`, `src/`, and `dev-tool customization apply` in a script
+    - **TypeSpec, no active customization** — has `tsp-location.yaml` and generation script, but no `generated/` directory or customization apply
+    - **Mostly hand-authored** — no `tsp-location.yaml` or generation is disabled (`echo skipped`)
+
+## Step 3 — Present Package Profile
+
+Print a concise summary:
+
+📋 **Package Profile**
+
+| Field | Value |
+|---|---|
+| Package | `@azure/<name>` or `@azure-rest/<name>` |
+| Path | `sdk/<service>/<package-name>` |
+| Package shape | TypeSpec + customization / TypeSpec only / Hand-authored |
+| Customization layout | Yes/No (`generated/` + `src/` with 3-way merge) |
+| Source files | N generated, M hand-written |
+| Barrel export | `src/index.ts` — manually maintained / auto-generated |
+| Generation command | Actual script content from `package.json` |
+| Entrypoints | `package.json` exports map (if subpath exports exist) |
+| Tests | Unit: Y, Live: Y/N, Recorded: Y/N |
+| Key hand-written files | List discovered files |
+
+## Step 4 — DECIDE
+
+Question: "Does this profile look right? Anything to add or correct?"
+
+📍 **Phase 0 complete** | Package scanned | Next: Phase 1
+
+---
+## → Next: Phase 1 — Scaffold SKILL.md
+Read [01-scaffold-skill.md](01-scaffold-skill.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/01-scaffold-skill.md
+++ b/.github/skills/create-package-skill/phases/01-scaffold-skill.md
@@ -1,0 +1,99 @@
+# Phase 1: Scaffold SKILL.md 📝
+
+> 📍 **Phase 1 — Scaffold SKILL.md** | Generate the main skill file with key sections.
+
+> 📖 Read `references/skill-template.md` for the full template.
+
+Using the package profile from Phase 0, generate a `SKILL.md` at:
+```
+sdk/<service>/<package-name>/.github/skills/<package-short-name>/SKILL.md
+```
+
+The skill directory name MUST match the `name` field in frontmatter. Use the short package name without the `@azure/` or `@azure-rest/` scope (e.g., `search-documents`, `cosmos`, `purview-catalog`). This is enforced by vally lint.
+
+## Content Principles
+
+- **Keep it static.** Document architecture, design patterns, and convenience layer patterns — things that rarely change. Do NOT include version numbers, current API versions, or anything that changes every release. The skill should be valid for years, not months.
+- **Point to source code, not hardcoded lists.** When referencing things that change (method names, type names, enum values), point the agent to the authoritative source file instead of enumerating values in the skill.
+- **Prefer TypeSpec customizations over source-level customizations.** When documenting customization patterns, always note: "Use source-level customizations (editing `src/` files) when TypeSpec cannot express the desired behavior. For TypeSpec-level customizations (preferred when possible), see [TypeSpec Client Customizations Reference](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/knowledge/customizing-client-tsp.md)."
+- **Don't re-document MCP tools or shared skills.** The `sdk-workflow` shared skill and MCP tools (`azsdk_package_generate_code`, `azsdk_package_build_code`, etc.) already handle generation, build, and testing workflows. The package skill adds only what those tools don't know.
+- **Focus on the convenience layer — when it exists.** The highest-value content is: how is the package designed, what convenience patterns exist, what does the agent need to know to write/maintain the convenience layer correctly. For mostly-generated or thin-wrapper packages, focus instead on entrypoints, exports, generation workflow, and any thin wrappers.
+
+## Required Sections
+
+### 1. Frontmatter
+
+```yaml
+---
+name: <package-short-name>
+description: '<Brief description>. WHEN: regenerate <package>; modify <package>; fix <package> bug; add <package> feature; <package> tsp-client update.'
+---
+```
+
+Use semicolons for trigger phrases (YAML-safe). Include package name in every trigger.
+
+### 2. Common Pitfalls (MUST be first section after heading)
+
+List the most dangerous mistakes. Include items **conditionally based on the package shape** detected in Phase 0:
+
+- **Never hand-edit files in `generated/`** — these are overwritten on every `tsp-client update`. All modifications go through editing `src/` files directly (the 3-way merge preserves your changes).
+- **(If customization layout exists)** **"Check for merge conflicts in `src/` FIRST after regeneration"** — `dev-tool customization apply` performs a 3-way merge that can produce conflict markers.
+- **(If `--skip index.ts` detected in generation script)** **`src/index.ts` is skipped during customization apply** — new exports must be manually added to the barrel export file.
+- **(If customization layout exists)** **"Hand-authored files in `src/` with counterparts in `generated/` are merged. Files without counterparts are preserved as-is."**
+- **(If mostly generated / thin wrapper)** Focus pitfalls on generation workflow, entrypoints, and exports — not convenience layer patterns.
+- Any package-specific gotchas found during scanning
+
+### 3. Architecture
+
+- Source layout with `generated/` vs `src/` distinction
+- Customization mechanism (`dev-tool customization apply`)
+- Key modules and their purpose
+
+### 4. Regeneration
+
+**Do NOT re-document the generation/build/test workflow.** The `sdk-workflow` shared skill and MCP tools handle that. The package skill adds only:
+
+- **Package-specific generation command** — document the actual script content from `package.json` (detected in Phase 0). Note any special flags. Do NOT assume the command shape — different packages use different scripts (`generate:client`, `customize`, `customization apply-v2`, or generation may be disabled).
+- **Error categorization table** — which file to fix based on error type:
+  - **(If customization layout)** Generated file in `generated/`, merged file in `src/`, hand-authored file in `src/`
+  - **(If no customization layout)** Generated file in `src/`, hand-authored file in `src/`
+- **Package-specific customization patterns** — what hand-authored files do and when they need updating
+- **Breaking change detection** — what to look for after spec changes
+- **(If service version management detected)** How the package handles API versions
+
+### 5. Where to Make Changes
+
+Add a table mapping goals to edit locations:
+
+| Goal | Where to edit |
+|---|---|
+| Add/modify type conversions | `src/<relevant-utils>.ts` |
+| Add/modify public model types | `src/<relevant-models>.ts` |
+| Change how operations work | `src/<relevant-client>.ts` |
+| Export a new public symbol | `src/index.ts` |
+
+**Prefer extension points over editing generated-mirrored code.** Many files in `src/` are copies from `generated/` and will be updated on regeneration (via 3-way merge). Instead, add conversion helpers or custom models in hand-authored files.
+
+### 6. Testing Notes
+
+How to run tests, recorded test setup, environment requirements.
+
+### 7. References table
+
+Link to `references/architecture.md` and `references/customization.md`.
+
+## Step 1 — Present
+
+Generate the full SKILL.md content and print it. Use the package profile to fill in package-specific details. Mark sections where domain expertise is needed with `<!-- TODO: Domain expert to fill in -->`.
+
+## Step 2 — CONFIRM
+
+Question: "Create this SKILL.md now (recommended), edit first, or skip?"
+
+If confirmed, create the skill directory and SKILL.md file.
+
+📍 **Phase 1 complete** | Created: SKILL.md | Next: Phase 2
+
+---
+## → Next: Phase 2 — Generate References
+Read [02-generate-references.md](02-generate-references.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/02-generate-references.md
+++ b/.github/skills/create-package-skill/phases/02-generate-references.md
@@ -1,0 +1,49 @@
+# Phase 2: Generate References 📚
+
+> 📍 **Phase 2 — Generate References** | Create supporting reference documents.
+
+## references/architecture.md
+
+Generate from the package scan. Include:
+
+- **Repository layout** — directory tree with `generated/` vs `src/` annotations
+- **Source layout** — module structure under `src/` (clients, models, helpers, etc.)
+- **Code generation** — toolchain (`TypeSpec → emitter → generated/ → dev-tool customization apply → src/`), `tsp-location.yaml` format
+- **Generated vs hand-authored** — table showing mechanism, location, when to use
+- **Public client types** — all client classes and their purpose
+- **Key hand-authored files** — table of important files in `src/` that don't exist in `generated/`
+- **Dependencies** — runtime and dev dependencies from `package.json`
+- **Build and test commands** — `pnpm turbo build --filter=@azure/<package>... --token 1`, `pnpm run test`
+
+**Important**: Only include information that is accurate based on scanning the actual code. Mark anything uncertain with `<!-- TODO: Verify -->`.
+
+## references/customization.md (if customization layout exists)
+
+Generate from comparing `generated/` and `src/`. Document:
+
+- **The customization command** — document the actual command detected in Phase 0 (e.g., `dev-tool customization apply`, `customization apply-v2`). Include required flags and prerequisites (committed state in both directories).
+- **The 3-way merge algorithm** — how base/custom/result snapshots work, merge scenarios table
+- **Merge conflict resolution** — how to resolve conflicts (start from `result`, identify hand-written intent from `custom` vs `base`, reapply intent onto `result`)
+- **Hand-authored file inventory** — for each hand-authored file: what it does, when to update it, what breaks if generated code changes under it
+- **Common scenarios after regeneration** — new operation added, model type changed, new sub-client added, operation signature changed
+- **(If `--skip` flag detected)** **Skipped file maintenance** — which files are skipped and must be manually updated (e.g., `src/index.ts`)
+
+Reference `documentation/modular-customization.md` for the full customization workflow details.
+
+Also include:
+- **Troubleshooting** — merge conflicts, missing exports, build failures after regeneration
+- **Quick-reference checklist** — post-regeneration verification steps
+
+## Step 1 — Present
+
+Print the proposed reference files content.
+
+## Step 2 — CONFIRM
+
+Question: "Create these reference files now (recommended), edit first, or skip?"
+
+📍 **Phase 2 complete** | Created: references/ | Next: Phase 3
+
+---
+## → Next: Phase 3 — Validate
+Read [03-validate.md](03-validate.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/03-validate.md
+++ b/.github/skills/create-package-skill/phases/03-validate.md
@@ -1,0 +1,46 @@
+# Phase 3: Validate
+
+> 📍 **Phase 3 — Validate** | Run structural validation on the new skill.
+
+> 📖 Read `references/validation-tools.md` for tool details.
+
+## Step 1 — Structural Validation (vally lint)
+
+Run vally lint against the skill:
+
+```powershell
+# If vally is installed (npm package from microsoft/evaluate)
+vally lint sdk/<service>/<package>/.github/skills/<skill-name>
+
+# If vally is not installed, check manually:
+# - SKILL.md exists with valid YAML frontmatter
+# - name field matches directory name
+# - All markdown links in SKILL.md resolve to existing files
+# - No orphaned files in references/ (every file linked from SKILL.md)
+```
+
+Expected: 3/3 checks pass (spec-compliance, valid-refs, orphan-files).
+
+**Common failure**: `name-directory-mismatch` — the `name` in frontmatter doesn't match the directory name. Fix by renaming the directory to match the short package name (e.g., `search-documents`).
+
+## Step 2 — Token Budget Check
+
+Verify token budgets:
+- SKILL.md: under 500 tokens (soft), under 5000 (hard)
+- Each reference file: under 1000 tokens
+
+If over budget, split content into additional reference files.
+
+## Step 3 — DECIDE
+
+Present validation results. If all pass:
+Question: "Validation passed. Proceed to register the skill?"
+
+If failures exist, present them and ask:
+Question: "These issues need fixing. Fix now, or skip validation?"
+
+📍 **Phase 3 complete** | Validation: pass/fail | Next: Phase 4
+
+---
+## → Next: Phase 4 — Register
+Read [04-register.md](04-register.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/04-register.md
+++ b/.github/skills/create-package-skill/phases/04-register.md
@@ -1,0 +1,41 @@
+# Phase 4: Register 📋
+
+> 📍 **Phase 4 — Register** | Add the skill to the find-package-skill discovery table.
+
+## Step 1 — Update find-package-skill
+
+Add a row to `.github/skills/find-package-skill/SKILL.md` in the **Package Skills** table:
+
+```markdown
+| `@azure/<package-name>` or `@azure-rest/<package-name>` | `sdk/<service>/<package>/.github/skills/<skill-name>/SKILL.md` |
+```
+
+## Step 2 — Summary
+
+Print a summary of everything created:
+
+📋 **Package Skill Created**
+
+| Item | Path | Status |
+|---|---|---|
+| SKILL.md | `sdk/<service>/<package-name>/.github/skills/<skill-name>/SKILL.md` | Created |
+| architecture.md | `...references/architecture.md` | Created/Skipped |
+| customization.md | `...references/customization.md` | Created/Skipped |
+| find-package-skill | `.github/skills/find-package-skill/SKILL.md` | Updated |
+| vally lint | 3/3 checks | Passed |
+
+**Next steps for the service team:**
+1. Fill in any `<!-- TODO -->` sections with domain-specific knowledge
+2. Test the skill by asking an agent to regenerate your package
+3. Iterate: agent gets something wrong → update skill → test again
+4. Submit a PR
+
+**Maintaining your skill:**
+- When your package's customizations change, update the skill
+- Keep content static — no version numbers or release-specific info
+
+## Step 3 — CONFIRM
+
+Question: "Register the skill in find-package-skill now (recommended), or skip?"
+
+📍 **Phase 4 complete** | Skill registered | Wizard done 🎉

--- a/.github/skills/create-package-skill/references/skill-template.md
+++ b/.github/skills/create-package-skill/references/skill-template.md
@@ -1,0 +1,52 @@
+# SKILL.md Template for Azure SDK Package Skills
+
+Use this template when creating a new package skill. Replace placeholders with package-specific content.
+
+```yaml
+---
+name: <package-short-name>
+description: '<Brief description>. WHEN: regenerate <package>; modify <package>; fix <package> bug; add <package> feature; <package> tsp-client update.'
+---
+```
+
+The `name` field and directory name MUST match the short package name without the `@azure/` or `@azure-rest/` scope (e.g., `search-documents`, `cosmos`, `purview-catalog`).
+
+## Content Principles
+
+- **Keep it static** — no version numbers, no current API versions. Document design and patterns, not release state.
+- **Prefer TypeSpec customizations over source-level edits** — always note when a customization could be a TypeSpec decorator instead.
+- **Don't re-document MCP tools or shared skills** — the `sdk-workflow` skill and MCP tools handle generation workflows.
+- **Focus on the convenience layer** — what does the agent need to know to write/maintain convenience patterns correctly.
+
+## Required Sections (in order)
+
+### Common Pitfalls
+List 3-5 most dangerous mistakes. This section MUST come first — agents read it before analyzing errors.
+
+### Architecture
+Source layout, `generated/` vs `src/` distinction, customization mechanism. No version numbers.
+
+### Regeneration
+Package-specific generation command and flags, error categorization table, breaking change detection. Do NOT re-document the generation/build/test steps — those are in the shared skill. Document the actual script content from `package.json` — do not assume the command shape.
+
+### Where to Make Changes
+Table mapping goals to edit locations. Emphasize preferring hand-authored extension points over editing generated-mirrored files (if applicable).
+
+### Testing Notes
+Commands, recorded test setup, environment requirements.
+
+### References
+Table linking to references/*.md files (e.g., `architecture.md`, `customization.md`).
+
+## Structural Rules
+
+| Rule | Enforced By |
+|---|---|
+| `name` matches directory name (= short package name) | `vally lint` |
+| All markdown links resolve | `vally lint` |
+| No orphaned reference files | `vally lint` |
+| Code references still exist in codebase | Manual review |
+| SKILL.md under 5000 tokens | `vally lint` |
+| No version numbers or release-specific info | Manual review |
+| Trigger phrases include package name | Manual review |
+| No cross-language content | Manual review |

--- a/.github/skills/create-package-skill/references/validation-tools.md
+++ b/.github/skills/create-package-skill/references/validation-tools.md
@@ -1,0 +1,24 @@
+# Validation Tools for Package Skills
+
+## vally lint (Structural Validation)
+
+**Source**: `microsoft/evaluate` (currently private, will be public)
+
+```bash
+# Install (once published)
+npm install -g @microsoft/vally-cli
+
+# Lint a skill
+vally lint sdk/<service>/<package>/.github/skills/<skill-name>
+
+# Lint all skills in repo
+vally lint .github/skills
+```
+
+### What it checks
+
+| Check | What it does | Common failure |
+|---|---|---|
+| `spec-compliance` | Validates frontmatter (name, description), name-directory match | Directory name doesn't match `name` field |
+| `valid-refs` | All markdown links resolve to existing files | Broken link to reference file |
+| `orphan-files` | No unreferenced files in references/ | File in references/ not linked from SKILL.md |

--- a/.github/skills/find-package-skill/SKILL.md
+++ b/.github/skills/find-package-skill/SKILL.md
@@ -22,4 +22,5 @@ you already know the package well.
 
 | Package                   | Path                                                                   |
 | ------------------------- | ---------------------------------------------------------------------- |
+| `@azure/keyvault-keys`    | `sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/SKILL.md`     |
 | `@azure/search-documents` | `sdk/search/search-documents/.github/skills/search-documents/SKILL.md` |

--- a/sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/SKILL.md
+++ b/sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: keyvault-keys
+description: 'Azure Key Vault Keys with hand-authored CryptographyClient and KeyClient convenience layer. WHEN: regenerate keyvault-keys; modify keyvault-keys; fix keyvault-keys bug; add keyvault-keys feature; keyvault-keys tsp-client update.'
+---
+
+# keyvault-keys
+
+## Common Pitfalls
+
+- **Never hand-edit files in `generated/`** — overwritten on every `tsp-client update`. All modifications go through editing `src/` files directly (the 3-way merge preserves your changes). Use source-level customizations when TypeSpec cannot express the desired behavior. For TypeSpec-level customizations (preferred when possible), see [TypeSpec Client Customizations Reference](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/knowledge/customizing-client-tsp.md).
+- **Check for merge conflicts in `src/` FIRST after regeneration** — `dev-tool customization apply` performs a 3-way merge that can produce conflict markers in merged files.
+- **`src/index.ts` is manually maintained** — it contains the `KeyClient` class definition AND all public exports. New exports must be added by hand.
+- **`CryptographyClient` is entirely hand-authored** — defined in `src/cryptographyClient.ts` with no counterpart in `generated/`. Don't look for it in generated code.
+- **Model aliases in `keysModels.ts`** re-export generated types with different names (e.g., `JsonWebKeyType` → `KeyType`, `JsonWebKeyOperation` → `KeyOperation`). After regeneration, verify aliases still match generated types in `models/models.ts`.
+- **`transformations.ts` bridges wire ↔ user types** — if generated models change shape, update transformations manually.
+
+## Architecture
+
+Three-layer architecture — see [references/architecture.md](references/architecture.md) for full details:
+
+1. **Generated layer** (`generated/`) — TypeSpec-generated wire client and models. Never edit.
+2. **Merged layer** (`src/keyVaultClient.ts`, `src/api/`, `src/models/`) — customized copies of generated files, maintained via 3-way merge.
+3. **Convenience layer** (hand-authored) — `KeyClient` in `src/index.ts`, `CryptographyClient` in `src/cryptographyClient.ts`, local crypto providers in `src/cryptography/`, LRO pollers in `src/lro/`, model transformations in `src/transformations.ts`.
+
+Key design decisions:
+- Auth uses `@azure/keyvault-common` challenge-based authentication policy (replaces default bearer token policy).
+- LRO for delete/recover is hand-authored using `@azure/core-lro` `Poller` primitives.
+- Local AES/RSA crypto providers in `src/cryptography/` enable offline operations on local `JsonWebKey` objects.
+
+## Regeneration
+
+**Generation command** (from `package.json`):
+```
+tsp-client update -d --emitter-options="generate-metadata=false;generate-test=false" && npm run format
+```
+
+**Error categorization after regeneration:**
+
+| Error location | What to fix |
+|---|---|
+| `generated/**/*.ts` | TypeSpec or emitter issue — do NOT fix locally |
+| `src/` file with counterpart in `generated/` | Merge conflict or breaking change — resolve in `src/` |
+| `src/transformations.ts` | Generated model shape changed — update transform functions |
+| `src/keysModels.ts` | Generated type renamed/removed — update re-export aliases |
+| `src/index.ts` (KeyClient methods) | Generated operation signature changed — update convenience wrapper |
+
+## Where to Make Changes
+
+| Goal | Where to edit |
+|---|---|
+| Add/modify user-facing model types | `src/keysModels.ts`, `src/cryptographyClientModels.ts` |
+| Add/modify wire ↔ user type conversions | `src/transformations.ts` |
+| Modify KeyClient behavior or add operations | `src/index.ts` (KeyClient class) |
+| Modify CryptographyClient behavior | `src/cryptographyClient.ts` |
+| Add/modify local crypto operations | `src/cryptography/` directory |
+| Add/modify LRO operations | `src/lro/` directory |
+| Export a new public symbol | `src/index.ts` (exports block) |
+| Modify key identifier parsing | `src/identifier.ts` |
+
+Prefer adding new hand-authored files over editing merged files in `src/` that have counterparts in `generated/`.
+
+## Testing Notes
+
+- Public tests in `test/public/` cover KeyClient and CryptographyClient operations (recorded via test proxy, `assets.json`).
+- Internal tests in `test/internal/` cover transformations, AES crypto, LRO edge cases.
+- HSM-specific tests (`*.hsm.spec.ts`) require Managed HSM resources.
+- Node-specific crypto tests in `test/public/node/`.
+- Browser tests are skipped.
+
+## References
+
+| Reference | Description |
+|---|---|
+| [references/architecture.md](references/architecture.md) | Detailed file map and module responsibilities |
+| [references/customization.md](references/customization.md) | Convenience layer patterns and customization details |

--- a/sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/references/architecture.md
+++ b/sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/references/architecture.md
@@ -1,0 +1,63 @@
+# Architecture — @azure/keyvault-keys
+
+## Directory Layout
+
+```
+sdk/keyvault/keyvault-keys/
+├── generated/                  # Auto-generated from TypeSpec — NEVER edit
+│   ├── api/                    # Wire-level operations, context, options
+│   ├── models/                 # Wire models and serializers
+│   ├── static-helpers/         # Paging and URL template helpers
+│   ├── keyVaultClient.ts       # Generated thin client
+│   ├── logger.ts
+│   └── index.ts
+├── src/                        # Source of truth for published code
+│   ├── api/                    # Merged copies of generated/api/ (3-way merge)
+│   ├── models/                 # Merged copies of generated/models/
+│   ├── static-helpers/         # Merged copies of generated/static-helpers/
+│   ├── cryptography/           # Hand-authored local crypto providers
+│   ├── lro/                    # Hand-authored LRO pollers (delete/recover)
+│   ├── index.ts                # KeyClient class + barrel export (hand-authored)
+│   ├── keyVaultClient.ts       # Merged copy of generated client
+│   ├── cryptographyClient.ts   # CryptographyClient (hand-authored)
+│   ├── keysModels.ts           # User-facing model types (hand-authored)
+│   ├── cryptographyClientModels.ts  # Crypto model types (hand-authored)
+│   ├── transformations.ts      # Wire ↔ user model transforms (hand-authored)
+│   ├── identifier.ts           # Key Vault key ID parser (hand-authored)
+│   ├── tracing.ts              # Tracing client (hand-authored)
+│   ├── constants.ts            # SDK version constant (hand-authored)
+│   └── logger.ts               # Merged copy of generated logger
+└── test/
+    ├── public/                 # Live/recorded integration tests
+    │   ├── node/               # Node-specific crypto tests
+    │   ├── *.hsm.spec.ts       # Managed HSM tests
+    │   └── *.spec.ts           # Standard tests
+    └── internal/               # Unit tests for internal modules
+```
+
+## Client Classes
+
+| Client | File | Purpose |
+|---|---|---|
+| `KeyVaultClient` | `src/keyVaultClient.ts` | Generated wire client (merged copy). Used internally. |
+| `KeyClient` | `src/index.ts` | Hand-authored convenience client. Wraps `KeyVaultClient`, transforms models, adds LRO support. **Public API.** |
+| `CryptographyClient` | `src/cryptographyClient.ts` | Hand-authored. Encrypt/decrypt/sign/verify/wrap/unwrap. Supports both remote (Key Vault) and local (`JsonWebKey`) modes. **Public API.** |
+
+## Cryptography Provider Chain
+
+`CryptographyClient` delegates to a chain of providers:
+1. **`AesCryptographyProvider`** (`src/cryptography/aesCryptographyProvider.ts`) — local AES-CBC operations
+2. **`RsaCryptographyProvider`** (`src/cryptography/rsaCryptographyProvider.ts`) — local RSA operations (sign, verify, encrypt, decrypt, wrap, unwrap)
+3. **`RemoteCryptographyProvider`** (`src/cryptography/remoteCryptographyProvider.ts`) — delegates to Key Vault service
+
+The client tries local providers first; falls back to remote if the local provider doesn't support the operation or key type.
+
+## Key Dependencies
+
+| Package | Purpose |
+|---|---|
+| `@azure/keyvault-common` | Shared Key Vault challenge-based auth policy |
+| `@azure-rest/core-client` | REST client primitives |
+| `@azure/core-lro` | `Poller` base class for delete/recover LROs |
+| `@azure/core-paging` | `PagedAsyncIterableIterator` for list operations |
+| `@azure/core-tracing` | Distributed tracing |

--- a/sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/references/customization.md
+++ b/sdk/keyvault/keyvault-keys/.github/skills/keyvault-keys/references/customization.md
@@ -1,0 +1,46 @@
+# Customization — @azure/keyvault-keys
+
+## Customization Workflow
+
+This package uses the **two-directory customization layout**:
+- `generated/` — output of TypeSpec code generation. Never edited directly.
+- `src/` — contains merged copies of generated files + hand-authored files.
+
+After running `tsp-client update`, `dev-tool customization apply` performs a 3-way merge to update files in `src/` that have counterparts in `generated/`. Hand-authored files (no counterpart in `generated/`) are preserved untouched.
+
+For full customization workflow details, see `documentation/modular-customization.md`.
+
+## Hand-Authored File Inventory
+
+| File | Purpose | Update when... |
+|---|---|---|
+| `src/index.ts` | `KeyClient` class + all public exports | New operations added, exports change |
+| `src/cryptographyClient.ts` | `CryptographyClient` (local + remote crypto) | New crypto algorithms, API changes |
+| `src/keysModels.ts` | User-facing types, type aliases from generated types | Generated type names change |
+| `src/cryptographyClientModels.ts` | Crypto-specific types (encrypt/decrypt params, results) | New crypto algorithms |
+| `src/transformations.ts` | Wire ↔ user-facing model converters | Generated model shapes change |
+| `src/identifier.ts` | `parseKeyVaultKeyIdentifier()` | Key ID format changes (unlikely) |
+| `src/lro/` | Delete/recover pollers | LRO response shapes change |
+| `src/cryptography/` | Local AES/RSA providers, DER conversions | New algorithms, crypto API changes |
+| `src/tracing.ts` | Tracing client setup | Namespace changes (unlikely) |
+| `src/constants.ts` | `SDK_VERSION` | Updated automatically by release tooling |
+
+## Post-Regeneration Checklist
+
+1. Run `tsp-client update -d --emitter-options="generate-metadata=false;generate-test=false" && npm run format`
+2. Check `src/` files with counterparts in `generated/` for merge conflict markers (`<<<<<<<`)
+3. Verify type aliases in `keysModels.ts` still match generated types in `models/models.ts`
+4. Verify `transformations.ts` functions handle any new/changed model properties
+5. Verify `src/index.ts` exports cover any new public types
+6. Build: `pnpm turbo build --filter=@azure/keyvault-keys... --token 1`
+7. Run tests: `npm run test:node`
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Merge conflict markers in `src/` files | 3-way merge conflict after regeneration | Resolve manually: compare `generated/` version with your `src/` customizations |
+| Type error in `transformations.ts` | Generated model shape changed | Update transform functions to match new wire types |
+| Missing export error | New type not added to `src/index.ts` | Add export to the barrel export block |
+| `keysModels.ts` type alias error | Generated type renamed or removed | Update the `import type` and re-export in `keysModels.ts` |
+| Local crypto test failure | Algorithm mapping changed | Check `src/cryptography/` providers match updated `JsonWebKey` types |


### PR DESCRIPTION
Building on https://github.com/Azure/azure-sdk-for-java/pull/48833, this PR
creates a skill that provides a structured workflow for creating
package-specific skills.

As a brief test I used this flow to create a skill for keyvault-keys. I plan to
review this with the feature crew and make any changes needed to get this
mergeable.
