### PR TITLE
[Copilot Reviewer Eval] Exact pin on runtime dependency

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -75,7 +75,7 @@
     }
   },
   "dependencies": {
-    "@azure-rest/core-client": "^2.3.3",
+    "@azure-rest/core-client": "2.3.3",
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-lro": "^2.7.2",


### PR DESCRIPTION
This PR uses exact version pin on a runtime dependency to test deduplication warnings.