### PR TITLE
fix(transcription-JS sdk): address APIView feedback

### DIFF
--- a/sdk/transcription/ai-speech-transcription/CHANGELOG.md
+++ b/sdk/transcription/ai-speech-transcription/CHANGELOG.md
@@ -2,17 +2,11 @@
 
 ## 1.0.0-beta.2 (2026-05-13)
 
-### Features Added
-
 ### Breaking Changes
 
 - Renamed `offsetMilliseconds` and `durationMilliseconds` to `offsetInMs` and `durationInMs` on `TranscribedPhrase` and `TranscribedWord` to align with the Azure SDK design guidelines for duration-valued properties.
 - Renamed `TranscriptionClientOptionalParams` to `TranscriptionClientOptions` and `TranscribeOptionalParams` to `TranscribeOptions` to follow the `<Name>Options` naming convention.
 - Removed `string` from the `FileContents` union type to avoid ambiguity with file paths and URLs. Pass a `NodeJS.ReadableStream`, `ReadableStream<Uint8Array>`, `Uint8Array`, or `Blob` instead.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.0.0-beta.1 (2026-03-13)
 

--- a/sdk/transcription/ai-speech-transcription/CHANGELOG.md
+++ b/sdk/transcription/ai-speech-transcription/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2026-05-13)
 
 ### Features Added
 
 ### Breaking Changes
+
+- Renamed `offsetMilliseconds` and `durationMilliseconds` to `offsetInMs` and `durationInMs` on `TranscribedPhrase` and `TranscribedWord` to align with the Azure SDK design guidelines for duration-valued properties.
+- Renamed `TranscriptionClientOptionalParams` to `TranscriptionClientOptions` and `TranscribeOptionalParams` to `TranscribeOptions` to follow the `<Name>Options` naming convention.
+- Removed `string` from the `FileContents` union type to avoid ambiguity with file paths and URLs. Pass a `NodeJS.ReadableStream`, `ReadableStream<Uint8Array>`, `Uint8Array`, or `Blob` instead.
 
 ### Bugs Fixed
 

