### PR TITLE
feat(warp): add build-time validation for platform-specific imports

### DIFF
--- a/common/tools/warp/src/build.ts
+++ b/common/tools/warp/src/build.ts
@@ -18,6 +18,7 @@ import {
   buildConditionsSet,
   validateNoDirectImports,
   resolveSubpathImport,
+  validatePlatformImports,
 } from "./resolveImports.ts";
 import type { ImportsMap } from "./resolveImports.ts";
 import { generateSizeReport, formatSizeReport, writeSizeReportJson } from "./sizeReport.ts";
@@ -306,6 +307,32 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
         config,
         totalTimeMs: performance.now() - buildStart,
       };
+    }
+
+    // Step 1c: Validate platform-specific files use #platform imports
+    // Only applies when polyfillSuffix is NOT active (polyfill handles it otherwise)
+    const usesPolyfill = config.targets.some((t) => t.polyfillSuffix);
+    if (!usesPolyfill) {
+      const platformViolations = await validatePlatformImports(importsMap, packageRoot);
+      if (platformViolations.length > 0) {
+        log.error(
+          `\n[warp] Found ${platformViolations.length} platform-specific file(s) bypassing #platform imports:`,
+        );
+        for (const v of platformViolations) {
+          log.error(
+            `  ${path.relative(packageRoot, v.file)}:${v.line}  ${v.specifier}  →  use ${v.suggestedImport}`,
+          );
+        }
+        log.error(
+          `\n[warp] Platform entry files (e.g., *-browser.mts) must use #platform imports to ensure correct resolution.`,
+        );
+        log.flush();
+        return {
+          success: false,
+          config,
+          totalTimeMs: performance.now() - buildStart,
+        };
+      }
     }
   }
 

--- a/common/tools/warp/src/build.ts
+++ b/common/tools/warp/src/build.ts
@@ -18,7 +18,6 @@ import {
   buildConditionsSet,
   validateNoDirectImports,
   resolveSubpathImport,
-  validatePlatformImports,
 } from "./resolveImports.ts";
 import type { ImportsMap } from "./resolveImports.ts";
 import { generateSizeReport, formatSizeReport, writeSizeReportJson } from "./sizeReport.ts";
@@ -288,32 +287,34 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
     for (const pc of parsedConfigs) {
       for (const f of pc.parsedConfig.fileNames) allSourceFiles.add(f);
     }
-    const violations = validateNoDirectImports([...allSourceFiles], importsMap, packageRoot);
+
+    // Also validate platform files when polyfillSuffix is NOT active
+    const usesPolyfill = config.targets.some((t) => t.polyfillSuffix);
+    const violations = validateNoDirectImports(
+      [...allSourceFiles],
+      importsMap,
+      packageRoot,
+      !usesPolyfill,
+    );
+
     if (violations.length > 0) {
-      log.error(
-        `\n[warp] Found ${violations.length} direct import(s) bypassing the #imports mechanism:`,
-      );
-      for (const v of violations) {
+      const platformViolations = violations.filter((v) => v.targetPlatform);
+      const regularViolations = violations.filter((v) => !v.targetPlatform);
+
+      if (regularViolations.length > 0) {
         log.error(
-          `  ${path.relative(packageRoot, v.file)}:${v.line}  ${v.specifier}  →  use ${v.suggestedImport}`,
+          `\n[warp] Found ${regularViolations.length} direct import(s) bypassing the #imports mechanism:`,
+        );
+        for (const v of regularViolations) {
+          log.error(
+            `  ${path.relative(packageRoot, v.file)}:${v.line}  ${v.specifier}  →  use ${v.suggestedImport}`,
+          );
+        }
+        log.error(
+          `\n[warp] These files are mapped via package.json "imports". Use the #-prefixed specifier to ensure correct platform-specific resolution.`,
         );
       }
-      log.error(
-        `\n[warp] These files are mapped via package.json "imports". Use the #-prefixed specifier to ensure correct platform-specific resolution.`,
-      );
-      log.flush();
-      return {
-        success: false,
-        config,
-        totalTimeMs: performance.now() - buildStart,
-      };
-    }
 
-    // Step 1c: Validate platform-specific files use #platform imports
-    // Only applies when polyfillSuffix is NOT active (polyfill handles it otherwise)
-    const usesPolyfill = config.targets.some((t) => t.polyfillSuffix);
-    if (!usesPolyfill) {
-      const platformViolations = await validatePlatformImports(importsMap, packageRoot);
       if (platformViolations.length > 0) {
         log.error(
           `\n[warp] Found ${platformViolations.length} platform-specific file(s) bypassing #platform imports:`,
@@ -326,13 +327,14 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
         log.error(
           `\n[warp] Platform entry files (e.g., *-browser.mts) must use #platform imports to ensure correct resolution.`,
         );
-        log.flush();
-        return {
-          success: false,
-          config,
-          totalTimeMs: performance.now() - buildStart,
-        };
       }
+
+      log.flush();
+      return {
+        success: false,
+        config,
+        totalTimeMs: performance.now() - buildStart,
+      };
     }
   }
 

--- a/common/tools/warp/src/build.ts
+++ b/common/tools/warp/src/build.ts
@@ -288,7 +288,10 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
       for (const f of pc.parsedConfig.fileNames) allSourceFiles.add(f);
     }
 
