### PR TITLE
[storage] update streamToBuffer helpers to handle chunks correctly

### DIFF
--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 12.32.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 12.32.0-beta.1 (2026-03-05)
 
 ### Features Added

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.32.0-beta.1",
+  "version": "12.32.0-beta.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/storage/storage-blob/samples-dev/customizedClientHeaders.ts
+++ b/sdk/storage/storage-blob/samples-dev/customizedClientHeaders.ts
@@ -13,16 +13,12 @@
  * @azsdk-weight 10
  **/
 
-import type {
-  WebResource,
-  RequestPolicy,
-  RequestPolicyOptions
-} from "@azure/storage-blob";
+import type { WebResource, RequestPolicy, RequestPolicyOptions } from "@azure/storage-blob";
 import {
   newPipeline,
   AnonymousCredential,
   BlobServiceClient,
-  BaseRequestPolicy
+  BaseRequestPolicy,
 } from "@azure/storage-blob";
 
 // Load the .env file if it exists

--- a/sdk/storage/storage-blob/samples-dev/customizedClientHeaders.ts
+++ b/sdk/storage/storage-blob/samples-dev/customizedClientHeaders.ts
@@ -13,14 +13,16 @@
  * @azsdk-weight 10
  **/
 
+import type {
+  WebResource,
+  RequestPolicy,
+  RequestPolicyOptions
+} from "@azure/storage-blob";
 import {
   newPipeline,
   AnonymousCredential,
   BlobServiceClient,
-  BaseRequestPolicy,
-  WebResource,
-  RequestPolicy,
-  RequestPolicyOptions,
+  BaseRequestPolicy
 } from "@azure/storage-blob";
 
 // Load the .env file if it exists

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.32.0-beta.1";
+export const SDK_VERSION: string = "12.32.0-beta.2";
 export const SERVICE_VERSION: string = "2026-04-06";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-blob/src/utils/utils.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.ts
@@ -31,6 +31,10 @@ export async function streamToBuffer(
     );
 
     stream.on("readable", () => {
+      // Already filled the requested amount; ignore any further `readable` events.
+      if (pos >= count) {
+        return;
+      }
       // Drain all currently-buffered chunks. Required since Node.js v26, where
       // `stream.read()` returns one buffered chunk at a time instead of the
       // concatenation of all queued data (see nodejs/node#60441).
@@ -62,6 +66,7 @@ export async function streamToBuffer(
             `Stream drains before getting enough data needed. Data read: ${pos}, data need: ${count}`,
           ),
         );
+        return;
       }
       resolve();
     });

