### PR TITLE
AzureDeveloperCliCredential: parse new auth error formats

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed `AzureDeveloperCliCredential` to correctly parse error messages from Azure Developer CLI v1.23.7 and later, which previously caused raw JSON to surface in the credential error instead of the underlying error text.
+- Fixed `AzureDeveloperCliCredential` to correctly parse error messages from Azure Developer CLI v1.23.7 and later, which previously caused raw JSON to surface in the credential error instead of the underlying error text. [#38416](https://github.com/Azure/azure-sdk-for-js/pull/38416)
 
 ### Other Changes
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `AzureDeveloperCliCredential` to correctly parse error messages from Azure Developer CLI v1.23.7 and later, which previously caused raw JSON to surface in the credential error instead of the underlying error text.
+
 ### Other Changes
 
 ## 4.14.0-beta.3 (2026-04-08)

--- a/sdk/identity/identity/src/credentials/azureDeveloperCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureDeveloperCliCredential.ts
@@ -37,25 +37,56 @@ export const azureDeveloperCliPublicErrorMessages = {
  */
 export const developerCliCredentialInternals = {
   /**
-   * Parses azd stderr JSON output to extract the error message.
-   * azd outputs JSON like: \{"type":"consoleMessage","timestamp":"...","data":\{"message":"ERROR: ..."\}\}
-   * If parsing succeeds and .data.message exists, returns the trimmed message.
-   * Otherwise, returns the raw stderr.
+   * Parses azd stderr JSON output to extract a human-readable error message.
+   *
+   * Three formats are supported across azd versions:
+   * - pre-v1.23.7: `{"type":"consoleMessage","data":{"message":"..."}}`
+   * - v1.23.7 - v1.23.15: an empty `consoleMessage` line followed by `{"error":"...","message":"...","suggestion":"..."}`
+   * - v1.24.0+: `{"error":"...","message":"...","suggestion":"..."}`
+   *
+   * The structured `error` field is preferred. If absent, falls back to the
+   * first non-empty `data.message` from a legacy `consoleMessage` line. If
+   * neither is found, the raw stderr is returned unchanged so plain-text and
+   * malformed output continue to surface to callers.
+   *
    * @param stderr - The stderr output from azd command
    * @returns The parsed error message or raw stderr
    * @internal
    */
   parseAzdStderr(stderr: string): string {
-    try {
-      const parsed = JSON.parse(stderr);
-      const message = parsed?.data?.message;
-      if (typeof message === "string" && message.trim().length > 0) {
-        return message.trim();
-      }
-    } catch {
-      // If JSON parsing fails, fall through to return raw stderr
+    if (!stderr?.trim()) {
+      return stderr;
     }
-    return stderr;
+
+    let fallback: string | undefined;
+
+    for (const rawLine of stderr.split("\n")) {
+      const line = rawLine.trim();
+      if (!line.startsWith("{")) {
+        continue;
+      }
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // Not valid JSON on this line; continue.
+        continue;
+      }
+
+      if (typeof parsed?.error === "string" && parsed.error.trim()) {
+        return parsed.error.trim();
+      }
+
+      if (fallback === undefined) {
+        const message = parsed?.data?.message;
+        if (typeof message === "string" && message.trim()) {
+          fallback = message.trim();
+        }
+      }
+    }
+
+    return fallback ?? stderr;
   },
 
   /**

--- a/sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts
+++ b/sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts
@@ -341,6 +341,81 @@ describe("AzureDeveloperCliCredential (internal)", function () {
       const result = developerCliCredentialInternals.parseAzdStderr(json);
       assert.equal(result, json);
     });
+
+    it("extracts structured error field (v1.24.0+ single line)", () => {
+      const aadError =
+        "fetching token: failed to authenticate:\n(invalid_tenant) AADSTS90002: Tenant 'test' not found";
+      const json = JSON.stringify({
+        error: aadError,
+        links: [{ title: "azd auth login reference", url: "https://example.com" }],
+        message: "Authentication with Azure failed.",
+        suggestion: "Run 'azd auth login' to sign in again.",
+      });
+      const result = developerCliCredentialInternals.parseAzdStderr(json);
+      assert.equal(result, aadError);
+    });
+
+    it("prefers structured error preceded by empty consoleMessage (v1.23.7 - v1.23.15)", () => {
+      const aadError = "fetching token: failed to authenticate";
+      const input =
+        JSON.stringify({
+          type: "consoleMessage",
+          timestamp: "2026-04-13T17:43:24.7558297-07:00",
+          data: { message: "\n" },
+        }) +
+        "\n" +
+        JSON.stringify({
+          error: aadError,
+          message: "Authentication with Azure failed.",
+          suggestion: "Run 'azd auth login' to sign in again.",
+        });
+      const result = developerCliCredentialInternals.parseAzdStderr(input);
+      assert.equal(result, aadError);
+    });
+
+    it("prefers structured error over non-empty consoleMessage", () => {
+      const aadError = "AADSTS70008: Refresh token expired";
+      const input =
+        JSON.stringify({
+          type: "consoleMessage",
+          timestamp: "2024-01-01T00:00:00Z",
+          data: { message: "some informational console output" },
+        }) +
+        "\n" +
+        JSON.stringify({
+          error: aadError,
+          message: "Authentication with Azure failed.",
+        });
+      const result = developerCliCredentialInternals.parseAzdStderr(input);
+      assert.equal(result, aadError);
+    });
+
+    it("falls back to first non-empty consoleMessage when no structured error", () => {
+      const firstMessage = "ERROR: fetching token: interactive login needed";
+      const input =
+        JSON.stringify({
+          type: "consoleMessage",
+          data: { message: "\n" },
+        }) +
+        "\n" +
+        JSON.stringify({
+          type: "consoleMessage",
+          data: { message: firstMessage },
+        }) +
+        "\n" +
+        JSON.stringify({
+          type: "consoleMessage",
+          data: { message: "trailing detail" },
+        });
+      const result = developerCliCredentialInternals.parseAzdStderr(input);
+      assert.equal(result, firstMessage);
+    });
+
+    it("returns raw stderr when structured error field is empty", () => {
+      const json = JSON.stringify({ error: "   ", message: "Authentication failed." });
+      const result = developerCliCredentialInternals.parseAzdStderr(json);
+      assert.equal(result, json);
+    });
   });
 
   describe("error message parsing integration", () => {
@@ -369,6 +444,47 @@ describe("AzureDeveloperCliCredential (internal)", function () {
         assert.fail("Expected error to be thrown");
       } catch (error: any) {
         assert.equal(error.message, "plain text error message");
+      }
+    });
+
+    it("parses structured error from azd v1.24.0+ stderr", async () => {
+      const aadError = "AADSTS90002: Tenant 'test' not found";
+      stdout = "";
+      stderr = JSON.stringify({
+        error: aadError,
+        message: "Authentication with Azure failed.",
+        suggestion: "Run 'azd auth login' to sign in again.",
+      });
+      const credential = new AzureDeveloperCliCredential();
+      try {
+        await credential.getToken("https://service/.default");
+        assert.fail("Expected error to be thrown");
+      } catch (error: any) {
+        assert.equal(error.message, aadError);
+      }
+    });
+
+    it("parses structured error preceded by empty consoleMessage from azd v1.23.7-v1.23.15 stderr", async () => {
+      const aadError = "AADSTS90002: Tenant 'test' not found";
+      stdout = "";
+      stderr =
+        JSON.stringify({
+          type: "consoleMessage",
+          timestamp: "2026-04-13T17:43:24.7558297-07:00",
+          data: { message: "\n" },
+        }) +
+        "\n" +
+        JSON.stringify({
+          error: aadError,
+          message: "Authentication with Azure failed.",
+          suggestion: "Run 'azd auth login' to sign in again.",
+        });
+      const credential = new AzureDeveloperCliCredential();
+      try {
+        await credential.getToken("https://service/.default");
+        assert.fail("Expected error to be thrown");
+      } catch (error: any) {
+        assert.equal(error.message, aadError);
       }
     });
   });


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/identity`

### Issues associated with this PR

Fixes https://github.com/Azure/azure-dev/issues/7857 (parent: https://github.com/Azure/azure-dev/issues/7728)

### Describe the problem that is addressed by this PR

Starting with [azd v1.23.7](https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.23.7) (PR [Azure/azure-dev#6827](https://github.com/Azure/azure-dev/pull/6827)), `azd auth token` changed its stderr error format from the legacy `consoleMessage` JSON to a structured `{"error":"..."}` JSON object. The stderr output may also include an extraneous empty `consoleMessage` line preceding the error (fixed in v1.24.0 via [Azure/azure-dev#7701](https://github.com/Azure/azure-dev/pull/7701)).

This PR updates `AzureDeveloperCliCredential` error parsing to handle all three formats:

| azd version | stderr format |
|---|---|
| pre-v1.23.7 | `{"type":"consoleMessage","data":{"message":"..."}}` |
| v1.23.7 – v1.23.15 | `{"type":"consoleMessage",...}\n{"error":"..."}` (two lines) |
| v1.24.0+ | `{"error":"..."}` (single line) |

`AzureDeveloperCliCredential.parseAzdStderr` previously only handled the legacy single-line `consoleMessage` shape. On azd v1.23.7+ it would fail to extract the message and surface the raw JSON blob in the credential's error message instead of the underlying AAD error.

The parser splits stderr by newline, prefers the structured `error` field, and falls back to the first non-empty `data.message` from a legacy `consoleMessage` line. If neither is found the raw text is returned unchanged, preserving existing behaviour for plain-text and malformed output.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Considered approaches:

1. **Single-pass split-by-newline parser (chosen).** Splits stderr on `\n`, attempts `JSON.parse` per line, prefers the structured `error` field, and falls back to the first non-empty `data.message`. Handles all three formats in one pass with minimal allocations. Returns the raw stderr unchanged when neither field is present, preserving existing behaviour for plain-text/malformed output.
2. **Try the new format only and drop legacy support.** Rejected — `@azure/identity` supports users on older azd installs; silently regressing them is unacceptable.

The chosen design also matches the equivalent fixes in [`azure-sdk-for-go`](https://github.com/Azure/azure-sdk-for-go/pull/26590) and [`azure-sdk-for-net`](https://github.com/Azure/azure-sdk-for-net/pull/58616), keeping behaviour consistent across the three SDKs.

### Are there test cases added in this PR? _(If not, why?)_

Yes, added unit tests in `sdk/identity/identity/test/internal/node/azureDeveloperCliCredential.spec.ts`

Also manually validated with small Node sample app:

```js
const credential = new AzureDeveloperCliCredential({
  // Well-formed UUID so client-side validation passes; AAD will reject it.
  tenantId: "00000000-0000-0000-0000-000000000001",
});

console.log("Requesting token for scope: https://management.azure.com/.default");

try {
  const token = await credential.getToken("https://management.azure.com/.default");
  console.log("Unexpected success:", token);
} catch (err) {
  console.log("---");
  console.log("Caught:", err.name);
  console.log(err.message);
}
```


#### Without changes (azd v1.23.7+)

```
Caught: CredentialUnavailableError
{"type":"consoleMessage","timestamp":"2026-05-04T16:48:58.6753928-07:00","data":{"message":"\n"}}
{"error":"fetching token: failed to authenticate:\n(invalid_tenant) AADSTS90002: Tenant '00000000-0000-0000-0000-000000000001' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: 7397ba12-327a-4555-8fa2-9accb81d9200 Correlation ID: c050f408-3a84-4359-b403-07f072c6e1b0 Timestamp: 2026-05-04 23:48:58Z\n","links":[{"title":"azd auth login reference","url":"https://learn.microsoft.com/azure/developer/azure-developer-cli/reference#azd-auth-login"}],"message":"Authentication with Azure failed.","suggestion":"Run 'azd auth login' to sign in again."}
```

#### With changes

```
Caught: CredentialUnavailableError
(invalid_tenant) AADSTS90002: Tenant '00000000-0000-0000-0000-000000000001' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: f8110e9d-7fe8-4367-9731-5c0c512daa00 Correlation ID: 65c635ef-5963-4d83-9cac-bd99197f1d0d Timestamp: 2026-05-04 23:47:44Z
```

### Provide a list of related PRs _(if any)_

- [Azure/azure-sdk-for-go#26590](https://github.com/Azure/azure-sdk-for-go/pull/26590) — equivalent Go fix
- [Azure/azure-sdk-for-net#58616](https://github.com/Azure/azure-sdk-for-net/pull/58616) — equivalent .NET fix

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_ — N/A, hand-written client code, no codegen involved.
- [x] Added a changelog (if necessary)
