### PR TITLE
[storage-common] Fix CRC64 module loading under ESM and CommonJS

### DIFF
--- a/sdk/storage/storage-common/CHANGELOG.md
+++ b/sdk/storage/storage-common/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed CRC64 checksum calculator failing under both module systems: `ReferenceError: require is not defined` when loaded as ESM under Node, and `SyntaxError: Unexpected token 'export'` when loaded as CommonJS. The bundled Emscripten output now polyfills `require`/`__filename`/`__dirname` from `import.meta.url` for the ESM build, and the CommonJS copy is rewritten to use `module.exports`. Issues [#38069](https://github.com/Azure/azure-sdk-for-js/issues/38069) and [#38501](https://github.com/Azure/azure-sdk-for-js/issues/38501).
+
 ### Other Changes
 
 ## 12.4.0-beta.1 (2026-03-05)

--- a/sdk/storage/storage-common/copyJSFiles.cjs
+++ b/sdk/storage/storage-common/copyJSFiles.cjs
@@ -1,9 +1,40 @@
-fs=require('fs')
-fs.cpSync('./src/crc64.js', './dist/commonjs/crc64.js');
-fs.cpSync('./src/crc64_glue.js', './dist/commonjs/crc64_glue.js');
-fs.cpSync('./src/crc64.js', './dist/browser/crc64.js');
-fs.cpSync('./src/crc64_glue.js', './dist/browser/crc64_glue.js');
-fs.cpSync('./src/crc64.js', './dist/esm/crc64.js');
-fs.cpSync('./src/crc64_glue.js', './dist/esm/crc64_glue.js');
-fs.cpSync('./src/crc64.js', './dist/react-native/crc64.js');
-fs.cpSync('./src/crc64_glue.js', './dist/react-native/crc64_glue.js');
+const fs = require('fs');
+
+const SRC_CRC64 = './src/crc64.js';
+const SRC_GLUE = './src/crc64_glue.js';
+
+// `dist/commonjs/package.json` is `{ "type": "commonjs" }`, so the same .js file
+// must use CommonJS syntax there. Strip the ESM-only polyfill block and rewrite
+// the ESM `export default` to `module.exports`. The other targets (esm, browser,
+// react-native) sit under `{ "type": "module" }` and get the ESM source verbatim.
+const ESM_COMPAT_BLOCK = /\/\/ ESM-COMPAT-START[\s\S]*?\/\/ ESM-COMPAT-END\r?\n?/;
+const ESM_EXPORT_BLOCK =
+  /\/\/ ESM-EXPORT-START[^\n]*\r?\nexport default NativeCRC64;\r?\n\/\/ ESM-EXPORT-END/;
+
+const esmSource = fs.readFileSync(SRC_CRC64, 'utf8');
+
+if (!ESM_COMPAT_BLOCK.test(esmSource)) {
+  throw new Error(
+    "copyJSFiles.cjs: expected ESM-COMPAT marker block in src/crc64.js was not found.",
+  );
+}
+if (!ESM_EXPORT_BLOCK.test(esmSource)) {
+  throw new Error(
+    "copyJSFiles.cjs: expected ESM-EXPORT marker block in src/crc64.js was not found.",
+  );
+}
+
+const cjsSource = esmSource
+  .replace(
+    ESM_COMPAT_BLOCK,
+    "// ESM compatibility block omitted in CommonJS build.\n",
+  )
+  .replace(ESM_EXPORT_BLOCK, "module.exports = NativeCRC64;");
+
+fs.writeFileSync('./dist/commonjs/crc64.js', cjsSource);
+fs.cpSync(SRC_GLUE, './dist/commonjs/crc64_glue.js');
+
+for (const dir of ['browser', 'esm', 'react-native']) {
+  fs.cpSync(SRC_CRC64, `./dist/${dir}/crc64.js`);
+  fs.cpSync(SRC_GLUE, `./dist/${dir}/crc64_glue.js`);
+}

--- a/sdk/storage/storage-common/src/crc64.js
+++ b/sdk/storage/storage-common/src/crc64.js
@@ -1,6 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// ESM-COMPAT-START (this block is stripped from dist/commonjs by copyJSFiles.cjs)
+// In ESM under Node, `require`, `__filename`, and `__dirname` are not defined.
+// Synthesize them from `import.meta.url` so the Emscripten Node branch below works as-is.
+// Specifiers are held in variables to prevent web bundlers from statically resolving `node:*`.
+const __isNode__ =
+  typeof process !== "undefined" && process.versions != null && process.versions.node != null;
+let require;
+let __filename;
+let __dirname;
+if (__isNode__) {
+  const _modSpecifier = "node:module";
+  const _urlSpecifier = "node:url";
+  const _pathSpecifier = "node:path";
+  const { createRequire } = await import(_modSpecifier);
+  const { fileURLToPath } = await import(_urlSpecifier);
+  const { dirname } = await import(_pathSpecifier);
+  require = createRequire(import.meta.url);
+  __filename = fileURLToPath(import.meta.url);
+  __dirname = dirname(__filename);
+}
+// ESM-COMPAT-END
+
 var NativeCRC64 = (() => {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
   if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;
@@ -2925,4 +2947,6 @@ Crc64Hash.prototype['OnFinal'] = Crc64Hash.prototype.OnFinal = /** @suppress {un
 // else if (typeof exports === 'object')
 //   exports["NativeCRC64"] = NativeCRC64;
 
-  export default NativeCRC64;
+// ESM-EXPORT-START (rewritten to `module.exports = NativeCRC64;` in dist/commonjs by copyJSFiles.cjs)
+export default NativeCRC64;
+// ESM-EXPORT-END

--- a/sdk/storage/storage-common/src/crc64.js
+++ b/sdk/storage/storage-common/src/crc64.js
@@ -5,8 +5,13 @@
 // In ESM under Node, `require`, `__filename`, and `__dirname` are not defined.
 // Synthesize them from `import.meta.url` so the Emscripten Node branch below works as-is.
 // Specifiers are held in variables to prevent web bundlers from statically resolving `node:*`.
+// The detection check below MUST stay byte-for-byte identical to the Emscripten-generated
+// `ENVIRONMENT_IS_NODE` check later in this file; otherwise the polyfill and the Node branch
+// can disagree and the ESM `ReferenceError: require is not defined` bug returns.
 const __isNode__ =
-  typeof process !== "undefined" && process.versions != null && process.versions.node != null;
+  typeof process === "object" &&
+  typeof process.versions === "object" &&
+  typeof process.versions.node === "string";
 let require;
 let __filename;
 let __dirname;


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/storage-common`

### Issues associated with this PR

- Fixes #38069 — `[Storage] content checksum feature broken when being used in ESM` (`ReferenceError: require is not defined` at `crc64.js:118:12`).
- Fixes #38501 — `[storage] latest beta version failed to run in CommonJS` (`SyntaxError: Unexpected token 'export'` on `export default NativeCRC64;`).

### Describe the problem that is addressed by this PR

The bundled Emscripten output for the CRC64 WASM module (`sdk/storage/storage-common/src/crc64.js`) fails to load under either Node module system in `12.4.0-beta.1`:

| Module system | Error | Cause |
| --- | --- | --- |
| ESM (Node) | `ReferenceError: require is not defined` | The Emscripten Node branch calls `require('fs')` / `require('path')` and reads `__dirname`, which are not available in ESM scope. |
| CommonJS (Node) | `SyntaxError: Unexpected token 'export'` | The file ends with `export default NativeCRC64;`, which is illegal in a CJS parser. The CJS copy lives under `dist/commonjs/package.json` = `{ "type": "commonjs" }`. |

`copyJSFiles.cjs` simply copies the source verbatim into `dist/commonjs`, `dist/esm`, `dist/browser`, and `dist/react-native`, so neither environment got a usable file.

### What changes did this PR make?

1. **`src/crc64.js`** — Prepended an ESM-compat block that, when running under Node, dynamically imports `node:module`/`node:url`/`node:path` and synthesizes module-scoped `require`, `__filename`, and `__dirname` from `import.meta.url`. The `node:*` specifiers are stored in variables so web bundlers (webpack / vite / Metro) won't statically resolve them.
2. **`src/crc64.js`** — Wrapped the trailing `export default NativeCRC64;` in `// ESM-EXPORT-START` / `// ESM-EXPORT-END` marker comments so the rewriter has stable anchors.
3. **`copyJSFiles.cjs`** — When copying the source into `dist/commonjs/`, strip the ESM-compat block and rewrite the export marker block to `module.exports = NativeCRC64;`. The other three targets (`esm`, `browser`, `react-native`) continue to receive the source verbatim. The script now throws a clear error if either marker block goes missing, so future drift is caught at build time.

### Verification

- `dev-tool run build-package` (via `azsdk_package_build_code`) — succeeds.
- `eslint package.json src test` — only pre-existing warnings on unrelated files (`crc64.js` / `crc64_glue.js` are excluded by `eslint.config.mjs`).
- `prettier --list-different` — no changes.
- `node --check` on all four emitted `dist/*/crc64.js` files — `exit=0`.
- Real round-trip in a fresh temp dir, both loaders successfully complete the WASM init and instantiate `Crc64Hash`:
  - CJS: `cjs init OK; Crc64Hash: object` (exit 0)
  - ESM: `esm init OK; Crc64Hash: object` (exit 0)

### Are there test cases added in this PR? _(If not, why?)_

No new automated tests. The fix is in a generated WASM glue file that is excluded from the existing test/lint config; the existing storage-common build + the manual round-trip checks above exercise both module variants. A future test would need to spawn a child Node process per module system, which is heavier than the existing test setup justifies for this single regression.

### Provide a list of related PRs _(if any)_

None.

### Command used to generate this PR's description

N/A — written by hand.

### Checklists

- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?* /cc @joheredi (no)
- [x] Added a changelog (if necessary)