### PR TITLE
Fix stale lockfile entries for arm-monitorslis package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20804,10 +20804,10 @@ importers:
         version: 20.19.39
       '@vitest/browser-playwright':
         specifier: catalog:testing
-        version: 4.1.4(playwright@1.59.1)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.5(playwright@1.59.1)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
-        version: 4.1.4(vitest@4.1.4)
+        version: 4.1.5(vitest@4.1.5)
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0
@@ -20822,16 +20822,16 @@ importers:
         version: 1.59.1
       prettier:
         specifier: 'catalog:'
-        version: 3.8.2
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
       typescript:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
       vitest:
         specifier: catalog:testing
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-istanbul@4.1.4)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-istanbul@4.1.5)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   sdk/monitor/monitor-ingestion:
     dependencies:


### PR DESCRIPTION
Updates resolved versions in the \rm-monitorslis\ section of \pnpm-lock.yaml\ to match catalog versions used by all other packages. Fixes \ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY\ for \@vitest/browser-playwright\ in the release pipeline.

Required to release the following PR:
https://github.com/Azure/azure-sdk-for-js/pull/38255

Currently release fails:

 ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@7.3.1(@types/node@20.19.39)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)' in pnpm-lock.yaml

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6215422&view=logs&j=7e6a3fb7-dbfe-5169-4db8-92b72295ba6c&t=8c9d508d-bea0-5b48-7de9-8dca11d8a5ce&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c