### PR TITLE
[engsys] Adopt Node 24 in actions.

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Pnpm
         run: npm install -g pnpm
@@ -33,4 +33,3 @@ jobs:
         shell: pwsh
         run: |
           ./eng/common/mcp/azure-sdk-mcp.ps1 -InstallDirectory $HOME/bin
-

--- a/.github/workflows/warp-ci.yml
+++ b/.github/workflows/warp-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
This has already been done for our GitHub Agentic Workflows and will be forced by GitHub soon:

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/