### PR TITLE
[skills] Add create-package-skill wizard and refactor search-documents skill

### DIFF
--- a/.github/skills/create-package-skill/SKILL.md
+++ b/.github/skills/create-package-skill/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-package-skill
+description: 'Interactive wizard that walks service teams through creating a package-specific skill for their Azure SDK package. Scans the package, detects customization patterns, scaffolds a SKILL.md with references, validates with vally lint, and registers in find-package-skill. WHEN: create package skill; add service skill; bootstrap skill for package; new package skill; skill for my SDK package; write skill for search; write skill for cosmos.'
+---
+
+# Create Package Skill Wizard
+
+> **Minimal beats comprehensive. Human-written beats auto-generated. Scaffold and iterate.**
+
+> Skills encode tribal knowledge — the "I wish someone had told me" stuff that's hard to learn from just reading code. Focus on what's non-obvious and package-specific.
+
+## Interaction Protocols
+
+**CONFIRM Protocol** (asset-producing steps — creating files):
+1. PRESENT the proposed assets and explain why.
+2. ASK exactly one question: "Create now (recommended), edit first, or skip?"
+3. ACT immediately. Create → write files this turn. Edit → refine, re-ask. Skip → move on.
+
+**DECIDE Protocol** (informational/correction steps — no files created):
+1. PRESENT the information or findings.
+2. ASK one specific question appropriate to the decision.
+3. PROCEED based on the answer.
+
+One question at a time. Respect "skip" — never re-ask or defer.
+
+## Wizard Flow
+
+Run each phase in order. **Progressive loading:** Read only the current phase file.
+
+| Phase | Description | Instructions |
+|---|---|---|
+| **Phase 0** | 🧭 Scan Package — detect architecture, customizations, key files | [phases/00-scan-package.md](phases/00-scan-package.md) |
+| **Phase 1** | 📝 Scaffold SKILL.md — generate skill with common pitfalls, architecture, workflow | [phases/01-scaffold-skill.md](phases/01-scaffold-skill.md) |
+| **Phase 2** | 📚 Generate References — create architecture.md and customization.md | [phases/02-generate-references.md](phases/02-generate-references.md) |
+| **Phase 3** | ✅ Validate — run vally lint | [phases/03-validate.md](phases/03-validate.md) |
+| **Phase 4** | 📋 Register — add to find-package-skill table | [phases/04-register.md](phases/04-register.md) |
+
+## Guardrails
+
+**Content:**
+- Every line must be non-obvious and package-specific. No generic TypeScript/SDK patterns.
+- SKILL.md should be under 500 tokens (soft limit). Move details to references/.
+- References under 1000 tokens each. Split if larger.
+- Never duplicate what's already in `.github/copilot-instructions.md` or shared skills.
+
+**Relationship to existing SDK tools:**
+- Package skills **complement** the Azure SDK MCP tools (`azsdk_package_generate_code`, `azsdk_package_build_code`, etc.) and the `sdk-workflow` shared skill — they do NOT replace them.
+- MCP tools handle deterministic operations (generate, build, test). Package skills provide the reasoning context an agent needs to use those tools correctly for a specific package.
+- Never redefine how generation, building, or testing works — reference the existing tools instead (e.g., "Run `npm run generate:client`", not custom generation steps).
+- If a workflow step is already handled by an MCP tool or shared skill, just reference it — don't re-document it.
+
+**Structure:**
+- Skill directory: `sdk/<service>/<package>/.github/skills/<skill-name>/`
+- Directory name MUST match `name` field in frontmatter (vally lint enforces this).
+- Use semicolons to separate trigger phrases in description (YAML-safe).
+
+**Security:**
+- Never embed secrets or credentials in skill content.
+- Never instruct agents to bypass CI, linters, or eslint rules.
+- Never instruct agents to edit files in `generated/` directly — always route through the customization workflow or TypeSpec decorators.
+
+## Key Principles (from eval data)
+
+Our eval showed that skill **structure** matters more than **volume**:
+
+| Pattern | Impact |
+|---|---|
+| "Common Pitfalls" section at the TOP | Agent reads pitfalls before analyzing errors → correct diagnosis |
+| "Check X FIRST" directives | Changes agent default from "fix the error location" to "check the customization layer" |
+| Error categorization tables | Gives agent a decision framework, not just procedures |
+| `generated/` vs `src/` distinction | Agent knows which files are safe to edit and which will be overwritten |
+
+## References (load on demand)
+
+- [references/skill-template.md](references/skill-template.md) — SKILL.md template with required sections
+- [references/validation-tools.md](references/validation-tools.md) — vally lint, CI workflow setup