--- a/sdk/storage/storage-blob/src/utils/utils.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.ts
@@ -31,25 +31,27 @@ export async function streamToBuffer(
     );
 
     stream.on("readable", () => {
-      if (pos >= count) {
-        clearTimeout(timeout);
-        resolve();
-        return;
-      }
+      // Drain all currently-buffered chunks. Required since Node.js v26, where
+      // `stream.read()` returns one buffered chunk at a time instead of the
+      // concatenation of all queued data (see nodejs/node#60441).
+      let chunk: string | Buffer | null;
+      while ((chunk = stream.read()) !== null) {
+        if (typeof chunk === "string") {
+          chunk = Buffer.from(chunk, encoding);
+        }
 
-      let chunk = stream.read();
-      if (!chunk) {
-        return;
-      }
-      if (typeof chunk === "string") {
-        chunk = Buffer.from(chunk, encoding);
-      }
+        // How much data needed in this chunk
+        const chunkLength = pos + chunk.length > count ? count - pos : chunk.length;
 
-      // How much data needed in this chunk
-      const chunkLength = pos + chunk.length > count ? count - pos : chunk.length;
+        buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
+        pos += chunkLength;
 
-      buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
-      pos += chunkLength;
+        if (pos >= count) {
+          clearTimeout(timeout);
+          resolve();
+          return;
+        }
+      }
     });
 
     stream.on("end", () => {
@@ -90,21 +92,23 @@ export async function streamToBuffer2(
 
   return new Promise<number>((resolve, reject) => {
     stream.on("readable", () => {
-      let chunk = stream.read();
-      if (!chunk) {
-        return;
-      }
-      if (typeof chunk === "string") {
-        chunk = Buffer.from(chunk, encoding);
-      }
+      // Drain all currently-buffered chunks. Required since Node.js v26, where
+      // `stream.read()` returns one buffered chunk at a time instead of the
+      // concatenation of all queued data (see nodejs/node#60441).
+      let chunk: string | Buffer | null;
+      while ((chunk = stream.read()) !== null) {
+        if (typeof chunk === "string") {
+          chunk = Buffer.from(chunk, encoding);
+        }
 
-      if (pos + chunk.length > bufferSize) {
-        reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
-        return;
-      }
+        if (pos + chunk.length > bufferSize) {
+          reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
+          return;
+        }
 
-      buffer.fill(chunk, pos, pos + chunk.length);
-      pos += chunk.length;
+        buffer.fill(chunk, pos, pos + chunk.length);
+        pos += chunk.length;
+      }
     });
 
     stream.on("end", () => {

--- a/sdk/storage/storage-blob/src/utils/utils.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.ts
@@ -33,6 +33,8 @@ export async function streamToBuffer(
     stream.on("readable", () => {
       // Already filled the requested amount; ignore any further `readable` events.
       if (pos >= count) {
+        clearTimeout(timeout);
+        resolve();
         return;
       }
       // Drain all currently-buffered chunks. Required since Node.js v26, where
@@ -66,7 +68,6 @@ export async function streamToBuffer(
             `Stream drains before getting enough data needed. Data read: ${pos}, data need: ${count}`,
           ),
         );
-        return;
       }
       resolve();
     });

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -21,7 +21,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-extension:
   "@autorest/typescript": "6.0.42"
-package-version: 12.32.0-beta.1
+package-version: 12.32.0-beta.2
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -51,7 +51,7 @@ describe("Utility Helpers Node.js only", () => {
     } catch (error: any) {
       assert.isTrue(
         error.message ===
-        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
+          "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
       );
     }
   });
@@ -394,7 +394,7 @@ describe("Utility Helpers Node.js only", () => {
     // multiple buffered chunks from a single `readable` event - the exact scenario
     // that regressed in Node.js v26 (see nodejs/node#60441).
     function makeMultiChunkStream(chunks: Buffer[]): Readable {
-      const stream = new Readable({ read() { } });
+      const stream = new Readable({ read() {} });
       for (const chunk of chunks) {
         stream.push(chunk);
       }

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -6,7 +6,12 @@ import path from "node:path";
 import { delay, extractConnectionStringParts } from "../../src/utils/utils.common.js";
 import type { ReadableOptions } from "node:stream";
 import { Readable, PassThrough } from "node:stream";
-import { readStreamToLocalFile, streamToBuffer2, streamToBuffer3 } from "../../src/utils/utils.js";
+import {
+  readStreamToLocalFile,
+  streamToBuffer,
+  streamToBuffer2,
+  streamToBuffer3,
+} from "../../src/utils/utils.js";
 import type { ReadableStreamGetter } from "../../src/utils/RetriableReadableStream.js";
 import { RetriableReadableStream } from "../../src/utils/RetriableReadableStream.js";
 import { describe, it, assert, afterEach } from "vitest";
@@ -46,7 +51,7 @@ describe("Utility Helpers Node.js only", () => {
     } catch (error: any) {
       assert.isTrue(
         error.message ===
-          "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
+        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
       );
     }
   });
@@ -380,6 +385,73 @@ describe("Utility Helpers Node.js only", () => {
           }
         }
       });
+    });
+  });
+
+  describe("streamToBuffer", () => {
+    // Build a Readable that already has multiple chunks queued internally before any
+    // consumer attaches a `readable` listener. This forces the consumer to drain
+    // multiple buffered chunks from a single `readable` event - the exact scenario
+    // that regressed in Node.js v26 (see nodejs/node#60441).
+    function makeMultiChunkStream(chunks: Buffer[]): Readable {
+      const stream = new Readable({ read() { } });
+      for (const chunk of chunks) {
+        stream.push(chunk);
+      }
+      stream.push(null);
+      return stream;
+    }
+
+    it("reads exactly `count` bytes when multiple chunks are pre-buffered", async () => {
+      const chunks = [Buffer.from("hello "), Buffer.from("buffered "), Buffer.from("world!")];
+      const expected = Buffer.concat(chunks);
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(expected.length);
+      await streamToBuffer(stream, output, 0, expected.length);
+
+      assert.deepEqual(output, expected);
+    });
+
+    it("fills the requested slice with multi-chunk data and stops at `count`", async () => {
+      const chunks = [Buffer.from("AAAA"), Buffer.from("BBBB"), Buffer.from("CCCC")];
+      const stream = makeMultiChunkStream(chunks);
+
+      // Pre-fill output with marker bytes so we can verify only [offset, end) is touched.
+      const marker = 0xff;
+      const output = Buffer.alloc(20, marker);
+      const offset = 4;
+      const end = 14; // request 10 bytes; stream has 12 available
+
+      await streamToBuffer(stream, output, offset, end);
+
+      // Bytes outside [offset, end) must remain marker.
+      for (let i = 0; i < offset; i++) {
+        assert.strictEqual(output[i], marker, `byte ${i} (before offset) modified`);
+      }
+      for (let i = end; i < output.length; i++) {
+        assert.strictEqual(output[i], marker, `byte ${i} (after end) modified`);
+      }
+      // Filled region must contain the first 10 bytes of the concatenated input.
+      assert.deepEqual(
+        output.subarray(offset, end),
+        Buffer.concat(chunks).subarray(0, end - offset),
+      );
+    });
+
+    it("rejects when the stream ends before `count` bytes are read", async () => {
+      const chunks = [Buffer.from("abc"), Buffer.from("def")];
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(10);
+      let caught: Error | undefined;
+      try {
+        await streamToBuffer(stream, output, 0, 10);
+      } catch (err: any) {
+        caught = err;
+      }
+      assert.isDefined(caught, "Expected streamToBuffer to reject");
+      assert.match(caught!.message, /Stream drains before/);
     });
   });
 });

