### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -60,6 +60,7 @@ jobs:
           PRBody: |
             This PR upgrades the JS REX Validation Tool to the latest version.
             Testing was done in $(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)
+          AuthToken: ''
 
   - job: UpdateDocsMsBuildConfig
     timeoutInMinutes: 90
@@ -149,6 +150,7 @@ jobs:
             TargetRepoName: $(DocRepoName)
             TargetRepoOwner: $(DocRepoOwner)
             WorkingDirectory: $(DocRepoLocation)
+            AuthToken: ''
 
         - task: AzureCLI@2
           displayName: Queue Docs CI build for main
@@ -224,6 +226,7 @@ jobs:
             WorkingDirectory: $(DocRepoLocation)
             ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts
             PushArgs: -f
+            AuthToken: ''
 
         - task: AzureCLI@2
           displayName: Queue Docs CI build for daily branch

--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -7,3 +7,4 @@ extends:
   template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
   parameters:
     Repository: Azure/azure-sdk-for-js
+    AuthToken: ''

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -63,6 +63,7 @@ stages:
                       RepoId: Azure/azure-sdk-for-js
                       WorkingDirectory: $(System.DefaultWorkingDirectory)
                       NpmConfigUserConfig: $(Agent.TempDirectory)/create-release-tag/.npmrc
+                      AuthToken: ''
 
               - ${{ if ne(artifact.skipPublishPackage, 'true') }}:
                   - template: /eng/common/pipelines/templates/jobs/npm-publish.yml

--- a/eng/pipelines/weekly_automation.yml
+++ b/eng/pipelines/weekly_automation.yml
@@ -42,6 +42,7 @@ jobs:
       PRTitle: "[EngSys] automatic pnpm update"
       PRBody: "This is an automatic PR generated weekly with changes from running the command pnpm update"
       PushArgs: "-f"
+      AuthToken: ''
 
 
 - job: 'CheckDependency'
@@ -66,6 +67,8 @@ jobs:
       git clean -xdf
     displayName: "Reset workspace"
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
   - task: PowerShell@2
     displayName: 'Check Dependency Warnings and File GitHub Issues'
     inputs:
@@ -74,7 +77,7 @@ jobs:
       arguments: >
         -RepoName azure-sdk-for-js
         -RepoOwner azure
-        -AuthToken "$(azuresdk-github-pat)"
+        -AuthToken "$(GH_TOKEN)"
       pwsh: true
 
   - script: |

--- a/eng/pipelines/weekly_automation.yml
+++ b/eng/pipelines/weekly_automation.yml
@@ -42,6 +42,7 @@ jobs:
       PRTitle: "[EngSys] automatic pnpm update"
       PRBody: "This is an automatic PR generated weekly with changes from running the command pnpm update"
       PushArgs: "-f"
+      AuthToken: ''
 
 
 - job: 'CheckDependency'
@@ -67,9 +68,6 @@ jobs:
     displayName: "Reset workspace"
 
   - template: /eng/common/pipelines/templates/steps/login-to-github.yml
-    parameters:
-      TokenOwners:
-        - Azure
 
   - task: PowerShell@2
     displayName: 'Check Dependency Warnings and File GitHub Issues'


### PR DESCRIPTION
This pull request adds the `AuthToken` parameter with an empty string value to several pipeline configuration files. This change ensures that the required `AuthToken` parameter is explicitly set, likely to satisfy template requirements or to enable future updates where a token may be provided dynamically. No functional behavior is changed at this time, as the value is set to an empty string.

Key changes by theme:

**Pipeline Parameter Updates:**

* Added `AuthToken: ''` to multiple jobs and templates in `eng/pipelines/docindex.yml` to explicitly set the authentication token parameter. [[1]](diffhunk://#diff-f1e244733dfe16323f099542a3b4a1ba8bb68f45cf329d8dac9d1613c5956c40R63) [[2]](diffhunk://#diff-f1e244733dfe16323f099542a3b4a1ba8bb68f45cf329d8dac9d1613c5956c40R153) [[3]](diffhunk://#diff-f1e244733dfe16323f099542a3b4a1ba8bb68f45cf329d8dac9d1613c5956c40R229)
* Added `AuthToken: ''` to the parameters in `eng/pipelines/prepare-pipelines.yml` to ensure the parameter is defined for the prepare-pipelines job.
* Added `AuthToken: ''` to the `archetype-js-release.yml` release stage template parameters.
* Added `AuthToken: ''` to the weekly automation job in `eng/pipelines/weekly_automation.yml`.

**Pipeline Template Cleanup:**

* Removed the `TokenOwners` parameter from the `login-to-github.yml` template invocation in `eng/pipelines/weekly_automation.yml`, simplifying the configuration.

Related to Azure/azure-sdk-tools#9842

Test pipelines
[js - weekly_automation](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6367179&view=results) - Passed
[js - docindex](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6367183&view=results) - Passed
[js - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6367561&view=results) - Passed