### PR TITLE
Fix/id encoding tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25407,7 +25407,7 @@ importers:
         version: 1.59.1
       prettier:
         specifier: 'catalog:'
-        version: 3.8.1
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
@@ -86,6 +86,9 @@ const executeTestCase = async function (
       assert.fail("response.resource should not be null");
     }
   } catch (err: any) {
+    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
+      throw err;
+    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedReadStatusCode);
   }
@@ -103,6 +106,9 @@ const executeTestCase = async function (
       assert.fail("response.resource should not be null");
     }
   } catch (err: any) {
+    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
+      throw err;
+    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedReplaceStatusCode);
   }
@@ -111,6 +117,9 @@ const executeTestCase = async function (
     const response = await container.item(scenario.id, scenario.id).delete();
     assert.strictEqual(response.statusCode, scenario.expectedDeleteStatusCode);
   } catch (err: any) {
+    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
+      throw err;
+    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedDeleteStatusCode);
   }
@@ -264,9 +273,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdEndingWithWhitespace",
       id: "Test ",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: 401,
-      expectedReplaceStatusCode: 401,
-      expectedDeleteStatusCode: 401,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);
@@ -290,9 +299,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdEndingWithWhitespaces",
       id: "Test   ",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: 401,
-      expectedReplaceStatusCode: 401,
-      expectedDeleteStatusCode: 401,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);
@@ -404,9 +413,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdEndingWithPercentEncodedWhitespace",
       id: "IdEndingWithPercentEncodedWhitespace%20",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: 401,
-      expectedReplaceStatusCode: 401,
-      expectedDeleteStatusCode: 401,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);
@@ -430,9 +439,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdWithPercentEncodedSpecialChar",
       id: "WithPercentEncodedSpecialChar%E9%B1%80",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: 401,
-      expectedReplaceStatusCode: 401,
-      expectedDeleteStatusCode: 401,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);
@@ -548,9 +557,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdWithCarriageReturn",
       id: "With\rCarriageReturn",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: undefined,
-      expectedReplaceStatusCode: undefined,
-      expectedDeleteStatusCode: undefined,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);
@@ -574,9 +583,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdWithTab",
       id: "With\tTab",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: undefined,
-      expectedReplaceStatusCode: undefined,
-      expectedDeleteStatusCode: undefined,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);
@@ -600,9 +609,9 @@ describe("Id encoding", { timeout: 10000 }, () => {
       name: "RGW_IdWithLineFeed",
       id: "With\nLineFeed",
       expectedCreateStatusCode: 201,
-      expectedReadStatusCode: undefined,
-      expectedReplaceStatusCode: undefined,
-      expectedDeleteStatusCode: undefined,
+      expectedReadStatusCode: 200,
+      expectedReplaceStatusCode: 200,
+      expectedDeleteStatusCode: 204,
     };
 
     await executeTestCase(scenario);

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
@@ -86,6 +86,9 @@ const executeTestCase = async function (
       assert.fail("response.resource should not be null");
     }
   } catch (err: any) {
+    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
+      throw err;
+    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedReadStatusCode);
   }
@@ -103,6 +106,9 @@ const executeTestCase = async function (
       assert.fail("response.resource should not be null");
     }
   } catch (err: any) {
+    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
+      throw err;
+    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedReplaceStatusCode);
   }
@@ -111,6 +117,9 @@ const executeTestCase = async function (
     const response = await container.item(scenario.id, scenario.id).delete();
     assert.strictEqual(response.statusCode, scenario.expectedDeleteStatusCode);
   } catch (err: any) {
+    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
+      throw err;
+    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedDeleteStatusCode);
   }

--- a/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/item/itemIdEncoding.spec.ts
@@ -86,9 +86,6 @@ const executeTestCase = async function (
       assert.fail("response.resource should not be null");
     }
   } catch (err: any) {
-    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
-      throw err;
-    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedReadStatusCode);
   }
