### PR TITLE
[Copilot Reviewer Eval] Missing workspace protocol

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -88,7 +88,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@azure-tools/test-credential": "workspace:^",
+    "@azure-tools/test-credential": "^1.0.0",
     "@azure-tools/test-recorder": "workspace:^",
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",


### PR DESCRIPTION
This PR intentionally uses a version instead of workspace: protocol to test Copilot reviewer.