### PR TITLE
[core-client-rest] preserve `tracingOptions` in request parameters 

### DIFF
--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix `operationOptionsToRequestParameters` to correctly preserve `tracingOptions` in the returned `RequestParameters`.
+
 ### Other Changes
 
 ## 2.6.0 (2026-04-07)

--- a/sdk/core/core-client-rest/CHANGELOG.md
+++ b/sdk/core/core-client-rest/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fix `operationOptionsToRequestParameters` to correctly preserve `tracingOptions` in the returned `RequestParameters`.
+- Fix `operationOptionsToRequestParameters` to correctly preserve `tracingOptions` in the returned `RequestParameters`. [PR #38285](https://github.com/Azure/azure-sdk-for-js/pull/38285)
 
 ### Other Changes
 

--- a/sdk/core/core-client-rest/src/operationOptionHelpers.ts
+++ b/sdk/core/core-client-rest/src/operationOptionHelpers.ts
@@ -14,7 +14,11 @@ import {
  * @returns the result of the conversion in RequestParameters of RLC layer
  */
 export function operationOptionsToRequestParameters(options: OperationOptions): RequestParameters {
-  return tspOperationOptionsToRequestParameters(
+  const tspRequestParameters = tspOperationOptionsToRequestParameters(
     options as TspOperationOptions,
   ) as RequestParameters;
+  return {
+    ...tspRequestParameters,
+    tracingOptions: options.tracingOptions,
+  };
 }

--- a/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
+++ b/sdk/core/core-client-rest/test/internal/operationOptionHelpers.spec.ts
@@ -36,4 +36,10 @@ describe("operationOptionsToRequestParameters", () => {
     assert.equal(result.abortSignal, abortController.signal);
     assert.equal(result.onResponse, onResponse);
   });
+
+  it("preserves tracingOptions", () => {
+    const tracingOptions = { tracingContext: {} as any };
+    const result = operationOptionsToRequestParameters({ tracingOptions });
+    assert.deepEqual(result.tracingOptions, tracingOptions);
+  });
 });

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Set `RestError.response.bodyAsText` when the error response body has `string` type [PR #38059](https://github.com/Azure/azure-sdk-for-js/pull/38059)
+- Forward `tracingOptions` to pipeline requests. [PR #38285](https://github.com/Azure/azure-sdk-for-js/pull/38285)
 
 ## 0.3.5 (2026-04-07)
 

--- a/sdk/core/ts-http-runtime/src/client/sendRequest.ts
+++ b/sdk/core/ts-http-runtime/src/client/sendRequest.ts
@@ -118,6 +118,7 @@ function getContentType(body: any): string | undefined {
 
 export interface InternalRequestParameters extends RequestParameters {
   responseAsStream?: boolean;
+  tracingOptions?: unknown;
 }
 
 function buildPipelineRequest(
@@ -136,7 +137,7 @@ function buildPipelineRequest(
     }),
   });
 
-  return createPipelineRequest({
+  const request = createPipelineRequest({
     url,
     method,
     body,
@@ -152,6 +153,10 @@ function buildPipelineRequest(
       ? new Set([Number.POSITIVE_INFINITY])
       : undefined,
   });
+
+  return options.tracingOptions
+    ? { ...request, ...{ tracingOptions: options.tracingOptions } }
+    : request;
 }
 
 interface RequestBody {

--- a/sdk/core/ts-http-runtime/src/client/sendRequest.ts
+++ b/sdk/core/ts-http-runtime/src/client/sendRequest.ts
@@ -118,7 +118,6 @@ function getContentType(body: any): string | undefined {
 
 export interface InternalRequestParameters extends RequestParameters {
   responseAsStream?: boolean;
-  tracingOptions?: unknown;
 }
 
 function buildPipelineRequest(
@@ -137,31 +136,41 @@ function buildPipelineRequest(
     }),
   });
 
+  const {
+    allowInsecureConnection,
+    abortSignal,
+    onUploadProgress,
+    onDownloadProgress,
+    timeout,
+    responseAsStream,
+    url: _url,
+    method: _method,
+    body: _body,
+    multipartBody: _multiBody,
+    headers: _headers,
+    ...rest
+  } = options as InternalRequestParameters & {
+    url: string;
+    method: string;
+    multipartBody: unknown;
+  };
+
   const request = createPipelineRequest({
     url,
     method,
     body,
     multipartBody,
     headers,
-    allowInsecureConnection: options.allowInsecureConnection,
-    abortSignal: options.abortSignal,
-    onUploadProgress: options.onUploadProgress,
-    onDownloadProgress: options.onDownloadProgress,
-    timeout: options.timeout,
+    allowInsecureConnection,
+    abortSignal,
+    onUploadProgress,
+    onDownloadProgress,
+    timeout,
     enableBrowserStreams: true,
-    streamResponseStatusCodes: options.responseAsStream
-      ? new Set([Number.POSITIVE_INFINITY])
-      : undefined,
+    streamResponseStatusCodes: responseAsStream ? new Set([Number.POSITIVE_INFINITY]) : undefined,
   });
 
-  if (options.tracingOptions) {
-    Object.defineProperty(request, "tracingOptions", {
-      value: options.tracingOptions,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
-  }
+  Object.assign(request, rest);
   return request;
 }
 

--- a/sdk/core/ts-http-runtime/src/client/sendRequest.ts
+++ b/sdk/core/ts-http-runtime/src/client/sendRequest.ts
@@ -155,7 +155,7 @@ function buildPipelineRequest(
   });
 
   return options.tracingOptions
-    ? { ...request, ...{ tracingOptions: options.tracingOptions } }
+    ? { ...request, tracingOptions: options.tracingOptions }
     : request;
 }
 

--- a/sdk/core/ts-http-runtime/src/client/sendRequest.ts
+++ b/sdk/core/ts-http-runtime/src/client/sendRequest.ts
@@ -154,9 +154,15 @@ function buildPipelineRequest(
       : undefined,
   });
 
-  return options.tracingOptions
-    ? { ...request, tracingOptions: options.tracingOptions }
-    : request;
+  if (options.tracingOptions) {
+    Object.defineProperty(request, "tracingOptions", {
+      value: options.tracingOptions,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return request;
 }
 
 interface RequestBody {

--- a/sdk/core/ts-http-runtime/test/internal/client/sendRequest.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/client/sendRequest.spec.ts
@@ -681,4 +681,25 @@ describe("sendRequest", () => {
     });
     assert.isTrue(called);
   });
+
+  it("should forward tracingOptions to the pipeline request", async () => {
+    const tracingOptions = { tracingContext: {} as any };
+    const mockPipeline: Pipeline = createEmptyPipeline();
+    mockPipeline.sendRequest = async (_client, request) => {
+      assert.deepEqual(request.tracingOptions, tracingOptions);
+      return { headers: createHttpHeaders() } as PipelineResponse;
+    };
+
+    await sendRequest("GET", mockBaseUrl, mockPipeline, { tracingOptions });
+  });
+
+  it("should not set tracingOptions on the pipeline request when not provided", async () => {
+    const mockPipeline: Pipeline = createEmptyPipeline();
+    mockPipeline.sendRequest = async (_client, request) => {
+      assert.isUndefined(request.tracingOptions);
+      return { headers: createHttpHeaders() } as PipelineResponse;
+    };
+
+    await sendRequest("GET", mockBaseUrl, mockPipeline);
+  });
 });


### PR DESCRIPTION
`ts-http-runtime` doesn't know about tracing. This workaround forwards the `tracingOptions` or other options not recognized by `ts-http-runtime` along with the request if they are passed in from core-client-rest or other layers above.

**Related issue** 

#38280 

**Alternative approach**

A `buildPipelineRequest` factory method callback from `core-client-rest` is passed to `getClient`, It is then plumbed through to before request is create so that the factory method can be used to create a request because the method knows about tracing options.  It requires significant changes though.