-    // Also validate platform files when polyfillSuffix is NOT active
+    // Validate platform files when polyfillSuffix is NOT configured.
+    // Note: We check config rather than whether polyfill files exist on disk.
+    // If polyfillSuffix is configured but no files exist, the build will fail
+    // later anyway. Calling discoverPolyfills here would add I/O overhead.
     const usesPolyfill = config.targets.some((t) => t.polyfillSuffix);
     const violations = validateNoDirectImports(
       [...allSourceFiles],
@@ -317,15 +320,15 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
 
       if (platformViolations.length > 0) {
         log.error(
-          `\n[warp] Found ${platformViolations.length} platform-specific file(s) bypassing #platform imports:`,
+          `\n[warp] Found ${platformViolations.length} platform-specific file(s) bypassing #imports:`,
         );
         for (const v of platformViolations) {
           log.error(
-            `  ${path.relative(packageRoot, v.file)}:${v.line}  ${v.specifier}  →  use ${v.suggestedImport}`,
+            `  ${path.relative(packageRoot, v.file)}:${v.line} [${v.targetPlatform}]  ${v.specifier}  →  use ${v.suggestedImport}`,
           );
         }
         log.error(
-          `\n[warp] Platform entry files (e.g., *-browser.mts) must use #platform imports to ensure correct resolution.`,
+          `\n[warp] Platform entry files must use #-prefixed imports to ensure correct resolution.`,
         );
       }
 

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -574,6 +574,8 @@ interface WildcardPattern {
   regex: RegExp;
   /** The `#`-prefixed key (with `*`) from the imports map, e.g., `#platform/*`. */
   key: string;
+  /** The condition under which this pattern applies (e.g., "browser", "default"). */
+  condition?: string;
 }
 
 /**
@@ -589,20 +591,24 @@ export function buildImportTargetIndex(
 ): { exactPaths: Map<string, string>; wildcardPatterns: WildcardPattern[] } {
   const exactPaths = new Map<string, string>();
   const wildcardPatterns: WildcardPattern[] = [];
-  // Deduplicate wildcard regexes by their source string
   const seenPatterns = new Set<string>();
 
-  function collectFromTarget(target: PackageTarget, key: string, hasWildcard: boolean): void {
+  function collectFromTarget(
+    target: PackageTarget,
+    key: string,
+    hasWildcard: boolean,
+    condition?: string,
+  ): void {
     if (target === null || target === undefined) return;
     if (typeof target === "string") {
       if (hasWildcard && target.includes("*")) {
-        // Convert wildcard target to regex: "./src/*-browser.mts" → /^\/abs\/src\/(.+)-browser\.mts$/
         const abs = path.resolve(packageRoot, target);
         const escaped = abs.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const regexSource = "^" + escaped.replace("\\*", "(.+)") + "$";
-        if (!seenPatterns.has(regexSource)) {
-          seenPatterns.add(regexSource);
-          wildcardPatterns.push({ regex: new RegExp(regexSource), key });
+        const dedupKey = `${regexSource}:${condition ?? ""}`;
+        if (!seenPatterns.has(dedupKey)) {
+          seenPatterns.add(dedupKey);
+          wildcardPatterns.push({ regex: new RegExp(regexSource), key, condition });
         }
       } else {
         const abs = path.resolve(packageRoot, target);
@@ -611,12 +617,12 @@ export function buildImportTargetIndex(
       return;
     }
     if (Array.isArray(target)) {
-      for (const item of target) collectFromTarget(item, key, hasWildcard);
+      for (const item of target) collectFromTarget(item, key, hasWildcard, condition);
       return;
     }
-    // Conditional object — recurse into all branches
-    for (const nested of Object.values(target)) {
-      collectFromTarget(nested, key, hasWildcard);
+    // Conditional object — recurse into branches with condition tracking
+    for (const [cond, nested] of Object.entries(target)) {
+      collectFromTarget(nested, key, hasWildcard, cond);
     }
   }
 
@@ -632,6 +638,16 @@ export function buildImportTargetIndex(
 }
 
 /**
+ * Result of looking up a file path in the import target index.
+ */
+interface ImportTargetMatch {
+  /** The resolved `#`-prefixed key (wildcards replaced). */
+  key: string;
+  /** The condition under which this target applies, if any. */
+  condition?: string;
+}
+
+/**
  * Look up a resolved file path in the import target index.
  * Returns the `#`-prefixed key if the path is a target, or undefined.
  *
@@ -642,17 +658,16 @@ function lookupImportTarget(
   resolvedPath: string,
   exactPaths: Map<string, string>,
   wildcardPatterns: WildcardPattern[],
-): string | undefined {
+): ImportTargetMatch | undefined {
   // Fast exact check first
   const exactKey = exactPaths.get(resolvedPath);
-  if (exactKey) return exactKey;
+  if (exactKey) return { key: exactKey };
 
   // Try wildcard patterns
-  for (const { regex, key } of wildcardPatterns) {
+  for (const { regex, key, condition } of wildcardPatterns) {
     const match = resolvedPath.match(regex);
     if (match && match[1]) {
-      // Replace * in key with matched portion
-      return key.replace("*", match[1]);
+      return { key: key.replace("*", match[1]), condition };
     }
   }
   return undefined;
@@ -839,11 +854,11 @@ export function validateNoDirectImports(
     // with divergent resolutions. These files only run under their specific
     // condition (e.g., Node default), so their direct imports to other
     // same-condition files are correct.
-    const selfKey = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
-    if (selfKey) {
-      const selfIsWildcard = selfKey !== exactPaths.get(filePath);
+    const selfMatch = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
+    if (selfMatch) {
+      const selfIsWildcard = selfMatch.key !== exactPaths.get(filePath);
       if (
-        hasDivergentResolutions(selfKey, importsMap, packageRoot, selfIsWildcard, divergenceCache)
+        hasDivergentResolutions(selfMatch.key, importsMap, packageRoot, selfIsWildcard, divergenceCache)
       ) {
         continue;
       }
@@ -868,21 +883,21 @@ export function validateNoDirectImports(
       const resolved = resolveRelativeSpecifier(specifier, filePath);
       if (!resolved) continue;
 
-      const key = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
-      if (!key) continue;
+      const match = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
+      if (!match) continue;
 
       // Only flag if the imported target has divergent resolutions.
       // For example, importing `./helper.js` is fine if `#platform/helper`
       // has only a `default` entry and no condition-specific variants.
-      const isWildcard = key !== exactPaths.get(resolved);
-      if (!hasDivergentResolutions(key, importsMap, packageRoot, isWildcard, divergenceCache)) {
+      const isWildcard = match.key !== exactPaths.get(resolved);
+      if (!hasDivergentResolutions(match.key, importsMap, packageRoot, isWildcard, divergenceCache)) {
         continue;
       }
 
       violations.push({
         file: filePath,
         specifier,
-        suggestedImport: key,
+        suggestedImport: match.key,
         line,
       });
     }
@@ -974,74 +989,6 @@ export interface PlatformImportViolation {
   targetPlatform: string;
 }
 
-/** A wildcard pattern with its condition. */
-interface ConditionedPattern {
-  regex: RegExp;
-  key: string;
-  condition: string;
-}
-
-/**
- * Build an index of wildcard patterns with their conditions.
- * For each non-default condition in a divergent import entry, creates a regex
- * that matches files targeted by that condition.
- */
-function buildConditionedPatternIndex(
-  importsMap: ImportsMap,
-  packageRoot: string,
-): ConditionedPattern[] {
-  const patterns: ConditionedPattern[] = [];
-  const seenPatterns = new Set<string>();
-
-  for (const [key, target] of Object.entries(importsMap)) {
-    if (!key.includes("*")) continue;
-    if (typeof target !== "object" || target === null || Array.isArray(target)) continue;
-
-    // Check if this entry has divergent resolutions (multiple distinct targets)
-    const leafTargets = new Set<string>();
-    for (const value of Object.values(target)) {
-      if (typeof value === "string" && value.includes("*")) {
-        leafTargets.add(value);
-      }
-    }
-    if (leafTargets.size < 2) continue; // Not divergent
-
-    // Build pattern for each non-default condition
-    for (const [condition, value] of Object.entries(target)) {
-      if (condition === "default") continue;
-      if (typeof value !== "string" || !value.includes("*")) continue;
-
-      const abs = path.resolve(packageRoot, value);
-      const escaped = abs.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regexSource = "^" + escaped.replace("\\*", "(.+)") + "$";
-
-      if (!seenPatterns.has(regexSource)) {
-        seenPatterns.add(regexSource);
-        patterns.push({ regex: new RegExp(regexSource), key, condition });
-      }
-    }
-  }
-
-  return patterns;
-}
-
-/**
- * Look up a file path in the conditioned pattern index.
- * Returns the key (with wildcard replaced) and condition if matched.
- */
-function lookupConditionedTarget(
-  filePath: string,
-  patterns: ConditionedPattern[],
-): { key: string; condition: string } | undefined {
-  for (const { regex, key, condition } of patterns) {
-    const match = filePath.match(regex);
-    if (match && match[1]) {
-      return { key: key.replace("*", match[1]), condition };
-    }
-  }
-  return undefined;
-}
-
 /**
  * Validate that platform-specific files use #-prefixed imports correctly.
  * Returns violations that should fail the build.
@@ -1057,15 +1004,13 @@ export async function validatePlatformImports(
 ): Promise<PlatformImportViolation[]> {
   const violations: PlatformImportViolation[] = [];
 
-  // Build index of platform-specific file patterns
-  const conditionedPatterns = buildConditionedPatternIndex(importsMap, packageRoot);
-  if (conditionedPatterns.length === 0) return violations;
-
-  // Build standard import target index for checking imported files
   const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, packageRoot);
+  
+  const hasPlatformPatterns = wildcardPatterns.some((p) => p.condition && p.condition !== "default");
+  if (!hasPlatformPatterns) return violations;
+
   const divergenceCache = new Map<string, boolean>();
 
-  // Find all source files
   const srcDir = path.join(packageRoot, "src");
   const sourceFiles: string[] = [];
 
@@ -1083,14 +1028,13 @@ export async function validatePlatformImports(
   let validatedCount = 0;
 
   for (const filePath of sourceFiles) {
-    // Check if this file is a platform-specific target
-    const match = lookupConditionedTarget(filePath, conditionedPatterns);
-    if (!match) continue;
+    // Check if this file is a platform-specific target (non-default condition)
+    const selfMatch = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
+    if (!selfMatch?.condition || selfMatch.condition === "default") continue;
 
     validatedCount++;
-    const { key: selfKey, condition } = match;
+    const { condition } = selfMatch;
 
-    // Parse file and extract imports
     const content = ts.sys.readFile(filePath);
     if (!content) continue;
 
@@ -1106,21 +1050,17 @@ export async function validatePlatformImports(
     const conditions = new Set([condition, "import", "default"]);
 
     for (const { text: specifier, line } of specifiers) {
-      // Resolve the import to an absolute path
       const resolved = resolveRelativeSpecifier(specifier, filePath);
       if (!resolved) continue;
 
-      // Check if the imported file is a target of an imports entry
-      const importKey = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
-      if (!importKey) continue;
+      const importMatch = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
+      if (!importMatch) continue;
 
-      // Check if this import key has divergent resolutions
-      const isWildcard = importKey !== exactPaths.get(resolved);
-      if (!hasDivergentResolutions(importKey, importsMap, packageRoot, isWildcard, divergenceCache))
+      const isWildcard = importMatch.key !== exactPaths.get(resolved);
+      if (!hasDivergentResolutions(importMatch.key, importsMap, packageRoot, isWildcard, divergenceCache))
         continue;
 
-      // The import bypasses #imports - resolve what it SHOULD be
-      const platformResolved = resolveSubpathImport(importKey, importsMap, conditions);
+      const platformResolved = resolveSubpathImport(importMatch.key, importsMap, conditions);
       if (!platformResolved) continue;
 
       const platformAbsPath = path.resolve(packageRoot, platformResolved);
@@ -1129,7 +1069,7 @@ export async function validatePlatformImports(
           file: filePath,
           line,
           specifier,
-          suggestedImport: importKey,
+          suggestedImport: importMatch.key,
           targetPlatform: condition,
         });
       }

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -866,7 +866,7 @@ export function validateNoDirectImports(
 
   for (const filePath of sourceFiles) {
     const selfMatch = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
-    
+
     // Determine if this is a platform-specific file (non-default condition)
     const platformCondition =
       selfMatch?.condition && selfMatch.condition !== "default" ? selfMatch.condition : undefined;
@@ -921,7 +921,9 @@ export function validateNoDirectImports(
 
       const exactEntry = exactPaths.get(resolved);
       const isWildcard = !exactEntry || exactEntry.key !== match.key;
-      if (!hasDivergentResolutions(match.key, importsMap, packageRoot, isWildcard, divergenceCache)) {
+      if (
+        !hasDivergentResolutions(match.key, importsMap, packageRoot, isWildcard, divergenceCache)
+      ) {
         continue;
       }
 
@@ -1021,4 +1023,3 @@ export function buildConditionsSet(
 
   return conditions;
 }
-

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -960,3 +960,129 @@ export function buildConditionsSet(
 
   return conditions;
 }
+
+// ---------------------------------------------------------------------------
+// Platform-specific file validation
+// ---------------------------------------------------------------------------
+
+/** Violation found during platform import validation. */
+export interface PlatformImportViolation {
+  file: string;
+  line: number;
+  specifier: string;
+  suggestedImport: string;
+  targetPlatform: string;
+}
+
+/**
+ * Detect the platform from a file's name based on suffix convention.
+ * Returns "browser", "react-native", "node", or undefined if not platform-specific.
+ */
+function detectFilePlatform(filePath: string): string | undefined {
+  const basename = path.basename(filePath);
+  if (basename.includes("-browser.")) return "browser";
+  if (basename.includes("-react-native.")) return "react-native";
+  if (basename.includes("-native.")) return "react-native";
+  if (basename.includes("-node.")) return "node";
+  if (basename.includes("-workerd.")) return "workerd";
+  return undefined;
+}
+
+/**
+ * Find all platform-specific files in a directory tree.
+ */
+function findPlatformFiles(dir: string): string[] {
+  const fss = require("node:fs") as typeof import("node:fs");
+  const result: string[] = [];
+  if (!fss.existsSync(dir)) return result;
+
+  const entries = fss.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...findPlatformFiles(fullPath));
+    } else if (entry.isFile() && detectFilePlatform(fullPath)) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+/**
+ * Validate that platform-specific files use #platform imports correctly.
+ * Returns violations that should fail the build.
+ *
+ * This validation only applies when polyfillSuffix is NOT active.
+ * When polyfillSuffix is used, the polyfill mechanism handles platform
+ * resolution at compile time, so direct imports work correctly.
+ */
+export async function validatePlatformImports(
+  importsMap: ImportsMap,
+  packageRoot: string,
+): Promise<PlatformImportViolation[]> {
+  const fss = require("node:fs") as typeof import("node:fs");
+  const violations: PlatformImportViolation[] = [];
+
+  const srcDir = path.join(packageRoot, "src");
+  const platformFiles = findPlatformFiles(srcDir);
+
+  for (const filePath of platformFiles) {
+    const platform = detectFilePlatform(filePath);
+    if (!platform) continue;
+
+    const content = ts.sys.readFile(filePath);
+    if (!content) continue;
+
+    const sourceFile = ts.createSourceFile(
+      path.basename(filePath),
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+
+    const conditions = new Set([platform, "import", "default"]);
+
+    ts.forEachChild(sourceFile, function visit(node) {
+      let specifier: string | undefined;
+      if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+        specifier = node.moduleSpecifier.text;
+      } else if (
+        ts.isExportDeclaration(node) &&
+        node.moduleSpecifier &&
+        ts.isStringLiteral(node.moduleSpecifier)
+      ) {
+        specifier = node.moduleSpecifier.text;
+      }
+
+      if (specifier && specifier.startsWith(".") && !specifier.startsWith("#")) {
+        const fromDir = path.dirname(filePath);
+        const resolved = path.resolve(fromDir, specifier);
+        const relPath = specifier.replace(/^\.\//, "").replace(/\.(js|ts|mts|mjs)$/, "");
+        const platformSpecifier = `#platform/${relPath}`;
+        const platformResolved = resolveSubpathImport(platformSpecifier, importsMap, conditions);
+
+        if (platformResolved) {
+          const platformAbsPath = path.resolve(packageRoot, platformResolved);
+          const exists = fss.existsSync(platformAbsPath);
+          if (exists && platformAbsPath !== resolved) {
+            const line = sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+            violations.push({
+              file: filePath,
+              line,
+              specifier,
+              suggestedImport: platformSpecifier,
+              targetPlatform: platform,
+            });
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    });
+  }
+
+  const log = getLogger();
+  log.info(`[warp] Validated ${platformFiles.length} platform-specific file(s)`);
+
+  return violations;
+}

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -974,62 +974,123 @@ export interface PlatformImportViolation {
   targetPlatform: string;
 }
 
+/** A wildcard pattern with its condition. */
+interface ConditionedPattern {
+  regex: RegExp;
+  key: string;
+  condition: string;
+}
+
 /**
- * Detect the platform from a file's name based on suffix convention.
- * Returns "browser", "react-native", "node", or undefined if not platform-specific.
+ * Build an index of wildcard patterns with their conditions.
+ * For each non-default condition in a divergent import entry, creates a regex
+ * that matches files targeted by that condition.
  */
-function detectFilePlatform(filePath: string): string | undefined {
-  const basename = path.basename(filePath);
-  if (basename.includes("-browser.")) return "browser";
-  if (basename.includes("-react-native.")) return "react-native";
-  if (basename.includes("-native.")) return "react-native";
-  if (basename.includes("-node.")) return "node";
-  if (basename.includes("-workerd.")) return "workerd";
+function buildConditionedPatternIndex(
+  importsMap: ImportsMap,
+  packageRoot: string,
+): ConditionedPattern[] {
+  const patterns: ConditionedPattern[] = [];
+  const seenPatterns = new Set<string>();
+
+  for (const [key, target] of Object.entries(importsMap)) {
+    if (!key.includes("*")) continue;
+    if (typeof target !== "object" || target === null || Array.isArray(target)) continue;
+
+    // Check if this entry has divergent resolutions (multiple distinct targets)
+    const leafTargets = new Set<string>();
+    for (const value of Object.values(target)) {
+      if (typeof value === "string" && value.includes("*")) {
+        leafTargets.add(value);
+      }
+    }
+    if (leafTargets.size < 2) continue; // Not divergent
+
+    // Build pattern for each non-default condition
+    for (const [condition, value] of Object.entries(target)) {
+      if (condition === "default") continue;
+      if (typeof value !== "string" || !value.includes("*")) continue;
+
+      const abs = path.resolve(packageRoot, value);
+      const escaped = abs.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const regexSource = "^" + escaped.replace("\\*", "(.+)") + "$";
+
+      if (!seenPatterns.has(regexSource)) {
+        seenPatterns.add(regexSource);
+        patterns.push({ regex: new RegExp(regexSource), key, condition });
+      }
+    }
+  }
+
+  return patterns;
+}
+
+/**
+ * Look up a file path in the conditioned pattern index.
+ * Returns the key (with wildcard replaced) and condition if matched.
+ */
+function lookupConditionedTarget(
+  filePath: string,
+  patterns: ConditionedPattern[],
+): { key: string; condition: string } | undefined {
+  for (const { regex, key, condition } of patterns) {
+    const match = filePath.match(regex);
+    if (match && match[1]) {
+      return { key: key.replace("*", match[1]), condition };
+    }
+  }
   return undefined;
 }
 
 /**
- * Find all platform-specific files in a directory tree.
- */
-function findPlatformFiles(dir: string): string[] {
-  const fss = require("node:fs") as typeof import("node:fs");
-  const result: string[] = [];
-  if (!fss.existsSync(dir)) return result;
-
-  const entries = fss.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      result.push(...findPlatformFiles(fullPath));
-    } else if (entry.isFile() && detectFilePlatform(fullPath)) {
-      result.push(fullPath);
-    }
-  }
-  return result;
-}
-
-/**
- * Validate that platform-specific files use #platform imports correctly.
+ * Validate that platform-specific files use #-prefixed imports correctly.
  * Returns violations that should fail the build.
  *
- * This validation only applies when polyfillSuffix is NOT active.
- * When polyfillSuffix is used, the polyfill mechanism handles platform
- * resolution at compile time, so direct imports work correctly.
+ * Platform-specific files are determined from the imports map in package.json.
+ * Files that are targets of divergent wildcard imports (non-default conditions
+ * like "browser", "react-native") are validated to ensure they use the
+ * #-prefixed import specifier for any import that has a platform variant.
  */
 export async function validatePlatformImports(
   importsMap: ImportsMap,
   packageRoot: string,
 ): Promise<PlatformImportViolation[]> {
-  const fss = require("node:fs") as typeof import("node:fs");
   const violations: PlatformImportViolation[] = [];
 
+  // Build index of platform-specific file patterns
+  const conditionedPatterns = buildConditionedPatternIndex(importsMap, packageRoot);
+  if (conditionedPatterns.length === 0) return violations;
+
+  // Build standard import target index for checking imported files
+  const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, packageRoot);
+  const divergenceCache = new Map<string, boolean>();
+
+  // Find all source files
   const srcDir = path.join(packageRoot, "src");
-  const platformFiles = findPlatformFiles(srcDir);
+  const sourceFiles: string[] = [];
 
-  for (const filePath of platformFiles) {
-    const platform = detectFilePlatform(filePath);
-    if (!platform) continue;
+  function collectSourceFiles(dir: string): void {
+    if (!ts.sys.directoryExists(dir)) return;
+    for (const entry of ts.sys.readDirectory(dir, [".ts", ".mts", ".cts"], [], [])) {
+      sourceFiles.push(entry);
+    }
+    for (const subdir of ts.sys.getDirectories(dir)) {
+      collectSourceFiles(path.join(dir, subdir));
+    }
+  }
+  collectSourceFiles(srcDir);
 
+  let validatedCount = 0;
+
+  for (const filePath of sourceFiles) {
+    // Check if this file is a platform-specific target
+    const match = lookupConditionedTarget(filePath, conditionedPatterns);
+    if (!match) continue;
+
+    validatedCount++;
+    const { key: selfKey, condition } = match;
+
+    // Parse file and extract imports
     const content = ts.sys.readFile(filePath);
     if (!content) continue;
 
@@ -1039,50 +1100,44 @@ export async function validatePlatformImports(
       ts.ScriptTarget.Latest,
       true,
     );
+    const specifiers = collectRelativeSpecifiers(sourceFile);
+    if (specifiers.length === 0) continue;
 
-    const conditions = new Set([platform, "import", "default"]);
+    const conditions = new Set([condition, "import", "default"]);
 
-    ts.forEachChild(sourceFile, function visit(node) {
-      let specifier: string | undefined;
-      if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
-        specifier = node.moduleSpecifier.text;
-      } else if (
-        ts.isExportDeclaration(node) &&
-        node.moduleSpecifier &&
-        ts.isStringLiteral(node.moduleSpecifier)
-      ) {
-        specifier = node.moduleSpecifier.text;
+    for (const { text: specifier, line } of specifiers) {
+      // Resolve the import to an absolute path
+      const resolved = resolveRelativeSpecifier(specifier, filePath);
+      if (!resolved) continue;
+
+      // Check if the imported file is a target of an imports entry
+      const importKey = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
+      if (!importKey) continue;
+
+      // Check if this import key has divergent resolutions
+      const isWildcard = importKey !== exactPaths.get(resolved);
+      if (!hasDivergentResolutions(importKey, importsMap, packageRoot, isWildcard, divergenceCache))
+        continue;
+
+      // The import bypasses #imports - resolve what it SHOULD be
+      const platformResolved = resolveSubpathImport(importKey, importsMap, conditions);
+      if (!platformResolved) continue;
+
+      const platformAbsPath = path.resolve(packageRoot, platformResolved);
+      if (platformAbsPath !== resolved) {
+        violations.push({
+          file: filePath,
+          line,
+          specifier,
+          suggestedImport: importKey,
+          targetPlatform: condition,
+        });
       }
-
-      if (specifier && specifier.startsWith(".") && !specifier.startsWith("#")) {
-        const fromDir = path.dirname(filePath);
-        const resolved = path.resolve(fromDir, specifier);
-        const relPath = specifier.replace(/^\.\//, "").replace(/\.(js|ts|mts|mjs)$/, "");
-        const platformSpecifier = `#platform/${relPath}`;
-        const platformResolved = resolveSubpathImport(platformSpecifier, importsMap, conditions);
-
-        if (platformResolved) {
-          const platformAbsPath = path.resolve(packageRoot, platformResolved);
-          const exists = fss.existsSync(platformAbsPath);
-          if (exists && platformAbsPath !== resolved) {
-            const line = sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1;
-            violations.push({
-              file: filePath,
-              line,
-              specifier,
-              suggestedImport: platformSpecifier,
-              targetPlatform: platform,
-            });
-          }
-        }
-      }
-
-      ts.forEachChild(node, visit);
-    });
+    }
   }
 
   const log = getLogger();
-  log.info(`[warp] Validated ${platformFiles.length} platform-specific file(s)`);
+  log.info(`[warp] Validated ${validatedCount} platform-specific file(s)`);
 
   return violations;
 }

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -683,8 +683,8 @@ export function collectImportTargetPaths(
 ): Map<string, string> {
   const index = buildImportTargetIndex(importsMap, packageRoot);
   const result = new Map<string, string>();
-  for (const [path, entry] of index.exactPaths) {
-    result.set(path, entry.key);
+  for (const [absPath, entry] of index.exactPaths) {
+    result.set(absPath, entry.key);
   }
   return result;
 }
@@ -948,7 +948,7 @@ export function validateNoDirectImports(
 
   if (validatePlatformFiles) {
     const log = getLogger();
-    log.info(`[warp] Validated ${platformFileCount} platform-specific file(s)`);
+    log.verbose(`[warp] Validated ${platformFileCount} platform-specific file(s)`);
   }
 
   return violations;

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -553,18 +553,6 @@ export async function resolveImportsInDir(
 // Direct import bypass validation
 // ---------------------------------------------------------------------------
 
-/** A direct import that bypasses the `#imports` mechanism. */
-export interface DirectImportViolation {
-  /** Absolute path of the source file containing the violation. */
-  file: string;
-  /** The relative import specifier that bypasses `#imports`. */
-  specifier: string;
-  /** The `#`-prefixed key that should be used instead. */
-  suggestedImport: string;
-  /** 1-based line number of the offending import. */
-  line: number;
-}
-
 /**
  * A pattern entry from a wildcard imports map target.
  * The `*` in the target is replaced with a regex capture group.
@@ -828,38 +816,62 @@ function hasDivergentResolutions(
   return result;
 }
 
+/** Violation found when a direct import bypasses the #imports mechanism. */
+export interface DirectImportViolation {
+  file: string;
+  specifier: string;
+  suggestedImport: string;
+  line: number;
+  /** If the violating file is a platform-specific file, its condition (e.g., "browser"). */
+  targetPlatform?: string;
+}
+
 /**
- * Validate that no source file directly imports a file that should be accessed
- * via the `#imports` mechanism.
+ * Validate that source files use #-prefixed imports correctly.
  *
- * Scans the provided source files for relative imports and checks whether any
- * of them resolve to a file that is a target in the package's imports map.
+ * This combines two complementary checks in a single pass:
+ * 1. Non-platform files must not directly import files behind #imports
+ * 2. Platform-specific files must use #imports for any divergent dependency
  *
  * @param sourceFiles - Absolute paths of source files to scan
  * @param importsMap - The package.json `imports` field
  * @param packageRoot - Absolute path to the package root
+ * @param validatePlatformFiles - If true, also validate platform-specific files
  * @returns Array of violations found
  */
 export function validateNoDirectImports(
   sourceFiles: readonly string[],
   importsMap: ImportsMap,
   packageRoot: string,
+  validatePlatformFiles = false,
 ): DirectImportViolation[] {
   const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, packageRoot);
   const divergenceCache = new Map<string, boolean>();
   const violations: DirectImportViolation[] = [];
 
+  let platformFileCount = 0;
+
   for (const filePath of sourceFiles) {
-    // Skip implementation files — files that are targets of import map entries
-    // with divergent resolutions. These files only run under their specific
-    // condition (e.g., Node default), so their direct imports to other
-    // same-condition files are correct.
     const selfMatch = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
-    if (selfMatch) {
-      const selfIsWildcard = selfMatch.key !== exactPaths.get(filePath);
-      if (
-        hasDivergentResolutions(selfMatch.key, importsMap, packageRoot, selfIsWildcard, divergenceCache)
-      ) {
+    
+    // Determine if this is a platform-specific file (non-default condition)
+    const isPlatformFile = selfMatch?.condition && selfMatch.condition !== "default";
+
+    // For platform files, only validate if requested
+    if (isPlatformFile) {
+      platformFileCount++;
+      if (!validatePlatformFiles) continue;
+    } else if (selfMatch) {
+      // Default-condition file that is an import target - check if divergent
+      const selfIsDivergent = hasDivergentResolutions(
+        selfMatch.key,
+        importsMap,
+        packageRoot,
+        selfMatch.key !== exactPaths.get(filePath),
+        divergenceCache,
+      );
+      if (selfIsDivergent) {
+        // Its imports are correct for its condition (default)
         continue;
       }
     }
@@ -867,17 +879,21 @@ export function validateNoDirectImports(
     const content = ts.sys.readFile(filePath);
     if (!content) continue;
 
-    // Quick check: skip files without any relative import
     if (!content.includes("./") && !content.includes("../")) continue;
 
     const sourceFile = ts.createSourceFile(
       path.basename(filePath),
       content,
       ts.ScriptTarget.Latest,
-      /* setParentNodes */ false,
+      false,
     );
 
     const relativeSpecifiers = collectRelativeSpecifiers(sourceFile);
+
+    // For platform files, we resolve imports under their specific condition
+    const conditions = isPlatformFile
+      ? new Set([selfMatch!.condition!, "import", "default"])
+      : undefined;
 
     for (const { text: specifier, line } of relativeSpecifiers) {
       const resolved = resolveRelativeSpecifier(specifier, filePath);
@@ -886,12 +902,18 @@ export function validateNoDirectImports(
       const match = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
       if (!match) continue;
 
-      // Only flag if the imported target has divergent resolutions.
-      // For example, importing `./helper.js` is fine if `#platform/helper`
-      // has only a `default` entry and no condition-specific variants.
       const isWildcard = match.key !== exactPaths.get(resolved);
       if (!hasDivergentResolutions(match.key, importsMap, packageRoot, isWildcard, divergenceCache)) {
         continue;
+      }
+
+      // For platform files, check if the import resolves to the wrong variant
+      if (isPlatformFile && conditions) {
+        const platformResolved = resolveSubpathImport(match.key, importsMap, conditions);
+        if (platformResolved) {
+          const platformAbsPath = path.resolve(packageRoot, platformResolved);
+          if (platformAbsPath === resolved) continue; // Correct resolution
+        }
       }
 
       violations.push({
@@ -899,8 +921,14 @@ export function validateNoDirectImports(
         specifier,
         suggestedImport: match.key,
         line,
+        targetPlatform: isPlatformFile ? selfMatch!.condition : undefined,
       });
     }
+  }
+
+  if (validatePlatformFiles) {
+    const log = getLogger();
+    log.info(`[warp] Validated ${platformFileCount} platform-specific file(s)`);
   }
 
   return violations;
@@ -976,108 +1004,3 @@ export function buildConditionsSet(
   return conditions;
 }
 
-// ---------------------------------------------------------------------------
-// Platform-specific file validation
-// ---------------------------------------------------------------------------
-
-/** Violation found during platform import validation. */
-export interface PlatformImportViolation {
-  file: string;
-  line: number;
-  specifier: string;
-  suggestedImport: string;
-  targetPlatform: string;
-}
-
-/**
- * Validate that platform-specific files use #-prefixed imports correctly.
- * Returns violations that should fail the build.
- *
- * Platform-specific files are determined from the imports map in package.json.
- * Files that are targets of divergent wildcard imports (non-default conditions
- * like "browser", "react-native") are validated to ensure they use the
- * #-prefixed import specifier for any import that has a platform variant.
- */
-export async function validatePlatformImports(
-  importsMap: ImportsMap,
-  packageRoot: string,
-): Promise<PlatformImportViolation[]> {
-  const violations: PlatformImportViolation[] = [];
-
-  const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, packageRoot);
-  
-  const hasPlatformPatterns = wildcardPatterns.some((p) => p.condition && p.condition !== "default");
-  if (!hasPlatformPatterns) return violations;
-
-  const divergenceCache = new Map<string, boolean>();
-
-  const srcDir = path.join(packageRoot, "src");
-  const sourceFiles: string[] = [];
-
-  function collectSourceFiles(dir: string): void {
-    if (!ts.sys.directoryExists(dir)) return;
-    for (const entry of ts.sys.readDirectory(dir, [".ts", ".mts", ".cts"], [], [])) {
-      sourceFiles.push(entry);
-    }
-    for (const subdir of ts.sys.getDirectories(dir)) {
-      collectSourceFiles(path.join(dir, subdir));
-    }
-  }
-  collectSourceFiles(srcDir);
-
-  let validatedCount = 0;
-
-  for (const filePath of sourceFiles) {
-    // Check if this file is a platform-specific target (non-default condition)
-    const selfMatch = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
-    if (!selfMatch?.condition || selfMatch.condition === "default") continue;
-
-    validatedCount++;
-    const { condition } = selfMatch;
-
-    const content = ts.sys.readFile(filePath);
-    if (!content) continue;
-
-    const sourceFile = ts.createSourceFile(
-      path.basename(filePath),
-      content,
-      ts.ScriptTarget.Latest,
-      true,
-    );
-    const specifiers = collectRelativeSpecifiers(sourceFile);
-    if (specifiers.length === 0) continue;
-
-    const conditions = new Set([condition, "import", "default"]);
-
-    for (const { text: specifier, line } of specifiers) {
-      const resolved = resolveRelativeSpecifier(specifier, filePath);
-      if (!resolved) continue;
-
-      const importMatch = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
-      if (!importMatch) continue;
-
-      const isWildcard = importMatch.key !== exactPaths.get(resolved);
-      if (!hasDivergentResolutions(importMatch.key, importsMap, packageRoot, isWildcard, divergenceCache))
-        continue;
-
-      const platformResolved = resolveSubpathImport(importMatch.key, importsMap, conditions);
-      if (!platformResolved) continue;
-
-      const platformAbsPath = path.resolve(packageRoot, platformResolved);
-      if (platformAbsPath !== resolved) {
-        violations.push({
-          file: filePath,
-          line,
-          specifier,
-          suggestedImport: importMatch.key,
-          targetPlatform: condition,
-        });
-      }
-    }
-  }
-
-  const log = getLogger();
-  log.info(`[warp] Validated ${validatedCount} platform-specific file(s)`);
-
-  return violations;
-}

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -554,6 +554,14 @@ export async function resolveImportsInDir(
 // ---------------------------------------------------------------------------
 
 /**
+ * Entry in the exact paths index, tracking key and condition.
+ */
+interface ExactPathEntry {
+  key: string;
+  condition?: string;
+}
+
+/**
  * A pattern entry from a wildcard imports map target.
  * The `*` in the target is replaced with a regex capture group.
  */
@@ -570,14 +578,14 @@ interface WildcardPattern {
  * Build lookup structures for matching resolved file paths against an imports map.
  *
  * Returns:
- * - `exactPaths`: Map from absolute path → `#key` for non-wildcard entries
+ * - `exactPaths`: Map from absolute path → {key, condition} for non-wildcard entries
  * - `wildcardPatterns`: Array of regex patterns for wildcard (`*`) entries
  */
 export function buildImportTargetIndex(
   importsMap: ImportsMap,
   packageRoot: string,
-): { exactPaths: Map<string, string>; wildcardPatterns: WildcardPattern[] } {
-  const exactPaths = new Map<string, string>();
+): { exactPaths: Map<string, ExactPathEntry>; wildcardPatterns: WildcardPattern[] } {
+  const exactPaths = new Map<string, ExactPathEntry>();
   const wildcardPatterns: WildcardPattern[] = [];
   const seenPatterns = new Set<string>();
 
@@ -600,7 +608,7 @@ export function buildImportTargetIndex(
         }
       } else {
         const abs = path.resolve(packageRoot, target);
-        exactPaths.set(abs, key);
+        exactPaths.set(abs, { key, condition });
       }
       return;
     }
@@ -644,12 +652,12 @@ interface ImportTargetMatch {
  */
 function lookupImportTarget(
   resolvedPath: string,
-  exactPaths: Map<string, string>,
+  exactPaths: Map<string, ExactPathEntry>,
   wildcardPatterns: WildcardPattern[],
 ): ImportTargetMatch | undefined {
   // Fast exact check first
-  const exactKey = exactPaths.get(resolvedPath);
-  if (exactKey) return { key: exactKey };
+  const exact = exactPaths.get(resolvedPath);
+  if (exact) return { key: exact.key, condition: exact.condition };
 
   // Try wildcard patterns
   for (const { regex, key, condition } of wildcardPatterns) {
@@ -673,7 +681,12 @@ export function collectImportTargetPaths(
   importsMap: ImportsMap,
   packageRoot: string,
 ): Map<string, string> {
-  return buildImportTargetIndex(importsMap, packageRoot).exactPaths;
+  const index = buildImportTargetIndex(importsMap, packageRoot);
+  const result = new Map<string, string>();
+  for (const [path, entry] of index.exactPaths) {
+    result.set(path, entry.key);
+  }
+  return result;
 }
 
 /**
@@ -864,11 +877,13 @@ export function validateNoDirectImports(
       if (!validatePlatformFiles) continue;
     } else if (selfMatch) {
       // Default-condition file that is an import target - check if divergent
+      const exactEntry = exactPaths.get(filePath);
+      const isWildcard = !exactEntry || exactEntry.key !== selfMatch.key;
       const selfIsDivergent = hasDivergentResolutions(
         selfMatch.key,
         importsMap,
         packageRoot,
-        selfMatch.key !== exactPaths.get(filePath),
+        isWildcard,
         divergenceCache,
       );
       if (selfIsDivergent) {
@@ -891,9 +906,10 @@ export function validateNoDirectImports(
 
     const relativeSpecifiers = collectRelativeSpecifiers(sourceFile);
 
-    // For platform files, we resolve imports under their specific condition
+    // For platform files, derive module type from file extension
+    const moduleType = filePath.endsWith(".cts") ? "require" : "import";
     const conditions = platformCondition
-      ? new Set([platformCondition, "import", "default"])
+      ? new Set([platformCondition, moduleType, "default"])
       : undefined;
 
     for (const { text: specifier, line } of relativeSpecifiers) {
@@ -903,7 +919,8 @@ export function validateNoDirectImports(
       const match = lookupImportTarget(resolved, exactPaths, wildcardPatterns);
       if (!match) continue;
 
-      const isWildcard = match.key !== exactPaths.get(resolved);
+      const exactEntry = exactPaths.get(resolved);
+      const isWildcard = !exactEntry || exactEntry.key !== match.key;
       if (!hasDivergentResolutions(match.key, importsMap, packageRoot, isWildcard, divergenceCache)) {
         continue;
       }

--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -855,10 +855,11 @@ export function validateNoDirectImports(
     const selfMatch = lookupImportTarget(filePath, exactPaths, wildcardPatterns);
     
     // Determine if this is a platform-specific file (non-default condition)
-    const isPlatformFile = selfMatch?.condition && selfMatch.condition !== "default";
+    const platformCondition =
+      selfMatch?.condition && selfMatch.condition !== "default" ? selfMatch.condition : undefined;
 
     // For platform files, only validate if requested
-    if (isPlatformFile) {
+    if (platformCondition) {
       platformFileCount++;
       if (!validatePlatformFiles) continue;
     } else if (selfMatch) {
@@ -891,8 +892,8 @@ export function validateNoDirectImports(
     const relativeSpecifiers = collectRelativeSpecifiers(sourceFile);
 
     // For platform files, we resolve imports under their specific condition
-    const conditions = isPlatformFile
-      ? new Set([selfMatch!.condition!, "import", "default"])
+    const conditions = platformCondition
+      ? new Set([platformCondition, "import", "default"])
       : undefined;
 
     for (const { text: specifier, line } of relativeSpecifiers) {
@@ -908,7 +909,7 @@ export function validateNoDirectImports(
       }
 
       // For platform files, check if the import resolves to the wrong variant
-      if (isPlatformFile && conditions) {
+      if (platformCondition && conditions) {
         const platformResolved = resolveSubpathImport(match.key, importsMap, conditions);
         if (platformResolved) {
           const platformAbsPath = path.resolve(packageRoot, platformResolved);
@@ -921,7 +922,7 @@ export function validateNoDirectImports(
         specifier,
         suggestedImport: match.key,
         line,
-        targetPlatform: isPlatformFile ? selfMatch!.condition : undefined,
+        targetPlatform: platformCondition,
       });
     }
   }

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -92,6 +92,22 @@ describe("validateNoDirectImports with platform file validation", () => {
     expect(violations[0].line).toBe(1);
   });
 
+  it("allows platform file to import its own platform variant directly", async () => {
+    // A browser file importing ./utils-browser.mjs resolves to the correct platform
+    // variant for that condition. This is intentionally allowed since the import
+    // resolves correctly at runtime.
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./utils-browser.mjs";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
+
+    const violations = await validate();
+    expect(violations).toEqual([]);
+  });
+
   it("detects multiple violations in same file", async () => {
     await fs.mkdir(path.join(tmpDir, "src"));
     await fs.writeFile(

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -160,4 +160,68 @@ export { a, b };`,
     expect(violations[0].targetPlatform).toBe("react-native");
     expect(violations[0].suggestedImport).toBe("#platform/hash");
   });
+
+  it("handles exact-match platform files (non-wildcard)", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+
+    // Exact mapping (no wildcard)
+    const exactImportsMap: ImportsMap = {
+      "#platform/crypto": {
+        browser: "./src/crypto-browser.mts",
+        default: "./src/crypto.ts",
+      },
+      "#platform/hash": {
+        browser: "./src/hash-browser.mts",
+        default: "./src/hash.ts",
+      },
+    };
+
+    // Browser file directly imports default variant (should use #platform/hash)
+    await fs.writeFile(
+      path.join(tmpDir, "src", "crypto-browser.mts"),
+      `export * from "./hash.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "crypto.ts"), `export const c = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "hash.ts"), `export const hash = () => {};`);
+    await fs.writeFile(
+      path.join(tmpDir, "src", "hash-browser.mts"),
+      `export const hash = () => {};`,
+    );
+
+    const srcDir = path.join(tmpDir, "src");
+    const sourceFiles = await collectSourceFiles(srcDir);
+    const violations = validateNoDirectImports(sourceFiles, exactImportsMap, tmpDir, true);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].targetPlatform).toBe("browser");
+    expect(violations[0].suggestedImport).toBe("#platform/hash");
+    expect(violations[0].file).toContain("crypto-browser.mts");
+  });
+
+  it("uses require condition for .cts files", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+
+    const ctsImportsMap: ImportsMap = {
+      "#platform/*": {
+        require: "./src/*-cjs.cts",
+        default: "./src/*.ts",
+      },
+    };
+
+    // CJS file directly imports default variant
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-cjs.cts"),
+      `export * from "./helper.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "helper.ts"), `export const h = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "helper-cjs.cts"), `export const h = 2;`);
+
+    const srcDir = path.join(tmpDir, "src");
+    const sourceFiles = await collectSourceFiles(srcDir);
+    const violations = validateNoDirectImports(sourceFiles, ctsImportsMap, tmpDir, true);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].targetPlatform).toBe("require");
+    expect(violations[0].suggestedImport).toBe("#platform/helper");
+  });
 });

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -224,4 +224,71 @@ export { a, b };`,
     expect(violations[0].targetPlatform).toBe("require");
     expect(violations[0].suggestedImport).toBe("#platform/helper");
   });
+
+  it("skips platform file validation when validatePlatformFiles is false", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+
+    // Browser file with direct import that would fail with validatePlatformFiles=true
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./utils.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
+
+    const srcDir = path.join(tmpDir, "src");
+    const sourceFiles = await collectSourceFiles(srcDir);
+
+    // With validatePlatformFiles=false, no violations should be reported
+    const violations = validateNoDirectImports(sourceFiles, importsMap, tmpDir, false);
+    expect(violations).toEqual([]);
+
+    // Verify that with validatePlatformFiles=true, it would find a violation
+    const violationsWithValidation = validateNoDirectImports(sourceFiles, importsMap, tmpDir, true);
+    expect(violationsWithValidation).toHaveLength(1);
+  });
+
+  it("detects violations in both browser and react-native files", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+
+    // Both platform files have violations
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./crypto.js";`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-react-native.mts"),
+      `export * from "./crypto.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "crypto.ts"), `export const c = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "crypto-browser.mts"), `export const c = 2;`);
+    await fs.writeFile(path.join(tmpDir, "src", "crypto-react-native.mts"), `export const c = 3;`);
+
+    const srcDir = path.join(tmpDir, "src");
+    const sourceFiles = await collectSourceFiles(srcDir);
+    const violations = validateNoDirectImports(sourceFiles, importsMap, tmpDir, true);
+
+    expect(violations).toHaveLength(2);
+    const platforms = violations.map((v) => v.targetPlatform).sort();
+    expect(platforms).toEqual(["browser", "react-native"]);
+  });
+
+  it("default parameter for validatePlatformFiles is false", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+
+    // Browser file with direct import
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./utils.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
+
+    const srcDir = path.join(tmpDir, "src");
+    const sourceFiles = await collectSourceFiles(srcDir);
+
+    // Call without explicit validatePlatformFiles parameter (should default to false)
+    const violations = validateNoDirectImports(sourceFiles, importsMap, tmpDir);
+    expect(violations).toEqual([]);
+  });
 });

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { validatePlatformImports } from "../../src/resolveImports.ts";
+import type { ImportsMap } from "../../src/resolveImports.ts";
+
+async function createTmpDir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "warp-platform-validation-"));
+}
+
+describe("validatePlatformImports", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const importsMap: ImportsMap = {
+    "#platform/*": {
+      browser: "./src/*-browser.mts",
+      "react-native": "./src/*-react-native.mts",
+      default: "./src/*.ts",
+    },
+  };
+
+  it("returns empty array when no platform files exist", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index.ts"),
+      `export * from "./utils.js";`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src", "utils.ts"),
+      `export const foo = 1;`,
+    );
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toEqual([]);
+  });
+
+  it("returns empty array when platform files use #platform imports", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "#platform/utils";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toEqual([]);
+  });
+
+  it("detects direct imports that should use #platform", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./utils.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      specifier: "./utils.js",
+      suggestedImport: "#platform/utils",
+      targetPlatform: "browser",
+    });
+    expect(violations[0].file).toContain("index-browser.mts");
+    expect(violations[0].line).toBe(1);
+  });
+
+  it("detects multiple violations in same file", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `import { a } from "./moduleA.js";
+import { b } from "./moduleB.js";
+export { a, b };`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "moduleA.ts"), `export const a = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "moduleA-browser.mts"), `export const a = 2;`);
+    await fs.writeFile(path.join(tmpDir, "src", "moduleB.ts"), `export const b = 1;`);
+    await fs.writeFile(path.join(tmpDir, "src", "moduleB-browser.mts"), `export const b = 2;`);
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toHaveLength(2);
+    expect(violations[0].specifier).toBe("./moduleA.js");
+    expect(violations[0].line).toBe(1);
+    expect(violations[1].specifier).toBe("./moduleB.js");
+    expect(violations[1].line).toBe(2);
+  });
+
+  it("ignores imports without platform variants", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./constants.js";`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src", "constants.ts"),
+      `export const VERSION = "1.0";`,
+    );
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toEqual([]);
+  });
+
+  it("handles subdirectory imports", async () => {
+    await fs.mkdir(path.join(tmpDir, "src", "policies"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "src", "index-browser.mts"),
+      `export * from "./policies/auth.js";`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src", "policies", "auth.ts"),
+      `export const auth = {};`,
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "src", "policies", "auth-browser.mts"),
+      `export const auth = { browser: true };`,
+    );
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].specifier).toBe("./policies/auth.js");
+    expect(violations[0].suggestedImport).toBe("#platform/policies/auth");
+  });
+
+  it("handles react-native platform files", async () => {
+    await fs.mkdir(path.join(tmpDir, "src"));
+    await fs.writeFile(
+      path.join(tmpDir, "src", "crypto-react-native.mts"),
+      `export * from "./hash.js";`,
+    );
+    await fs.writeFile(path.join(tmpDir, "src", "hash.ts"), `export const hash = () => {};`);
+    await fs.writeFile(
+      path.join(tmpDir, "src", "hash-react-native.mts"),
+      `export const hash = () => {};`,
+    );
+
+    const violations = await validatePlatformImports(importsMap, tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].targetPlatform).toBe("react-native");
+    expect(violations[0].suggestedImport).toBe("#platform/hash");
+  });
+});

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -209,10 +209,7 @@ export { a, b };`,
     };
 
     // CJS file directly imports default variant
-    await fs.writeFile(
-      path.join(tmpDir, "src", "index-cjs.cts"),
-      `export * from "./helper.js";`,
-    );
+    await fs.writeFile(path.join(tmpDir, "src", "index-cjs.cts"), `export * from "./helper.js";`);
     await fs.writeFile(path.join(tmpDir, "src", "helper.ts"), `export const h = 1;`);
     await fs.writeFile(path.join(tmpDir, "src", "helper-cjs.cts"), `export const h = 2;`);
 

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -5,14 +5,27 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
-import { validatePlatformImports } from "../../src/resolveImports.ts";
+import { validateNoDirectImports } from "../../src/resolveImports.ts";
 import type { ImportsMap } from "../../src/resolveImports.ts";
+import ts from "typescript";
 
 async function createTmpDir(): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), "warp-platform-validation-"));
 }
 
-describe("validatePlatformImports", () => {
+async function collectSourceFiles(srcDir: string): Promise<string[]> {
+  const sourceFiles: string[] = [];
+  if (!ts.sys.directoryExists(srcDir)) return sourceFiles;
+  for (const entry of ts.sys.readDirectory(srcDir, [".ts", ".mts", ".cts"], [], [])) {
+    sourceFiles.push(entry);
+  }
+  for (const subdir of ts.sys.getDirectories(srcDir)) {
+    sourceFiles.push(...(await collectSourceFiles(path.join(srcDir, subdir))));
+  }
+  return sourceFiles;
+}
+
+describe("validateNoDirectImports with platform file validation", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
@@ -31,18 +44,18 @@ describe("validatePlatformImports", () => {
     },
   };
 
+  async function validate() {
+    const srcDir = path.join(tmpDir, "src");
+    const sourceFiles = await collectSourceFiles(srcDir);
+    return validateNoDirectImports(sourceFiles, importsMap, tmpDir, true);
+  }
+
   it("returns empty array when no platform files exist", async () => {
     await fs.mkdir(path.join(tmpDir, "src"));
-    await fs.writeFile(
-      path.join(tmpDir, "src", "index.ts"),
-      `export * from "./utils.js";`,
-    );
-    await fs.writeFile(
-      path.join(tmpDir, "src", "utils.ts"),
-      `export const foo = 1;`,
-    );
+    await fs.writeFile(path.join(tmpDir, "src", "index.ts"), `export * from "./utils.js";`);
+    await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toEqual([]);
   });
 
@@ -55,7 +68,7 @@ describe("validatePlatformImports", () => {
     await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
     await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toEqual([]);
   });
 
@@ -68,7 +81,7 @@ describe("validatePlatformImports", () => {
     await fs.writeFile(path.join(tmpDir, "src", "utils.ts"), `export const foo = 1;`);
     await fs.writeFile(path.join(tmpDir, "src", "utils-browser.mts"), `export const foo = 2;`);
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toHaveLength(1);
     expect(violations[0]).toMatchObject({
       specifier: "./utils.js",
@@ -92,7 +105,7 @@ export { a, b };`,
     await fs.writeFile(path.join(tmpDir, "src", "moduleB.ts"), `export const b = 1;`);
     await fs.writeFile(path.join(tmpDir, "src", "moduleB-browser.mts"), `export const b = 2;`);
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toHaveLength(2);
     expect(violations[0].specifier).toBe("./moduleA.js");
     expect(violations[0].line).toBe(1);
@@ -106,12 +119,9 @@ export { a, b };`,
       path.join(tmpDir, "src", "index-browser.mts"),
       `export * from "./constants.js";`,
     );
-    await fs.writeFile(
-      path.join(tmpDir, "src", "constants.ts"),
-      `export const VERSION = "1.0";`,
-    );
+    await fs.writeFile(path.join(tmpDir, "src", "constants.ts"), `export const VERSION = "1.0";`);
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toEqual([]);
   });
 
@@ -121,16 +131,13 @@ export { a, b };`,
       path.join(tmpDir, "src", "index-browser.mts"),
       `export * from "./policies/auth.js";`,
     );
-    await fs.writeFile(
-      path.join(tmpDir, "src", "policies", "auth.ts"),
-      `export const auth = {};`,
-    );
+    await fs.writeFile(path.join(tmpDir, "src", "policies", "auth.ts"), `export const auth = {};`);
     await fs.writeFile(
       path.join(tmpDir, "src", "policies", "auth-browser.mts"),
       `export const auth = { browser: true };`,
     );
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toHaveLength(1);
     expect(violations[0].specifier).toBe("./policies/auth.js");
     expect(violations[0].suggestedImport).toBe("#platform/policies/auth");
@@ -148,7 +155,7 @@ export { a, b };`,
       `export const hash = () => {};`,
     );
 
-    const violations = await validatePlatformImports(importsMap, tmpDir);
+    const violations = await validate();
     expect(violations).toHaveLength(1);
     expect(violations[0].targetPlatform).toBe("react-native");
     expect(violations[0].suggestedImport).toBe("#platform/hash");

--- a/common/tools/warp/test/public/resolveImports.spec.ts
+++ b/common/tools/warp/test/public/resolveImports.spec.ts
@@ -998,12 +998,16 @@ describe("buildImportTargetIndex", () => {
 
     const { exactPaths, wildcardPatterns } = buildImportTargetIndex(importsMap, "/pkg");
 
-    // Exact: nodeTypes entries
+    // Exact: nodeTypes entries (now return {key, condition})
     expect(exactPaths.size).toBe(2);
-    expect(exactPaths.get(path.resolve("/pkg", "./src/nodeTypes-browser.mts"))).toBe(
-      "#platform/nodeTypes",
-    );
-    expect(exactPaths.get(path.resolve("/pkg", "./src/nodeTypes.ts"))).toBe("#platform/nodeTypes");
+    expect(exactPaths.get(path.resolve("/pkg", "./src/nodeTypes-browser.mts"))).toEqual({
+      key: "#platform/nodeTypes",
+      condition: "browser",
+    });
+    expect(exactPaths.get(path.resolve("/pkg", "./src/nodeTypes.ts"))).toEqual({
+      key: "#platform/nodeTypes",
+      condition: "default",
+    });
 
     // Wildcard: 2 patterns (browser + default)
     expect(wildcardPatterns.length).toBe(2);


### PR DESCRIPTION
## Current Behavior

`validateNoDirectImports` fails the build when **non-platform files** directly import files behind the `#imports` map (e.g., `import "./nodeTypes.js"` instead of `import "#platform/nodeTypes"`).

Platform-specific files (e.g., `*-browser.mts`) are **skipped** entirely since they only run under their specific condition.

## New Behavior

When `polyfillSuffix` is NOT active, platform-specific files are now validated too. A browser file importing `"./utils.js"` will fail if `utils` has platform variants:

```
[warp] Found 1 platform-specific file(s) bypassing #platform imports:
  src/index-browser.mts:4  ./utils.js  →  use #platform/utils
```

This catches bugs like the storage-common issue where a browser entry file imported a module directly instead of using `#platform/*`.

When `polyfillSuffix` IS active, platform files remain skipped (the polyfill mechanism handles resolution at compile time).