--- a/.github/skills/create-package-skill/phases/00-scan-package.md
+++ b/.github/skills/create-package-skill/phases/00-scan-package.md
@@ -1,0 +1,77 @@
+# Phase 0: Scan Package 🧭
+
+> 📍 **Phase 0 — Scan Package** | Detect the package's architecture, customization patterns, and key files.
+
+## Step 1 — Identify the Package
+
+Ask the user: "Which SDK package should I create a skill for?"
+
+The user should provide either:
+- A package name (e.g., `@azure/search-documents`, `@azure/cosmos`, `@azure-rest/purview-catalog`)
+- A path (e.g., `sdk/search/search-documents`, `sdk/cosmos/cosmos`)
+
+Resolve to the package root directory. Verify it exists and contains `package.json` or `tsp-location.yaml`.
+
+## Step 2 — Scan the Package
+
+Scan the package using the checklist below. Use glob/grep/view tools.
+
+### Scan Checklist
+
+1. **Code generation**: Check for `tsp-location.yaml` → TypeSpec-generated package. If present, note the spec directory and commit SHA.
+
+2. **Customization layout**: Check for a `generated/` directory → customization workflow is set up (via `dev-tool customization init`). If present, the package uses the two-directory layout:
+   - `generated/` — auto-generated from TypeSpec. Never hand-edit.
+   - `src/` — mirrors `generated/` structure plus hand-authored convenience layer.
+
+3. **Source layout**: Glob `src/**/*.{ts,mts,cts}` and `generated/**/*.{ts,mts,cts}` → count files. Identify modules (clients, models, api, helpers, etc.).
+
+4. **Hand-written vs generated**: Files in `generated/` are auto-generated. Files in `src/` that have a counterpart in `generated/` are merged copies. Files in `src/` with NO counterpart in `generated/` are purely hand-authored. List the hand-authored files.
+
+5. **Barrel export and entrypoints**: Check `src/index.ts` for the barrel export. Check `package.json` `exports` field for subpath entrypoints. If the generation script uses `--skip index.ts`, note that the barrel export must be manually maintained.
+
+6. **Generation script**: Check `package.json` scripts for generation-related commands. Common patterns:
+   - `generate:client` — runs TypeSpec generation + formatting + customization apply
+   - `customize` — runs customization apply separately
+   - `echo skipped` — generation is disabled for this package
+   - Note the exact script content and flags (e.g., `--skip index.ts`, `customization apply` vs `customization apply-v2`, emitter options). Do NOT assume the script shape — read the actual value.
+
+7. **Key hand-written files**: Look for non-generated utility files in `src/` (e.g., custom clients, type converters, serializers, helper utilities, custom models).
+
+8. **Tests**: Check `test/` structure. Look for `assets.json` (recorded tests), test config files (`vitest.config.ts`), and test patterns (`*.spec.ts`). Note if there are separate node/browser test configs.
+
+9. **Package metadata**: Read `package.json` for package name (may be `@azure/*` or `@azure-rest/*`), dependencies (especially `@azure/core-*` packages), and any notable scripts.
+
+10. **Package shape classification**: Based on the scan, classify the package:
+    - **TypeSpec + modular customization** — has `tsp-location.yaml`, `generated/`, `src/`, and `dev-tool customization apply` in a script
+    - **TypeSpec, no active customization** — has `tsp-location.yaml` and generation script, but no `generated/` directory or customization apply
+    - **Mostly hand-authored** — no `tsp-location.yaml` or generation is disabled (`echo skipped`)
+
+## Step 3 — Present Package Profile
+
+Print a concise summary:
+
+📋 **Package Profile**
+
+| Field | Value |
+|---|---|
+| Package | `@azure/<name>` or `@azure-rest/<name>` |
+| Path | `sdk/<service>/<package-name>` |
+| Package shape | TypeSpec + customization / TypeSpec only / Hand-authored |
+| Customization layout | Yes/No (`generated/` + `src/` with 3-way merge) |
+| Source files | N generated, M hand-written |
+| Barrel export | `src/index.ts` — manually maintained / auto-generated |
+| Generation command | Actual script content from `package.json` |
+| Entrypoints | `package.json` exports map (if subpath exports exist) |
+| Tests | Unit: Y, Live: Y/N, Recorded: Y/N |
+| Key hand-written files | List discovered files |
+
+## Step 4 — DECIDE
+
+Question: "Does this profile look right? Anything to add or correct?"
+
+📍 **Phase 0 complete** | Package scanned | Next: Phase 1
+
+---
+## → Next: Phase 1 — Scaffold SKILL.md
+Read [01-scaffold-skill.md](01-scaffold-skill.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/01-scaffold-skill.md
+++ b/.github/skills/create-package-skill/phases/01-scaffold-skill.md
@@ -1,0 +1,99 @@
+# Phase 1: Scaffold SKILL.md 📝
+
+> 📍 **Phase 1 — Scaffold SKILL.md** | Generate the main skill file with key sections.
+
+> 📖 Read `references/skill-template.md` for the full template.
+
+Using the package profile from Phase 0, generate a `SKILL.md` at:
+```
+sdk/<service>/<package-name>/.github/skills/<package-short-name>/SKILL.md
+```
+
+The skill directory name MUST match the `name` field in frontmatter. Use the short package name without the `@azure/` or `@azure-rest/` scope (e.g., `search-documents`, `cosmos`, `purview-catalog`). This is enforced by vally lint.
+
+## Content Principles
+
+- **Keep it static.** Document architecture, design patterns, and convenience layer patterns — things that rarely change. Do NOT include version numbers, current API versions, or anything that changes every release. The skill should be valid for years, not months.
+- **Point to source code, not hardcoded lists.** When referencing things that change (method names, type names, enum values), point the agent to the authoritative source file instead of enumerating values in the skill.
+- **Prefer TypeSpec customizations over source-level customizations.** When documenting customization patterns, always note: "Use source-level customizations (editing `src/` files) when TypeSpec cannot express the desired behavior. For TypeSpec-level customizations (preferred when possible), see [TypeSpec Client Customizations Reference](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/knowledge/customizing-client-tsp.md)."
+- **Don't re-document MCP tools or shared skills.** The `sdk-workflow` shared skill and MCP tools (`azsdk_package_generate_code`, `azsdk_package_build_code`, etc.) already handle generation, build, and testing workflows. The package skill adds only what those tools don't know.
+- **Focus on the convenience layer — when it exists.** The highest-value content is: how is the package designed, what convenience patterns exist, what does the agent need to know to write/maintain the convenience layer correctly. For mostly-generated or thin-wrapper packages, focus instead on entrypoints, exports, generation workflow, and any thin wrappers.
+
+## Required Sections
+
+### 1. Frontmatter
+
+```yaml
+---
+name: <package-short-name>
+description: '<Brief description>. WHEN: regenerate <package>; modify <package>; fix <package> bug; add <package> feature; <package> tsp-client update.'
+---
+```
+
+Use semicolons for trigger phrases (YAML-safe). Include package name in every trigger.
+
+### 2. Common Pitfalls (MUST be first section after heading)
+
+List the most dangerous mistakes. Include items **conditionally based on the package shape** detected in Phase 0:
+
+- **Never hand-edit files in `generated/`** — these are overwritten on every `tsp-client update`. All modifications go through editing `src/` files directly (the 3-way merge preserves your changes).
+- **(If customization layout exists)** **"Check for merge conflicts in `src/` FIRST after regeneration"** — `dev-tool customization apply` performs a 3-way merge that can produce conflict markers.
+- **(If `--skip index.ts` detected in generation script)** **`src/index.ts` is skipped during customization apply** — new exports must be manually added to the barrel export file.
+- **(If customization layout exists)** **"Hand-authored files in `src/` with counterparts in `generated/` are merged. Files without counterparts are preserved as-is."**
+- **(If mostly generated / thin wrapper)** Focus pitfalls on generation workflow, entrypoints, and exports — not convenience layer patterns.
+- Any package-specific gotchas found during scanning
+
+### 3. Architecture
+
+- Source layout with `generated/` vs `src/` distinction
+- Customization mechanism (`dev-tool customization apply`)
+- Key modules and their purpose
+
+### 4. Regeneration
+
+**Do NOT re-document the generation/build/test workflow.** The `sdk-workflow` shared skill and MCP tools handle that. The package skill adds only:
+
+- **Package-specific generation command** — document the actual script content from `package.json` (detected in Phase 0). Note any special flags. Do NOT assume the command shape — different packages use different scripts (`generate:client`, `customize`, `customization apply-v2`, or generation may be disabled).
+- **Error categorization table** — which file to fix based on error type:
+  - **(If customization layout)** Generated file in `generated/`, merged file in `src/`, hand-authored file in `src/`
+  - **(If no customization layout)** Generated file in `src/`, hand-authored file in `src/`
+- **Package-specific customization patterns** — what hand-authored files do and when they need updating
+- **Breaking change detection** — what to look for after spec changes
+- **(If service version management detected)** How the package handles API versions
+
+### 5. Where to Make Changes
+
+Add a table mapping goals to edit locations:
+
+| Goal | Where to edit |
+|---|---|
+| Add/modify type conversions | `src/<relevant-utils>.ts` |
+| Add/modify public model types | `src/<relevant-models>.ts` |
+| Change how operations work | `src/<relevant-client>.ts` |
+| Export a new public symbol | `src/index.ts` |
+
+**Prefer extension points over editing generated-mirrored code.** Many files in `src/` are copies from `generated/` and will be updated on regeneration (via 3-way merge). Instead, add conversion helpers or custom models in hand-authored files.
+
+### 6. Testing Notes
+
+How to run tests, recorded test setup, environment requirements.
+
+### 7. References table
+
+Link to `references/architecture.md` and `references/customization.md`.
+
+## Step 1 — Present
+
+Generate the full SKILL.md content and print it. Use the package profile to fill in package-specific details. Mark sections where domain expertise is needed with `<!-- TODO: Domain expert to fill in -->`.
+
+## Step 2 — CONFIRM
+
+Question: "Create this SKILL.md now (recommended), edit first, or skip?"
+
+If confirmed, create the skill directory and SKILL.md file.
+
+📍 **Phase 1 complete** | Created: SKILL.md | Next: Phase 2
+
+---
+## → Next: Phase 2 — Generate References
+Read [02-generate-references.md](02-generate-references.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/02-generate-references.md
+++ b/.github/skills/create-package-skill/phases/02-generate-references.md
@@ -1,0 +1,49 @@
+# Phase 2: Generate References 📚
+
+> 📍 **Phase 2 — Generate References** | Create supporting reference documents.
+
+## references/architecture.md
+
+Generate from the package scan. Include:
+
+- **Repository layout** — directory tree with `generated/` vs `src/` annotations
+- **Source layout** — module structure under `src/` (clients, models, helpers, etc.)
+- **Code generation** — toolchain (`TypeSpec → emitter → generated/ → dev-tool customization apply → src/`), `tsp-location.yaml` format
+- **Generated vs hand-authored** — table showing mechanism, location, when to use
+- **Public client types** — all client classes and their purpose
+- **Key hand-authored files** — table of important files in `src/` that don't exist in `generated/`
+- **Dependencies** — runtime and dev dependencies from `package.json`
+- **Build and test commands** — `pnpm turbo build --filter=@azure/<package>... --token 1`, `pnpm run test`
+
+**Important**: Only include information that is accurate based on scanning the actual code. Mark anything uncertain with `<!-- TODO: Verify -->`.
+
+## references/customization.md (if customization layout exists)
+
+Generate from comparing `generated/` and `src/`. Document:
+
+- **The customization command** — document the actual command detected in Phase 0 (e.g., `dev-tool customization apply`, `customization apply-v2`). Include required flags and prerequisites (committed state in both directories).
+- **The 3-way merge algorithm** — how base/custom/result snapshots work, merge scenarios table
+- **Merge conflict resolution** — how to resolve conflicts (start from `result`, identify hand-written intent from `custom` vs `base`, reapply intent onto `result`)
+- **Hand-authored file inventory** — for each hand-authored file: what it does, when to update it, what breaks if generated code changes under it
+- **Common scenarios after regeneration** — new operation added, model type changed, new sub-client added, operation signature changed
+- **(If `--skip` flag detected)** **Skipped file maintenance** — which files are skipped and must be manually updated (e.g., `src/index.ts`)
+
+Reference `documentation/modular-customization.md` for the full customization workflow details.
+
+Also include:
+- **Troubleshooting** — merge conflicts, missing exports, build failures after regeneration
+- **Quick-reference checklist** — post-regeneration verification steps
+
+## Step 1 — Present
+
+Print the proposed reference files content.
+
+## Step 2 — CONFIRM
+
+Question: "Create these reference files now (recommended), edit first, or skip?"
+
+📍 **Phase 2 complete** | Created: references/ | Next: Phase 3
+
+---
+## → Next: Phase 3 — Validate
+Read [03-validate.md](03-validate.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/03-validate.md
+++ b/.github/skills/create-package-skill/phases/03-validate.md
@@ -1,0 +1,46 @@
+# Phase 3: Validate
+
+> 📍 **Phase 3 — Validate** | Run structural validation on the new skill.
+
+> 📖 Read `references/validation-tools.md` for tool details.
+
+## Step 1 — Structural Validation (vally lint)
+
+Run vally lint against the skill:
+
+```powershell
+# If vally is installed (npm package from microsoft/evaluate)
+vally lint sdk/<service>/<package>/.github/skills/<skill-name>
+
+# If vally is not installed, check manually:
+# - SKILL.md exists with valid YAML frontmatter
+# - name field matches directory name
+# - All markdown links in SKILL.md resolve to existing files
+# - No orphaned files in references/ (every file linked from SKILL.md)
+```
+
+Expected: 3/3 checks pass (spec-compliance, valid-refs, orphan-files).
+
+**Common failure**: `name-directory-mismatch` — the `name` in frontmatter doesn't match the directory name. Fix by renaming the directory to match the short package name (e.g., `search-documents`).
+
+## Step 2 — Token Budget Check
+
+Verify token budgets:
+- SKILL.md: under 500 tokens (soft), under 5000 (hard)
+- Each reference file: under 1000 tokens
+
+If over budget, split content into additional reference files.
+
+## Step 3 — DECIDE
+
+Present validation results. If all pass:
+Question: "Validation passed. Proceed to register the skill?"
+
+If failures exist, present them and ask:
+Question: "These issues need fixing. Fix now, or skip validation?"
+
+📍 **Phase 3 complete** | Validation: pass/fail | Next: Phase 4
+
+---
+## → Next: Phase 4 — Register
+Read [04-register.md](04-register.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/04-register.md
+++ b/.github/skills/create-package-skill/phases/04-register.md
@@ -1,0 +1,41 @@
+# Phase 4: Register 📋
+
+> 📍 **Phase 4 — Register** | Add the skill to the find-package-skill discovery table.
+
+## Step 1 — Update find-package-skill
+
+Add a row to `.github/skills/find-package-skill/SKILL.md` in the **Package Skills** table:
+
+```markdown
+| `@azure/<package-name>` or `@azure-rest/<package-name>` | `sdk/<service>/<package>/.github/skills/<skill-name>/SKILL.md` |
+```
+
+## Step 2 — Summary
+
+Print a summary of everything created:
+
+📋 **Package Skill Created**
+
+| Item | Path | Status |
+|---|---|---|
+| SKILL.md | `sdk/<service>/<package-name>/.github/skills/<skill-name>/SKILL.md` | Created |
+| architecture.md | `...references/architecture.md` | Created/Skipped |
+| customization.md | `...references/customization.md` | Created/Skipped |
+| find-package-skill | `.github/skills/find-package-skill/SKILL.md` | Updated |
+| vally lint | 3/3 checks | Passed |
+
+**Next steps for the service team:**
+1. Fill in any `<!-- TODO -->` sections with domain-specific knowledge
+2. Test the skill by asking an agent to regenerate your package
+3. Iterate: agent gets something wrong → update skill → test again
+4. Submit a PR
+
+**Maintaining your skill:**
+- When your package's customizations change, update the skill
+- Keep content static — no version numbers or release-specific info
+
+## Step 3 — CONFIRM
+
+Question: "Register the skill in find-package-skill now (recommended), or skip?"
+
+📍 **Phase 4 complete** | Skill registered | Wizard done 🎉

--- a/.github/skills/create-package-skill/references/skill-template.md
+++ b/.github/skills/create-package-skill/references/skill-template.md
@@ -1,0 +1,52 @@
+# SKILL.md Template for Azure SDK Package Skills
+
+Use this template when creating a new package skill. Replace placeholders with package-specific content.
+
+```yaml
+---
+name: <package-short-name>
+description: '<Brief description>. WHEN: regenerate <package>; modify <package>; fix <package> bug; add <package> feature; <package> tsp-client update.'
+---
+```
+
+The `name` field and directory name MUST match the short package name without the `@azure/` or `@azure-rest/` scope (e.g., `search-documents`, `cosmos`, `purview-catalog`).
+
+## Content Principles
+
+- **Keep it static** — no version numbers, no current API versions. Document design and patterns, not release state.
+- **Prefer TypeSpec customizations over source-level edits** — always note when a customization could be a TypeSpec decorator instead.
+- **Don't re-document MCP tools or shared skills** — the `sdk-workflow` skill and MCP tools handle generation workflows.
+- **Focus on the convenience layer** — what does the agent need to know to write/maintain convenience patterns correctly.
+
+## Required Sections (in order)
+
+### Common Pitfalls
+List 3-5 most dangerous mistakes. This section MUST come first — agents read it before analyzing errors.
+
+### Architecture
+Source layout, `generated/` vs `src/` distinction, customization mechanism. No version numbers.
+
+### Regeneration
+Package-specific generation command and flags, error categorization table, breaking change detection. Do NOT re-document the generation/build/test steps — those are in the shared skill. Document the actual script content from `package.json` — do not assume the command shape.
+
+### Where to Make Changes
+Table mapping goals to edit locations. Emphasize preferring hand-authored extension points over editing generated-mirrored files (if applicable).
+
+### Testing Notes
+Commands, recorded test setup, environment requirements.
+
+### References
+Table linking to references/*.md files (e.g., `architecture.md`, `customization.md`).
+
+## Structural Rules
+
+| Rule | Enforced By |
+|---|---|
+| `name` matches directory name (= short package name) | `vally lint` |
+| All markdown links resolve | `vally lint` |
+| No orphaned reference files | `vally lint` |
+| Code references still exist in codebase | Manual review |
+| SKILL.md under 5000 tokens | `vally lint` |
+| No version numbers or release-specific info | Manual review |
+| Trigger phrases include package name | Manual review |
+| No cross-language content | Manual review |

--- a/.github/skills/create-package-skill/references/validation-tools.md
+++ b/.github/skills/create-package-skill/references/validation-tools.md
@@ -1,0 +1,24 @@
+# Validation Tools for Package Skills
+
+## vally lint (Structural Validation)
+
+**Source**: `microsoft/evaluate` (currently private, will be public)
+
+```bash
+# Install (once published)
+npm install -g @microsoft/vally-cli
+
+# Lint a skill
+vally lint sdk/<service>/<package>/.github/skills/<skill-name>
+
+# Lint all skills in repo
+vally lint .github/skills
+```
+
+### What it checks
+
+| Check | What it does | Common failure |
+|---|---|---|
+| `spec-compliance` | Validates frontmatter (name, description), name-directory match | Directory name doesn't match `name` field |
+| `valid-refs` | All markdown links resolve to existing files | Broken link to reference file |
+| `orphan-files` | No unreferenced files in references/ | File in references/ not linked from SKILL.md |

--- a/sdk/search/search-documents/.github/skills/search-documents/SKILL.md
+++ b/sdk/search/search-documents/.github/skills/search-documents/SKILL.md
@@ -1,316 +1,148 @@
 ---
 name: search-documents
-description: '**UTILITY SKILL** — Domain knowledge for the @azure/search-documents SDK package. Covers architecture, pagination, data flow, type mappings, and common pitfalls. WHEN: "regenerate search-documents", "modify search-documents", "fix search client", "add search feature", "search type conversion".'
+description: 'Domain knowledge for @azure/search-documents. Covers architecture, type conversions, data flow, and common pitfalls. WHEN: regenerate search-documents; modify search-documents; fix search-documents bug; add search-documents feature; search-documents tsp-client update.'
 ---
 
 # @azure/search-documents — Package Skill
 
+## Common Pitfalls
+
+- **Generated sub-client ≠ convenience client** — `src/search/searchClient.ts` is the GENERATED sub-client (overwritten on regeneration). `src/searchClient.ts` is the HAND-AUTHORED convenience client. Adding methods to the generated file does nothing for consumers. Always edit the hand-authored file at the `src/` root. See the "Generated vs Hand-Authored Files" table in Architecture.
+- **New operations must be wired through the convenience layer** — after regeneration, new operations appearing in generated files are NOT available to consumers until explicitly exposed via the hand-authored convenience clients, model files, and `src/index.ts`. Do not stop at regeneration. See "Exposing New Operations" below.
+- **Never hand-edit files in `generated/`** — these are overwritten on every `tsp-client update`. Edit `src/` files directly; the 3-way merge preserves your changes.
+- **Never hand-edit generated-mirrored files** — files under `src/search/`, `src/searchIndex/`, `src/searchIndexer/`, `src/knowledgeBaseRetrieval/`, and `src/models/` are mirrored from `generated/`. Edits will be overwritten on next regeneration.
+- **Check for merge conflicts FIRST after regeneration** — `dev-tool customization apply` can produce conflict markers in `src/`. Run `grep -r "<<<<<<" src/ --include="*.ts"`.
+- **`src/index.ts` is skipped during customization apply** — new exports must be manually added. The `ae-forgotten-export` lint error catches missing exports.
+- **`test/snippets.spec.ts` is documentation, not tests** — it contains source code for README and doc-comment snippets. Never delete or replace its contents when updating real tests.
+- **Uses `@azure-rest/core-client`** not `@azure/core-client` — this TypeSpec package uses the REST variant for `OperationOptions`, `ClientOptions`, etc.
+- **`knownSkills` whitelist** — `convertSkillsToPublic()` in `src/serviceUtils.ts` silently drops unknown skill types. New service skill types require updating this hardcoded record.
+- **No reverse conversion for some types** — `vectorSearch` and individual skills are passed through directly without dedicated public-to-generated converters.
+- **`search()` uses custom POST pagination** — not standard `nextLink` GET paging. Uses `nextPageParameters` POST body with opaque Base64 continuation tokens.
+- **Date deserialization is strict** — only matches UTC ISO strings with 0-3 fractional seconds and `Z` suffix. Non-UTC strings are not auto-converted.
+- **`indexDocuments` 207 behavior** — partial success (HTTP 207) is thrown as an exception when `throwOnAnyFailure` is set. This is intentional.
+
 ## Architecture
 
-This package has a **two-directory layout** with a customization merge step:
+Two-directory layout with customization merge:
 
-- `generated/` — Auto-generated from TypeSpec. **Never hand-edit.**
-- `src/` — Mirrors `generated/` structure plus hand-authored convenience layer.
+- `generated/` — auto-generated from TypeSpec. Never hand-edit.
+- `src/` — mirrors `generated/` structure plus hand-authored convenience layer. Files with counterparts in `generated/` are merged; files without counterparts are preserved as-is.
 
-During code generation, `npx dev-tool customization apply --skip index.ts` performs a 3-way merge of `generated/` into `src/`. Files that exist only in `src/` (hand-authored) are preserved. `src/index.ts` is skipped entirely — **new exports must be manually added there**.
+Four convenience clients wrap generated sub-clients:
+
+| Client | Constructor | Purpose |
+|---|---|---|
+| `SearchClient<TModel>` | `(endpoint, indexName, credential, options?)` | Search, suggest, autocomplete, document CRUD |
+| `SearchIndexClient` | `(endpoint, credential, options?)` | Index CRUD, synonym maps, aliases, knowledge bases |
+| `SearchIndexerClient` | `(endpoint, credential, options?)` | Indexer, data source, skillset CRUD |
+| `KnowledgeRetrievalClient` | `(endpoint, knowledgeBaseName, credential, options?)` | Knowledge base retrieval |
+
+Each client: creates generated client → replaces auth with search-specific auth (API key header or bearer token) → adds OData metadata policy → wraps every method in `tracingClient.withSpan()` with type conversion. `SearchClient` uses OData metadata `"none"`; others use `"minimal"`.
+
+### Generated vs Hand-Authored Files — Know the Difference
+
+The file paths look deceptively similar. Confusing them is the single most common mistake:
+
+| File | Type | Edit? |
+|---|---|---|
+| `src/search/searchClient.ts` | **Generated** sub-client (mirrored from `generated/`) | **NEVER** — overwritten on regeneration |
+| `src/searchClient.ts` | **Hand-authored** convenience client (`SearchClient<TModel>`) | ✅ Add operations here |
+| `src/searchIndex/searchIndexClient.ts` | **Generated** sub-client | **NEVER** |
+| `src/searchIndexClient.ts` | **Hand-authored** convenience client (`SearchIndexClient`) | ✅ Add operations here |
+| `src/searchIndexer/searchIndexerClient.ts` | **Generated** sub-client | **NEVER** |
+| `src/searchIndexerClient.ts` | **Hand-authored** convenience client (`SearchIndexerClient`) | ✅ Add operations here |
+| `src/knowledgeBaseRetrieval/knowledgeBaseRetrievalClient.ts` | **Generated** sub-client | **NEVER** |
+| `src/knowledgeRetrievalClient.ts` | **Hand-authored** convenience client (`KnowledgeRetrievalClient`) | ✅ Add operations here |
+| `src/search/api/operations.ts` | **Generated** operations | **NEVER** |
+| `src/models/models.ts` | **Generated** models | **NEVER** |
+
+**Rule:** Any file under `src/{subclient}/` (i.e. `src/search/`, `src/searchIndex/`, `src/searchIndexer/`, `src/knowledgeBaseRetrieval/`) or `src/models/` is generated-mirrored code. Never hand-edit these files.
+
+The convenience layer converts between generated and public types via `src/serviceUtils.ts` (200+ conversion functions). Key patterns: `additionalProperties` unwrapping, field visibility inversion (`hidden` ↔ `!retrievable`), encryption key renames (`vaultUrl` ↔ `vaultUri`), and custom serialization for NaN/Infinity/Date/GeographyPoint.
 
 ## Regeneration
 
-To regenerate from a new TypeSpec spec commit:
-
-1. **Commit all changes first** — the 3-way merge requires committed state in both `generated/` and `src/`.
-2. Update `tsp-location.yaml` with the new commit SHA.
-3. Run `npm run generate:client` — this single command runs all three steps:
-   - `tsp-client update -d --emitter-options="ignore-nullable-on-optional=true"` — generates into `generated/`
-   - `npm run format` — formats generated code
-   - `npx dev-tool customization apply --skip index.ts` — 3-way merges into `src/`
-4. Check for merge conflicts: `grep -r "<<<<<<" src/ --include="*.ts"`
-5. **Build the package:** `pnpm turbo build --filter=@azure/search-documents... --token 1` — builds the package and all its dependencies.
-6. **Run tests:** `pnpm run test` — runs the internal tests (no env vars, proxy, or Azure resources needed). All tests should pass before proceeding. To run the tests, copy sample.env to `.env` and fill in the values, then run `pnpm run test:node` for Node.js tests and `pnpm run test:browser` for browser tests. Prompt user for values if env vars are missing.
-
-**Do not run these steps individually (steps 1-4)** — use `npm run generate:client` which ensures correct ordering and flags. Steps 5-6 must be run after regeneration to verify the output.
-
-For details on the 3-way merge algorithm, conflict resolution, and common post-regeneration scenarios (new operation added, model type changed, new sub-client added), see `references/customization.md`.
-
-### Where to Make Changes
-
-| Goal                                                                      | Where to edit                     |
-| ------------------------------------------------------------------------- | --------------------------------- |
-| Add/modify type conversions (generated <-> public)                        | `src/serviceUtils.ts`             |
-| Add/modify public model types for indexes, indexers, skills, data sources | `src/serviceModels.ts`            |
-| Add/modify public types for search/suggest/autocomplete operations        | `src/indexModels.ts`              |
-| Add/modify public types for knowledge base operations                     | `src/knowledgeBaseModels.ts`      |
-| Change how search/suggest/autocomplete/getDocument/indexDocuments work    | `src/searchClient.ts`             |
-| Change how index management (create/get/list/delete indexes) works        | `src/searchIndexClient.ts`        |
-| Change how indexer/data source/skillset management works                  | `src/searchIndexerClient.ts`      |
-| Change how knowledge retrieval works                                      | `src/knowledgeRetrievalClient.ts` |
-| Add/modify special serialization (NaN, Infinity, Date, GeographyPoint)    | `src/serialization.ts`            |
-| Export a new public symbol                                                | `src/index.ts`                    |
-
-**Prefer extension points over editing generated-mirrored code.** Many files in `src/` are copies from `generated/` and will be overwritten on regeneration. Instead:
-
-- Add conversion helpers in `serviceUtils.ts`, call them from the convenience client.
-- Add custom public models in `serviceModels.ts` or `indexModels.ts`, map to/from generated models in `serviceUtils.ts`.
-
-### Key Hand-Authored Files
-
-| File                                  | Purpose                                                                                         |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `src/searchClient.ts`                 | `SearchClient<TModel>` convenience wrapper — search, suggest, autocomplete, document operations |
-| `src/searchIndexClient.ts`            | `SearchIndexClient` convenience wrapper — index CRUD, synonym maps, aliases                     |
-| `src/searchIndexerClient.ts`          | `SearchIndexerClient` convenience wrapper — indexer, data source, skillset CRUD                 |
-| `src/knowledgeRetrievalClient.ts`     | `KnowledgeRetrievalClient` convenience wrapper — knowledge base retrieval                       |
-| `src/serviceUtils.ts`                 | 200+ type conversion functions between generated and public types                               |
-| `src/serviceModels.ts`                | User-facing types for indexes, indexers, skills, data sources                                   |
-| `src/indexModels.ts`                  | User-facing types for search, suggest, autocomplete operations                                  |
-| `src/serialization.ts`                | NaN/Infinity/Date/GeographyPoint serialization                                                  |
-| `src/walk.ts`                         | Recursive immutable tree walker with cycle detection for serialization                          |
-| `src/indexDocumentsBatch.ts`          | Batch builder for document upload/merge/delete actions                                          |
-| `src/searchIndexingBufferedSender.ts` | Auto-flush buffered sender with retry and adaptive batch sizing                                 |
-| `src/odata.ts`                        | `odata` template tag for safe OData filter expressions                                          |
-| `src/geographyPoint.ts`               | `GeographyPoint` class with GeoJSON/EPSG:4326 conversion                                        |
-| `src/odataMetadataPolicy.ts`          | Pipeline policy setting OData metadata Accept header                                            |
-| `src/searchApiKeyCredentialPolicy.ts` | Pipeline policy adding `api-key` header                                                         |
-| `src/index.ts`                        | Barrel export — `--skip`'d during merge, must be manually updated                               |
-
-## The Four Clients
-
-| Client                     | Constructor                                           | Wraps                                                        |
-| -------------------------- | ----------------------------------------------------- | ------------------------------------------------------------ |
-| `SearchClient<TModel>`     | `(endpoint, indexName, credential, options?)`         | `src/search/searchClient.ts`                                 |
-| `SearchIndexClient`        | `(endpoint, credential, options?)`                    | `src/searchIndex/searchIndexClient.ts`                       |
-| `SearchIndexerClient`      | `(endpoint, credential, options?)`                    | `src/searchIndexer/searchIndexerClient.ts`                   |
-| `KnowledgeRetrievalClient` | `(endpoint, knowledgeBaseName, credential, options?)` | `src/knowledgeBaseRetrieval/knowledgeBaseRetrievalClient.ts` |
-
-Each follows the same pattern:
-
-1. Constructor creates a generated client, replaces default auth with search-specific auth (API key header or bearer token), and adds an OData metadata policy.
-2. Each public method wraps a `tracingClient.withSpan()` call that converts public types to generated types, calls the generated client, and converts back.
-
-**OData metadata level differs by client:**
-
-- `SearchClient` uses `"none"` — document responses don't need type annotations.
-- `SearchIndexClient` and `SearchIndexerClient` use `"minimal"` — management operations need them.
-
-### SearchIndexClient Extras
-
-- `getSearchClient(indexName)` — factory that spawns a `SearchClient` for a specific index, sharing the credential.
-- `listIndexesNames()` — uses server-side projection (`select: "name"`) via `listIndexesWithSelectedProperties` to reduce payload, wrapped with `mapPagedAsyncIterable`.
-
-## Search Pagination
-
-The `search()` method has a **fully custom pagination implementation**. It does NOT use the standard `buildPagedAsyncIterator` from `pagingHelpers.ts`.
-
-### How It Works
-
-1. **`search(searchText, options)`** (public entry point) eagerly fetches the first page by calling the private `searchDocuments()` method, then wraps the result in a `SearchIterator` via `listSearchResults()`.
-
-2. **`searchDocuments()`** transforms public `SearchOptions` into generated types (joining arrays, encoding semantic options), calls `this.client.searchPost()`, converts results back (unwrapping `additionalProperties`), and encodes the continuation token.
-
-3. **The generated `searchPost()`** is a simple one-shot POST — it returns raw `results`, `nextLink`, and `nextPageParameters` with zero pagination logic.
-
-4. **`listSearchResultsPage()`** is an `async *` generator that decodes the continuation token, calls `searchDocuments()` with the decoded `nextPageParameters`, yields the page, and loops while there's a continuation token.
-
-5. **`listSearchResultsAll()`** is an `async *` generator that yields individual items from the first page, then delegates to `listSearchResultsPage()` for subsequent pages.
-
-6. **`listSearchResults()`** assembles the `SearchIterator` with `next()` (item-by-item) and `byPage()` (page-by-page) support.
-
-### Continuation Token Encoding
-
-The service returns two values for pagination:
-
-- `nextLink` — an `@odata.nextLink` URL
-- `nextPageParameters` — an `@search.nextPageParameters` JSON object (a full search request body)
-
-The convenience layer **combines these into a single opaque token**:
+Generation command (from `package.json`):
 
 ```
-encode(JSON.stringify({ apiVersion, nextLink, nextPageParameters }))
+tsp-client update -d --emitter-options="ignore-nullable-on-optional=true;wrap-non-model-return=false" && npm run format && npx dev-tool customization apply --skip index.ts
 ```
 
-- Base64-encoded (via `src/base64.ts` / `src/base64-browser.mts`)
-- Includes `apiVersion` as a version guard — tokens from a different API version are rejected with `RangeError`
-- Returns `undefined` if either `nextLink` or `nextPageParameters` is missing (no more pages)
-- **`nextLink` is stored but never used for fetching** — only `nextPageParameters` drives page fetches (see comment at line ~419 in searchClient.ts)
+Run via: `npm run generate:client`. **All changes must be committed first** — the 3-way merge requires committed state.
 
-### Key Types
+**Important flags:**
 
-- `SearchIterator<TModel, TFields>` — `PagedAsyncIterableIterator` alias for the `results` property
-- `SearchDocumentsResult<TModel, TFields>` — top-level return type from `search()`, contains first-page metadata (count, facets, answers) plus `results: SearchIterator`
-- `SearchDocumentsPageResult<TModel, TFields>` — a single page: `results: SearchResult[]` (plain array) plus `continuationToken?: string`
-- `ListSearchResultsPageSettings` — settings for `byPage()`, containing only `continuationToken?: string`
+- `ignore-nullable-on-optional=true` — mitigates TypeSpec's `T | null` on optional properties
+- `wrap-non-model-return=false` — prevents wrapping non-model return types
+- `--skip index.ts` — barrel export is manually maintained
 
-### Why It's Custom
+### Error Categorization
 
-Standard Azure SDK paging follows `nextLink` URLs with GET requests. Search differs:
+| Error Location | Root Cause | Fix In |
+|---|---|---|
+| `generated/**/*.ts` | TypeSpec spec change | Update `tsp-location.yaml`, re-run `npm run generate:client` |
+| `src/<sub-client>/api/*.ts` (merged) | Merge conflict from spec change | Resolve conflict in `src/`, preserving hand-authored intent |
+| `src/serviceUtils.ts` | Type conversion mismatch | Update conversion functions to match new generated types |
+| `src/serviceModels.ts` or `src/indexModels.ts` | Public type doesn't match generated shape | Update public type definitions and their conversions |
+| `src/index.ts` | Missing export after regeneration | Manually add new exports |
+| `src/searchClient.ts` | Wire format encoding changed | Update conversion/encoding helpers in searchClient.ts |
 
-- Uses POST with `nextPageParameters` body payloads, not GET with nextLink URLs.
-- First page is eagerly fetched (metadata like facets/count available immediately without iteration).
-- Continuation tokens are opaque Base64 blobs with version pinning.
-- Dual result types: top-level `results` is an async iterator, but each page's `results` is a plain array.
+### Breaking Change Detection
 
-## Data Flow Patterns
+After spec changes, check for:
 
-### additionalProperties Unwrapping
+- New/removed/renamed properties in generated models → update conversions in `serviceUtils.ts`
+- New/removed operations → add/remove convenience wrappers and exports
+- New sub-clients → create convenience wrapper, add exports
+- Changed discriminator values → update union handling in conversion functions
 
-TypeSpec wraps user document fields in `additionalProperties`. The convenience layer unwraps:
+For 3-way merge details and conflict resolution, see [references/customization.md](references/customization.md).
 
-```
-Generated: { searchScore, additionalProperties: { hotelName, rating, ... } }
-     -> generatedSearchResultToPublicSearchResult()
-Public:    { score, document: { hotelName, rating, ... } }
-```
+### Exposing New Operations
 
-Affects: `search()`, `suggest()`, `autocomplete()`, `getDocument()`.
+New operations appearing after regeneration are **not available to consumers** until explicitly wired through the hand-authored convenience clients. Do not stop at regeneration. Complete ALL of these steps for each new operation:
 
-### The Reverse: `__actionType` Convention
+1. **Add a public method** to the correct hand-authored convenience client (e.g. `src/searchClient.ts`, NOT `src/search/searchClient.ts`). The method must wrap `tracingClient.withSpan()`, convert public types to generated types, call the generated operation, and convert the response back.
+2. **Define public model types** in `src/indexModels.ts`, `src/serviceModels.ts`, or `src/knowledgeBaseModels.ts` for any new request/response types.
+3. **Add conversion functions** in `src/serviceUtils.ts` to translate between generated and public types (or add inline conversions in the convenience client for simple cases).
+4. **Export all new public symbols** from `src/index.ts` — this file is skipped during merge and must always be updated manually.
+5. **Run `api-extractor`** and verify new types/methods appear in `review/search-documents-node.api.md`. If they don't appear, they are not part of the public API.
 
-For `indexDocuments()`, the public API uses `IndexDocumentsAction<TModel>` which spreads the document and adds `__actionType: "upload" | "merge" | "mergeOrUpload" | "delete"`. The double-underscore prefix avoids collision with user document fields.
+The task is not complete until every new operation is callable from the public convenience client and visible in the API report.
 
-`convertPublicActionsToGeneratedActions()` transforms each action by extracting `__actionType` into `actionType` and moving remaining properties into `additionalProperties` — the inverse of the response unwrapping.
+For a detailed example (wrong vs right), see [references/architecture.md](references/architecture.md).
 
-`IndexDocumentsBatch` provides a builder pattern: `upload()`, `merge()`, `mergeOrUpload()`, `delete()` methods accumulate actions. The `delete()` method has two overloads: delete by documents or delete by `keyName` + `keyValues`.
+## Where to Make Changes
 
-### The Serialization Sandwich
+| Goal | Where to edit |
+|---|---|
+| Add/modify type conversions (generated ↔ public) | `src/serviceUtils.ts` |
+| Add/modify public model types for indexes, indexers, skills, data sources | `src/serviceModels.ts` |
+| Add/modify public types for search/suggest/autocomplete operations | `src/indexModels.ts` |
+| Add/modify public types for knowledge base operations | `src/knowledgeBaseModels.ts` |
+| Change how search/suggest/autocomplete/document operations work | `src/searchClient.ts` |
+| Change how index management works | `src/searchIndexClient.ts` |
+| Change how indexer/data source/skillset management works | `src/searchIndexerClient.ts` |
+| Change how knowledge retrieval works | `src/knowledgeRetrievalClient.ts` |
+| Add/modify special serialization (NaN, Infinity, Date, GeographyPoint) | `src/serialization.ts` |
+| Export a new public symbol | `src/index.ts` |
 
-Every document boundary applies serialize (outbound) and deserialize (inbound) via `walk()`:
-
-**Serialize:** `NaN` -> `"NaN"`, `Infinity` -> `"INF"`, `-Infinity` -> `"-INF"`, `Date` -> ISO 8601, `GeographyPoint` -> GeoJSON Point with CRS  
-**Deserialize:** Reverse of above. Date regex matches `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$` (0-3 fractional seconds, UTC only).
-
-`GeographyPoint` serializes to GeoJSON with `[longitude, latitude]` order (not `[lat, lng]`) and requires CRS `EPSG:4326`. The CRS property is required by the search service, not standard GeoJSON.
-
-### Field Visibility Inversion
-
-The public API uses `hidden: boolean` (user-friendly). The wire format uses `retrievable: boolean`. They are **logical inverses**: `hidden = !retrievable`. The `convertFieldsToPublic` and `convertFieldsToGenerated` functions flip this flag.
-
-### SimpleField Default Overrides
-
-When converting fields via `convertFieldsToGenerated`, `searchable`, `filterable`, `facetable`, and `sortable` are explicitly set to `false` if not provided. This overrides the service defaults to minimize storage for simple types.
-
-### Encryption Key Property Renames
-
-The public API uses `vaultUrl`; the wire format uses `vaultUri`. This rename appears everywhere encryption keys are used (indexes, synonym maps, skillsets, data sources, indexers, knowledge bases).
-
-### Optimistic Concurrency
-
-Every update/delete operation checks `options.onlyIfUnchanged` and passes `etag` as `ifMatch` to the generated client. Delete methods accept either a name (string) or an object (with etag) for conditional delete.
-
-## Wire Format Encodings
-
-### Array-to-String Joins (in searchClient.ts)
-
-| User Option              | Wire Format            | Notes                             |
-| ------------------------ | ---------------------- | --------------------------------- |
-| `searchFields: string[]` | comma-separated string |                                   |
-| `select: string[]`       | comma-separated string | Defaults to `"*"` if not provided |
-| `orderBy: string[]`      | comma-separated string |                                   |
-
-### Pipe-Delimited Semantic Encoding (in searchClient.ts)
-
-| User Option                                                       | Wire Format Example                                     |
-| ----------------------------------------------------------------- | ------------------------------------------------------- |
-| `queryAnswers: { answerType, count, threshold, maxAnswerLength }` | `"extractive\|count-3,threshold-0.7,maxcharlength-200"` |
-| `queryCaptions: { captionType, highlight, maxCaptionLength }`     | `"extractive\|highlight-true,maxcharlength-200"`        |
-| `queryRewrites: { rewritesType, count }`                          | `"generative\|count-5"`                                 |
-
-Note: `maxAnswerLength` maps to `maxcharlength` (not `maxanswerlength`). Config items are only appended if present.
-
-### Vector Query Dispatch
-
-`convertVectorQuery()` dispatches on `vectorQuery.kind`: `"text"`, `"vector"`, `"imageUrl"`, `"imageBinary"`. Only the `"text"` kind has `queryRewrites` to convert. For all kinds, `fields` is joined into a comma-separated string. Unknown kinds get a logger warning and are passed through (forward-compat).
-
-### SynonymMap Wire Format
-
-- `format: "solr"` is always injected — the public type doesn't expose a format field.
-- The generated type has `synonyms` as a string (newline-delimited); the public type has `synonyms` as `string[]`.
-- The generated type uses `eTag`; the public type uses `etag` (lowercase).
-
-### resetDocuments Body Restructuring
-
-`resetDocuments()` restructures flat options (`documentKeys`, `datasourceDocumentIds`) into a nested `keysOrIds` object expected by the wire format.
-
-## Type Mappings
-
-For the full property name change tables, conversion function inventory, null handling patterns, readonly array workarounds, and import source changes, see `references/type-mapping.md`.
-
-### Property Name Changes
-
-| User-Facing Property        | Generated (Wire) Name     | Context          |
-| --------------------------- | ------------------------- | ---------------- |
-| `analyzerName`              | `analyzerName`            | Search fields    |
-| `searchAnalyzerName`        | `searchAnalyzerName`      | Search fields    |
-| `indexAnalyzerName`         | `indexAnalyzerName`       | Search fields    |
-| `normalizerName`            | `normalizerName`          | Search fields    |
-| `synonymMapNames`           | `synonymMapNames`         | Search fields    |
-| `tokenizerName`             | `tokenizer`               | CustomAnalyzer   |
-| `applicationId`             | `applicationId`           | Encryption keys  |
-| `applicationSecret`         | `applicationSecret`       | Encryption keys  |
-| `parameters` (CustomWebApi) | `webApiParameters`        | Vector search    |
-| `vaultUrl`                  | `vaultUri`                | Encryption keys  |
-| `hidden`                    | `!retrievable` (inverted) | Field visibility |
-| `etag`                      | `eTag`                    | SynonymMap       |
-
-### Key Conversion Functions (serviceUtils.ts)
-
-**Index:** `publicIndexToGeneratedIndex()`, `generatedIndexToPublicIndex()`, `convertFieldsToGenerated()`, `convertFieldsToPublic()`
-
-**Search Results:** `generatedSearchResultToPublicSearchResult()`, `generatedSuggestDocumentsResultToPublicSuggestDocumentsResult()`, `convertGeneratedFacetsToPublic()`, `convertGeneratedAnswersToPublic()`, `convertGeneratedCaptionsToPublic()`
-
-**Vector Search:** `generatedVectorSearchToPublicVectorSearch()`, `generatedVectorSearchVectorizerToPublicVectorizer()`, `generatedVectorSearchAlgorithmConfigurationToPublicVectorSearchAlgorithmConfiguration()`. Note: no reverse `publicVectorSearchToGeneratedVectorSearch()` — `publicIndexToGeneratedIndex()` passes `vectorSearch` through directly.
-
-**Skillsets/Indexers:** `generatedSkillsetToPublicSkillset()` / `publicSkillsetToGeneratedSkillset()`, `publicSearchIndexerToGeneratedSearchIndexer()` / `generatedSearchIndexerToPublicSearchIndexer()`, `publicDataSourceToGeneratedDataSource()` / `generatedDataSourceToPublicDataSource()`. Note: no `convertSkillsToGenerated()` — skills are passed through as `SearchIndexerSkillUnion`.
-
-**Synonym Maps:** `generatedSynonymMapToPublicSynonymMap()`, `publicSynonymMapToGeneratedSynonymMap()`
-
-**Knowledge Base:** `convertKnowledgeBaseToPublic()` / `convertKnowledgeBaseToGenerated()`, `convertKnowledgeSourceToPublic()` / `convertKnowledgeSourceToGenerated()`
-
-**SearchClient-Specific (in searchClient.ts, NOT serviceUtils.ts):** `convertSearchFields()`, `convertSelect()`, `convertVectorQuery()`, `convertQueryAnswers()`, `convertQueryCaptions()`, `convertQueryRewrites()`, continuation token Base64 encode/decode
-
-### AML Vectorizer Auth Kind Inference
-
-`generatedAzureMachineLearningVectorizerParametersToPublic...` infers `authKind` via `switch(true)`: `resourceId` non-null -> `"token"`, `authenticationKey` non-null -> `"key"`, `scoringUri` non-null -> `"none"`. Order of checks matters.
-
-### Known Skills Whitelist
-
-`convertSkillsToPublic()` filters through a hardcoded `knownSkills` record. Unknown skill types returned by the service are **silently dropped**. Adding support for new skill types requires updating this record.
-
-## SearchIndexingBufferedSender
-
-The buffered sender (`src/searchIndexingBufferedSender.ts`) has several non-obvious behaviors:
-
-- **Auto-flush timer:** When `autoFlush: true` (default), a `setInterval` fires every `flushWindowInMs` (default 60s). The interval is `unref()`'d so it doesn't keep Node.js alive.
-- **Deduplication:** `pruneActions` ensures each batch has at most one action per document key. Duplicate keys are deferred to the next batch.
-- **Adaptive batch sizing on 413:** If the service returns 413 (Payload Too Large), the batch is split in half and retried. `initialBatchActionCount` is **permanently reduced** — a one-way ratchet that never grows back.
-- **Exponential backoff:** For retryable errors (422, 409, 503): `delay * 2^retryAttempt`, clamped to `maxThrottlingDelayInMs`, jittered by up to 50%. Max retries default to 3.
-- **Partial success throws:** If `throwOnAnyFailure` is set and the HTTP status is `207`, the result itself is thrown as an exception.
-
-## OData Template Tag
-
-The `odata` tagged template literal (`src/odata.ts`) handles:
-
-- `null`/`undefined` -> the string `"null"` (OData null literal)
-- Strings -> auto-quoted with single quotes, internal single quotes escaped by doubling (`'` -> `''`)
-- Smart quoting: if the preceding template fragment already ends with `'`, the string is NOT re-quoted
-- Numbers and other types interpolated as-is
-
-## Strong Typing: `TModel`, `TFields`, `NarrowedModel`
-
-`SearchClient` is generic over `TModel extends object`. The `search()`, `suggest()`, `getDocument()` methods accept a second type parameter `TFields extends SelectFields<TModel>` that narrows the return type based on selected fields. `SelectFields<TModel>` recursively generates valid OData `$select` paths (e.g., slash-delimited for nested fields). `NarrowedModel` uses `SearchPick` with `UnionToIntersection` to deeply narrow the return type at compile time.
+**Prefer extension points over editing generated-mirrored code.** Add conversion helpers in `src/serviceUtils.ts` and custom public models in `src/serviceModels.ts`/`src/indexModels.ts`, rather than editing files that have counterparts in `generated/`.
 
 ## Testing Notes
 
-- **Recorder sanitizer removals:** The test recorder removes default sanitizers `AZSDK2021` and `AZSDK3493` because they interfere with search-specific headers.
-- **Test data:** `Hotel` interface in `test/public/utils/interfaces.ts`, mock 1536-dim embeddings in `mockEmbeddings.ts`, setup helpers (`createIndex`, `populateIndex` with 10 hotel docs, `createRandomIndexName`) in `setup.ts`.
+- **Stable API tests** in `test/public/node/`, **preview feature tests** in `test/public/node/preview/`.
+- **Recorded tests** use `@azure-tools/test-recorder`. The recorder removes sanitizers `AZSDK2021` and `AZSDK3493`.
 - **WAIT_TIME pattern:** `isPlaybackMode() ? 0 : 4000` — live/record mode needs 4s delays for index consistency.
-- **Stable vs preview:** Stable API tests in `test/public/node/`, preview features (e.g., KnowledgeRetrievalClient) in `test/public/node/preview/`.
+- **Test data:** `Hotel` interface in `test/public/utils/interfaces.ts`, mock embeddings in `mockEmbeddings.ts`.
 - **`test/snippets.spec.ts`** is NOT a real test — it contains doc snippet source code.
+- To run live tests, copy `sample.env` to `.env` and fill in values.
 
-## Common Pitfalls
+## References
 
-- **`src/index.ts` is `--skip`'d** — after regeneration or adding new types, you must manually add exports there. The `ae-forgotten-export` lint error catches this.
-- **`@azure-rest/core-client`** not `@azure/core-client` — TypeSpec packages use the REST variant for `OperationOptions`, `ClientOptions`, etc.
-- **`knownSkills` whitelist** — `convertSkillsToPublic()` silently drops unknown skill types. New service skill types require updating this hardcoded record.
-- **No reverse conversion for some types** — `vectorSearch` and individual skills are passed through directly without dedicated public-to-generated converters. Don't look for functions that don't exist.
-- **`indexDocuments` 207 behavior** — partial success (HTTP 207) is thrown as an exception when `throwOnAnyFailure` is set. This is intentional, not a bug.
-- **Date deserialization is strict** — only matches UTC ISO strings with 0-3 fractional seconds and `Z` suffix. Non-UTC strings won't be auto-converted.
+| Reference | Contents |
+|---|---|
+| [references/architecture.md](references/architecture.md) | Source layout, four clients, key hand-authored files |
+| [references/data-flow.md](references/data-flow.md) | Search pagination, serialization, data flow patterns, buffered sender, strong typing |
+| [references/customization.md](references/customization.md) | 3-way merge algorithm, conflict resolution, post-regeneration scenarios |
+| [references/type-mapping.md](references/type-mapping.md) | Property name mappings, wire format encodings, conversion function inventory |

--- a/sdk/search/search-documents/.github/skills/search-documents/references/architecture.md
+++ b/sdk/search/search-documents/.github/skills/search-documents/references/architecture.md
@@ -1,0 +1,119 @@
+# Architecture Reference
+
+## Source Layout
+
+```
+sdk/search/search-documents/
+├── generated/                    # Auto-generated from TypeSpec. Never hand-edit.
+│   ├── search/                   # SearchClient sub-client
+│   ├── searchIndex/              # SearchIndexClient sub-client
+│   ├── searchIndexer/            # SearchIndexerClient sub-client
+│   ├── knowledgeBaseRetrieval/   # KnowledgeBaseRetrievalClient sub-client
+│   ├── models/                   # Generated model types (namespaced)
+│   ├── static-helpers/           # Serialization helpers, URL template, paging
+│   ├── index.ts                  # Generated barrel export
+│   └── logger.ts                 # Generated logger
+├── src/                          # Hand-authored + merged from generated/
+│   ├── search/                   # Merged: generated search sub-client
+│   ├── searchIndex/              # Merged: generated searchIndex sub-client
+│   ├── searchIndexer/            # Merged: generated searchIndexer sub-client
+│   ├── knowledgeBaseRetrieval/   # Merged: generated knowledgeBaseRetrieval sub-client
+│   ├── models/                   # Merged: generated model types
+│   ├── static-helpers/           # Merged: serialization helpers
+│   ├── (hand-authored files)     # See "Key Hand-Authored Files" below
+│   └── index.ts                  # Hand-authored: barrel export (--skip'd during merge)
+├── test/
+│   ├── public/node/              # Stable API integration tests
+│   ├── public/node/preview/      # Preview feature tests
+│   ├── internal/                 # Internal unit tests
+│   └── snippets.spec.ts          # NOT a test — doc snippet source
+├── tsp-location.yaml             # TypeSpec spec location
+└── package.json
+```
+
+## The Four Clients
+
+Each convenience client follows the same construction pattern:
+
+1. Constructor accepts `(endpoint, [resourceName,] credential, options?)` where credential is `KeyCredential | TokenCredential`.
+2. Creates the generated sub-client with `{ endpoint, credentials: { apiKeyHeaderName: "api-key" } }`.
+3. Replaces the default auth policy — if `TokenCredential`, adds `bearerTokenAuthenticationPolicy` with the search-specific scope; if `KeyCredential`, adds `searchApiKeyCredentialPolicy` (sets `api-key` header).
+4. Adds `odataMetadataPolicy` to control OData metadata level.
+5. Each public method wraps `tracingClient.withSpan()` which converts public→generated types, calls the generated client, and converts generated→public types on return.
+
+**OData metadata level:**
+
+- `SearchClient` uses `"none"` — document responses don't need type annotations.
+- `SearchIndexClient`, `SearchIndexerClient`, `KnowledgeRetrievalClient` use `"minimal"` — management operations need discriminator annotations.
+
+**SearchIndexClient extras:**
+
+- `getSearchClient(indexName)` — factory that spawns a `SearchClient` sharing the credential.
+- `getKnowledgeRetrievalClient(knowledgeBaseName)` — factory for `KnowledgeRetrievalClient`.
+- `listIndexNames()` — server-side projection (`select: "name"`) via `listIndexesWithSelectedProperties`, wrapped with `mapPagedAsyncIterable`.
+
+## Key Hand-Authored Files
+
+| File | Purpose |
+|---|---|
+| `src/searchClient.ts` | `SearchClient<TModel>` convenience wrapper — search, suggest, autocomplete, document operations |
+| `src/searchIndexClient.ts` | `SearchIndexClient` convenience wrapper — index CRUD, synonym maps, aliases, knowledge bases |
+| `src/searchIndexerClient.ts` | `SearchIndexerClient` convenience wrapper — indexer, data source, skillset CRUD |
+| `src/knowledgeRetrievalClient.ts` | `KnowledgeRetrievalClient` convenience wrapper — knowledge base retrieval |
+| `src/serviceUtils.ts` | 200+ type conversion functions between generated and public types |
+| `src/serviceModels.ts` | User-facing types for indexes, indexers, skills, data sources |
+| `src/indexModels.ts` | User-facing types for search, suggest, autocomplete operations |
+| `src/knowledgeBaseModels.ts` | User-facing types for knowledge base operations |
+| `src/serialization.ts` | NaN/Infinity/Date/GeographyPoint serialization via `walk()` |
+| `src/walk.ts` | Recursive immutable tree walker with cycle detection |
+| `src/indexDocumentsBatch.ts` | Batch builder for document upload/merge/delete actions |
+| `src/searchIndexingBufferedSender.ts` | Auto-flush buffered sender with retry and adaptive batch sizing |
+| `src/odata.ts` | `odata` template tag for safe OData filter expressions |
+| `src/geographyPoint.ts` | `GeographyPoint` class with GeoJSON/EPSG:4326 conversion |
+| `src/odataMetadataPolicy.ts` | Pipeline policy setting OData metadata Accept header |
+| `src/searchApiKeyCredentialPolicy.ts` | Pipeline policy adding `api-key` header |
+| `src/synonymMapHelper.ts` | `createSynonymMapFromFile()` — Node.js only file helper |
+| `src/errorModels.ts` | Error response types (ErrorResponse, ErrorDetail, ErrorAdditionalInfo) |
+| `src/base64.ts` | Base64 encode/decode for continuation tokens |
+| `src/tracing.ts` | Tracing client setup (namespace: `Microsoft.Search`) |
+| `src/searchAudience.ts` | `KnownSearchAudience` enum (Azure Public, China, Government) |
+| `src/logger.ts` | Merged logger (overrides generated version) |
+
+## Exposing New Operations — Wrong vs Right
+
+**WRONG** — Adding a method to the generated sub-client:
+
+```typescript
+// WRONG: src/search/searchClient.ts is a GENERATED file — this will be overwritten
+import { explainPost } from "./api/operations.js";
+export class SearchClient {
+  explainPost(body, options) {
+    return explainPost(this._client, body, options); // raw generated types, no conversion
+  }
+}
+```
+
+This does nothing for consumers. The generated sub-client is an internal implementation detail.
+
+**RIGHT** — Adding a method to the hand-authored convenience client:
+
+```typescript
+// RIGHT: src/searchClient.ts is the HAND-AUTHORED convenience client
+export class SearchClient<TModel extends object> {
+  async explain(documentKey: string, searchText: string, options: ExplainOptions = {}) {
+    return tracingClient.withSpan("SearchClient.explain", options, async (updatedOptions) => {
+      // Convert public types -> generated types
+      const { body, operationOptions } = convertExplainOptions(
+        documentKey,
+        searchText,
+        updatedOptions,
+      );
+      const result = await this.client.explainPost(body, operationOptions);
+      // Convert generated types -> public types
+      return convertExplainResult(result);
+    });
+  }
+}
+```
+
+Then define `ExplainOptions` and `ExplainResult` in `src/indexModels.ts`, add conversion functions in `src/serviceUtils.ts`, and export all new symbols from `src/index.ts`.

--- a/sdk/search/search-documents/.github/skills/search-documents/references/data-flow.md
+++ b/sdk/search/search-documents/.github/skills/search-documents/references/data-flow.md
@@ -1,0 +1,106 @@
+# Data Flow Reference
+
+## Search Pagination
+
+`search()` uses a **fully custom pagination implementation** — it does NOT use `buildPagedAsyncIterator` from `pagingHelpers.ts`.
+
+### Flow
+
+1. **`search(searchText, options)`** — eagerly fetches first page via `searchDocuments()`, wraps in `SearchIterator` via `listSearchResults()`.
+2. **`searchDocuments()`** — converts public `SearchOptions` to generated types (joins arrays, encodes semantic options), calls `this.client.searchPost()`, converts results back (unwraps `additionalProperties`), encodes continuation token.
+3. **`listSearchResultsPage()`** — `async *` generator: decodes token, calls `searchDocuments()` with decoded `nextPageParameters`, yields page, loops while token exists.
+4. **`listSearchResultsAll()`** — `async *` generator: yields items from first page, then delegates to `listSearchResultsPage()`.
+5. **`listSearchResults()`** — assembles `SearchIterator` with `next()` (item-by-item) and `byPage()` (page-by-page).
+
+### Continuation Token
+
+Service returns `nextLink` (URL) and `nextPageParameters` (full POST body). Combined into one opaque Base64 token:
+
+```
+encode(JSON.stringify({ apiVersion, nextLink, nextPageParameters }))
+```
+
+- `apiVersion` guards against mixing tokens from different API versions (rejected with `RangeError`)
+- `nextLink` is stored but **never used for fetching** — only `nextPageParameters` drives page fetches
+- Returns `undefined` if either value is missing (no more pages)
+
+### Why Custom
+
+- Uses POST with `nextPageParameters` body, not GET with `nextLink` URLs
+- First page is eagerly fetched (metadata like facets/count available immediately)
+- Continuation tokens are opaque Base64 blobs with version pinning
+- Dual result types: top-level `results` is an async iterator, each page's `results` is a plain array
+
+### Key Types
+
+- `SearchIterator<TModel, TFields>` — `PagedAsyncIterableIterator` alias for the `results` property
+- `SearchDocumentsResult<TModel, TFields>` — top-level return from `search()`, contains first-page metadata (count, facets, answers) plus `results: SearchIterator`
+- `SearchDocumentsPageResult<TModel, TFields>` — single page: `results: SearchResult[]` (plain array) plus `continuationToken?: string`
+- `ListSearchResultsPageSettings` — settings for `byPage()`, containing only `continuationToken?: string`
+
+## additionalProperties Unwrapping
+
+TypeSpec wraps user document fields in `additionalProperties`. The convenience layer unwraps:
+
+```
+Generated: { searchScore, additionalProperties: { hotelName, rating } }
+     → generatedSearchResultToPublicSearchResult()
+Public:    { score, document: { hotelName, rating } }
+```
+
+Affects: `search()`, `suggest()`, `autocomplete()`, `getDocument()`.
+
+## The Reverse: `__actionType` Convention
+
+For `indexDocuments()`, `IndexDocumentsAction<TModel>` spreads the document and adds `__actionType: "upload" | "merge" | "mergeOrUpload" | "delete"`. The double-underscore prefix avoids collision with user document fields.
+
+`IndexDocumentsBatch` provides builder methods: `upload()`, `merge()`, `mergeOrUpload()`, `delete()`. The `delete()` method has two overloads: by documents or by `keyName` + `keyValues`.
+
+## The Serialization Sandwich
+
+Every document boundary applies serialize (outbound) and deserialize (inbound) via `walk()`:
+
+**Serialize:** `NaN` → `"NaN"`, `Infinity` → `"INF"`, `-Infinity` → `"-INF"`, `Date` → ISO 8601, `GeographyPoint` → GeoJSON Point with CRS EPSG:4326
+
+**Deserialize:** Reverse of above. Date regex: `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$` (0-3 fractional seconds, UTC only).
+
+`GeographyPoint` serializes with `[longitude, latitude]` order (not `[lat, lng]`). CRS `EPSG:4326` is required by the search service (not standard GeoJSON).
+
+## Field Visibility Inversion
+
+Public API: `hidden: boolean`. Wire format: `retrievable: boolean`. Logical inverses — `convertFieldsToPublic` and `convertFieldsToGenerated` flip this flag.
+
+## SimpleField Default Overrides
+
+`convertFieldsToGenerated` sets `searchable`, `filterable`, `facetable`, and `sortable` to `false` when not provided. This overrides service defaults to minimize storage for simple types.
+
+## Encryption Key Property Renames
+
+Public: `vaultUrl`. Wire: `vaultUri`. Applies everywhere encryption keys are used (indexes, synonym maps, skillsets, data sources, indexers, knowledge bases).
+
+## Optimistic Concurrency
+
+Every update/delete operation checks `options.onlyIfUnchanged` and passes `etag` as `ifMatch`. Delete methods accept either a name (string) or object (with etag) for conditional delete.
+
+## SearchIndexingBufferedSender
+
+Non-obvious behaviors of `src/searchIndexingBufferedSender.ts`:
+
+- **Auto-flush timer:** `autoFlush: true` (default) fires `setInterval` every `flushWindowInMs` (default 60s). Interval is `unref()`'d to not keep Node.js alive.
+- **Deduplication:** `pruneActions` ensures at most one action per document key per batch. Duplicates deferred to next batch.
+- **Adaptive batch sizing on 413:** Payload Too Large → batch split in half, `initialBatchActionCount` permanently reduced (one-way ratchet).
+- **Exponential backoff:** For 422/409/503: `delay * 2^retryAttempt`, clamped to `maxThrottlingDelayInMs`, jittered ±50%. Max retries default to 3.
+- **Partial success throws:** HTTP 207 + `throwOnAnyFailure` → result thrown as exception.
+
+## OData Template Tag
+
+`odata` tagged template (`src/odata.ts`):
+
+- `null`/`undefined` → string `"null"` (OData null literal)
+- Strings → auto-quoted with single quotes, internal `'` escaped by doubling
+- Smart quoting: if preceding fragment ends with `'`, string is NOT re-quoted
+- Numbers/other types interpolated as-is
+
+## Strong Typing
+
+`SearchClient<TModel extends object>`. The `search()`, `suggest()`, `getDocument()` methods accept `TFields extends SelectFields<TModel>` to narrow the return type. `SelectFields<TModel>` recursively generates valid OData `$select` paths (slash-delimited for nested). `NarrowedModel` uses `SearchPick` with `UnionToIntersection` for deep compile-time narrowing.

--- a/sdk/search/search-documents/.github/skills/search-documents/references/type-mapping.md
+++ b/sdk/search/search-documents/.github/skills/search-documents/references/type-mapping.md
@@ -4,41 +4,41 @@
 
 ### Search Fields
 
-| User-Facing Property | Generated (Wire) Name | Location                                           |
-| -------------------- | --------------------- | -------------------------------------------------- |
-| `analyzerName`       | `analyzerName`        | `serviceUtils.ts: convertFieldsToGenerated/Public` |
-| `searchAnalyzerName` | `searchAnalyzerName`  | `serviceUtils.ts`                                  |
-| `indexAnalyzerName`  | `indexAnalyzerName`   | `serviceUtils.ts`                                  |
-| `normalizerName`     | `normalizerName`      | `serviceUtils.ts`                                  |
-| `synonymMapNames`    | `synonymMapNames`     | `serviceUtils.ts`                                  |
+| User-Facing Property | Generated (Wire) Name | Location |
+|---|---|---|
+| `analyzerName` | `analyzerName` | `serviceUtils.ts: convertFieldsToGenerated/Public` |
+| `searchAnalyzerName` | `searchAnalyzerName` | `serviceUtils.ts` |
+| `indexAnalyzerName` | `indexAnalyzerName` | `serviceUtils.ts` |
+| `normalizerName` | `normalizerName` | `serviceUtils.ts` |
+| `synonymMapNames` | `synonymMapNames` | `serviceUtils.ts` |
 
 ### Encryption Keys
 
-| User-Facing         | Generated (Wire) Name |
-| ------------------- | --------------------- |
-| `applicationId`     | `applicationId`       |
-| `applicationSecret` | `applicationSecret`   |
-| `vaultUrl`          | `vaultUri`            |
+| User-Facing | Generated (Wire) Name |
+|---|---|
+| `applicationId` | `applicationId` |
+| `applicationSecret` | `applicationSecret` |
+| `vaultUrl` | `vaultUri` |
 
 ### Vector Search
 
-| User-Facing                  | Generated (Wire) Name                 |
-| ---------------------------- | ------------------------------------- |
-| `parameters` (CustomWebApi)  | `webApiParameters`                    |
+| User-Facing | Generated (Wire) Name |
+|---|---|
+| `parameters` (CustomWebApi) | `webApiParameters` |
 | `aIServicesVisionParameters` | `aiServicesVisionParameters` (casing) |
 
 ### Custom Analyzers
 
-| User-Facing     | Generated (Wire) Name   |
-| --------------- | ----------------------- |
+| User-Facing | Generated (Wire) Name |
+|---|---|
 | `tokenizerName` | `tokenizer` (shortened) |
 
 ### Other
 
-| User-Facing | Generated (Wire) Name     | Context          |
-| ----------- | ------------------------- | ---------------- |
-| `hidden`    | `!retrievable` (inverted) | Field visibility |
-| `etag`      | `eTag`                    | SynonymMap       |
+| User-Facing | Generated (Wire) Name | Context |
+|---|---|---|
+| `hidden` | `!retrievable` (inverted) | Field visibility |
+| `etag` | `eTag` | SynonymMap |
 
 ## The additionalProperties Pattern
 
@@ -63,6 +63,40 @@ function generatedSearchResultToPublicSearchResult<TModel>(results) {
 
 Affects: `search()`, `suggest()`, `autocomplete()`, `getDocument()`, `indexDocuments()`
 
+## Wire Format Encodings
+
+### Array-to-String Joins (in searchClient.ts)
+
+| User Option | Wire Format | Notes |
+|---|---|---|
+| `searchFields: string[]` | comma-separated string | |
+| `select: string[]` | comma-separated string | Defaults to `"*"` if not provided |
+| `orderBy: string[]` | comma-separated string | |
+
+### Pipe-Delimited Semantic Encoding (in searchClient.ts)
+
+| User Option | Wire Format Example |
+|---|---|
+| `queryAnswers: { answerType, count, threshold, maxAnswerLength }` | `"extractive\|count-3,threshold-0.7,maxcharlength-200"` |
+| `queryCaptions: { captionType, highlight, maxCaptionLength }` | `"extractive\|highlight-true,maxcharlength-200"` |
+| `queryRewrites: { rewritesType, count }` | `"generative\|count-5"` |
+
+Note: `maxAnswerLength` maps to `maxcharlength` (not `maxanswerlength`). Config items are only appended if present.
+
+### Vector Query Dispatch
+
+`convertVectorQuery()` dispatches on `vectorQuery.kind`: `"text"`, `"vector"`, `"imageUrl"`, `"imageBinary"`. Only `"text"` has `queryRewrites` to convert. For all kinds, `fields` is joined into a comma-separated string. Unknown kinds get a logger warning and are passed through (forward-compat).
+
+### SynonymMap Wire Format
+
+- `format: "solr"` is always injected — the public type doesn't expose a format field.
+- Generated type: `synonyms` as string (newline-delimited). Public type: `synonyms` as `string[]`.
+- Generated type: `eTag`. Public type: `etag` (lowercase).
+
+### resetDocuments Body Restructuring
+
+`resetDocuments()` restructures flat options (`documentKeys`, `datasourceDocumentIds`) into a nested `keysOrIds` object expected by the wire format.
+
 ## Null Handling
 
 TypeSpec marks many optional properties as `T | null`. Mitigation:
@@ -77,6 +111,14 @@ User code uses `as const` (readonly). Cast when passing to generated code:
 ```typescript
 select: userSelect as string[] | undefined;
 ```
+
+## AML Vectorizer Auth Kind Inference
+
+`generatedAzureMachineLearningVectorizerParametersToPublic...` infers `authKind` via `switch(true)`: `resourceId` non-null → `"token"`, `authenticationKey` non-null → `"key"`, `scoringUri` non-null → `"none"`. Order of checks matters.
+
+## Known Skills Whitelist
+
+`convertSkillsToPublic()` filters through a hardcoded `knownSkills` record in `serviceUtils.ts`. Unknown skill types returned by the service are **silently dropped**. Adding support for new skill types requires updating this record.
 
 ## Backward Compat (`backcompatTypes.ts`)
 
@@ -96,13 +138,13 @@ Deprecated enums preserved: `KnownEntityCategory`, `KnownEntityRecognitionSkillL
 
 `generatedVectorSearchToPublicVectorSearch()`, `generatedVectorSearchVectorizerToPublicVectorizer()`, `generatedVectorSearchAlgorithmConfigurationToPublicVectorSearchAlgorithmConfiguration()`
 
-Note: There is no `publicVectorSearchToGeneratedVectorSearch()` — `publicIndexToGeneratedIndex()` passes `vectorSearch` through directly without a dedicated reverse conversion.
+Note: No `publicVectorSearchToGeneratedVectorSearch()` — `publicIndexToGeneratedIndex()` passes `vectorSearch` through directly.
 
 ### Skillsets/Indexers
 
 `convertSkillsToPublic()`, `convertCognitiveServicesAccountToPublic()`, `convertCognitiveServicesAccountToGenerated()`, `generatedSkillsetToPublicSkillset()`, `publicSkillsetToGeneratedSkillset()`, `publicSearchIndexerToGeneratedSearchIndexer()`, `generatedSearchIndexerToPublicSearchIndexer()`, `publicDataSourceToGeneratedDataSource()`, `generatedDataSourceToPublicDataSource()`
 
-Note: There is no `convertSkillsToGenerated()` — `publicSkillsetToGeneratedSkillset()` passes individual skills through directly via `SearchIndexerSkillUnion`.
+Note: No `convertSkillsToGenerated()` — skills are passed through as `SearchIndexerSkillUnion`.
 
 ### Synonym Maps
 


### PR DESCRIPTION
Initial port of the create-package-skill wizard from Java, plus a restructure of the search-documents package skill based on eval learnings.

## Create Package Skill (new)

Added `.github/skills/create-package-skill/` — an interactive wizard that walks service teams through creating a package-specific skill for their SDK package. It's a phased workflow:

1. **Scan Package** — detect architecture, customizations, key files
2. **Scaffold SKILL.md** — generate the skill with common pitfalls, architecture notes, workflow
3. **Generate References** — create reference docs (architecture.md, customization.md)
4. **Validate** — run vally lint
5. **Register** — add to find-package-skill table

Key guardrails: skills should be under 500 tokens, focus on non-obvious package-specific knowledge, and complement (not replace) existing MCP tools and shared skills.

## Search Documents Skill (refactored)

Restructured the search-documents SKILL.md based on eval data showing that skill **structure** matters more than **volume**:

- **Moved Common Pitfalls to the top** — agent reads pitfalls before analyzing errors, leading to correct diagnosis
- **Extracted detailed content into reference files** — new `architecture.md` and `data-flow.md` references keep the main skill lean while preserving all the detail
- **Added "Exposing New Operations" section** — step-by-step guide for wiring new operations through the convenience layer (this was the most common mistake in evals)
- **Added Error Categorization table** — gives the agent a decision framework for where to look based on error location
- **Tightened the generated vs hand-authored distinction** — this was the single most common source of confusion

The SKILL.md went from a wall of text to a focused document with clear references for deep dives.