--- a/sdk/storage/storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/storage-file-datalake/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 12.30.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 12.30.0-beta.2 (Unreleased)
 
 ### Features Added

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.30.0-beta.2",
+  "version": "12.30.0-beta.3",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.30.0-beta.2";
+export const SDK_VERSION: string = "12.30.0-beta.3";
 export const SERVICE_VERSION: string = "2026-04-06";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-datalake/src/utils/utils.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.ts
@@ -25,24 +25,26 @@ export async function streamToBuffer(
 
   return new Promise<void>((resolve, reject) => {
     stream.on("readable", () => {
-      if (pos >= count) {
-        resolve();
-        return;
-      }
+      // Drain all currently-buffered chunks. Required since Node.js v26, where
+      // `stream.read()` returns one buffered chunk at a time instead of the
+      // concatenation of all queued data (see nodejs/node#60441).
+      let chunk: string | Buffer | null;
+      while ((chunk = stream.read()) !== null) {
+        if (typeof chunk === "string") {
+          chunk = Buffer.from(chunk, encoding);
+        }
 
-      let chunk = stream.read();
-      if (!chunk) {
-        return;
-      }
-      if (typeof chunk === "string") {
-        chunk = Buffer.from(chunk, encoding);
-      }
+        // How much data needed in this chunk
+        const chunkLength = pos + chunk.length > count ? count - pos : chunk.length;
 
-      // How much data needed in this chunk
-      const chunkLength = pos + chunk.length > count ? count - pos : chunk.length;
+        buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
+        pos += chunkLength;
 
-      buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
-      pos += chunkLength;
+        if (pos >= count) {
+          resolve();
+          return;
+        }
+      }
     });
 
     stream.on("end", () => {
@@ -79,21 +81,23 @@ export async function streamToBuffer2(
 
   return new Promise<number>((resolve, reject) => {
     stream.on("readable", () => {
-      let chunk = stream.read();
-      if (!chunk) {
-        return;
-      }
-      if (typeof chunk === "string") {
-        chunk = Buffer.from(chunk, encoding);
-      }
+      // Drain all currently-buffered chunks. Required since Node.js v26, where
+      // `stream.read()` returns one buffered chunk at a time instead of the
+      // concatenation of all queued data (see nodejs/node#60441).
+      let chunk: string | Buffer | null;
+      while ((chunk = stream.read()) !== null) {
+        if (typeof chunk === "string") {
+          chunk = Buffer.from(chunk, encoding);
+        }
 
-      if (pos + chunk.length > bufferSize) {
-        reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
-        return;
-      }
+        if (pos + chunk.length > bufferSize) {
+          reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
+          return;
+        }
 
-      buffer.fill(chunk, pos, pos + chunk.length);
-      pos += chunk.length;
+        buffer.fill(chunk, pos, pos + chunk.length);
+        pos += chunk.length;
+      }
     });
 
     stream.on("end", () => {

--- a/sdk/storage/storage-file-datalake/src/utils/utils.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.ts
@@ -27,6 +27,7 @@ export async function streamToBuffer(
     stream.on("readable", () => {
       // Already filled the requested amount; ignore any further `readable` events.
       if (pos >= count) {
+        resolve();
         return;
       }
       // Drain all currently-buffered chunks. Required since Node.js v26, where
@@ -58,7 +59,6 @@ export async function streamToBuffer(
             `Stream drains before getting enough data needed. Data read: ${pos}, data need: ${count}`,
           ),
         );
-        return;
       }
       resolve();
     });

--- a/sdk/storage/storage-file-datalake/src/utils/utils.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.ts
@@ -25,6 +25,10 @@ export async function streamToBuffer(
 
   return new Promise<void>((resolve, reject) => {
     stream.on("readable", () => {
+      // Already filled the requested amount; ignore any further `readable` events.
+      if (pos >= count) {
+        return;
+      }
       // Drain all currently-buffered chunks. Required since Node.js v26, where
       // `stream.read()` returns one buffered chunk at a time instead of the
       // concatenation of all queued data (see nodejs/node#60441).
@@ -54,6 +58,7 @@ export async function streamToBuffer(
             `Stream drains before getting enough data needed. Data read: ${pos}, data need: ${count}`,
           ),
         );
+        return;
       }
       resolve();
     });

--- a/sdk/storage/storage-file-datalake/swagger/README.md
+++ b/sdk/storage/storage-file-datalake/swagger/README.md
@@ -21,7 +21,7 @@ core-http-compat-mode: true
 add-credentials: false
 use-extension:
   "@autorest/typescript": "6.0.42"
-package-version: 12.30.0-beta.2
+package-version: 12.30.0-beta.3
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-datalake/test/node/streamToBuffer.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/streamToBuffer.spec.ts
@@ -11,7 +11,7 @@ describe("streamToBuffer helpers", () => {
   // multiple buffered chunks from a single `readable` event - the exact scenario
   // that regressed in Node.js v26 (see nodejs/node#60441).
   function makeMultiChunkStream(chunks: Buffer[]): Readable {
-    const stream = new Readable({ read() { } });
+    const stream = new Readable({ read() {} });
     for (const chunk of chunks) {
       stream.push(chunk);
     }

--- a/sdk/storage/storage-file-datalake/test/node/streamToBuffer.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/node/streamToBuffer.spec.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Readable } from "node:stream";
+import { streamToBuffer, streamToBuffer2 } from "../../src/utils/utils.js";
+import { describe, it, assert } from "vitest";
+
+describe("streamToBuffer helpers", () => {
+  // Build a Readable that already has multiple chunks queued internally before any
+  // consumer attaches a `readable` listener. This forces the consumer to drain
+  // multiple buffered chunks from a single `readable` event - the exact scenario
+  // that regressed in Node.js v26 (see nodejs/node#60441).
+  function makeMultiChunkStream(chunks: Buffer[]): Readable {
+    const stream = new Readable({ read() { } });
+    for (const chunk of chunks) {
+      stream.push(chunk);
+    }
+    stream.push(null);
+    return stream;
+  }
+
+  describe("streamToBuffer", () => {
+    it("reads exactly `count` bytes when multiple chunks are pre-buffered", async () => {
+      const chunks = [Buffer.from("hello "), Buffer.from("buffered "), Buffer.from("world!")];
+      const expected = Buffer.concat(chunks);
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(expected.length);
+      await streamToBuffer(stream, output, 0, expected.length);
+
+      assert.deepEqual(output, expected);
+    });
+
+    it("fills the requested slice with multi-chunk data and stops at `count`", async () => {
+      const chunks = [Buffer.from("AAAA"), Buffer.from("BBBB"), Buffer.from("CCCC")];
+      const stream = makeMultiChunkStream(chunks);
+
+      // Pre-fill output with marker bytes so we can verify only [offset, end) is touched.
+      const marker = 0xff;
+      const output = Buffer.alloc(20, marker);
+      const offset = 4;
+      const end = 14; // request 10 bytes; stream has 12 available
+
+      await streamToBuffer(stream, output, offset, end);
+
+      for (let i = 0; i < offset; i++) {
+        assert.strictEqual(output[i], marker, `byte ${i} (before offset) modified`);
+      }
+      for (let i = end; i < output.length; i++) {
+        assert.strictEqual(output[i], marker, `byte ${i} (after end) modified`);
+      }
+      assert.deepEqual(
+        output.subarray(offset, end),
+        Buffer.concat(chunks).subarray(0, end - offset),
+      );
+    });
+
+    it("rejects when the stream ends before `count` bytes are read", async () => {
+      const chunks = [Buffer.from("abc"), Buffer.from("def")];
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(10);
+      let caught: Error | undefined;
+      try {
+        await streamToBuffer(stream, output, 0, 10);
+      } catch (err: any) {
+        caught = err;
+      }
+      assert.isDefined(caught, "Expected streamToBuffer to reject");
+      assert.match(caught!.message, /Stream drains before/);
+    });
+  });
+
+  describe("streamToBuffer2", () => {
+    it("reads all bytes when multiple chunks are pre-buffered", async () => {
+      const chunks = [Buffer.from("first "), Buffer.from("second "), Buffer.from("third")];
+      const expected = Buffer.concat(chunks);
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(expected.length);
+      const bytesRead = await streamToBuffer2(stream, output);
+
+      assert.strictEqual(bytesRead, expected.length);
+      assert.deepEqual(output, expected);
+    });
+
+    it("rejects when concatenated chunks exceed the buffer size", async () => {
+      const chunks = [Buffer.from("AAAA"), Buffer.from("BBBB"), Buffer.from("CCCC")];
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(8); // total chunks = 12 bytes > 8
+      let caught: Error | undefined;
+      try {
+        await streamToBuffer2(stream, output);
+      } catch (err: any) {
+        caught = err;
+      }
+      assert.isDefined(caught, "Expected streamToBuffer2 to reject");
+      assert.match(caught!.message, /Stream exceeds buffer size/);
+    });
+  });
+});

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 12.31.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 12.31.0-beta.1 (2026-03-05)
 
 ### Features Added

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.31.0-beta.1",
+  "version": "12.31.0-beta.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.31.0-beta.1";
+export const SDK_VERSION: string = "12.31.0-beta.2";
 export const SERVICE_VERSION: string = "2026-04-06";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-file-share/src/utils/utils.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.ts
@@ -32,6 +32,8 @@ export async function streamToBuffer(
     stream.on("readable", () => {
       // Already filled the requested amount; ignore any further `readable` events.
       if (pos >= count) {
+        clearTimeout(timeout);
+        resolve();
         return;
       }
       // Drain all currently-buffered chunks. Required since Node.js v26, where
@@ -65,7 +67,6 @@ export async function streamToBuffer(
             `Stream drains before getting enough data needed. Data read: ${pos}, data need: ${count}`,
           ),
         );
-        return;
       }
       resolve();
     });

--- a/sdk/storage/storage-file-share/src/utils/utils.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.ts
@@ -30,6 +30,10 @@ export async function streamToBuffer(
       REQUEST_TIMEOUT,
     );
     stream.on("readable", () => {
+      // Already filled the requested amount; ignore any further `readable` events.
+      if (pos >= count) {
+        return;
+      }
       // Drain all currently-buffered chunks. Required since Node.js v26, where
       // `stream.read()` returns one buffered chunk at a time instead of the
       // concatenation of all queued data (see nodejs/node#60441).
@@ -61,6 +65,7 @@ export async function streamToBuffer(
             `Stream drains before getting enough data needed. Data read: ${pos}, data need: ${count}`,
           ),
         );
+        return;
       }
       resolve();
     });

--- a/sdk/storage/storage-file-share/src/utils/utils.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.ts
@@ -30,25 +30,27 @@ export async function streamToBuffer(
       REQUEST_TIMEOUT,
     );
     stream.on("readable", () => {
-      if (pos >= count) {
-        clearTimeout(timeout);
-        resolve();
-        return;
-      }
+      // Drain all currently-buffered chunks. Required since Node.js v26, where
+      // `stream.read()` returns one buffered chunk at a time instead of the
+      // concatenation of all queued data (see nodejs/node#60441).
+      let chunk: string | Buffer | null;
+      while ((chunk = stream.read()) !== null) {
+        if (typeof chunk === "string") {
+          chunk = Buffer.from(chunk, encoding);
+        }
 
-      let chunk = stream.read();
-      if (!chunk) {
-        return;
-      }
-      if (typeof chunk === "string") {
-        chunk = Buffer.from(chunk, encoding);
-      }
+        // How much data needed in this chunk
+        const chunkLength = pos + chunk.length > count ? count - pos : chunk.length;
 
-      // How much data needed in this chunk
-      const chunkLength = pos + chunk.length > count ? count - pos : chunk.length;
+        buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
+        pos += chunkLength;
 
-      buffer.fill(chunk.slice(0, chunkLength), offset + pos, offset + pos + chunkLength);
-      pos += chunkLength;
+        if (pos >= count) {
+          clearTimeout(timeout);
+          resolve();
+          return;
+        }
+      }
     });
 
     stream.on("end", () => {

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -21,7 +21,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-extension:
   "@autorest/typescript": "6.0.42"
-package-version: 12.31.0-beta.1
+package-version: 12.31.0-beta.2
 ```
 
 ## Customizations for Track 2 Generator

--- a/sdk/storage/storage-file-share/test/node/utils.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/utils.spec.ts
@@ -155,7 +155,7 @@ describe("Utility Helpers Node.js only", () => {
     // multiple buffered chunks from a single `readable` event - the exact scenario
     // that regressed in Node.js v26 (see nodejs/node#60441).
     function makeMultiChunkStream(chunks: Buffer[]): Readable {
-      const stream = new Readable({ read() { } });
+      const stream = new Readable({ read() {} });
       for (const chunk of chunks) {
         stream.push(chunk);
       }

--- a/sdk/storage/storage-file-share/test/node/utils.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/utils.spec.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+import { Readable } from "node:stream";
 import { extractConnectionStringParts } from "../../src/utils/utils.common.js";
+import { streamToBuffer } from "../../src/utils/utils.js";
 import { describe, it, assert } from "vitest";
 
 describe("Utility Helpers Node.js only", () => {
@@ -145,5 +147,72 @@ describe("Utility Helpers Node.js only", () => {
         AccountKey=${accountKey};
         EndpointSuffix=${endpointSuffix};`,
     );
+  });
+
+  describe("streamToBuffer", () => {
+    // Build a Readable that already has multiple chunks queued internally before any
+    // consumer attaches a `readable` listener. This forces the consumer to drain
+    // multiple buffered chunks from a single `readable` event - the exact scenario
+    // that regressed in Node.js v26 (see nodejs/node#60441).
+    function makeMultiChunkStream(chunks: Buffer[]): Readable {
+      const stream = new Readable({ read() { } });
+      for (const chunk of chunks) {
+        stream.push(chunk);
+      }
+      stream.push(null);
+      return stream;
+    }
+
+    it("reads exactly `count` bytes when multiple chunks are pre-buffered", async () => {
+      const chunks = [Buffer.from("hello "), Buffer.from("buffered "), Buffer.from("world!")];
+      const expected = Buffer.concat(chunks);
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(expected.length);
+      await streamToBuffer(stream, output, 0, expected.length);
+
+      assert.deepEqual(output, expected);
+    });
+
+    it("fills the requested slice with multi-chunk data and stops at `count`", async () => {
+      const chunks = [Buffer.from("AAAA"), Buffer.from("BBBB"), Buffer.from("CCCC")];
+      const stream = makeMultiChunkStream(chunks);
+
+      // Pre-fill output with marker bytes so we can verify only [offset, end) is touched.
+      const marker = 0xff;
+      const output = Buffer.alloc(20, marker);
+      const offset = 4;
+      const end = 14; // request 10 bytes; stream has 12 available
+
+      await streamToBuffer(stream, output, offset, end);
+
+      // Bytes outside [offset, end) must remain marker.
+      for (let i = 0; i < offset; i++) {
+        assert.strictEqual(output[i], marker, `byte ${i} (before offset) modified`);
+      }
+      for (let i = end; i < output.length; i++) {
+        assert.strictEqual(output[i], marker, `byte ${i} (after end) modified`);
+      }
+      // Filled region must contain the first 10 bytes of the concatenated input.
+      assert.deepEqual(
+        output.subarray(offset, end),
+        Buffer.concat(chunks).subarray(0, end - offset),
+      );
+    });
+
+    it("rejects when the stream ends before `count` bytes are read", async () => {
+      const chunks = [Buffer.from("abc"), Buffer.from("def")];
+      const stream = makeMultiChunkStream(chunks);
+
+      const output = Buffer.alloc(10);
+      let caught: Error | undefined;
+      try {
+        await streamToBuffer(stream, output, 0, 10);
+      } catch (err: any) {
+        caught = err;
+      }
+      assert.isDefined(caught, "Expected streamToBuffer to reject");
+      assert.match(caught!.message, /Stream drains before/);
+    });
   });
 });


### PR DESCRIPTION
in Node.js v26

Historically, `readable.read()` has always returned all queued data. In v26, calling `stream.read()` (no size argument) now returns only the first chunk in the internal queue, not the concatenation of all queued chunks.  This PR changes to read multiple chunks.