### PR TITLE
fix: set RECORDINGS_RELATIVE_PATH in shared browser vitest config

### DIFF
--- a/eng/vitestconfigs/browser.config.ts
+++ b/eng/vitestconfigs/browser.config.ts
@@ -24,6 +24,9 @@ export default mergeConfig(
     resolve: {
       conditions: ["browser"],
     },
+    optimizeDeps: {
+      include: ["@azure-tools/test-recorder"],
+    },
     test: {
       include: ["test/**/*.spec.ts"],
       exclude: ["test/**/node/**", "test/**/react-native/**", "test/snippets.spec.ts"],

--- a/eng/vitestconfigs/browser.config.ts
+++ b/eng/vitestconfigs/browser.config.ts
@@ -4,6 +4,14 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import base from "../../vitest.browser.base.config.ts";
 
+// Set recordings path if test-recorder is available (for packages with recorded tests)
+try {
+  const { relativeRecordingsPath } = await import("@azure-tools/test-recorder");
+  process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
+} catch {
+  // Package doesn't use test-recorder, skip setting recordings path
+}
+
 export default mergeConfig(
   base,
   defineConfig({

--- a/eng/vitestconfigs/browser.config.ts
+++ b/eng/vitestconfigs/browser.config.ts
@@ -8,8 +8,14 @@ import base from "../../vitest.browser.base.config.ts";
 try {
   const { relativeRecordingsPath } = await import("@azure-tools/test-recorder");
   process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
-} catch {
-  // Package doesn't use test-recorder, skip setting recordings path
+} catch (e: unknown) {
+  // Only ignore module-not-found errors (package doesn't use test-recorder)
+  // Rethrow any other errors to avoid masking real issues
+  if (e instanceof Error && "code" in e && e.code === "ERR_MODULE_NOT_FOUND") {
+    // Package doesn't use test-recorder, skip setting recordings path
+  } else {
+    throw e;
+  }
 }
 
 export default mergeConfig(

--- a/vitest.browser.shared.config.ts
+++ b/vitest.browser.shared.config.ts
@@ -2,10 +2,21 @@
 // Licensed under the MIT License.
 
 import { defineConfig, mergeConfig } from "vitest/config";
-import { relativeRecordingsPath } from "@azure-tools/test-recorder";
 import base from "./vitest.browser.base.config.ts";
 
-process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
+// Set recordings path if test-recorder is available (for packages with recorded tests)
+try {
+  const { relativeRecordingsPath } = await import("@azure-tools/test-recorder");
+  process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
+} catch (e: unknown) {
+  // Only ignore module-not-found errors (package doesn't use test-recorder)
+  // Rethrow any other errors to avoid masking real issues
+  if (e instanceof Error && "code" in e && e.code === "ERR_MODULE_NOT_FOUND") {
+    // Package doesn't use test-recorder, skip setting recordings path
+  } else {
+    throw e;
+  }
+}
 
 export default mergeConfig(
   base,


### PR DESCRIPTION
## Problem

Packages using the shared browser vitest config at `eng/vitestconfigs/browser.config.ts` need to set `RECORDINGS_RELATIVE_PATH` for test recordings to work correctly.

## Solution

Add a dynamic import of `@azure-tools/test-recorder` to set the recordings path automatically:

```typescript
try {
  const { relativeRecordingsPath } = await import("@azure-tools/test-recorder");
  process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
} catch {
  // Package doesn't use test-recorder, skip setting recordings path
}
```

The try-catch ensures packages that don't use test-recorder aren't affected.

## Related

Extracted from #38346 to enable independent review and merge.