@@ -106,9 +103,6 @@ const executeTestCase = async function (
       assert.fail("response.resource should not be null");
     }
   } catch (err: any) {
-    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
-      throw err;
-    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedReplaceStatusCode);
   }
@@ -117,9 +111,6 @@ const executeTestCase = async function (
     const response = await container.item(scenario.id, scenario.id).delete();
     assert.strictEqual(response.statusCode, scenario.expectedDeleteStatusCode);
   } catch (err: any) {
-    if (err?.name === "AssertionError" || err?.code === "ERR_ASSERTION") {
-      throw err;
-    }
     console.log("ERROR: " + err.code + " - " + err.message + " - " + err.stack);
     assert.strictEqual(err.code, scenario.expectedDeleteStatusCode);
   }

--- a/sdk/cosmosdb/cosmos/test/public/functional/offer.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/public/functional/offer.spec.ts
@@ -29,7 +29,6 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
   describe("Validate Offer CRUD", () => {
     it("nativeApi Should do offer read and query operations successfully name based single partition collection", async () => {
       const mbInBytes = 1024 * 1024;
-      const offerThroughput = 400;
       const container = await getTestContainer("Validate Offer CRUD");
 
       const { headers } = await container.read({ populateQuotaInfo: true });
@@ -49,12 +48,13 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
       assert.equal(collectionSize, 10 * mbInBytes, "Collection size is unexpected");
 
       const { resources: offers } = await client.offers.readAll().fetchAll();
-      assert.equal(offers.length, 1);
-      const expectedOffer = offers[0];
-      assert.equal(
-        expectedOffer.content.offerThroughput,
-        offerThroughput,
-        "Expected offerThroughput to be " + offerThroughput,
+      const { resource: containerInfo } = await container.read();
+      const containerRid = containerInfo._rid;
+      const expectedOffer = offers.find((offer) => offer.resource.includes(containerRid));
+      assert.ok(expectedOffer, "Expected to find offer for the test container");
+      assert.ok(
+        expectedOffer.content.offerThroughput > 0,
+        "Expected offerThroughput to be a positive number",
       );
       validateOfferResponseBody(expectedOffer);
 
@@ -94,10 +94,12 @@ describe("NodeJS CRUD Tests", { timeout: 10000 }, () => {
     });
 
     it("nativeApi Should do offer replace operations successfully name based", async () => {
-      await getTestContainer("Validate Offer CRUD");
+      const container = await getTestContainer("Validate Offer CRUD");
       const { resources: offers } = await client.offers.readAll().fetchAll();
-      assert.equal(offers.length, 1);
-      const expectedOffer = offers[0];
+      const { resource: containerInfo } = await container.read();
+      const containerRid = containerInfo._rid;
+      const expectedOffer = offers.find((offer) => offer.resource.includes(containerRid));
+      assert.ok(expectedOffer, "Expected to find offer for the test container");
       validateOfferResponseBody(expectedOffer);
       // Replace the offer.
       const offerToReplace = Object.assign({}, expectedOffer);


### PR DESCRIPTION
### Packages impacted by this PR
@azure/cosmos

### Describe the problem that is addressed by this PR
1. The Cosmos DB backend now returns 200 for read/replace and 204 for delete operations on items with trailing whitespace, control, and percent-encoded character IDs. Previously these returned 401 (auth token mismatch).
Updated 4 RGW test scenarios:
-RGW_IdEndingWithWhitespace
-RGW_IdEndingWithWhitespaces
-RGW_IdEndingWithPercentEncodedWhitespace
-RGW_IdWithPercentEncodedSpecialChar
-RGW_IdWithCarriageReturn
-RGW_IdWithTab
-RGW_IdWithLineFeed

2.  Fixed offer.spec.ts tests that assumed exactly 1 offer exists in the account. On shared staging environments, other containers create additional offers causing assertion failures.
Changes:
   - Find the specific offer for the test container by matching container _rid instead of assuming offers[0]
   - Assert offerThroughput > 0 instead of hardcoding 400, since the default throughput varies by environment
3. Fixed broken pnpm lockfile

