### PR TITLE
[EngSys] remove turborepo `daemon` option

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
-  "daemon": false,
   "remoteCache": {
     "teamSlug": "azsdkjs",
     "teamId": "azsdkjs",


### PR DESCRIPTION
it is deprecated and no longer used as the warning indicates

>  WARNING  the `daemon` configuration option is deprecated and will be removed in version 3.0. The daemon is no longer used for `turbo run`.