### PR TITLE
[dev-tool] update the compiler options for generated typescript samples

### DIFF
--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -86,7 +86,7 @@ function isValidNpmVersionSpecifier(specifier: string) {
       specifier.startsWith("^") || specifier.startsWith("~") ? specifier.substring(1) : specifier,
     ) ||
     semver.validRange(specifier) ||
-    ["latest", "dev", "next"].includes(specifier)
+    ["latest", "dev", "beta"].includes(specifier)
   );
 }
 
@@ -160,8 +160,8 @@ export async function makeSampleGenerationInfo(
   );
 
   const defaultDependencies: Record<string, string> = {
-    // If we are a beta package, use "next", otherwise we will use "latest"
-    [projectInfo.name]: projectInfo.version.includes("beta") ? "next" : "latest",
+    // If we are a beta package, use "beta", otherwise we will use "latest"
+    [projectInfo.name]: projectInfo.version.includes("beta") ? "beta" : "latest",
     // We use this universally
     dotenv: "latest",
   };
@@ -367,8 +367,10 @@ export async function createTsconfig(projectInfo: ProjectInfo): Promise<string> 
   delete tsconfig.compilerOptions.declarationMap;
   delete tsconfig.compilerOptions.inlineSources;
   delete tsconfig.compilerOptions.sourceMap;
+  delete tsconfig.compilerOptions.verbatimModuleSyntax;
   tsconfig.include = ["./src"];
   tsconfig.compilerOptions.outDir = "./dist";
+  tsconfig.compilerOptions.rootDir = "./src";
   tsconfig.compilerOptions.resolveJsonModule = true;
 
   tsconfig.compilerOptions.moduleResolution = "nodenext"; // ts.ModuleResolutionKind.NodeNext

--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -371,8 +371,8 @@ export async function createTsconfig(projectInfo: ProjectInfo): Promise<string> 
   tsconfig.compilerOptions.outDir = "./dist";
   tsconfig.compilerOptions.resolveJsonModule = true;
 
-  tsconfig.compilerOptions.moduleResolution = "node10"; // ts.ModuleResolutionKind.Node10
-  tsconfig.compilerOptions.module = "commonjs"; // ts.ModuleKind.CommonJS
+  tsconfig.compilerOptions.moduleResolution = "nodenext"; // ts.ModuleResolutionKind.NodeNext
+  tsconfig.compilerOptions.module = "nodenext"; // ts.ModuleKind.NodeNext
   return jsonify(tsconfig);
 }
 

--- a/common/tools/dev-tool/src/util/samples/info.ts
+++ b/common/tools/dev-tool/src/util/samples/info.ts
@@ -14,23 +14,18 @@ export const PUBLIC_SAMPLES_BASE = "samples";
 /**
  * Default TypeScript compiler configuration for sample projects.
  *
- * The default configuration targets ES2018 to support async iteration
- * by default with no `lib` entry.
+ * The default configuration targets ES2023 to support the latest JavaScript features.
  */
 export const DEFAULT_TYPESCRIPT_CONFIG = {
   compilerOptions: {
-    target: "ES2020",
-    module: "commonjs",
-
-    moduleResolution: "node",
+    target: "ES2023",
+    module: "nodenext",
+    moduleResolution: "nodenext",
     resolveJsonModule: true,
-
     esModuleInterop: true,
     allowSyntheticDefaultImports: true,
-
     strict: true,
     alwaysStrict: true,
-
     outDir: "dist",
     rootDir: "src",
   },

--- a/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/javascript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/javascript/package.json
@@ -24,7 +24,7 @@
     "cjs-forms": "latest",
     "dotenv": "latest",
     "@azure/test1": "latest",
-    "@azure-test2/test2": "next"
+    "@azure-test2/test2": "beta"
   },
   "devDependencies": {
     "cross-env": "latest"

--- a/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/package.json
@@ -28,7 +28,7 @@
     "cjs-forms": "latest",
     "dotenv": "latest",
     "@azure/test1": "latest",
-    "@azure-test2/test2": "next"
+    "@azure-test2/test2": "beta"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/cjs-forms/typescript/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/output-customization/typescript/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple/typescript/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/javascript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/javascript/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1",
   "dependencies": {
-    "simple@1.0.0-beta.1": "next",
+    "simple@1.0.0-beta.1": "beta",
     "dotenv": "latest"
   },
   "devDependencies": {

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1",
   "dependencies": {
-    "simple@1.0.0-beta.1": "next",
+    "simple@1.0.0-beta.1": "beta",
     "dotenv": "latest"
   },
   "devDependencies": {

--- a/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/simple@1.0.0-beta.1/typescript/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/common/tools/dev-tool/test/samples/files/expectations/special-characters/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/special-characters/typescript/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/common/tools/dev-tool/test/samples/files/inputs/cjs-forms/config.json
+++ b/common/tools/dev-tool/test/samples/files/inputs/cjs-forms/config.json
@@ -9,6 +9,6 @@
   },
   "dependencyOverrides": {
     "@azure/test1": "latest",
-    "@azure-test2/test2": "next"
+    "@azure-test2/test2": "beta"
   }
 }


### PR DESCRIPTION
- update to use "beta" tag for preview version. We have moved away from "next" to "beta"
- update typescript samples tsconfig compiler options to have more modern options