### PR TITLE
feat(communication-toll-free-verification): add dba field to CampaignBrief (v1.0.0-beta.3)

### DIFF
--- a/sdk/communication/communication-toll-free-verification/CHANGELOG.md
+++ b/sdk/communication/communication-toll-free-verification/CHANGELOG.md
@@ -11,13 +11,7 @@
 
 ### Other Changes
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2026-03-09)
 
 ### Features Added
 - APIs for querying and managing Toll Free Verification Campaign Briefs
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes

--- a/sdk/communication/communication-toll-free-verification/CHANGELOG.md
+++ b/sdk/communication/communication-toll-free-verification/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+- Added optional `dba` (Doing Business As) field to `CampaignBrief`.
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.2 (Unreleased)
 
 ### Features Added

--- a/sdk/communication/communication-toll-free-verification/package.json
+++ b/sdk/communication/communication-toll-free-verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/communication-toll-free-verification",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "SDK for Azure Communication Services which facilitates Toll Free Verification.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-toll-free-verification/review/communication-toll-free-verification-node.api.md
+++ b/sdk/communication/communication-toll-free-verification/review/communication-toll-free-verification-node.api.md
@@ -71,6 +71,7 @@ export interface CampaignBrief {
     businessPointOfContact?: BusinessPointOfContact;
     businessRegistrationDetails?: BusinessRegistrationDetails;
     countryCode?: string;
+    dba?: string;
     estimatedMonthlyVolume?: EstimatedMonthlyVolume;
     id: string;
     // (undocumented)

--- a/sdk/communication/communication-toll-free-verification/src/generated/src/models/index.ts
+++ b/sdk/communication/communication-toll-free-verification/src/generated/src/models/index.ts
@@ -37,6 +37,8 @@ export interface CampaignBrief {
   attachments?: CampaignBriefAttachmentSummary[];
   optInDetails?: OptInDetails;
   multipleNumbersJustification?: string;
+  /** Doing Business As (DBA). Must be filled if the company name used to contact customers differs from the legal entity name. */
+  dba?: string;
   /** URL to the privacy policy for the campaign. */
   privacyPolicyUrl?: string;
   /** URL to the terms and conditions for the campaign. */

--- a/sdk/communication/communication-toll-free-verification/src/generated/src/models/mappers.ts
+++ b/sdk/communication/communication-toll-free-verification/src/generated/src/models/mappers.ts
@@ -125,6 +125,12 @@ export const CampaignBrief: coreClient.CompositeMapper = {
           name: "String",
         },
       },
+      dba: {
+        serializedName: "dba",
+        type: {
+          name: "String",
+        },
+      },
       privacyPolicyUrl: {
         serializedName: "privacyPolicyUrl",
         type: {

--- a/sdk/communication/communication-toll-free-verification/src/generated/src/tollFreeVerificationClient.ts
+++ b/sdk/communication/communication-toll-free-verification/src/generated/src/tollFreeVerificationClient.ts
@@ -41,7 +41,7 @@ export class TollFreeVerificationClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-toll-free-verification/1.0.0-beta.2`;
+    const packageDetails = `azsdk-js-communication-toll-free-verification/1.0.0-beta.3`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-toll-free-verification/src/generated/src/tracing.ts
+++ b/sdk/communication/communication-toll-free-verification/src/generated/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Microsoft.Communication",
   packageName: "@azure-tools/communication-toll-free-verification",
-  packageVersion: "1.0.0-beta.2",
+  packageVersion: "1.0.0-beta.3",
 });

--- a/sdk/communication/communication-toll-free-verification/src/utils/constants.ts
+++ b/sdk/communication/communication-toll-free-verification/src/utils/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "1.0.0-beta.2";
+export const SDK_VERSION: string = "1.0.0-beta.3";

--- a/sdk/communication/communication-toll-free-verification/swagger/README.md
+++ b/sdk/communication/communication-toll-free-verification/swagger/README.md
@@ -7,7 +7,7 @@
 ```yaml
 package-name: "@azure-tools/communication-toll-free-verification"
 description: Toll Free Verification client
-package-version: 1.0.0-beta.2
+package-version: 1.0.0-beta.3
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
 input-file: ./swagger.json

--- a/sdk/communication/communication-toll-free-verification/swagger/swagger.json
+++ b/sdk/communication/communication-toll-free-verification/swagger/swagger.json
@@ -768,6 +768,10 @@
         "multipleNumbersJustification": {
           "type": "string"
         },
+        "dba": {
+          "description": "Doing Business As (DBA). Must be filled if the company name used to contact customers differs from the legal entity name.",
+          "type": "string"
+        },
         "privacyPolicyUrl": {
           "description": "URL to the privacy policy for the campaign.",
           "type": "string"


### PR DESCRIPTION
## Summary

Adds a new optional `dba` (Doing Business As) string field to `CampaignBrief` in the Toll Free Verification SDK, mirroring the field that shipped on the Number Management backend.

This unblocks the Azure Portal TFV form to collect a customer-facing business name when it differs from the legal entity name.

## Changes

- **swagger/swagger.json** — added `dba` property between `multipleNumbersJustification` and `privacyPolicyUrl` (same position as the NM backend swagger).
- **swagger/README.md, package.json, src/utils/constants.ts** — bumped version to `1.0.0-beta.3`. All three required: `SDK_VERSION` in `constants.ts` is hand-maintained and drives the user-agent header tests.
- **CHANGELOG.md** — new `1.0.0-beta.3 (Unreleased)` section, and dated the prior `1.0.0-beta.2` entry to `2026-03-09` (its merge date) so the file follows the standard "single Unreleased at top, prior versions dated" convention.
- **src/generated/** — regenerated via `npx autorest swagger/README.md` (no hand edits to generated files).
- **review/communication-toll-free-verification-node.api.md** — `dba?: string;` in alphabetical order, regenerated by api-extractor.

## Test plan

- [x] `pnpm --filter "@azure-tools/communication-toll-free-verification..." build` — all 4 warp targets compile (browser, react-native, esm, commonjs).
- [x] `pnpm lint` — clean.
- [x] `pnpm test:node` — 14/14 tests pass.
- [x] `npm pack` — produced `azure-tools-communication-toll-free-verification-1.0.0-beta.3.tgz` (76.5 kB, 295 files).

## Cross-Model Review

Model: gpt-5.4 — 0 CRITICAL / 0 IMPORTANT findings. Two MINOR notes (informational, no action needed):
- The `dba?: string;` entry in `api.md` correctly omits `// (undocumented)` (JSDoc is in the generated `index.ts`).
- Property position is a hygiene choice; serialization is driven by `serializedName: "dba"` in the mapper.

## Iteration history

- Initial commit: SDK changes for `dba`, version bump to `1.0.0-beta.3`, regenerated artifacts.
- PR feedback: dated `1.0.0-beta.2` to `2026-03-09` (merge date of #37538) so the CHANGELOG follows the repo's "single Unreleased at top, prior versions dated" convention (e.g. `sdk/core/core-util/CHANGELOG.md`).

## Related

- Companion portal PR (consumes the new `.tgz`): tracked under work item #4524418.
- Backend that exposed `dba` (already shipped): #4524417.
- Precedent for this SDK update pattern: #4470388 (BusinessRegistrationDetails, beta.2).
