### PR TITLE
[warp] fix test failures on windows

### DIFF
--- a/common/tools/warp/src/resolveImports.ts
+++ b/common/tools/warp/src/resolveImports.ts
@@ -663,7 +663,7 @@ function lookupImportTarget(
   for (const { regex, key, condition } of wildcardPatterns) {
     const match = resolvedPath.match(regex);
     if (match && match[1]) {
-      return { key: key.replace("*", match[1]), condition };
+      return { key: key.replace("*", match[1].replaceAll("\\", "/")), condition };
     }
   }
   return undefined;

--- a/common/tools/warp/test/public/build.spec.ts
+++ b/common/tools/warp/test/public/build.spec.ts
@@ -514,7 +514,7 @@ describe("build (integration)", () => {
     // Must contain the directory component — NOT just "helper.ts"
     expect(helperMap.sources.some((s) => s.endsWith("helper.ts"))).toBe(true);
     // The path must reach back to src/ (relative from dist/commonjs/internal/)
-    expect(helperMap.sources.some((s) => s.includes("src/"))).toBe(true);
+    expect(helperMap.sources.some((s) => s.includes("src/") || s.includes("src\\"))).toBe(true);
 
     // Root-level file should also point to .ts
     const indexMap = await readSourceMap(path.join(tmpDir, "dist/commonjs/index.js.map"));

--- a/common/tools/warp/test/public/parallel.spec.ts
+++ b/common/tools/warp/test/public/parallel.spec.ts
@@ -1084,6 +1084,7 @@ describe("parallel chaos tests", () => {
 // ---------------------------------------------------------------------------
 
 const isRoot = process.getuid?.() === 0;
+const isWindows = process.platform === "win32";
 
 describe("fault injection: filesystem errors in workers", () => {
   let tmpDir: string;
@@ -1123,7 +1124,7 @@ describe("fault injection: filesystem errors in workers", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it.skipIf(isRoot)(
+  it.skipIf(isRoot || isWindows)(
     "EACCES: read-only dist/ causes worker crash during emit, fails cleanly",
     async () => {
       await setupProject(tmpDir, {
@@ -1144,7 +1145,7 @@ describe("fault injection: filesystem errors in workers", () => {
     },
   );
 
-  it.skipIf(isRoot)(
+  it.skipIf(isRoot || isWindows)(
     "EACCES: read-only target outDir causes worker crash, other targets still report",
     async () => {
       await setupProject(tmpDir, {
@@ -1169,7 +1170,7 @@ describe("fault injection: filesystem errors in workers", () => {
     },
   );
 
-  it.skipIf(isRoot)(
+  it.skipIf(isRoot || isWindows)(
     "EACCES: unreadable source file produces diagnostic, does not hang",
     async () => {
       await setupProject(tmpDir, {
@@ -1193,28 +1194,31 @@ describe("fault injection: filesystem errors in workers", () => {
     },
   );
 
-  it("broken symlink source file produces diagnostic, does not crash workers", async () => {
-    await setupProject(tmpDir, {
-      sources: {
-        "index.ts": 'import { broken } from "./broken.js";\nexport { broken };\n',
-      },
-      targets: [{ name: "esm", condition: "import" }],
-    });
+  it.skipIf(isWindows)(
+    "broken symlink source file produces diagnostic, does not crash workers",
+    async () => {
+      await setupProject(tmpDir, {
+        sources: {
+          "index.ts": 'import { broken } from "./broken.js";\nexport { broken };\n',
+        },
+        targets: [{ name: "esm", condition: "import" }],
+      });
 
-    await fs.symlink(
-      path.join(tmpDir, "src/nonexistent-target.ts"),
-      path.join(tmpDir, "src/broken.ts"),
-    );
+      await fs.symlink(
+        path.join(tmpDir, "src/nonexistent-target.ts"),
+        path.join(tmpDir, "src/broken.ts"),
+      );
 
-    let threw = false;
-    let result: Awaited<ReturnType<typeof build>> | undefined;
-    try {
-      result = await build({ cwd: tmpDir, parallel: true });
-    } catch {
-      threw = true;
-    }
-    expect(threw || result?.success === false).toBe(true);
-  });
+      let threw = false;
+      let result: Awaited<ReturnType<typeof build>> | undefined;
+      try {
+        result = await build({ cwd: tmpDir, parallel: true });
+      } catch {
+        threw = true;
+      }
+      expect(threw || result?.success === false).toBe(true);
+    },
+  );
 
   it("output path collision: dist/esm is a file, not a directory", async () => {
     await setupProject(tmpDir, {

--- a/common/tools/warp/test/public/platformValidation.spec.ts
+++ b/common/tools/warp/test/public/platformValidation.spec.ts
@@ -17,7 +17,9 @@ async function collectSourceFiles(srcDir: string): Promise<string[]> {
   const sourceFiles: string[] = [];
   if (!ts.sys.directoryExists(srcDir)) return sourceFiles;
   for (const entry of ts.sys.readDirectory(srcDir, [".ts", ".mts", ".cts"], [], [])) {
-    sourceFiles.push(entry);
+    // Normalize to OS-native separators so paths match regex patterns
+    // built by buildImportTargetIndex (which uses path.resolve).
+    sourceFiles.push(path.resolve(entry));
   }
   for (const subdir of ts.sys.getDirectories(srcDir)) {
     sourceFiles.push(...(await collectSourceFiles(path.join(srcDir, subdir))));


### PR DESCRIPTION
- normalize path separator
- skip symlink tests that require admin elevation