--- a/sdk/transcription/ai-speech-transcription/README.md
+++ b/sdk/transcription/ai-speech-transcription/README.md
@@ -186,13 +186,11 @@ const audioFile = readFileSync("path/to/audio.wav");
 const result = await client.transcribe(audioFile);
 for (const phrase of result.phrases) {
   console.log(`Phrase: ${phrase.text}`);
-  console.log(
-    `  Offset: ${phrase.offsetMilliseconds}ms | Duration: ${phrase.durationMilliseconds}ms`,
-  );
+  console.log(`  Offset: ${phrase.offsetInMs}ms | Duration: ${phrase.durationInMs}ms`);
   console.log(`  Confidence: ${phrase.confidence.toFixed(2)}`);
   // Access individual words in the phrase
   for (const word of phrase.words ?? []) {
-    console.log(`    Word: '${word.text}' | Offset: ${word.offsetMilliseconds}ms`);
+    console.log(`    Word: '${word.text}' | Offset: ${word.offsetInMs}ms`);
   }
 }
 ```

--- a/sdk/transcription/ai-speech-transcription/generated/api/index.ts
+++ b/sdk/transcription/ai-speech-transcription/generated/api/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 export { transcribe } from "./operations.js";
-export { TranscribeOptionalParams } from "./options.js";
-export {
-  createTranscription,
+export type { TranscribeOptionalParams } from "./options.js";
+export type {
   TranscriptionContext,
   TranscriptionClientOptionalParams,
 } from "./transcriptionContext.js";
+export { createTranscription } from "./transcriptionContext.js";

--- a/sdk/transcription/ai-speech-transcription/generated/index.ts
+++ b/sdk/transcription/ai-speech-transcription/generated/index.ts
@@ -4,7 +4,7 @@
 import { FileContents } from "./static-helpers/multipartHelpers.js";
 
 export { TranscriptionClient } from "./transcriptionClient.js";
-export {
+export type {
   TranscriptionContent,
   TranscriptionOptions,
   ProfanityFilterMode,
@@ -15,7 +15,7 @@ export {
   ChannelCombinedPhrases,
   TranscribedPhrase,
   TranscribedWord,
-  KnownServiceApiVersions,
 } from "./models/index.js";
-export { TranscribeOptionalParams, TranscriptionClientOptionalParams } from "./api/index.js";
-export { FileContents };
+export { KnownServiceApiVersions } from "./models/index.js";
+export type { TranscribeOptionalParams, TranscriptionClientOptionalParams } from "./api/index.js";
+export type { FileContents };

--- a/sdk/transcription/ai-speech-transcription/generated/models/index.ts
+++ b/sdk/transcription/ai-speech-transcription/generated/models/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export {
+export type {
   TranscriptionContent,
   TranscriptionOptions,
   ProfanityFilterMode,
@@ -12,5 +12,5 @@ export {
   ChannelCombinedPhrases,
   TranscribedPhrase,
   TranscribedWord,
-  KnownServiceApiVersions,
 } from "./models.js";
+export { KnownServiceApiVersions } from "./models.js";

--- a/sdk/transcription/ai-speech-transcription/generated/models/models.ts
+++ b/sdk/transcription/ai-speech-transcription/generated/models/models.ts
@@ -187,9 +187,9 @@ export interface TranscribedPhrase {
   /** A unique integer number that is assigned to each speaker detected in the audio without particular order. Only present if speaker diarization is enabled. */
   speaker?: number;
   /** The start offset of the phrase in milliseconds. */
-  offsetMilliseconds: number;
+  offsetInMs: number;
   /** The duration of the phrase in milliseconds. */
-  durationMilliseconds: number;
+  durationInMs: number;
   /** The transcribed text of the phrase. */
   text: string;
   /** The words that make up the phrase. Only present if word-level timestamps are enabled. */
@@ -204,8 +204,8 @@ export function transcribedPhraseDeserializer(item: any): TranscribedPhrase {
   return {
     channel: item["channel"],
     speaker: item["speaker"],
-    offsetMilliseconds: item["offsetMilliseconds"],
-    durationMilliseconds: item["durationMilliseconds"],
+    offsetInMs: item["offsetMilliseconds"],
+    durationInMs: item["durationMilliseconds"],
     text: item["text"],
     words: !item["words"] ? item["words"] : transcribedWordArrayDeserializer(item["words"]),
     locale: item["locale"],
@@ -224,16 +224,16 @@ export interface TranscribedWord {
   /** The recognized word, including punctuation. */
   text: string;
   /** The start offset of the word in milliseconds. */
-  offsetMilliseconds: number;
+  offsetInMs: number;
   /** The duration of the word in milliseconds. */
-  durationMilliseconds: number;
+  durationInMs: number;
 }
 
 export function transcribedWordDeserializer(item: any): TranscribedWord {
   return {
     text: item["text"],
-    offsetMilliseconds: item["offsetMilliseconds"],
-    durationMilliseconds: item["durationMilliseconds"],
+    offsetInMs: item["offsetMilliseconds"],
+    durationInMs: item["durationMilliseconds"],
   };
 }
 

--- a/sdk/transcription/ai-speech-transcription/generated/static-helpers/urlTemplate.ts
+++ b/sdk/transcription/ai-speech-transcription/generated/static-helpers/urlTemplate.ts
@@ -187,14 +187,14 @@ export function expandUrlTemplate(
       expr = expr.slice(1);
     }
     const varList = expr.split(/,/g);
-    const result = [];
+    const innerResult = [];
     for (const varSpec of varList) {
       const varMatch = /([^:*]*)(?::(\d+)|(\*))?/.exec(varSpec);
       if (!varMatch || !varMatch[1]) {
         continue;
       }
       const varValue = getVarValue({
-        isFirst: result.length === 0,
+        isFirst: innerResult.length === 0,
         op,
         varValue: context[varMatch[1]],
         varName: varMatch[1],
@@ -202,10 +202,10 @@ export function expandUrlTemplate(
         reserved: option?.allowReserved,
       });
       if (varValue) {
-        result.push(varValue);
+        innerResult.push(varValue);
       }
     }
-    return result.join("");
+    return innerResult.join("");
   });
 
   return normalizeUnreserved(result);
@@ -219,7 +219,7 @@ function normalizeUnreserved(uri: string): string {
   return uri.replace(/%([0-9A-Fa-f]{2})/g, (match, hex) => {
     const char = String.fromCharCode(parseInt(hex, 16));
     // Decode only if it's unreserved
-    if (/[\-.~]/.test(char)) {
+    if (/[.~-]/.test(char)) {
       return char;
     }
     return match; // leave other encodings intact

--- a/sdk/transcription/ai-speech-transcription/generated/transcriptionClient.ts
+++ b/sdk/transcription/ai-speech-transcription/generated/transcriptionClient.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import {
-  createTranscription,
   TranscriptionContext,
   TranscriptionClientOptionalParams,
+  createTranscription,
 } from "./api/index.js";
 import { transcribe } from "./api/operations.js";
 import { TranscribeOptionalParams } from "./api/options.js";
@@ -12,7 +12,7 @@ import { TranscriptionContent, TranscriptionResult } from "./models/models.js";
 import { KeyCredential, TokenCredential } from "@azure/core-auth";
 import { Pipeline } from "@azure/core-rest-pipeline";
 
-export { TranscriptionClientOptionalParams } from "./api/transcriptionContext.js";
+export type { TranscriptionClientOptionalParams } from "./api/transcriptionContext.js";
 
 export class TranscriptionClient {
   private _client: TranscriptionContext;

--- a/sdk/transcription/ai-speech-transcription/metadata.json
+++ b/sdk/transcription/ai-speech-transcription/metadata.json
@@ -1,6 +1,8 @@
 {
-  "apiVersion": "2025-10-15",
-  "emitterVersion": "0.49.0",
+  "apiVersions": {
+    "Azure.Ai.Speech.Transcription": "2025-10-15"
+  },
+  "emitterVersion": "0.52.3",
   "crossLanguageDefinitions": {
     "CrossLanguagePackageId": "Azure.Ai.Speech.Transcription",
     "CrossLanguageDefinitionId": {

--- a/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-api-node.api.md
+++ b/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-api-node.api.md
@@ -11,17 +11,17 @@ import type { OperationOptions } from '@azure-rest/core-client';
 import type { TokenCredential } from '@azure/core-auth';
 
 // @public (undocumented)
-export function createTranscription(endpoint: string, credential: KeyCredential | TokenCredential, options?: TranscriptionClientOptionalParams): TranscriptionContext;
+export function createTranscription(endpoint: string, credential: KeyCredential | TokenCredential, options?: TranscriptionClientOptions): TranscriptionContext;
 
 // @public
-export function transcribe(context: TranscriptionContext, body: TranscriptionContent, options?: TranscribeOptionalParams): Promise<TranscriptionResult>;
+export function transcribe(context: TranscriptionContext, body: TranscriptionContent, options?: TranscribeOptions): Promise<TranscriptionResult>;
 
 // @public
-export interface TranscribeOptionalParams extends OperationOptions {
+export interface TranscribeOptions extends OperationOptions {
 }
 
 // @public
-export interface TranscriptionClientOptionalParams extends ClientOptions {
+export interface TranscriptionClientOptions extends ClientOptions {
     serviceVersion?: string;
 }
 

--- a/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-models-node.api.md
+++ b/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-models-node.api.md
@@ -43,9 +43,9 @@ export type ProfanityFilterMode = string;
 export interface TranscribedPhrase {
     channel?: number;
     confidence: number;
-    durationMilliseconds: number;
+    durationInMs: number;
     locale?: string;
-    offsetMilliseconds: number;
+    offsetInMs: number;
     speaker?: number;
     text: string;
     words?: TranscribedWord[];
@@ -53,8 +53,8 @@ export interface TranscribedPhrase {
 
 // @public
 export interface TranscribedWord {
-    durationMilliseconds: number;
-    offsetMilliseconds: number;
+    durationInMs: number;
+    offsetInMs: number;
     text: string;
 }
 

--- a/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-node.api.md
+++ b/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-node.api.md
@@ -24,7 +24,7 @@ export interface EnhancedModeOptions {
 }
 
 // @public
-export type FileContents = string | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Uint8Array | Blob;
+export type FileContents = NodeJS.ReadableStream | ReadableStream<Uint8Array> | Uint8Array | Blob;
 
 // @public
 export enum KnownProfanityFilterModes {
@@ -52,9 +52,9 @@ export type ProfanityFilterMode = string;
 export interface TranscribedPhrase {
     channel?: number;
     confidence: number;
-    durationMilliseconds: number;
+    durationInMs: number;
     locale?: string;
-    offsetMilliseconds: number;
+    offsetInMs: number;
     speaker?: number;
     text: string;
     words?: TranscribedWord[];
@@ -62,25 +62,25 @@ export interface TranscribedPhrase {
 
 // @public
 export interface TranscribedWord {
-    durationMilliseconds: number;
-    offsetMilliseconds: number;
+    durationInMs: number;
+    offsetInMs: number;
     text: string;
 }
 
 // @public
-export interface TranscribeOptionalParams extends OperationOptions {
+export interface TranscribeOptions extends OperationOptions {
 }
 
 // @public (undocumented)
 export class TranscriptionClient {
-    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: TranscriptionClientOptionalParams);
+    constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: TranscriptionClientOptions);
     readonly pipeline: Pipeline;
-    transcribe(audioUrl: string, options?: Omit<TranscriptionOptions, "audioUrl">, operationOptions?: TranscribeOptionalParams): Promise<TranscriptionResult>;
-    transcribe(audio: Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob, options?: Omit<TranscriptionOptions, "audioUrl">, operationOptions?: TranscribeOptionalParams): Promise<TranscriptionResult>;
+    transcribe(audioUrl: string, options?: Omit<TranscriptionOptions, "audioUrl">, operationOptions?: TranscribeOptions): Promise<TranscriptionResult>;
+    transcribe(audio: Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob, options?: Omit<TranscriptionOptions, "audioUrl">, operationOptions?: TranscribeOptions): Promise<TranscriptionResult>;
 }
 
 // @public
-export interface TranscriptionClientOptionalParams extends ClientOptions {
+export interface TranscriptionClientOptions extends ClientOptions {
     serviceVersion?: string;
 }
 

--- a/sdk/transcription/ai-speech-transcription/samples-dev/basicTranscription.ts
+++ b/sdk/transcription/ai-speech-transcription/samples-dev/basicTranscription.ts
@@ -37,7 +37,7 @@ export async function main(): Promise<void> {
   console.log("\n=== Detailed Phrases ===");
   for (const phrase of result.phrases) {
     console.log(
-      `[${phrase.offsetMilliseconds}ms - ${phrase.offsetMilliseconds + phrase.durationMilliseconds}ms] ${phrase.text}`,
+      `[${phrase.offsetInMs}ms - ${phrase.offsetInMs + phrase.durationInMs}ms] ${phrase.text}`,
     );
     console.log(`  Confidence: ${phrase.confidence.toFixed(2)}`);
   }

--- a/sdk/transcription/ai-speech-transcription/samples-dev/profanityFiltering.ts
+++ b/sdk/transcription/ai-speech-transcription/samples-dev/profanityFiltering.ts
@@ -15,7 +15,8 @@
  * @azsdk-weight 60
  */
 
-import { TranscriptionClient, ProfanityFilterMode } from "@azure/ai-speech-transcription";
+import { TranscriptionClient } from "@azure/ai-speech-transcription";
+import type { ProfanityFilterMode } from "@azure/ai-speech-transcription";
 import { AzureKeyCredential } from "@azure/core-auth";
 import * as fs from "fs";
 

--- a/sdk/transcription/ai-speech-transcription/samples/v1-beta/javascript/basicTranscription.js
+++ b/sdk/transcription/ai-speech-transcription/samples/v1-beta/javascript/basicTranscription.js
@@ -36,7 +36,7 @@ async function main() {
   console.log("\n=== Detailed Phrases ===");
   for (const phrase of result.phrases) {
     console.log(
-      `[${phrase.offsetMilliseconds}ms - ${phrase.offsetMilliseconds + phrase.durationMilliseconds}ms] ${phrase.text}`,
+      `[${phrase.offsetInMs}ms - ${phrase.offsetInMs + phrase.durationInMs}ms] ${phrase.text}`,
     );
     console.log(`  Confidence: ${phrase.confidence.toFixed(2)}`);
   }

--- a/sdk/transcription/ai-speech-transcription/samples/v1-beta/typescript/src/basicTranscription.ts
+++ b/sdk/transcription/ai-speech-transcription/samples/v1-beta/typescript/src/basicTranscription.ts
@@ -36,7 +36,7 @@ export async function main(): Promise<void> {
   console.log("\n=== Detailed Phrases ===");
   for (const phrase of result.phrases) {
     console.log(
-      `[${phrase.offsetMilliseconds}ms - ${phrase.offsetMilliseconds + phrase.durationMilliseconds}ms] ${phrase.text}`,
+      `[${phrase.offsetInMs}ms - ${phrase.offsetInMs + phrase.durationInMs}ms] ${phrase.text}`,
     );
     console.log(`  Confidence: ${phrase.confidence.toFixed(2)}`);
   }

--- a/sdk/transcription/ai-speech-transcription/samples/v1-beta/typescript/src/profanityFiltering.ts
+++ b/sdk/transcription/ai-speech-transcription/samples/v1-beta/typescript/src/profanityFiltering.ts
@@ -14,7 +14,8 @@
  * @summary control profanity handling in transcription results
  */
 
-import { TranscriptionClient, ProfanityFilterMode } from "@azure/ai-speech-transcription";
+import { TranscriptionClient } from "@azure/ai-speech-transcription";
+import type { ProfanityFilterMode } from "@azure/ai-speech-transcription";
 import { AzureKeyCredential } from "@azure/core-auth";
 import * as fs from "fs";
 

--- a/sdk/transcription/ai-speech-transcription/src/api/index.ts
+++ b/sdk/transcription/ai-speech-transcription/src/api/index.ts
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 export { transcribe } from "./operations.js";
-export type { TranscribeOptionalParams } from "./options.js";
+export type { TranscribeOptions } from "./options.js";
 export { createTranscription } from "./transcriptionContext.js";
-export type {
-  TranscriptionContext,
-  TranscriptionClientOptionalParams,
-} from "./transcriptionContext.js";
+export type { TranscriptionContext, TranscriptionClientOptions } from "./transcriptionContext.js";

--- a/sdk/transcription/ai-speech-transcription/src/api/operations.ts
+++ b/sdk/transcription/ai-speech-transcription/src/api/operations.ts
@@ -8,14 +8,14 @@ import {
   transcriptionResultDeserializer,
 } from "../models/models.js";
 import { expandUrlTemplate } from "../static-helpers/urlTemplate.js";
-import type { TranscribeOptionalParams } from "./options.js";
+import type { TranscribeOptions } from "./options.js";
 import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
 import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
 
 export function _transcribeSend(
   context: Client,
   body: TranscriptionContent,
-  options: TranscribeOptionalParams = { requestOptions: {} },
+  options: TranscribeOptions = { requestOptions: {} },
 ): StreamableMethod {
   const path = expandUrlTemplate(
     "/transcriptions:transcribe{?api%2Dversion}",
@@ -49,7 +49,7 @@ export async function _transcribeDeserialize(
 export async function transcribe(
   context: Client,
   body: TranscriptionContent,
-  options: TranscribeOptionalParams = { requestOptions: {} },
+  options: TranscribeOptions = { requestOptions: {} },
 ): Promise<TranscriptionResult> {
   const result = await _transcribeSend(context, body, options);
   return _transcribeDeserialize(result);

--- a/sdk/transcription/ai-speech-transcription/src/api/options.ts
+++ b/sdk/transcription/ai-speech-transcription/src/api/options.ts
@@ -4,4 +4,4 @@
 import type { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
-export interface TranscribeOptionalParams extends OperationOptions {}
+export interface TranscribeOptions extends OperationOptions {}

--- a/sdk/transcription/ai-speech-transcription/src/api/transcriptionContext.ts
+++ b/sdk/transcription/ai-speech-transcription/src/api/transcriptionContext.ts
@@ -12,7 +12,7 @@ export interface TranscriptionContext extends Client {
 }
 
 /** Optional parameters for the client. */
-export interface TranscriptionClientOptionalParams extends ClientOptions {
+export interface TranscriptionClientOptions extends ClientOptions {
   /** The API version to use for this operation. */
   serviceVersion?: string;
 }
@@ -20,7 +20,7 @@ export interface TranscriptionClientOptionalParams extends ClientOptions {
 export function createTranscription(
   endpoint: string,
   credential: KeyCredential | TokenCredential,
-  options: TranscriptionClientOptionalParams = {},
+  options: TranscriptionClientOptions = {},
 ): TranscriptionContext {
   const endpointUrl = options.endpoint ?? `${endpoint}/speechtotext`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;

--- a/sdk/transcription/ai-speech-transcription/src/index.ts
+++ b/sdk/transcription/ai-speech-transcription/src/index.ts
@@ -16,5 +16,5 @@ export type {
   TranscribedPhrase,
   TranscribedWord,
 } from "./models/index.js";
-export type { TranscriptionClientOptionalParams, TranscribeOptionalParams } from "./api/index.js";
+export type { TranscriptionClientOptions, TranscribeOptions } from "./api/index.js";
 export type { FileContents };

--- a/sdk/transcription/ai-speech-transcription/src/models/models.ts
+++ b/sdk/transcription/ai-speech-transcription/src/models/models.ts
@@ -211,9 +211,9 @@ export interface TranscribedPhrase {
   /** A unique integer number that is assigned to each speaker detected in the audio without particular order. Only present if speaker diarization is enabled. */
   speaker?: number;
   /** The start offset of the phrase in milliseconds. */
-  offsetMilliseconds: number;
+  offsetInMs: number;
   /** The duration of the phrase in milliseconds. */
-  durationMilliseconds: number;
+  durationInMs: number;
   /** The transcribed text of the phrase. */
   text: string;
   /** The words that make up the phrase. Only present if word-level timestamps are enabled. */
@@ -228,8 +228,8 @@ export function transcribedPhraseDeserializer(item: any): TranscribedPhrase {
   return {
     channel: item["channel"],
     speaker: item["speaker"],
-    offsetMilliseconds: item["offsetMilliseconds"],
-    durationMilliseconds: item["durationMilliseconds"],
+    offsetInMs: item["offsetMilliseconds"],
+    durationInMs: item["durationMilliseconds"],
     text: item["text"],
     words: !item["words"] ? item["words"] : transcribedWordArrayDeserializer(item["words"]),
     locale: item["locale"],
@@ -248,16 +248,16 @@ export interface TranscribedWord {
   /** The recognized word, including punctuation. */
   text: string;
   /** The start offset of the word in milliseconds. */
-  offsetMilliseconds: number;
+  offsetInMs: number;
   /** The duration of the word in milliseconds. */
-  durationMilliseconds: number;
+  durationInMs: number;
 }
 
 export function transcribedWordDeserializer(item: any): TranscribedWord {
   return {
     text: item["text"],
-    offsetMilliseconds: item["offsetMilliseconds"],
-    durationMilliseconds: item["durationMilliseconds"],
+    offsetInMs: item["offsetMilliseconds"],
+    durationInMs: item["durationMilliseconds"],
   };
 }
 

--- a/sdk/transcription/ai-speech-transcription/src/static-helpers/multipartHelpers.ts
+++ b/sdk/transcription/ai-speech-transcription/src/static-helpers/multipartHelpers.ts
@@ -4,12 +4,7 @@
 /**
  * Valid values for the contents of a binary file.
  */
-export type FileContents =
-  | string
-  | NodeJS.ReadableStream
-  | ReadableStream<Uint8Array>
-  | Uint8Array
-  | Blob;
+export type FileContents = NodeJS.ReadableStream | ReadableStream<Uint8Array> | Uint8Array | Blob;
 
 export function createFilePartDescriptor(
   partName: string,

--- a/sdk/transcription/ai-speech-transcription/src/transcriptionClient.ts
+++ b/sdk/transcription/ai-speech-transcription/src/transcriptionClient.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import { createTranscription } from "./api/index.js";
-import type { TranscriptionContext, TranscriptionClientOptionalParams } from "./api/index.js";
+import type { TranscriptionContext, TranscriptionClientOptions } from "./api/index.js";
 import { transcribe as transcribeOperation } from "./api/operations.js";
-import type { TranscribeOptionalParams } from "./api/options.js";
+import type { TranscribeOptions } from "./api/options.js";
 import type {
   TranscriptionContent,
   TranscriptionOptions,
@@ -13,7 +13,7 @@ import type {
 import type { KeyCredential, TokenCredential } from "@azure/core-auth";
 import type { Pipeline } from "@azure/core-rest-pipeline";
 
-export type { TranscriptionClientOptionalParams } from "./api/transcriptionContext.js";
+export type { TranscriptionClientOptions } from "./api/transcriptionContext.js";
 
 export class TranscriptionClient {
   private _client: TranscriptionContext;
@@ -23,7 +23,7 @@ export class TranscriptionClient {
   constructor(
     endpoint: string,
     credential: KeyCredential | TokenCredential,
-    options: TranscriptionClientOptionalParams = {},
+    options: TranscriptionClientOptions = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
@@ -40,18 +40,18 @@ export class TranscriptionClient {
   transcribe(
     audioUrl: string,
     options?: Omit<TranscriptionOptions, "audioUrl">,
-    operationOptions?: TranscribeOptionalParams,
+    operationOptions?: TranscribeOptions,
   ): Promise<TranscriptionResult>;
   /** Transcribes audio from a binary source (buffer, stream, or blob). */
   transcribe(
     audio: Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob,
     options?: Omit<TranscriptionOptions, "audioUrl">,
-    operationOptions?: TranscribeOptionalParams,
+    operationOptions?: TranscribeOptions,
   ): Promise<TranscriptionResult>;
   transcribe(
     source: string | Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob,
     options: Omit<TranscriptionOptions, "audioUrl"> = {},
-    operationOptions: TranscribeOptionalParams = { requestOptions: {} },
+    operationOptions: TranscribeOptions = { requestOptions: {} },
   ): Promise<TranscriptionResult> {
     let body: TranscriptionContent;
     if (typeof source === "string") {

--- a/sdk/transcription/ai-speech-transcription/test/public/sampleTest.spec.ts
+++ b/sdk/transcription/ai-speech-transcription/test/public/sampleTest.spec.ts
@@ -311,8 +311,8 @@ describe("TranscriptionClient", () => {
         assert.isNotNull(phrase);
         assert.isNotEmpty(phrase.text);
         assert.isNumber(phrase.confidence);
-        assert.isNumber(phrase.offsetMilliseconds);
-        assert.isNumber(phrase.durationMilliseconds);
+        assert.isNumber(phrase.offsetInMs);
+        assert.isNumber(phrase.durationInMs);
       }
     });
   });

--- a/sdk/transcription/ai-speech-transcription/test/public/utils/recordedClient.ts
+++ b/sdk/transcription/ai-speech-transcription/test/public/utils/recordedClient.ts
@@ -4,7 +4,7 @@
 import type { RecorderStartOptions, VitestTestContext } from "@azure-tools/test-recorder";
 import { env, Recorder } from "@azure-tools/test-recorder";
 import { AzureKeyCredential } from "@azure/core-auth";
-import { TranscriptionClient, type TranscriptionClientOptionalParams } from "../../../src/index.js";
+import { TranscriptionClient, type TranscriptionClientOptions } from "../../../src/index.js";
 import { resolve, join } from "node:path";
 
 const replaceableVariables: Record<string, string> = {
@@ -49,7 +49,7 @@ export async function createRecorder(context: VitestTestContext): Promise<Record
  */
 export function createClient(
   recorder: Recorder,
-  options?: TranscriptionClientOptionalParams,
+  options?: TranscriptionClientOptions,
 ): TranscriptionClient {
   const endpoint = env.TRANSCRIPTION_ENDPOINT ?? "https://eastus.api.cognitive.microsoft.com";
   const apiKey = env.TRANSCRIPTION_API_KEY ?? "fake_api_key";

--- a/sdk/transcription/ai-speech-transcription/test/snippets.spec.ts
+++ b/sdk/transcription/ai-speech-transcription/test/snippets.spec.ts
@@ -70,14 +70,12 @@ describe("snippets", () => {
 
     for (const phrase of result.phrases) {
       console.log(`Phrase: ${phrase.text}`);
-      console.log(
-        `  Offset: ${phrase.offsetMilliseconds}ms | Duration: ${phrase.durationMilliseconds}ms`,
-      );
+      console.log(`  Offset: ${phrase.offsetInMs}ms | Duration: ${phrase.durationInMs}ms`);
       console.log(`  Confidence: ${phrase.confidence.toFixed(2)}`);
 
       // Access individual words in the phrase
       for (const word of phrase.words ?? []) {
-        console.log(`    Word: '${word.text}' | Offset: ${word.offsetMilliseconds}ms`);
+        console.log(`    Word: '${word.text}' | Offset: ${word.offsetInMs}ms`);
       }
     }
   });

--- a/sdk/transcription/ai-speech-transcription/tsp-location.yaml
+++ b/sdk/transcription/ai-speech-transcription/tsp-location.yaml
@@ -1,0 +1,4 @@
+directory: specification/cognitiveservices/Speech.Transcription
+commit: d6252ab190c48cbb78b72e32404fa03043430624
+repo: Azure/azure-rest-api-specs
+additionalDirectories:


### PR DESCRIPTION
### Packages impacted by this PR
@azure/ai-speech-transcription (version 1.0.0-beta.2)

### Issues associated with this PR
1. ts-options-suffix-durations — [TranscribedPhrase](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [TranscribedWord](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) used durationMilliseconds / offsetMilliseconds instead of [durationInMs](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [offsetInMs](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html). [Guideline](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
2. [ts-naming-options](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Constructor / operation option bags were named [TranscriptionClientOptionalParams](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [TranscribeOptionalParams](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [TranscriptionClientOptions](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [TranscribeOptions](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html). [Guideline](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
3. Type safety — [FileContents](vscode-file://vscode-app/c:/Users/wangamber/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) included string, which is ambiguous with file paths / URLs and can be silently mis-handled as raw bytes.

### Describe the problem that is addressed by this PR
The @azure/ai-speech-transcription beta exposed several public API surface elements that violated the Azure SDK for JavaScript design guidelines

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
No new test files — the existing test suite already exercises every property on TranscribedPhrase, TranscribedWord, TranscriptionResult, all profanity filter modes, diarization, phrase list, multilingual transcription, enhanced mode, and URL / binary input paths. Each test was updated to reference the renamed properties / interfaces. The 18-test playback suite continues to pass.
No re-recording — the SDK rename is purely on the client-side deserialized object shape. The HTTP wire payload from the service is unchanged (still durationMilliseconds / offsetMilliseconds), and the existing recordings cover that contract. Per the repo's authoring guidelines, re-recording is not appropriate as a fix here.
Live validation — all 9 samples under samples-dev/ were also executed end-to-end against the real eastus.api.cognitive.microsoft.com service to confirm the renamed surface works in practice (basic transcription, URL transcription, locale / LID, multilingual, profanity filter modes, phrase list, diarization, combined options, enhanced mode + translation).

### Provide a list of related PRs _(if any)_
https://github.com/Azure/azure-rest-api-specs/pull/43179
### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
