### PR TITLE
[ContentUnderstanding] Update release date for @azure/ai-content-understanding 1.1.0

### DIFF
--- a/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/ai-content-understanding/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0 (2026-04-27)
+## 1.1.0 (2026-04-24)
 
 ### Features Added
 


### PR DESCRIPTION
### Packages impacted by this PR

@azure/ai-content-understanding

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

Updates the CHANGELOG.md release date for `@azure/ai-content-understanding` 1.1.0 to match the actual release date (2026-04-24).

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A — metadata-only change.

### Are there test cases added in this PR? _(If not, why?)_

No — changelog-only change, no functional impact.

### Provide a list of related PRs _(if any)_

- #38263 — [ContentUnderstanding] Move usage and operationId to AnalysisOperationState

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)