### PR TITLE
[ContentUnderstanding] Add preview disclaimer for toLlmInput

### DIFF
--- a/sdk/contentunderstanding/ai-content-understanding/README.md
+++ b/sdk/contentunderstanding/ai-content-understanding/README.md
@@ -11,6 +11,8 @@ Use the client library for Azure AI Content Understanding to:
 - **Create custom analyzers** - Build domain-specific analyzers for specialized content extraction needs across all four modalities (documents, video, audio, and images)
 - **Classify documents and video** - Automatically categorize and extract information from documents and video by type
 
+If you have encountered issues or want to suggest features, please [file an issue][file_issue].
+
 Key links:
 
 - [Source code](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/contentunderstanding/ai-content-understanding)
@@ -330,9 +332,8 @@ if (result.contents && result.contents.length > 0) {
 
 > [!NOTE]
 > **Preview feature**: `toLlmInput()` is currently in preview and may change in
-> future releases. We welcome feedback — please file suggestions or issues on
-> [GitHub Issues](https://github.com/Azure/azure-sdk-for-js/issues) with the
-> `Cognitive - Content Understanding` label.
+> future releases. We welcome feedback — please
+> [file an issue][file_issue].
 
 Use the `toLlmInput()` helper to convert any analysis result into a text format that LLMs
 can consume directly — YAML front matter with extracted fields followed by the markdown body.
@@ -652,3 +653,4 @@ If you'd like to contribute to this library, please read the [contributing guide
 [handling_failures]: https://learn.microsoft.com/javascript/api/@azure/core-rest-pipeline/resterror?view=azure-node-latest
 [diagnostics]: https://learn.microsoft.com/javascript/api/@azure/logger?view=azure-node-latest
 [client_lifetime]: https://learn.microsoft.com/azure/developer/javascript/sdk/use-azure-sdk
+[file_issue]: https://github.com/Azure/azure-sdk-for-js/issues/new?labels=Cognitive%20-%20Content%20Understanding&title=[ContentUnderstanding]%20&body=%23%23%20Library%20Version%0A%0A%23%23%20Repro%20Steps%0A%0A%23%23%20Expected%20Result%0A%0A%23%23%20Actual%20Result

--- a/sdk/contentunderstanding/ai-content-understanding/README.md
+++ b/sdk/contentunderstanding/ai-content-understanding/README.md
@@ -328,6 +328,12 @@ if (result.contents && result.contents.length > 0) {
 
 ### Convert results to LLM-ready text
 
+> [!NOTE]
+> **Preview feature**: `toLlmInput()` is currently in preview and may change in
+> future releases. We welcome feedback — please file suggestions or issues on
+> [GitHub Issues](https://github.com/Azure/azure-sdk-for-js/issues) with the
+> `Cognitive - Content Understanding` label.
+
 Use the `toLlmInput()` helper to convert any analysis result into a text format that LLMs
 can consume directly — YAML front matter with extracted fields followed by the markdown body.
 This works with all content types (documents, images, audio, video) and handles multi-segment

--- a/sdk/contentunderstanding/ai-content-understanding/README.md
+++ b/sdk/contentunderstanding/ai-content-understanding/README.md
@@ -330,10 +330,8 @@ if (result.contents && result.contents.length > 0) {
 
 ### Convert results to LLM-ready text
 
-> [!NOTE]
-> **Preview feature**: `toLlmInput()` is currently in preview and may change in
-> future releases. We welcome feedback — please
-> [file an issue][file_issue].
+> **Note:** `toLlmInput()` is currently in preview and may change in future releases.
+> We welcome feedback — please [file an issue][file_issue].
 
 Use the `toLlmInput()` helper to convert any analysis result into a text format that LLMs
 can consume directly — YAML front matter with extracted fields followed by the markdown body.


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/ai-content-understanding`

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

Adds a preview feature disclaimer to the `toLlmInput()` section in the README using GitHub admonition syntax (`> [!NOTE]`), directing users to file feedback on GitHub Issues with the `Cognitive - Content Understanding` label.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

N/A — documentation-only change.

### Are there test cases added in this PR? _(If not, why?)_

No — README-only change, no code modifications.

### Provide a list of related PRs _(if any)_

- Java: https://github.com/Azure/azure-sdk-for-java/pull/49000
- .NET: https://github.com/Azure/azure-sdk-for-net/pull/58929

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** No
- [ ] Added a changelog (if necessary) — Not needed for documentation-only change