### PR TITLE
Web PubSub: Register group stream handler factory globally

### DIFF
--- a/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client-node.api.md
+++ b/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client-node.api.md
@@ -106,12 +106,6 @@ export interface GroupDataMessage extends WebPubSubMessageBase {
 }
 
 // @public
-export interface GroupStream {
-    readonly group: string;
-    readonly streamId: string;
-}
-
-// @public
 export interface GroupStreamHandler {
     onComplete?: (args: OnGroupStreamEndArgs) => void;
     onError?: (args: OnGroupStreamEndArgs) => void;
@@ -220,6 +214,12 @@ export interface OnDisconnectedArgs {
 // @public
 export interface OnGroupDataMessageArgs {
     message: GroupDataMessage;
+}
+
+// @public
+export interface OnGroupStreamArgs {
+    readonly group: string;
+    readonly streamId: string;
 }
 
 // @public
@@ -486,15 +486,15 @@ export class WebPubSubClient {
     off(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     off(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
     off(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
-    off(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
     off(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
+    offGroupStream(factory: (args: OnGroupStreamArgs) => GroupStreamHandler): void;
     on(event: "connected", listener: (e: OnConnectedArgs) => void): void;
     on(event: "disconnected", listener: (e: OnDisconnectedArgs) => void): void;
     on(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     on(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
     on(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
-    on(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
     on(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
+    onGroupStream(factory: (args: OnGroupStreamArgs) => GroupStreamHandler): void;
     sendEvent(eventName: string, content: JSONTypes | ArrayBuffer, dataType: WebPubSubDataType, options?: SendEventOptions): Promise<WebPubSubResult>;
     sendToGroup(groupName: string, content: JSONTypes | ArrayBuffer, dataType: WebPubSubDataType, options?: SendToGroupOptions): Promise<WebPubSubResult>;
     start(options?: StartOptions): Promise<void>;

--- a/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client-node.api.md
+++ b/sdk/web-pubsub/web-pubsub-client/review/web-pubsub-client-node.api.md
@@ -106,6 +106,12 @@ export interface GroupDataMessage extends WebPubSubMessageBase {
 }
 
 // @public
+export interface GroupStream {
+    readonly group: string;
+    readonly streamId: string;
+}
+
+// @public
 export interface GroupStreamHandler {
     onComplete?: (args: OnGroupStreamEndArgs) => void;
     onError?: (args: OnGroupStreamEndArgs) => void;
@@ -113,8 +119,9 @@ export interface GroupStreamHandler {
 }
 
 // @public
-export interface GroupStreamSubscription {
-    close(): void;
+export interface GroupStreamOptions {
+    handleFromStart?: boolean;
+    ttlInMs?: number;
 }
 
 // @public
@@ -230,12 +237,6 @@ export interface OnGroupStreamEndArgs {
     error?: StreamDataError;
     group: string;
     streamId: string;
-}
-
-// @public
-export interface OnGroupStreamOptions {
-    handleFromStart?: boolean;
-    ttlInMs?: number;
 }
 
 // @public
@@ -485,14 +486,15 @@ export class WebPubSubClient {
     off(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     off(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
     off(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
+    off(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
     off(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
     on(event: "connected", listener: (e: OnConnectedArgs) => void): void;
     on(event: "disconnected", listener: (e: OnDisconnectedArgs) => void): void;
     on(event: "stopped", listener: (e: OnStoppedArgs) => void): void;
     on(event: "server-message", listener: (e: OnServerDataMessageArgs) => void): void;
     on(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
+    on(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
     on(event: "rejoin-group-failed", listener: (e: OnRejoinGroupFailedArgs) => void): void;
-    onGroupStream(groupName: string, handlerFactory: (streamId: string) => GroupStreamHandler, options?: OnGroupStreamOptions): GroupStreamSubscription;
     sendEvent(eventName: string, content: JSONTypes | ArrayBuffer, dataType: WebPubSubDataType, options?: SendEventOptions): Promise<WebPubSubResult>;
     sendToGroup(groupName: string, content: JSONTypes | ArrayBuffer, dataType: WebPubSubDataType, options?: SendToGroupOptions): Promise<WebPubSubResult>;
     start(options?: StartOptions): Promise<void>;
@@ -509,6 +511,7 @@ export interface WebPubSubClientCredential {
 export interface WebPubSubClientOptions {
     autoReconnect?: boolean;
     autoRejoinGroups?: boolean;
+    groupStreamOptions?: GroupStreamOptions;
     keepAliveIntervalInMs?: number;
     keepAliveTimeoutInMs?: number;
     messageRetryOptions?: WebPubSubRetryOptions;

--- a/sdk/web-pubsub/web-pubsub-client/samples-dev/helloworld.ts
+++ b/sdk/web-pubsub/web-pubsub-client/samples-dev/helloworld.ts
@@ -9,7 +9,7 @@ import type {
   WebPubSubClientCredential,
   GetClientAccessUrlOptions,
   WebPubSubClientOptions,
-  GroupStream,
+  OnGroupStreamArgs,
   GroupStreamHandler,
 } from "@azure/web-pubsub-client";
 import { WebPubSubClient } from "@azure/web-pubsub-client";
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
     console.log(`Received message from ${e.message.group} ${formatPayload(e.message.data)}`);
   });
 
-  const groupStreamFactory = (stream: GroupStream): GroupStreamHandler => ({
+  const groupStreamFactory = (stream: OnGroupStreamArgs): GroupStreamHandler => ({
     onMessage: (args) => {
       console.log(
         `[stream:${stream.group}/${stream.streamId}] seq=${args.stream.streamSequenceId} ${formatPayload(args.data)}`,
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
       );
     },
   });
-  client.on("group-stream", groupStreamFactory);
+  client.onGroupStream(groupStreamFactory);
 
   await client.start();
 
@@ -107,7 +107,7 @@ async function main(): Promise<void> {
   await stream.complete();
 
   await delay(200);
-  client.off("group-stream", groupStreamFactory);
+  client.offGroupStream(groupStreamFactory);
   client.stop();
   console.log("Client stopped");
 }

--- a/sdk/web-pubsub/web-pubsub-client/samples-dev/helloworld.ts
+++ b/sdk/web-pubsub/web-pubsub-client/samples-dev/helloworld.ts
@@ -9,6 +9,8 @@ import type {
   WebPubSubClientCredential,
   GetClientAccessUrlOptions,
   WebPubSubClientOptions,
+  GroupStream,
+  GroupStreamHandler,
 } from "@azure/web-pubsub-client";
 import { WebPubSubClient } from "@azure/web-pubsub-client";
 import { WebPubSubServiceClient } from "@azure/web-pubsub";
@@ -58,23 +60,22 @@ async function main(): Promise<void> {
     console.log(`Received message from ${e.message.group} ${formatPayload(e.message.data)}`);
   });
 
-  const streamSubscription = client.onGroupStream(groupName, (streamId) => {
-    return {
-      onMessage: (args) => {
-        console.log(
-          `[stream:${streamId}] seq=${args.stream.streamSequenceId} ${formatPayload(args.data)}`,
-        );
-      },
-      onComplete: () => {
-        console.log(`[stream:${streamId}] completed`);
-      },
-      onError: (args) => {
-        console.log(
-          `[stream:${streamId}] failed: ${args.error?.name}${args.error?.message ? ` - ${args.error.message}` : ""}`,
-        );
-      },
-    };
+  const groupStreamFactory = (stream: GroupStream): GroupStreamHandler => ({
+    onMessage: (args) => {
+      console.log(
+        `[stream:${stream.group}/${stream.streamId}] seq=${args.stream.streamSequenceId} ${formatPayload(args.data)}`,
+      );
+    },
+    onComplete: () => {
+      console.log(`[stream:${stream.group}/${stream.streamId}] completed`);
+    },
+    onError: (args) => {
+      console.log(
+        `[stream:${stream.group}/${stream.streamId}] failed: ${args.error?.name}${args.error?.message ? ` - ${args.error.message}` : ""}`,
+      );
+    },
   });
+  client.on("group-stream", groupStreamFactory);
 
   await client.start();
 
@@ -95,7 +96,7 @@ async function main(): Promise<void> {
     fireAndForget: true,
   });
 
-  const stream = await client.stream(groupName);
+  const stream = await client.streamToGroup(groupName, { noEcho: false });
   stream.onError((error) => {
     console.log(
       `[publisher:${stream.streamId}] failed: ${error.name}${error.message ? ` - ${error.message}` : ""}`,
@@ -106,7 +107,7 @@ async function main(): Promise<void> {
   await stream.complete();
 
   await delay(200);
-  streamSubscription.close();
+  client.off("group-stream", groupStreamFactory);
   client.stop();
   console.log("Client stopped");
 }

--- a/sdk/web-pubsub/web-pubsub-client/src/inboundStreamSession.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/inboundStreamSession.ts
@@ -1,61 +1,49 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { randomUUID } from "@azure/core-util";
 import { logger } from "./logger.js";
 import type {
+  GroupStream,
+  GroupStreamHandler,
+  GroupStreamOptions,
   OnGroupStreamDataArgs,
   OnGroupStreamEndArgs,
-  OnGroupStreamOptions,
-  GroupStreamHandler,
-  GroupStreamSubscription,
 } from "./models/index.js";
 import type { GroupDataMessage, StreamDataError } from "./models/messages.js";
 
-interface InboundStreamOptions {
-  ttlInMs: number;
-  handleFromStart: boolean;
-}
+const DEFAULT_TTL_IN_MS = 300000;
+const DEFAULT_HANDLE_FROM_START = false;
+
+/**
+ * Factory invoked once for every newly observed inbound stream. The returned
+ * `GroupStreamHandler` is bound to that single stream's lifecycle.
+ */
+export type GroupStreamFactory = (stream: GroupStream) => GroupStreamHandler;
+
+/**
+ * Provides the current set of registered factories. Read at message-processing
+ * time so on/off mutations between fragments are observed immediately.
+ */
+export type GetGroupStreamFactoriesFn = () => readonly GroupStreamFactory[];
 
 export class InboundStreamSession {
-  private readonly _subscriptionsByGroup: Map<string, Set<InboundStreamSubscription>>;
-  // One active handler per (subscription, group, streamId).
-  private readonly _activeHandlers: Map<string, ActiveStreamHandler>;
+  private readonly _getFactories: GetGroupStreamFactoriesFn;
+  private readonly _ttlInMs: number;
+  private readonly _handleFromStart: boolean;
+
+  // Active streams keyed by `${group}|${streamId}`.
+  private readonly _activeStreams: Map<string, ActiveStream>;
   private readonly _activeTimeouts: Map<string, ReturnType<typeof setTimeout>>;
+  // Tracks streamIds skipped by handleFromStart=true, keyed by `${group}|${streamId}`.
+  private readonly _ignored: Set<string>;
 
-  constructor() {
-    this._subscriptionsByGroup = new Map<string, Set<InboundStreamSubscription>>();
-    this._activeHandlers = new Map<string, ActiveStreamHandler>();
+  constructor(getFactories: GetGroupStreamFactoriesFn, options?: GroupStreamOptions) {
+    this._getFactories = getFactories;
+    this._ttlInMs = options?.ttlInMs ?? DEFAULT_TTL_IN_MS;
+    this._handleFromStart = options?.handleFromStart ?? DEFAULT_HANDLE_FROM_START;
+    this._activeStreams = new Map<string, ActiveStream>();
     this._activeTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
-  }
-
-  public subscribe(
-    groupName: string,
-    handlerFactory: (streamId: string) => GroupStreamHandler,
-    options?: OnGroupStreamOptions,
-  ): GroupStreamSubscription {
-    const subscription = new InboundStreamSubscription(
-      randomUUID(),
-      groupName,
-      {
-        ttlInMs: options?.ttlInMs ?? 300000,
-        handleFromStart: options?.handleFromStart ?? false,
-      },
-      handlerFactory,
-    );
-
-    let groupSubscriptions = this._subscriptionsByGroup.get(groupName);
-    if (groupSubscriptions == null) {
-      groupSubscriptions = new Set<InboundStreamSubscription>();
-      this._subscriptionsByGroup.set(groupName, groupSubscriptions);
-    }
-    groupSubscriptions.add(subscription);
-
-    return {
-      close: () => {
-        this._removeSubscription(subscription);
-      },
-    };
+    this._ignored = new Set<string>();
   }
 
   public clearActiveHandlers(): void {
@@ -63,7 +51,8 @@ export class InboundStreamSession {
       clearTimeout(timeout);
     });
     this._activeTimeouts.clear();
-    this._activeHandlers.clear();
+    this._activeStreams.clear();
+    this._ignored.clear();
   }
 
   public handleGroupMessage(message: GroupDataMessage): void {
@@ -72,152 +61,148 @@ export class InboundStreamSession {
       return;
     }
 
-    const subscriptions = this._subscriptionsByGroup.get(message.group);
-    if (subscriptions == null || subscriptions.size === 0) {
+    const factories = this._getFactories();
+    if (factories.length === 0) {
+      // No factory registered, do not allocate per-stream state.
       return;
     }
 
-    subscriptions.forEach((subscription) => {
-      // For handleFromStart=true, if we first observe a mid-stream fragment,
-      // ignore that streamId until its terminal frame arrives.
-      if (subscription.ignoredStreamIds.has(stream.streamId)) {
-        if (stream.endOfStream) {
-          subscription.ignoredStreamIds.delete(stream.streamId);
+    const key = this._buildKey(message.group, stream.streamId);
+
+    // For handleFromStart=true, if we first observe a mid-stream fragment,
+    // ignore that streamId until its terminal frame arrives.
+    if (this._ignored.has(key)) {
+      if (stream.endOfStream) {
+        this._ignored.delete(key);
+      }
+      return;
+    }
+
+    let active = this._activeStreams.get(key);
+    if (active == null) {
+      if (this._handleFromStart && stream.streamSequenceId !== 1) {
+        if (!stream.endOfStream) {
+          this._ignored.add(key);
         }
         return;
       }
 
-      const key = this._buildHandlerKey(subscription.id, message.group, stream.streamId);
-      let activeHandler = this._activeHandlers.get(key);
-      if (activeHandler == null) {
-        if (subscription.options.handleFromStart && stream.streamSequenceId !== 1) {
-          if (!stream.endOfStream) {
-            subscription.ignoredStreamIds.add(stream.streamId);
-          }
-          return;
-        }
-
-        const handler = subscription.handlerFactory(stream.streamId);
-        // A subscription can attach to many streamIds; each streamId gets its own active handler state.
-        activeHandler = new ActiveStreamHandler(
-          key,
-          stream.streamId,
-          message.group,
-          handler,
-          subscription.options.ttlInMs,
-        );
-        this._activeHandlers.set(key, activeHandler);
-      }
-
-      this._resetActiveTimeout(activeHandler);
-
-      const shouldEmitMessage = !stream.endOfStream || this._hasStreamPayload(message);
-      if (shouldEmitMessage) {
-        const onMessageArgs: OnGroupStreamDataArgs = {
-          group: message.group,
-          fromUserId: message.fromUserId,
-          sequenceId: message.sequenceId,
-          dataType: message.dataType,
-          data: message.data,
-          stream,
-        };
-        this._invokeOnMessage(activeHandler, onMessageArgs);
-      }
-
-      if (stream.endOfStream) {
-        const terminalArgs: OnGroupStreamEndArgs = {
-          streamId: stream.streamId,
-          group: message.group,
-          error: stream.error,
-        };
-        if (stream.error != null) {
-          this._invokeOnError(activeHandler, stream.error, terminalArgs);
-        } else {
-          this._invokeOnComplete(activeHandler, terminalArgs);
-        }
-        this._clearActiveTimeout(key);
-        this._activeHandlers.delete(key);
-      }
-    });
-  }
-
-  private _removeSubscription(subscription: InboundStreamSubscription): void {
-    const subscriptions = this._subscriptionsByGroup.get(subscription.groupName);
-    if (subscriptions != null) {
-      subscriptions.delete(subscription);
-      if (subscriptions.size === 0) {
-        this._subscriptionsByGroup.delete(subscription.groupName);
-      }
+      const streamView: GroupStream = {
+        group: message.group,
+        streamId: stream.streamId,
+      };
+      const handlers = this._invokeFactories(factories, streamView);
+      active = {
+        key,
+        group: message.group,
+        streamId: stream.streamId,
+        ttlInMs: this._ttlInMs,
+        handlers,
+      };
+      this._activeStreams.set(key, active);
     }
 
-    const prefix = `${subscription.id}|`;
-    const keysToRemove: string[] = [];
-    // Handler keys are prefixed by subscription id, so one prefix scan removes
-    // all active stream states created by this subscription.
-    this._activeHandlers.forEach((_, key) => {
-      if (key.startsWith(prefix)) {
-        keysToRemove.push(key);
-      }
-    });
+    this._resetActiveTimeout(active);
 
-    keysToRemove.forEach((key) => {
+    const shouldEmitMessage = !stream.endOfStream || this._hasStreamPayload(message);
+    if (shouldEmitMessage) {
+      const onMessageArgs: OnGroupStreamDataArgs = {
+        group: message.group,
+        fromUserId: message.fromUserId,
+        sequenceId: message.sequenceId,
+        dataType: message.dataType,
+        data: message.data,
+        stream,
+      };
+      this._fireMessage(active.handlers, onMessageArgs);
+    }
+
+    if (stream.endOfStream) {
+      const terminalArgs: OnGroupStreamEndArgs = {
+        streamId: stream.streamId,
+        group: message.group,
+        error: stream.error,
+      };
+      if (stream.error != null) {
+        this._fireError(active.handlers, terminalArgs);
+      } else {
+        this._fireComplete(active.handlers, terminalArgs);
+      }
       this._clearActiveTimeout(key);
-      this._activeHandlers.delete(key);
-    });
-  }
-
-  private _buildHandlerKey(subscriptionId: string, groupName: string, streamId: string): string {
-    return `${subscriptionId}|${groupName}|${streamId}`;
-  }
-
-  private _invokeOnMessage(active: ActiveStreamHandler, args: OnGroupStreamDataArgs): void {
-    try {
-      active.handler.onMessage?.(args);
-    } catch (err) {
-      logger.warning("Stream handler onMessage failed.", err);
+      this._activeStreams.delete(key);
     }
   }
 
-  private _invokeOnComplete(active: ActiveStreamHandler, args: OnGroupStreamEndArgs): void {
-    try {
-      active.handler.onComplete?.(args);
-    } catch (err) {
-      logger.warning("Stream handler onComplete failed.", err);
+  private _invokeFactories(
+    factories: readonly GroupStreamFactory[],
+    streamView: GroupStream,
+  ): GroupStreamHandler[] {
+    const handlers: GroupStreamHandler[] = [];
+    for (const factory of factories) {
+      try {
+        handlers.push(factory(streamView));
+      } catch (err) {
+        logger.warning("group-stream factory threw.", err);
+      }
+    }
+    return handlers;
+  }
+
+  private _fireMessage(handlers: GroupStreamHandler[], args: OnGroupStreamDataArgs): void {
+    for (const handler of handlers) {
+      if (handler.onMessage == null) continue;
+      try {
+        handler.onMessage(args);
+      } catch (err) {
+        logger.warning("group-stream onMessage handler failed.", err);
+      }
     }
   }
 
-  private _invokeOnError(
-    active: ActiveStreamHandler,
-    error: StreamDataError,
-    args?: OnGroupStreamEndArgs,
-  ): void {
-    try {
-      active.handler.onError?.(
-        args ?? {
-          streamId: active.streamId,
-          group: active.group,
-          error,
-        },
-      );
-    } catch (err) {
-      logger.warning("Stream handler onError failed.", err);
+  private _fireComplete(handlers: GroupStreamHandler[], args: OnGroupStreamEndArgs): void {
+    for (const handler of handlers) {
+      if (handler.onComplete == null) continue;
+      try {
+        handler.onComplete(args);
+      } catch (err) {
+        logger.warning("group-stream onComplete handler failed.", err);
+      }
     }
   }
 
-  private _resetActiveTimeout(active: ActiveStreamHandler): void {
+  private _fireError(handlers: GroupStreamHandler[], args: OnGroupStreamEndArgs): void {
+    for (const handler of handlers) {
+      if (handler.onError == null) continue;
+      try {
+        handler.onError(args);
+      } catch (err) {
+        logger.warning("group-stream onError handler failed.", err);
+      }
+    }
+  }
+
+  private _buildKey(groupName: string, streamId: string): string {
+    return `${groupName}|${streamId}`;
+  }
+
+  private _resetActiveTimeout(active: ActiveStream): void {
     this._clearActiveTimeout(active.key);
     const timeout = setTimeout(() => {
-      const current = this._activeHandlers.get(active.key);
+      const current = this._activeStreams.get(active.key);
       if (current == null || current !== active) {
         return;
       }
 
       const timeoutError: StreamDataError = {
         name: "IdleTimeout",
-        message: "Stream handler idle timeout: no data received within ttlInMs in client registry.",
+        message: "Stream idle timeout: no data received within ttlInMs in client registry.",
       };
-      this._invokeOnError(current, timeoutError);
-      this._activeHandlers.delete(active.key);
+      this._fireError(current.handlers, {
+        streamId: current.streamId,
+        group: current.group,
+        error: timeoutError,
+      });
+      this._activeStreams.delete(active.key);
       this._clearActiveTimeout(active.key);
     }, active.ttlInMs);
 
@@ -257,51 +242,10 @@ export class InboundStreamSession {
   }
 }
 
-class InboundStreamSubscription {
-  public readonly id: string;
-  public readonly groupName: string;
-  public readonly options: InboundStreamOptions;
-  public readonly handlerFactory: (streamId: string) => GroupStreamHandler;
-  // Tracks streamIds currently skipped by handleFromStart=true.
-  public readonly ignoredStreamIds: Set<string>;
-
-  constructor(
-    id: string,
-    groupName: string,
-    options: InboundStreamOptions,
-    handlerFactory: (streamId: string) => GroupStreamHandler,
-  ) {
-    this.id = id;
-    this.groupName = groupName;
-    this.options = options;
-    this.handlerFactory = handlerFactory;
-    this.ignoredStreamIds = new Set<string>();
-  }
-}
-
-class ActiveStreamHandler {
-  // Composite key: `${subscriptionId}|${groupName}|${streamId}`.
-  public readonly key: string;
-  public readonly streamId: string;
-  public readonly group: string;
-  public readonly handler: GroupStreamHandler;
-  private readonly _ttlInMs: number;
-
-  constructor(
-    key: string,
-    streamId: string,
-    group: string,
-    handler: GroupStreamHandler,
-    ttlInMs: number,
-  ) {
-    this.key = key;
-    this.streamId = streamId;
-    this.group = group;
-    this.handler = handler;
-    this._ttlInMs = ttlInMs;
-  }
-
-  public get ttlInMs(): number {
-    return this._ttlInMs;
-  }
+interface ActiveStream {
+  readonly key: string;
+  readonly group: string;
+  readonly streamId: string;
+  readonly ttlInMs: number;
+  readonly handlers: GroupStreamHandler[];
 }

--- a/sdk/web-pubsub/web-pubsub-client/src/inboundStreamSession.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/inboundStreamSession.ts
@@ -3,7 +3,7 @@
 
 import { logger } from "./logger.js";
 import type {
-  GroupStream,
+  OnGroupStreamArgs,
   GroupStreamHandler,
   GroupStreamOptions,
   OnGroupStreamDataArgs,
@@ -18,7 +18,7 @@ const DEFAULT_HANDLE_FROM_START = false;
  * Factory invoked once for every newly observed inbound stream. The returned
  * `GroupStreamHandler` is bound to that single stream's lifecycle.
  */
-export type GroupStreamFactory = (stream: GroupStream) => GroupStreamHandler;
+export type GroupStreamFactory = (args: OnGroupStreamArgs) => GroupStreamHandler;
 
 /**
  * Provides the current set of registered factories. Read at message-processing
@@ -87,7 +87,7 @@ export class InboundStreamSession {
         return;
       }
 
-      const streamView: GroupStream = {
+      const streamView: OnGroupStreamArgs = {
         group: message.group,
         streamId: stream.streamId,
       };
@@ -135,7 +135,7 @@ export class InboundStreamSession {
 
   private _invokeFactories(
     factories: readonly GroupStreamFactory[],
-    streamView: GroupStream,
+    streamView: OnGroupStreamArgs,
   ): GroupStreamHandler[] {
     const handlers: GroupStreamHandler[] = [];
     for (const factory of factories) {

--- a/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
@@ -55,7 +55,7 @@ export interface WebPubSubClientOptions {
   keepAliveIntervalInMs?: number;
   /**
    * Options that control how inbound group streams are tracked and dispatched
-   * to `"group-stream"` listeners.
+   * to factories registered via `client.onGroupStream(...)`.
    */
   groupStreamOptions?: GroupStreamOptions;
 }
@@ -384,11 +384,11 @@ export interface OnGroupStreamEndArgs {
 }
 
 /**
- * Per-stream value object passed to a `"group-stream"` factory. Each unique
- * `(group, streamId)` produces exactly one `GroupStream` instance. The factory
- * returns a `GroupStreamHandler` whose callbacks consume that single stream.
+ * Per-stream value object passed to a factory registered via
+ * `client.onGroupStream(...)`. * `GroupStream` instance is created per observed stream lifecycle. The factory returns a `GroupStreamHandler`
+ * whose callbacks consume that single stream.
  */
-export interface GroupStream {
+export interface OnGroupStreamArgs {
   /**
    * The group this stream belongs to.
    */
@@ -401,7 +401,7 @@ export interface GroupStream {
 
 /**
  * Callbacks attached to a single inbound group stream. Returned by the factory
- * registered via `client.on("group-stream", factory)`. All callbacks are optional.
+ * registered via `client.onGroupStream(factory)`. All callbacks are optional.
  */
 export interface GroupStreamHandler {
   /**
@@ -420,7 +420,7 @@ export interface GroupStreamHandler {
 
 /**
  * Client-wide options controlling how inbound group streams are tracked and
- * dispatched to `"group-stream"` listeners.
+ * dispatched to factories registered via `client.onGroupStream(...)`.
  */
 export interface GroupStreamOptions {
   /**

--- a/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/models/index.ts
@@ -53,6 +53,11 @@ export interface WebPubSubClientOptions {
    * (again, about 3x lower) so the timeout only triggers when multiple pings fail.
    */
   keepAliveIntervalInMs?: number;
+  /**
+   * Options that control how inbound group streams are tracked and dispatched
+   * to `"group-stream"` listeners.
+   */
+  groupStreamOptions?: GroupStreamOptions;
 }
 
 /**
@@ -379,31 +384,49 @@ export interface OnGroupStreamEndArgs {
 }
 
 /**
- * Callback contract for consuming one logical stream.
+ * Per-stream value object passed to a `"group-stream"` factory. Each unique
+ * `(group, streamId)` produces exactly one `GroupStream` instance. The factory
+ * returns a `GroupStreamHandler` whose callbacks consume that single stream.
+ */
+export interface GroupStream {
+  /**
+   * The group this stream belongs to.
+   */
+  readonly group: string;
+  /**
+   * The stream identifier assigned by the publisher.
+   */
+  readonly streamId: string;
+}
+
+/**
+ * Callbacks attached to a single inbound group stream. Returned by the factory
+ * registered via `client.on("group-stream", factory)`. All callbacks are optional.
  */
 export interface GroupStreamHandler {
   /**
-   * Called for every stream fragment.
+   * Called for each non-terminal data fragment.
    */
   onMessage?: (args: OnGroupStreamDataArgs) => void;
   /**
-   * Called when the stream completes without error.
+   * Called once when the stream completes successfully.
    */
   onComplete?: (args: OnGroupStreamEndArgs) => void;
   /**
-   * Called when the stream ends with error.
+   * Called once when the stream terminates with an error (including `IdleTimeout`).
    */
   onError?: (args: OnGroupStreamEndArgs) => void;
 }
 
 /**
- * onGroupStream operation options.
+ * Client-wide options controlling how inbound group streams are tracked and
+ * dispatched to `"group-stream"` listeners.
  */
-export interface OnGroupStreamOptions {
+export interface GroupStreamOptions {
   /**
-   * Inactivity timeout in milliseconds for a stream handler in the client-side registry.
+   * Inactivity timeout in milliseconds for an active stream in the client-side registry.
    * The timer is reset whenever a new stream fragment is received.
-   * If no fragment arrives within this duration, the stream handler is evicted.
+   * If no fragment arrives within this duration, the stream is terminated with an `IdleTimeout` error.
    * Default: 300000 (5 minutes).
    */
   ttlInMs?: number;
@@ -414,16 +437,6 @@ export interface OnGroupStreamOptions {
    * Default: false.
    */
   handleFromStart?: boolean;
-}
-
-/**
- * Group stream subscription handle returned by `onGroupStream`.
- */
-export interface GroupStreamSubscription {
-  /**
-   * Unregister this stream subscription.
-   */
-  close(): void;
 }
 
 /**

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -322,7 +322,7 @@ export class WebPubSubClient {
       | "server-message"
       | "group-message"
       | "rejoin-group-failed",
-    listener: (arg: any) => any,
+    listener: (e: any) => void,
   ): void {
     this._emitter.on(event, listener);
   }
@@ -383,7 +383,7 @@ export class WebPubSubClient {
       | "server-message"
       | "group-message"
       | "rejoin-group-failed",
-    listener: (arg: any) => any,
+    listener: (e: any) => void,
   ): void {
     this._emitter.removeListener(event, listener);
   }

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -29,7 +29,7 @@ import type {
   SendStreamDataOptions,
   SendStreamKeepaliveOptions,
   EndStreamOptions,
-  GroupStream,
+  OnGroupStreamArgs,
   GroupStreamHandler,
   StreamPublisher,
 } from "./models/index.js";
@@ -107,6 +107,8 @@ export class WebPubSubClient {
   private readonly _keepAliveIntervalInMs: number;
 
   private readonly _emitter: EventEmitter = new EventEmitter();
+  private readonly _groupStreamFactories: Array<(args: OnGroupStreamArgs) => GroupStreamHandler> =
+    [];
   private _state: WebPubSubClientState;
   private _isStopping: boolean = false;
   private _pingKeepaliveTask: AbortableTask | undefined;
@@ -153,10 +155,7 @@ export class WebPubSubClient {
     this._protocol = this._options.protocol!;
     this._groupMap = new Map<string, WebPubSubGroup>();
     this._inboundStreams = new InboundStreamSession(
-      () =>
-        this._emitter.listeners("group-stream") as Array<
-          (stream: GroupStream) => GroupStreamHandler
-        >,
+      () => this._groupStreamFactories,
       this._options.groupStreamOptions,
     );
     this._outboundStreams = new Map<string, OutboundStreamSession>();
@@ -310,16 +309,6 @@ export class WebPubSubClient {
    */
   public on(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
   /**
-   * Register a factory invoked once for each newly observed inbound group stream
-   * (across all groups). The factory receives a per-stream `GroupStream` value
-   * (`{ group, streamId }`) and must return a `GroupStreamHandler` whose callbacks
-   * consume that single stream. Returning a fresh closure per call gives every
-   * stream its own independent state.
-   * @param event - The event name
-   * @param factory - Per-stream factory returning a `GroupStreamHandler`.
-   */
-  public on(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
-  /**
    * Add handler for rejoining group failed
    * @param event - The event name
    * @param listener - The handler
@@ -332,11 +321,22 @@ export class WebPubSubClient {
       | "stopped"
       | "server-message"
       | "group-message"
-      | "group-stream"
       | "rejoin-group-failed",
-    listenerOrFactory: (arg: any) => any,
+    listener: (arg: any) => any,
   ): void {
-    this._emitter.on(event, listenerOrFactory);
+    this._emitter.on(event, listener);
+  }
+
+  /**
+   * Register a factory invoked once for each newly observed inbound group stream
+   * (across all groups). The factory receives a per-stream `OnGroupStreamArgs`
+   * value (`{ group, streamId }`) and must return a `GroupStreamHandler` whose
+   * callbacks consume that single stream. Returning a fresh closure per call
+   * gives every stream its own independent state.
+   * @param factory - Per-stream factory returning a `GroupStreamHandler`.
+   */
+  public onGroupStream(factory: (args: OnGroupStreamArgs) => GroupStreamHandler): void {
+    this._groupStreamFactories.push(factory);
   }
 
   /**
@@ -370,13 +370,6 @@ export class WebPubSubClient {
    */
   public off(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
   /**
-   * Remove a previously registered `"group-stream"` factory. Pass the same
-   * factory reference that was supplied to `on`.
-   * @param event - The event name
-   * @param factory - The factory reference originally registered via `on`.
-   */
-  public off(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
-  /**
    * Remove handler for rejoining group failed
    * @param event - The event name
    * @param listener - The handler
@@ -389,11 +382,22 @@ export class WebPubSubClient {
       | "stopped"
       | "server-message"
       | "group-message"
-      | "group-stream"
       | "rejoin-group-failed",
-    listenerOrFactory: (arg: any) => any,
+    listener: (arg: any) => any,
   ): void {
-    this._emitter.removeListener(event, listenerOrFactory);
+    this._emitter.removeListener(event, listener);
+  }
+
+  /**
+   * Remove a previously registered group stream factory. Pass the same factory
+   * reference that was supplied to {@link onGroupStream}.
+   * @param factory - The factory reference originally registered via {@link onGroupStream}.
+   */
+  public offGroupStream(factory: (args: OnGroupStreamArgs) => GroupStreamHandler): void {
+    const index = this._groupStreamFactories.indexOf(factory);
+    if (index >= 0) {
+      this._groupStreamFactories.splice(index, 1);
+    }
   }
 
   private _emitEvent(event: "connected", args: OnConnectedArgs): void;

--- a/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
+++ b/sdk/web-pubsub/web-pubsub-client/src/webPubSubClient.ts
@@ -29,10 +29,9 @@ import type {
   SendStreamDataOptions,
   SendStreamKeepaliveOptions,
   EndStreamOptions,
+  GroupStream,
   GroupStreamHandler,
-  OnGroupStreamOptions,
   StreamPublisher,
-  GroupStreamSubscription as GroupStreamSubscriptionHandle,
 } from "./models/index.js";
 import type {
   ConnectedMessage,
@@ -153,7 +152,13 @@ export class WebPubSubClient {
 
     this._protocol = this._options.protocol!;
     this._groupMap = new Map<string, WebPubSubGroup>();
-    this._inboundStreams = new InboundStreamSession();
+    this._inboundStreams = new InboundStreamSession(
+      () =>
+        this._emitter.listeners("group-stream") as Array<
+          (stream: GroupStream) => GroupStreamHandler
+        >,
+      this._options.groupStreamOptions,
+    );
     this._outboundStreams = new Map<string, OutboundStreamSession>();
     this._ackManager = new AckManager();
     this._invocationManager = new InvocationManager();
@@ -305,6 +310,16 @@ export class WebPubSubClient {
    */
   public on(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
   /**
+   * Register a factory invoked once for each newly observed inbound group stream
+   * (across all groups). The factory receives a per-stream `GroupStream` value
+   * (`{ group, streamId }`) and must return a `GroupStreamHandler` whose callbacks
+   * consume that single stream. Returning a fresh closure per call gives every
+   * stream its own independent state.
+   * @param event - The event name
+   * @param factory - Per-stream factory returning a `GroupStreamHandler`.
+   */
+  public on(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
+  /**
    * Add handler for rejoining group failed
    * @param event - The event name
    * @param listener - The handler
@@ -317,10 +332,11 @@ export class WebPubSubClient {
       | "stopped"
       | "server-message"
       | "group-message"
+      | "group-stream"
       | "rejoin-group-failed",
-    listener: (e: any) => void,
+    listenerOrFactory: (arg: any) => any,
   ): void {
-    this._emitter.on(event, listener);
+    this._emitter.on(event, listenerOrFactory);
   }
 
   /**
@@ -354,6 +370,13 @@ export class WebPubSubClient {
    */
   public off(event: "group-message", listener: (e: OnGroupDataMessageArgs) => void): void;
   /**
+   * Remove a previously registered `"group-stream"` factory. Pass the same
+   * factory reference that was supplied to `on`.
+   * @param event - The event name
+   * @param factory - The factory reference originally registered via `on`.
+   */
+  public off(event: "group-stream", factory: (stream: GroupStream) => GroupStreamHandler): void;
+  /**
    * Remove handler for rejoining group failed
    * @param event - The event name
    * @param listener - The handler
@@ -366,25 +389,11 @@ export class WebPubSubClient {
       | "stopped"
       | "server-message"
       | "group-message"
+      | "group-stream"
       | "rejoin-group-failed",
-    listener: (e: any) => void,
+    listenerOrFactory: (arg: any) => any,
   ): void {
-    this._emitter.removeListener(event, listener);
-  }
-
-  /**
-   * Register a stream handler factory for a group.
-   * @param groupName - The target group name.
-   * @param handlerFactory - Creates one handler per stream id.
-   * @param options - Stream receive options.
-   * @returns A stream subscription object. Call `close()` to unregister this stream subscription.
-   */
-  public onGroupStream(
-    groupName: string,
-    handlerFactory: (streamId: string) => GroupStreamHandler,
-    options?: OnGroupStreamOptions,
-  ): GroupStreamSubscriptionHandle {
-    return this._inboundStreams.subscribe(groupName, handlerFactory, options);
+    this._emitter.removeListener(event, listenerOrFactory);
   }
 
   private _emitEvent(event: "connected", args: OnConnectedArgs): void;

--- a/sdk/web-pubsub/web-pubsub-client/test/integration/client.streaming.integration.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/integration/client.streaming.integration.spec.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { WebPubSubServiceClient } from "@azure/web-pubsub";
 import { WebPubSubClient } from "../../src/webPubSubClient.js";
 import type {
-  GroupStream,
+  OnGroupStreamArgs,
   GroupStreamHandler,
   WebPubSubClientOptions,
 } from "../../src/models/index.js";
@@ -109,7 +109,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<{ streamId: string; text: string }>();
-    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((stream: OnGroupStreamArgs): GroupStreamHandler => {
       const chunks: string[] = [];
       return {
         onMessage: (args) => {
@@ -144,7 +144,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<{ streamId: string; messageCount: number }>();
-    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((stream: OnGroupStreamArgs): GroupStreamHandler => {
       let messageCount = 0;
       return {
         onMessage: () => {
@@ -177,7 +177,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<Array<{ index: number; payload: string }>>();
-    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((stream: OnGroupStreamArgs): GroupStreamHandler => {
       const records: Array<{ index: number; payload: string }> = [];
       return {
         onMessage: (args) => {
@@ -222,7 +222,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<Uint8Array>();
-    receiver.on("group-stream", (_stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((_stream: OnGroupStreamArgs): GroupStreamHandler => {
       let latest = new Uint8Array();
       return {
         onMessage: (args) => {
@@ -257,7 +257,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
 
     const allDone = createDeferred<Record<string, string>>();
     const result: Record<string, string> = {};
-    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((stream: OnGroupStreamArgs): GroupStreamHandler => {
       const chunks: string[] = [];
       return {
         onMessage: (args) => {
@@ -339,7 +339,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const secondCompleted = createDeferred<{ generation: number; chunks: string[] }>();
     let generation = 0;
 
-    receiver.on("group-stream", (_stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((_stream: OnGroupStreamArgs): GroupStreamHandler => {
       generation++;
       const currentGeneration = generation;
       const chunks: string[] = [];
@@ -404,7 +404,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const freshCompleted = createDeferred<{ generation: number; chunks: string[] }>();
     let generation = 0;
 
-    receiver.on("group-stream", (_stream: GroupStream): GroupStreamHandler => {
+    receiver.onGroupStream((_stream: OnGroupStreamArgs): GroupStreamHandler => {
       generation++;
       const currentGeneration = generation;
       const chunks: string[] = [];
@@ -472,9 +472,8 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const errored = createDeferred<{ name: string; message?: string; userErrorCode?: string }>();
-    receiver.on(
-      "group-stream",
-      (_stream: GroupStream): GroupStreamHandler => ({
+    receiver.onGroupStream(
+      (_stream: OnGroupStreamArgs): GroupStreamHandler => ({
         onError: (args) => {
           if (args.error != null) {
             errored.resolve({

--- a/sdk/web-pubsub/web-pubsub-client/test/integration/client.streaming.integration.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/integration/client.streaming.integration.spec.ts
@@ -4,6 +4,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { WebPubSubServiceClient } from "@azure/web-pubsub";
 import { WebPubSubClient } from "../../src/webPubSubClient.js";
+import type {
+  GroupStream,
+  GroupStreamHandler,
+  WebPubSubClientOptions,
+} from "../../src/models/index.js";
 import { createDeferred, sleep, withTimeout } from "../testUtils.js";
 
 async function waitForStreamIdReusable(
@@ -47,9 +52,10 @@ async function createAuthedClient(
   userId: string,
   roles: string[],
   clients: WebPubSubClient[],
+  options?: WebPubSubClientOptions,
 ): Promise<WebPubSubClient> {
   const token = await serviceClient.getClientAccessToken({ userId, roles });
-  const client = new WebPubSubClient(token.url);
+  const client = new WebPubSubClient(token.url, options);
   clients.push(client);
   return client;
 }
@@ -58,6 +64,7 @@ async function createSenderReceiver(
   serviceClient: WebPubSubServiceClient,
   ts: number,
   clients: WebPubSubClient[],
+  receiverOptions?: WebPubSubClientOptions,
 ): Promise<{ sender: WebPubSubClient; receiver: WebPubSubClient }> {
   const sender = await createAuthedClient(
     serviceClient,
@@ -70,6 +77,7 @@ async function createSenderReceiver(
     `receiver-${ts}`,
     DEFAULT_RECEIVER_ROLES,
     clients,
+    receiverOptions,
   );
   return { sender, receiver };
 }
@@ -101,14 +109,14 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<{ streamId: string; text: string }>();
-    receiver.onGroupStream(group, (streamId) => {
+    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
       const chunks: string[] = [];
       return {
         onMessage: (args) => {
           chunks.push(args.data as string);
         },
         onComplete: () => {
-          completed.resolve({ streamId, text: chunks.join("") });
+          completed.resolve({ streamId: stream.streamId, text: chunks.join("") });
         },
       };
     });
@@ -136,14 +144,14 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<{ streamId: string; messageCount: number }>();
-    receiver.onGroupStream(group, (streamId) => {
+    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
       let messageCount = 0;
       return {
         onMessage: () => {
           messageCount++;
         },
         onComplete: () => {
-          completed.resolve({ streamId, messageCount });
+          completed.resolve({ streamId: stream.streamId, messageCount });
         },
       };
     });
@@ -169,7 +177,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<Array<{ index: number; payload: string }>>();
-    receiver.onGroupStream(group, (streamId) => {
+    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
       const records: Array<{ index: number; payload: string }> = [];
       return {
         onMessage: (args) => {
@@ -184,7 +192,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
           }
         },
         onComplete: (args) => {
-          if (args.streamId === streamId) {
+          if (args.streamId === stream.streamId) {
             completed.resolve(records);
           }
         },
@@ -214,7 +222,7 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const completed = createDeferred<Uint8Array>();
-    receiver.onGroupStream(group, () => {
+    receiver.on("group-stream", (_stream: GroupStream): GroupStreamHandler => {
       let latest = new Uint8Array();
       return {
         onMessage: (args) => {
@@ -249,14 +257,14 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
 
     const allDone = createDeferred<Record<string, string>>();
     const result: Record<string, string> = {};
-    receiver.onGroupStream(group, (streamId) => {
+    receiver.on("group-stream", (stream: GroupStream): GroupStreamHandler => {
       const chunks: string[] = [];
       return {
         onMessage: (args) => {
           chunks.push(args.data as string);
         },
         onComplete: () => {
-          result[streamId] = chunks.join("");
+          result[stream.streamId] = chunks.join("");
           if (Object.keys(result).length === 2) {
             allDone.resolve(result);
           }
@@ -322,40 +330,38 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const ts = Date.now();
     const group = `stream-receiver-expire-start-${ts}`;
 
-    const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
+    const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients, {
+      groupStreamOptions: { ttlInMs: 200, handleFromStart: false },
+    });
 
     const firstMessage = createDeferred<void>();
     const firstExpired = createDeferred<void>();
     const secondCompleted = createDeferred<{ generation: number; chunks: string[] }>();
     let generation = 0;
 
-    receiver.onGroupStream(
-      group,
-      () => {
-        generation++;
-        const currentGeneration = generation;
-        const chunks: string[] = [];
-        return {
-          onMessage: (args) => {
-            chunks.push(args.data as string);
-            if (currentGeneration === 1 && args.stream.streamSequenceId === 1) {
-              firstMessage.resolve();
-            }
-          },
-          onError: (args) => {
-            if (currentGeneration === 1 && args.error?.name === "IdleTimeout") {
-              firstExpired.resolve();
-            }
-          },
-          onComplete: () => {
-            if (currentGeneration === 2) {
-              secondCompleted.resolve({ generation: currentGeneration, chunks: [...chunks] });
-            }
-          },
-        };
-      },
-      { ttlInMs: 200, handleFromStart: false },
-    );
+    receiver.on("group-stream", (_stream: GroupStream): GroupStreamHandler => {
+      generation++;
+      const currentGeneration = generation;
+      const chunks: string[] = [];
+      return {
+        onMessage: (args) => {
+          chunks.push(args.data as string);
+          if (currentGeneration === 1 && args.stream.streamSequenceId === 1) {
+            firstMessage.resolve();
+          }
+        },
+        onError: (args) => {
+          if (currentGeneration === 1 && args.error?.name === "IdleTimeout") {
+            firstExpired.resolve();
+          }
+        },
+        onComplete: () => {
+          if (currentGeneration === 2) {
+            secondCompleted.resolve({ generation: currentGeneration, chunks: [...chunks] });
+          }
+        },
+      };
+    });
 
     await startSenderReceiverInGroup(sender, receiver, group);
 
@@ -389,40 +395,38 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const group = `stream-receiver-expire-strict-${ts}`;
     const streamId = `s-receiver-expire-strict-${ts}`;
 
-    const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
+    const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients, {
+      groupStreamOptions: { ttlInMs: 200, handleFromStart: true },
+    });
 
     const firstMessage = createDeferred<void>();
     const firstExpired = createDeferred<void>();
     const freshCompleted = createDeferred<{ generation: number; chunks: string[] }>();
     let generation = 0;
 
-    receiver.onGroupStream(
-      group,
-      () => {
-        generation++;
-        const currentGeneration = generation;
-        const chunks: string[] = [];
-        return {
-          onMessage: (args) => {
-            chunks.push(args.data as string);
-            if (currentGeneration === 1 && args.stream.streamSequenceId === 1) {
-              firstMessage.resolve();
-            }
-          },
-          onError: (args) => {
-            if (currentGeneration === 1 && args.error?.name === "IdleTimeout") {
-              firstExpired.resolve();
-            }
-          },
-          onComplete: () => {
-            if (currentGeneration === 2) {
-              freshCompleted.resolve({ generation: currentGeneration, chunks: [...chunks] });
-            }
-          },
-        };
-      },
-      { ttlInMs: 200, handleFromStart: true },
-    );
+    receiver.on("group-stream", (_stream: GroupStream): GroupStreamHandler => {
+      generation++;
+      const currentGeneration = generation;
+      const chunks: string[] = [];
+      return {
+        onMessage: (args) => {
+          chunks.push(args.data as string);
+          if (currentGeneration === 1 && args.stream.streamSequenceId === 1) {
+            firstMessage.resolve();
+          }
+        },
+        onError: (args) => {
+          if (currentGeneration === 1 && args.error?.name === "IdleTimeout") {
+            firstExpired.resolve();
+          }
+        },
+        onComplete: () => {
+          if (currentGeneration === 2) {
+            freshCompleted.resolve({ generation: currentGeneration, chunks: [...chunks] });
+          }
+        },
+      };
+    });
 
     await startSenderReceiverInGroup(sender, receiver, group);
 
@@ -468,17 +472,20 @@ describe.skipIf(skipIntegration)("WebPubSubClient streaming integration", () => 
     const { sender, receiver } = await createSenderReceiver(serviceClient, ts, clients);
 
     const errored = createDeferred<{ name: string; message?: string; userErrorCode?: string }>();
-    receiver.onGroupStream(group, () => ({
-      onError: (args) => {
-        if (args.error != null) {
-          errored.resolve({
-            name: args.error.name,
-            message: args.error.message,
-            userErrorCode: args.error.userErrorCode,
-          });
-        }
-      },
-    }));
+    receiver.on(
+      "group-stream",
+      (_stream: GroupStream): GroupStreamHandler => ({
+        onError: (args) => {
+          if (args.error != null) {
+            errored.resolve({
+              name: args.error.name,
+              message: args.error.message,
+              userErrorCode: args.error.userErrorCode,
+            });
+          }
+        },
+      }),
+    );
 
     await startSenderReceiverInGroup(sender, receiver, group);
 

--- a/sdk/web-pubsub/web-pubsub-client/test/node/client.streaming.e2e.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/node/client.streaming.e2e.spec.ts
@@ -6,6 +6,7 @@ import type { AddressInfo } from "node:net";
 import { WebSocketServer, type WebSocket } from "ws";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { WebPubSubClient } from "../../src/webPubSubClient.js";
+import type { GroupStream, GroupStreamHandler } from "../../src/models/index.js";
 import { createDeferred, withTimeout } from "../testUtils.js";
 
 async function waitForSocketConnection(wss: WebSocketServer): Promise<WebSocket> {
@@ -268,16 +269,19 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const socket = await startClientAndConnect(client, wss);
 
-    const streamErrorViaOnGroupStream = withTimeout(
+    const streamErrorViaGroupStream = withTimeout(
       new Promise<{ streamId: string; group: string; error: any }>((resolve) => {
-        client!.onGroupStream("g1", () => ({
-          onError: (args) => {
-            resolve({ streamId: args.streamId, group: args.group, error: args.error });
-          },
-        }));
+        client!.on(
+          "group-stream",
+          (_stream): GroupStreamHandler => ({
+            onError: (args) => {
+              resolve({ streamId: args.streamId, group: args.group, error: args.error });
+            },
+          }),
+        );
       }),
       2000,
-      "Timed out waiting for endOfStream error to trigger onGroupStream.onError.",
+      "Timed out waiting for endOfStream error to trigger group-stream onError.",
     );
 
     // First message creates the active handler
@@ -297,7 +301,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       error: { name: "StreamNotFound", message: "not found" },
     });
 
-    await expect(streamErrorViaOnGroupStream).resolves.toEqual({
+    await expect(streamErrorViaGroupStream).resolves.toEqual({
       streamId: "s-closed",
       group: "g1",
       error: { name: "StreamNotFound", message: "not found" },
@@ -406,16 +410,16 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       autoReconnect: false,
       keepAliveIntervalInMs: 0,
       keepAliveTimeoutInMs: 0,
+      groupStreamOptions: { handleFromStart: true, ttlInMs: 2000 },
     });
 
     const socket = await startClientAndConnect(client, wss);
 
     const streamDone = withTimeout(
       new Promise<{ result: string; error?: any }>((resolve) => {
-        const chunks: string[] = [];
-        client!.onGroupStream(
-          "g1",
-          () => ({
+        client!.on("group-stream", (_stream): GroupStreamHandler => {
+          const chunks: string[] = [];
+          return {
             onMessage: (args) => {
               chunks.push(args.data as string);
             },
@@ -425,9 +429,8 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
             onError: (args) => {
               resolve({ result: chunks.join(""), error: args.error });
             },
-          }),
-          { handleFromStart: true, ttlInMs: 2000 },
-        );
+          };
+        });
       }),
       2000,
       "Timed out waiting for stream completion.",
@@ -454,19 +457,19 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       autoReconnect: false,
       keepAliveIntervalInMs: 0,
       keepAliveTimeoutInMs: 0,
+      groupStreamOptions: { handleFromStart: true },
     });
 
     const socket = await startClientAndConnect(client, wss);
 
     let called = false;
-    client.onGroupStream(
-      "g1",
-      () => ({
+    client.on(
+      "group-stream",
+      (_stream): GroupStreamHandler => ({
         onMessage: () => {
           called = true;
         },
       }),
-      { handleFromStart: true },
     );
 
     sendGroupStreamMessage(socket, {
@@ -485,25 +488,24 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       autoReconnect: false,
       keepAliveIntervalInMs: 0,
       keepAliveTimeoutInMs: 0,
+      groupStreamOptions: { ttlInMs: 120, handleFromStart: true },
     });
 
     const socket = await startClientAndConnect(client, wss);
 
     const timeoutResult = withTimeout(
       new Promise<{ messageCount: number; errorName?: string }>((resolve) => {
-        let messageCount = 0;
-        client!.onGroupStream(
-          "g1",
-          () => ({
+        client!.on("group-stream", (_stream): GroupStreamHandler => {
+          let messageCount = 0;
+          return {
             onMessage: () => {
               messageCount++;
             },
             onError: (args) => {
               resolve({ messageCount, errorName: args.error?.name });
             },
-          }),
-          { ttlInMs: 120, handleFromStart: true },
-        );
+          };
+        });
       }),
       2000,
       "Timed out waiting for stream idle timeout callback.",
@@ -533,16 +535,18 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const sequence = withTimeout(
       new Promise<string[]>((resolve) => {
-        const order: string[] = [];
-        client!.onGroupStream("g1", () => ({
-          onMessage: (args) => {
-            order.push(`message:${args.data as string}`);
-          },
-          onError: (args) => {
-            order.push(`error:${args.error?.name}`);
-            resolve(order);
-          },
-        }));
+        client!.on("group-stream", (_stream): GroupStreamHandler => {
+          const order: string[] = [];
+          return {
+            onMessage: (args) => {
+              order.push(`message:${args.data as string}`);
+            },
+            onError: (args) => {
+              order.push(`error:${args.error?.name}`);
+              resolve(order);
+            },
+          };
+        });
       }),
       2000,
       "Timed out waiting for endOfStream error callbacks.",
@@ -570,15 +574,17 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const result = withTimeout(
       new Promise<{ messageCount: number; completed: boolean }>((resolve) => {
-        let messageCount = 0;
-        client!.onGroupStream("g1", () => ({
-          onMessage: () => {
-            messageCount++;
-          },
-          onComplete: () => {
-            resolve({ messageCount, completed: true });
-          },
-        }));
+        client!.on("group-stream", (_stream): GroupStreamHandler => {
+          let messageCount = 0;
+          return {
+            onMessage: () => {
+              messageCount++;
+            },
+            onComplete: () => {
+              resolve({ messageCount, completed: true });
+            },
+          };
+        });
       }),
       2000,
       "Timed out waiting for endOfStream completion callback.",
@@ -599,21 +605,20 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       autoReconnect: false,
       keepAliveIntervalInMs: 0,
       keepAliveTimeoutInMs: 0,
+      groupStreamOptions: { handleFromStart: true },
     });
 
     const socket = await startClientAndConnect(client, wss);
 
     const done = withTimeout(
       new Promise<string>((resolve) => {
-        const chunks: string[] = [];
-        client!.onGroupStream(
-          "g1",
-          () => ({
+        client!.on("group-stream", (_stream): GroupStreamHandler => {
+          const chunks: string[] = [];
+          return {
             onMessage: (args) => chunks.push(args.data as string),
             onComplete: () => resolve(chunks.join("")),
-          }),
-          { handleFromStart: true },
-        );
+          };
+        });
       }),
       3000,
       "Timed out waiting for reused streamId to complete.",
@@ -655,21 +660,20 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       autoReconnect: false,
       keepAliveIntervalInMs: 0,
       keepAliveTimeoutInMs: 0,
+      groupStreamOptions: { handleFromStart: true },
     });
 
     const socket = await startClientAndConnect(client, wss);
 
     const done = withTimeout(
       new Promise<string>((resolve) => {
-        const chunks: string[] = [];
-        client!.onGroupStream(
-          "g1",
-          () => ({
+        client!.on("group-stream", (_stream): GroupStreamHandler => {
+          const chunks: string[] = [];
+          return {
             onMessage: (args) => chunks.push(args.data as string),
             onComplete: () => resolve(chunks.join("")),
-          }),
-          { handleFromStart: true },
-        );
+          };
+        });
       }),
       3000,
       "Timed out waiting for stream completion after late terminal fragment.",
@@ -735,7 +739,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
     expect(removedHandlerCalled).toBe(false);
   });
 
-  it("stops delivering stream lifecycle callbacks after onGroupStream disposer is called", async () => {
+  it("stops delivering stream lifecycle callbacks after group-stream listener is removed", async () => {
     client = new WebPubSubClient(`ws://127.0.0.1:${port}`, {
       autoReconnect: false,
       keepAliveIntervalInMs: 0,
@@ -749,7 +753,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
     client.on("group-message", onGroupMessage);
 
     let invoked = false;
-    const subscription = client.onGroupStream("g1", () => ({
+    const groupStreamFactory = (_stream: GroupStream): GroupStreamHandler => ({
       onMessage: () => {
         invoked = true;
       },
@@ -759,8 +763,9 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
       onError: () => {
         invoked = true;
       },
-    }));
-    subscription.close();
+    });
+    client.on("group-stream", groupStreamFactory);
+    client.off("group-stream", groupStreamFactory);
 
     sendGroupStreamMessage(socket, {
       streamId: "disposed-stream",

--- a/sdk/web-pubsub/web-pubsub-client/test/node/client.streaming.e2e.spec.ts
+++ b/sdk/web-pubsub/web-pubsub-client/test/node/client.streaming.e2e.spec.ts
@@ -6,7 +6,7 @@ import type { AddressInfo } from "node:net";
 import { WebSocketServer, type WebSocket } from "ws";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { WebPubSubClient } from "../../src/webPubSubClient.js";
-import type { GroupStream, GroupStreamHandler } from "../../src/models/index.js";
+import type { OnGroupStreamArgs, GroupStreamHandler } from "../../src/models/index.js";
 import { createDeferred, withTimeout } from "../testUtils.js";
 
 async function waitForSocketConnection(wss: WebSocketServer): Promise<WebSocket> {
@@ -271,8 +271,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const streamErrorViaGroupStream = withTimeout(
       new Promise<{ streamId: string; group: string; error: any }>((resolve) => {
-        client!.on(
-          "group-stream",
+        client!.onGroupStream(
           (_stream): GroupStreamHandler => ({
             onError: (args) => {
               resolve({ streamId: args.streamId, group: args.group, error: args.error });
@@ -417,7 +416,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const streamDone = withTimeout(
       new Promise<{ result: string; error?: any }>((resolve) => {
-        client!.on("group-stream", (_stream): GroupStreamHandler => {
+        client!.onGroupStream((_stream): GroupStreamHandler => {
           const chunks: string[] = [];
           return {
             onMessage: (args) => {
@@ -463,8 +462,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
     const socket = await startClientAndConnect(client, wss);
 
     let called = false;
-    client.on(
-      "group-stream",
+    client.onGroupStream(
       (_stream): GroupStreamHandler => ({
         onMessage: () => {
           called = true;
@@ -495,7 +493,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const timeoutResult = withTimeout(
       new Promise<{ messageCount: number; errorName?: string }>((resolve) => {
-        client!.on("group-stream", (_stream): GroupStreamHandler => {
+        client!.onGroupStream((_stream): GroupStreamHandler => {
           let messageCount = 0;
           return {
             onMessage: () => {
@@ -535,7 +533,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const sequence = withTimeout(
       new Promise<string[]>((resolve) => {
-        client!.on("group-stream", (_stream): GroupStreamHandler => {
+        client!.onGroupStream((_stream): GroupStreamHandler => {
           const order: string[] = [];
           return {
             onMessage: (args) => {
@@ -574,7 +572,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const result = withTimeout(
       new Promise<{ messageCount: number; completed: boolean }>((resolve) => {
-        client!.on("group-stream", (_stream): GroupStreamHandler => {
+        client!.onGroupStream((_stream): GroupStreamHandler => {
           let messageCount = 0;
           return {
             onMessage: () => {
@@ -612,7 +610,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const done = withTimeout(
       new Promise<string>((resolve) => {
-        client!.on("group-stream", (_stream): GroupStreamHandler => {
+        client!.onGroupStream((_stream): GroupStreamHandler => {
           const chunks: string[] = [];
           return {
             onMessage: (args) => chunks.push(args.data as string),
@@ -667,7 +665,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
 
     const done = withTimeout(
       new Promise<string>((resolve) => {
-        client!.on("group-stream", (_stream): GroupStreamHandler => {
+        client!.onGroupStream((_stream): GroupStreamHandler => {
           const chunks: string[] = [];
           return {
             onMessage: (args) => chunks.push(args.data as string),
@@ -753,7 +751,7 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
     client.on("group-message", onGroupMessage);
 
     let invoked = false;
-    const groupStreamFactory = (_stream: GroupStream): GroupStreamHandler => ({
+    const groupStreamFactory = (_stream: OnGroupStreamArgs): GroupStreamHandler => ({
       onMessage: () => {
         invoked = true;
       },
@@ -764,8 +762,8 @@ describe("WebPubSubClient streaming e2e compatibility", () => {
         invoked = true;
       },
     });
-    client.on("group-stream", groupStreamFactory);
-    client.off("group-stream", groupStreamFactory);
+    client.onGroupStream(groupStreamFactory);
+    client.offGroupStream(groupStreamFactory);
 
     sendGroupStreamMessage(socket, {
       streamId: "disposed-stream",


### PR DESCRIPTION
### Packages impacted by this PR
- `@azure/web-pubsub-client`

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
The previous group-stream API required callers to subscribe per-stream via a
dedicated `subscribeGroupStream(group, streamId => handler, options)` call. This PR replaces that surface with
an event-style registration on the client itself, so consumers register **once**
and the client routes every incoming group stream to the registered handler
factory.

This API has not been released yet (the package is still at `1.0.5` Unreleased),
so it is a direct replacement rather than a deprecation.

Provide a list of related PRs (if any)
N/A

Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

Checklists
 

- [x] Added impacted package name to the issue description

 - [ ] Does this PR needs any fixes in the SDK Generator? — N/A, this package is not generated.
 - [ ]  Added a changelog