### PR TITLE
[Identity] Update dockerfile for internal MCR

### DIFF
--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -2,14 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-ARG NODE_VERSION=22
+ARG NODE_VERSION=24
 
-# Use the MCR-hosted Node.js image (Azure Linux 3) instead of docker.io/library/node
-# to avoid Docker Hub pull rate limits and intermittent registry timeouts in CI.
-# Override REGISTRY (e.g. with an ACR login server) if pulling through a cache.
-ARG REGISTRY="mcr.microsoft.com/"
+ARG BASE_IMAGE="mcr.microsoft.com/azurelinux/base/nodejs:${NODE_VERSION}"
 
-FROM ${REGISTRY}azurelinux/base/nodejs:${NODE_VERSION} AS builder
+FROM ${BASE_IMAGE} AS builder
 WORKDIR /app
 
 COPY . .
@@ -18,7 +15,7 @@ RUN npm install --no-package-lock
 
 RUN npm run build
 
-FROM ${REGISTRY}azurelinux/base/nodejs:${NODE_VERSION}
+FROM ${BASE_IMAGE}
 WORKDIR /app
 
 # Copy only the built app and necessary files

--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -4,10 +4,12 @@
 # ------------------------------------
 ARG NODE_VERSION=22
 
-# Optional registry prefix. Leave blank to use Docker Hub.
-ARG REGISTRY=""
+# Use the MCR-hosted Node.js image (Azure Linux 3) instead of docker.io/library/node
+# to avoid Docker Hub pull rate limits and intermittent registry timeouts in CI.
+# Override REGISTRY (e.g. with an ACR login server) if pulling through a cache.
+ARG REGISTRY="mcr.microsoft.com/"
 
-FROM ${REGISTRY}node:${NODE_VERSION}-alpine as builder
+FROM ${REGISTRY}azurelinux/base/nodejs:${NODE_VERSION} AS builder
 WORKDIR /app
 
 COPY . .
@@ -16,7 +18,7 @@ RUN npm install --no-package-lock
 
 RUN npm run build
 
-FROM ${REGISTRY}node:${NODE_VERSION}-alpine
+FROM ${REGISTRY}azurelinux/base/nodejs:${NODE_VERSION}
 WORKDIR /app
 
 # Copy only the built app and necessary files

--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -18,6 +18,9 @@ RUN npm run build
 FROM ${BASE_IMAGE}
 WORKDIR /app
 
+# Azure Linux base image does not include wget by default
+RUN tdnf install -y wget && tdnf clean all
+
 # Copy only the built app and necessary files
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./


### PR DESCRIPTION
Similar to #30442 so update to using `azurelinux/base/nodejs` in MCR. Pipelines pass [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6251776&view=results)