### PR TITLE
communication-common: Support teams extension scope in gcch

### DIFF
--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for the GCCH Teams Phone Extensibility Entra scope `https://auth.msft.communication.azure.us/TeamsExtension.ManageCalls`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/communication/communication-common/CHANGELOG.md
+++ b/sdk/communication/communication-common/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Updated the `EntraTokenCredential` scope validation error message and fixed string interpolation in the error text.
+
 ### Other Changes
 
 ## 2.4.0 (2025-06-04)

--- a/sdk/communication/communication-common/README.md
+++ b/sdk/communication/communication-common/README.md
@@ -117,7 +117,7 @@ For scenarios where an Entra user can be used with Communication Services, you n
 Along with this, you must provide the URI of the Azure Communication Services resource and the scopes required for the Entra user token. These scopes determine the permissions granted to the token.
 
 This approach needs to be used for authorizing an Entra user with a Teams license to use Teams Phone Extensibility features through your Azure Communication Services resource.
-This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope.
+This requires providing the `https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls` scope. For the GCCH cloud environment, use `https://auth.msft.communication.azure.us/TeamsExtension.ManageCalls`.
 
 ```ts snippet:ReadmeSampleCredentialEntraUserTeamsPhoneExtensibility 
 import { InteractiveBrowserCredential } from "@azure/identity";

--- a/sdk/communication/communication-common/src/entraTokenCredential.ts
+++ b/sdk/communication/communication-common/src/entraTokenCredential.ts
@@ -180,18 +180,20 @@ export class EntraTokenCredential implements AcsTokenCredential {
   private determineEndpointAndApiVersion(): [string, string] {
     if (!this.options.scopes || this.options.scopes.length === 0) {
       throw new Error(ScopeValidationErrorMessage);
-    } else if (
+    }
+
+    if (
       this.options.scopes.every((scope) =>
         TeamsExtensionScopePrefixes.some((prefix) => scope.startsWith(prefix)),
       )
     ) {
       return [TeamsExtensionEndpoint, TeamsExtensionApiVersion];
-    } else if (
-      this.options.scopes.every((scope) => scope.startsWith(CommunicationClientsScopePrefix))
-    ) {
-      return [CommunicationClientsEndpoint, CommunicationClientsApiVersion];
-    } else {
-      throw new Error(ScopeValidationErrorMessage);
     }
+
+    if (this.options.scopes.every((scope) => scope.startsWith(CommunicationClientsScopePrefix))) {
+      return [CommunicationClientsEndpoint, CommunicationClientsApiVersion];
+    }
+
+    throw new Error(ScopeValidationErrorMessage);
   }
 }

--- a/sdk/communication/communication-common/src/entraTokenCredential.ts
+++ b/sdk/communication/communication-common/src/entraTokenCredential.ts
@@ -20,6 +20,10 @@ const TeamsExtensionScopePrefixes = [
   "https://auth.msft.communication.azure.us/",
 ];
 const CommunicationClientsScopePrefix = "https://communication.azure.com/clients/";
+const ScopeValidationErrorMessage = `Scopes validation failed. Ensure all scopes start with one of ${[
+  ...TeamsExtensionScopePrefixes,
+  CommunicationClientsScopePrefix,
+].join(", ")}.`;
 const TeamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
 const TeamsExtensionApiVersion = "2025-06-30";
 const CommunicationClientsEndpoint = "/access/entra/:exchangeAccessToken";
@@ -175,9 +179,7 @@ export class EntraTokenCredential implements AcsTokenCredential {
 
   private determineEndpointAndApiVersion(): [string, string] {
     if (!this.options.scopes || this.options.scopes.length === 0) {
-      throw new Error(
-        `Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {CommunicationClientsScopePrefix}.`,
-      );
+      throw new Error(ScopeValidationErrorMessage);
     } else if (
       this.options.scopes.every((scope) =>
         TeamsExtensionScopePrefixes.some((prefix) => scope.startsWith(prefix)),
@@ -189,9 +191,7 @@ export class EntraTokenCredential implements AcsTokenCredential {
     ) {
       return [CommunicationClientsEndpoint, CommunicationClientsApiVersion];
     } else {
-      throw new Error(
-        `Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {CommunicationClientsScopePrefix}.`,
-      );
+      throw new Error(ScopeValidationErrorMessage);
     }
   }
 }

--- a/sdk/communication/communication-common/src/entraTokenCredential.ts
+++ b/sdk/communication/communication-common/src/entraTokenCredential.ts
@@ -15,7 +15,10 @@ import {
   createPipelineRequest,
 } from "@azure/core-rest-pipeline";
 
-const TeamsExtensionScopePrefix = "https://auth.msft.communication.azure.com/";
+const TeamsExtensionScopePrefixes = [
+  "https://auth.msft.communication.azure.com/",
+  "https://auth.msft.communication.azure.us/",
+];
 const CommunicationClientsScopePrefix = "https://communication.azure.com/clients/";
 const TeamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken";
 const TeamsExtensionApiVersion = "2025-06-30";
@@ -175,7 +178,11 @@ export class EntraTokenCredential implements AcsTokenCredential {
       throw new Error(
         `Scopes validation failed. Ensure all scopes start with either {TeamsExtensionScopePrefix} or {CommunicationClientsScopePrefix}.`,
       );
-    } else if (this.options.scopes.every((scope) => scope.startsWith(TeamsExtensionScopePrefix))) {
+    } else if (
+      this.options.scopes.every((scope) =>
+        TeamsExtensionScopePrefixes.some((prefix) => scope.startsWith(prefix)),
+      )
+    ) {
       return [TeamsExtensionEndpoint, TeamsExtensionApiVersion];
     } else if (
       this.options.scopes.every((scope) => scope.startsWith(CommunicationClientsScopePrefix))

--- a/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
+++ b/sdk/communication/communication-common/test/public/node/entraCommunicationTokenCredential.spec.ts
@@ -20,6 +20,8 @@ const comunicationClientsEndpoint =
 const communicationClientsScope = "https://communication.azure.com/clients/VoIP";
 const teamsExtensionEndpoint = "/access/teamsExtension/:exchangeAccessToken?api-version=2025-06-30";
 const teamsExtensionScope = "https://auth.msft.communication.azure.com/TeamsExtension.ManageCalls";
+const teamsExtensionGcchScope =
+  "https://auth.msft.communication.azure.us/TeamsExtension.ManageCalls";
 
 const tokenCredential: TokenCredential = {
   getToken: async (_scopes: string, _options?: GetTokenOptions) => {
@@ -79,6 +81,12 @@ describe("Entra CommunicationTokenCredential", function () {
       successMock: teamsSuccessApiMock,
       mock: teamsApiMock,
       scopes: teamsExtensionScope,
+      endpoint: teamsExtensionEndpoint,
+    },
+    {
+      successMock: teamsSuccessApiMock,
+      mock: teamsApiMock,
+      scopes: teamsExtensionGcchScope,
       endpoint: teamsExtensionEndpoint,
     },
   ];


### PR DESCRIPTION
Added GCCH TeamsExtension scope support for @azure/communication-common