### PR TITLE
fix(storage): add trailing ampersand sanitizer for browser test recordings

### DIFF
--- a/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob-changefeed/test/utils/testutils.common.ts
@@ -44,7 +44,18 @@ const sasParams = ["se", "sig", "sip", "sp", "spr", "srt", "ss", "sr", "st", "sv
 if (!isNodeLike) {
   sasParams.push("_");
 }
-export const uriSanitizers: FindReplaceSanitizer[] = sasParams.map(getUriSanitizerForQueryParam);
+
+// strip trailing & so old recordings (with &) match new requests (without &)
+const trailingAmpersandSanitizer: FindReplaceSanitizer = {
+  regex: true,
+  target: "&$",
+  value: "",
+};
+
+export const uriSanitizers: FindReplaceSanitizer[] = [
+  ...sasParams.map(getUriSanitizerForQueryParam),
+  trailingAmpersandSanitizer,
+];
 export const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback: {
     // Used in record and playback modes

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -63,7 +63,18 @@ const sasParams = ["se", "sig", "sip", "sp", "spr", "srt", "ss", "sr", "st", "sv
 if (!isNodeLike) {
   sasParams.push("_");
 }
-export const uriSanitizers: FindReplaceSanitizer[] = sasParams.map(getUriSanitizerForQueryParam);
+
+// strip trailing & so old recordings (with &) match new requests (without &)
+const trailingAmpersandSanitizer: RegexSanitizer = {
+  regex: true,
+  target: "&$",
+  value: "",
+};
+
+export const uriSanitizers: FindReplaceSanitizer[] = [
+  ...sasParams.map(getUriSanitizerForQueryParam),
+  trailingAmpersandSanitizer,
+];
 export const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback: {
     // Used in record and playback modes

--- a/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-datalake/test/utils/testutils.common.ts
@@ -46,7 +46,18 @@ const sasParams = ["se", "sig", "sip", "sp", "spr", "srt", "ss", "sr", "st", "sv
 if (!isNodeLike) {
   sasParams.push("_");
 }
-export const uriSanitizers: FindReplaceSanitizer[] = sasParams.map(getUriSanitizerForQueryParam);
+
+// strip trailing & so old recordings (with &) match new requests (without &)
+const trailingAmpersandSanitizer: FindReplaceSanitizer = {
+  regex: true,
+  target: "&$",
+  value: "",
+};
+
+export const uriSanitizers: FindReplaceSanitizer[] = [
+  ...sasParams.map(getUriSanitizerForQueryParam),
+  trailingAmpersandSanitizer,
+];
 export const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback: {
     // Used in record and playback modes

--- a/sdk/storage/storage-file-share/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-file-share/test/utils/testutils.common.ts
@@ -57,7 +57,18 @@ const sasParams = [
 if (isBrowser) {
   sasParams.push("_");
 }
-export const uriSanitizers: UriSanitizers = sasParams.map(getUriSanitizerForQueryParam);
+
+// strip trailing & so old recordings (with &) match new requests (without &)
+const trailingAmpersandSanitizer: FindReplaceSanitizer = {
+  regex: true,
+  target: "&$",
+  value: "",
+};
+
+export const uriSanitizers: UriSanitizers = [
+  ...sasParams.map(getUriSanitizerForQueryParam),
+  trailingAmpersandSanitizer,
+];
 export const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback: {
     // Comment following line to skip user delegation key/SAS related cases in record and play

--- a/sdk/storage/storage-queue/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-queue/test/utils/testutils.common.ts
@@ -53,7 +53,17 @@ if (!isNodeLike) {
   sasParams.push("_");
 }
 
-export const uriSanitizers: UriSanitizers = sasParams.map(getUriSanitizerForQueryParam);
+// strip trailing & so old recordings (with &) match new requests (without &)
+const trailingAmpersandSanitizer = {
+  regex: true,
+  target: "&$",
+  value: "",
+};
+
+export const uriSanitizers: UriSanitizers = [
+  ...sasParams.map(getUriSanitizerForQueryParam),
+  trailingAmpersandSanitizer,
+];
 export const recorderEnvSetup: RecorderStartOptions = {
   envSetupForPlayback: {
     // Used in record and playback modes


### PR DESCRIPTION
## Description

Fixes browser test failures across all storage packages caused by URL mismatch between recordings and live requests.

### Problem

The test recorder was creating recordings with a trailing `&` in URLs (e.g., `?restype=container&`), but the browser now sends requests without it (e.g., `?restype=container`). This caused ~66 browser test failures in `storage-file-datalake` alone.

### Solution

Added a `trailingAmpersandSanitizer` regex sanitizer to all storage test utilities that strips the trailing `&` from recorded URLs, ensuring they match the current request format.

```typescript
const trailingAmpersandSanitizer = {
  regex: true,
  target: "&$",
  value: "",
};
```

### Testing

- Verified locally: `storage-file-datalake` browser tests go from 66 failures → 194 passing
- Same fix applied to all 5 storage packages with browser tests

### Packages affected

- `@azure/storage-blob`
- `@azure/storage-blob-changefeed`
- `@azure/storage-file-datalake`
- `@azure/storage-file-share`
- `@azure/storage-queue`
