### PR TITLE
[Monitor OpenTelemetry Exporter] Fix String Log Body Passed to Custom Events

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.0.0-beta.41 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Fixed a `TypeError: Cannot use 'in' operator to search for 'measurements'` crash that occurred when a log record's `body` was a non-object value (such as a string) on the custom event / legacy Application Insights export path.
+
+### Other Changes
+
 ## 1.0.0-beta.40 (2026-05-07)
 
 ### Breaking Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/monitor-opentelemetry-exporter",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.0-beta.40",
+  "version": "1.0.0-beta.41",
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -20,7 +20,7 @@ export const TIME_SINCE_ENQUEUED = "timeSinceEnqueued";
  * AzureMonitorTraceExporter version.
  * @internal
  */
-export const packageVersion = "1.0.0-beta.40";
+export const packageVersion = "1.0.0-beta.41";
 
 /**
  * Telemetry base data version.

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -250,9 +250,12 @@ function getLegacyApplicationInsightsName(log: ReadableLogRecord): string {
 
 function getLegacyApplicationInsightsMeasurements(log: ReadableLogRecord): Measurements {
   let measurements: Measurements = {};
-  const body = log.body as Record<string, unknown> | undefined;
-  if (body && "measurements" in body && body.measurements) {
-    measurements = { ...(body.measurements as Measurements) };
+  const body = log.body;
+  if (body && typeof body === "object" && !Array.isArray(body) && "measurements" in body) {
+    const bodyMeasurements = (body as Record<string, unknown>).measurements;
+    if (bodyMeasurements && typeof bodyMeasurements === "object") {
+      measurements = { ...(bodyMeasurements as Measurements) };
+    }
   }
   return measurements;
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/logUtils.ts
@@ -249,12 +249,20 @@ function getLegacyApplicationInsightsName(log: ReadableLogRecord): string {
 }
 
 function getLegacyApplicationInsightsMeasurements(log: ReadableLogRecord): Measurements {
-  let measurements: Measurements = {};
+  const measurements: Measurements = {};
   const body = log.body;
   if (body && typeof body === "object" && !Array.isArray(body) && "measurements" in body) {
     const bodyMeasurements = (body as Record<string, unknown>).measurements;
-    if (bodyMeasurements && typeof bodyMeasurements === "object") {
-      measurements = { ...(bodyMeasurements as Measurements) };
+    if (
+      bodyMeasurements &&
+      typeof bodyMeasurements === "object" &&
+      !Array.isArray(bodyMeasurements)
+    ) {
+      for (const [key, value] of Object.entries(bodyMeasurements as Record<string, unknown>)) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          measurements[key] = value;
+        }
+      }
     }
   }
   return measurements;

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/logUtils.spec.ts
@@ -724,6 +724,40 @@ describe("logUtils.ts", () => {
         expectedServiceTagsBase,
       );
     });
+
+    it("should create a Custom Event Envelope when the log body is a string", () => {
+      testLogRecord.attributes = {
+        "microsoft.custom_event.name": "testing name",
+        "extra.attribute": "foo",
+        [ATTR_CLIENT_ADDRESS]: "127.0.0.1",
+        [experimentalOpenTelemetryValues.SYNTHETIC_TYPE]: "bot",
+      };
+      testLogRecord.body = "MyEventName";
+      const expectedTime = hrTimeToDate(testLogRecord.hrTime);
+      const expectedProperties = {
+        "extra.attribute": "foo",
+      };
+      const expectedBaseData: TelemetryEventData = {
+        name: "testing name",
+        version: 2,
+        properties: expectedProperties,
+        measurements: {},
+      } as any;
+
+      // Should not throw a TypeError when the body is a string (regression for #38497).
+      const envelope = logToEnvelope(testLogRecord as ReadableLogRecord, "ikey");
+      assertEnvelope(
+        envelope,
+        "Microsoft.ApplicationInsights.Event",
+        100,
+        "EventData",
+        expectedProperties,
+        emptyMeasurements,
+        expectedBaseData,
+        expectedTime,
+        expectedServiceTagsBase,
+      );
+    });
   });
 
   it("should parse objects if passed as the message field of a legacy ApplicationInsights log", () => {


### PR DESCRIPTION
### Packages impacted by this PR
@azure/monitor-opentelemetry-exporter

### Issues associated with this PR
https://github.com/Azure/azure-sdk-for-js/issues/38497

### Describe the problem that is addressed by this PR
This pull request addresses a bug in the `@azure/monitor-opentelemetry-exporter` package where a `TypeError` could occur if a log record's `body` was a non-object value, such as a string, particularly in the legacy Application Insights export path. The fix ensures safer handling of log bodies and adds a regression test to prevent future issues. Additionally, the package version is incremented and changelogs are updated. There is also a documentation update for the related `monitor-opentelemetry` package.

**Bug Fixes and Testing**

* Fixed a `TypeError` in `logUtils.ts` that occurred when the log record's `body` was a non-object value (e.g., a string) by adding type checks before accessing the `measurements` property.
* Added a regression test in `logUtils.spec.ts` to ensure that log records with string bodies are handled correctly and do not throw errors.

**Versioning and Documentation**

* Bumped the version of `@azure/monitor-opentelemetry-exporter` to `1.0.0-beta.41` and updated the changelog to reflect the bug fix. [[1]](diffhunk://#diff-0368ef6fc04c4f6cef130c34bd2f1ba562602a417532ada0ecdf2b4fd3c8074aL5-R5) [[2]](diffhunk://#diff-994a7fbc4177f96448b6098ea5c95fc5872615b8537e18822a17817cd3d70870R3-R14)
* Updated the `monitor-opentelemetry` changelog to note the restructuring of `samples-dev` for improved documentation and development tooling.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
