### PR TITLE
Disable InitialIssueTriage to unblock Agentic Triage

### DIFF
--- a/.github/event-processor.config
+++ b/.github/event-processor.config
@@ -1,5 +1,5 @@
 {
-  "InitialIssueTriage": "On",
+  "InitialIssueTriage": "Off",
   "ManualIssueTriage": "On",
   "ServiceAttention": "On",
   "ManualTriageAfterExternalAssignment": "On",


### PR DESCRIPTION
The old event processor and the new Agentic Triage both fire on `issues.opened`. The event processor wins the race and slaps `customer-reported`/`question`/`needs-triage` on the issue before the agent gets to it. The agent sees labels already exist, hits its precondition check, and noops every time ([example run](https://github.com/Azure/azure-sdk-for-js/actions/runs/25003714209)).

This turns off `InitialIssueTriage` in the event processor config so the agent can actually do its job. Same thing .NET already did, their config has it `Off` and their agent runs are producing real results.