### PR TITLE
fix: consolidate duplicate changelog sections for core-rest-pipeline and core-xml

### DIFF
--- a/sdk/core/core-rest-pipeline/CHANGELOG.md
+++ b/sdk/core/core-rest-pipeline/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Release History
 
-## 1.23.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.23.1 (Unreleased)
 
 ### Features Added

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-rest-pipeline",
-  "version": "1.23.2",
+  "version": "1.23.1",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/core-rest-pipeline/src/constants.ts
+++ b/sdk/core/core-rest-pipeline/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "1.23.2";
+export const SDK_VERSION: string = "1.23.1";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;

--- a/sdk/core/core-xml/CHANGELOG.md
+++ b/sdk/core/core-xml/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Release History
 
-## 1.5.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.5.2 (Unreleased)
 
 ### Features Added

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-xml",
-  "version": "1.5.3",
+  "version": "1.5.2",
   "description": "Core library for interacting with XML payloads",
   "sdk-type": "client",
   "type": "module",


### PR DESCRIPTION
The version bump tool created a new unreleased section while the previous unreleased section still existed on main. This consolidates them into a single unreleased section per package.

### Packages affected
- `@azure/core-rest-pipeline`: merged 1.23.1 (Unreleased) into 1.23.2 (Unreleased)
- `@azure/core-xml`: merged 1.5.2 (Unreleased) into 1.5.3 (Unreleased)