### PR TITLE
[app-configuration] Address `run-samples` failure in appconfig

### DIFF
--- a/sdk/appconfiguration/app-configuration/samples-dev/featureFlag.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/featureFlag.ts
@@ -6,28 +6,24 @@
  *
  * @azsdk-weight 20
  */
+import type { ConfigurationSetting, FeatureFlagValue } from "@azure/app-configuration";
 import {
   AppConfigurationClient,
-  ConfigurationSetting,
   featureFlagContentType,
   featureFlagPrefix,
-  FeatureFlagValue,
 } from "@azure/app-configuration";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Use configuration provider and feature management library to consume feature flags
 import { load } from "@azure/app-configuration-provider";
-import {
-  ConfigurationMapFeatureFlagProvider,
-  FeatureManager,
-  ITargetingContext,
-} from "@microsoft/feature-management";
+import type { ITargetingContext } from "@microsoft/feature-management";
+import { ConfigurationMapFeatureFlagProvider, FeatureManager } from "@microsoft/feature-management";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
 dotenv.config();
 
-export async function main() {
+export async function main(): Promise<void> {
   console.log(`Running featureFlag sample`);
 
   const featureFlagName = "sample-feature-flag";

--- a/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/secretReference.ts
@@ -5,12 +5,8 @@
  * @summary SecretReference represents a configuration setting that references as KeyVault secret.
  * @azsdk-weight 30
  */
-import {
-  AppConfigurationClient,
-  SecretReferenceValue,
-  secretReferenceContentType,
-  ConfigurationSetting,
-} from "@azure/app-configuration";
+import type { SecretReferenceValue, ConfigurationSetting } from "@azure/app-configuration";
+import { AppConfigurationClient, secretReferenceContentType } from "@azure/app-configuration";
 import { SecretClient } from "@azure/keyvault-secrets";
 import { DefaultAzureCredential } from "@azure/identity";
 
@@ -21,7 +17,7 @@ import { load } from "@azure/app-configuration-provider";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-export async function main() {
+export async function main(): Promise<void> {
   console.log(`Running secretReference sample`);
 
   const secretName = `secret${new Date().getTime()}`;

--- a/sdk/appconfiguration/app-configuration/samples-dev/updateSyncTokenSample.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/updateSyncTokenSample.ts
@@ -11,7 +11,8 @@
  */
 
 import { AppConfigurationClient } from "@azure/app-configuration";
-import { isSystemEvent, EventGridEvent, EventGridDeserializer } from "@azure/eventgrid";
+import type { EventGridEvent } from "@azure/eventgrid";
+import { isSystemEvent, EventGridDeserializer } from "@azure/eventgrid";
 import { appConfigTestEvent } from "./testData.js";
 
 // Load the .env file if it exists
@@ -31,7 +32,7 @@ async function processEvent(): Promise<EventGridEvent<unknown>[]> {
   return consumer.deserializeEventGridEvents(appConfigTestEvent);
 }
 
-export async function main() {
+export async function main(): Promise<void> {
   // Set the following environment variable or edit the value on the following line.
   const endpoint = process.env["AZ_CONFIG_ENDPOINT"] || "<endpoint>";
 

--- a/tsconfig.samples.base.json
+++ b/tsconfig.samples.base.json
@@ -1,7 +1,8 @@
 {
   "extends": ["./tsconfig", "./tsconfig.nonlib"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "verbatimModuleSyntax": true
   },
   "include": ["${configDir}/samples-dev"]
 }


### PR DESCRIPTION
dev-tool now requires samples to comply with 'verbatimModuleSyntax' in order to locally execute. This PR updates the main samples tsconfig to enforce this going forward.