### PR TITLE
Address APIView feedback - Merge transcribe() options and operationOptions into a single options bag

### DIFF
--- a/sdk/transcription/ai-speech-transcription/CHANGELOG.md
+++ b/sdk/transcription/ai-speech-transcription/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the first stable (GA) release of the `@azure/ai-speech-transcription` cl
 
 ### Breaking Changes
 
-- Combined `TranscriptionClient.transcribe`'s `options` and `operationOptions` parameters into a single options bag. `TranscriptionOptions` now extends `OperationOptions`, so callers can pass `abortSignal`, `requestOptions`, `tracingOptions`, and `onResponse` alongside transcription-specific parameters in the same object. The standalone `TranscribeOptions` interface has been removed. Callers that previously passed `(source, options, operationOptions)` should merge both objects into a single `options` argument.
+- Combined `TranscriptionClient.transcribe`'s `options` and `operationOptions` parameters into a single options bag. `TranscriptionOptions` now extends `OperationOptions`, so callers can pass `abortSignal`, `requestOptions`, `tracingOptions`, and `onResponse` alongside transcription-specific parameters in the same object. `TranscribeOptions` is no longer re-exported from the package root; it remains available from the `@azure/ai-speech-transcription/api` subpath for advanced scenarios that call the underlying operation directly. Callers that previously passed `(source, options, operationOptions)` should merge both objects into a single `options` argument.
 
 ## 1.0.0-beta.2 (2026-05-13)
 

--- a/sdk/transcription/ai-speech-transcription/CHANGELOG.md
+++ b/sdk/transcription/ai-speech-transcription/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.0.0 (2026-05-14)
+## 1.0.0 (2026-05-15)
 
 ### Features Added
 
 This is the first stable (GA) release of the `@azure/ai-speech-transcription` client library. It targets the `2025-10-15` Azure AI Speech Transcription service API version.
+
+### Breaking Changes
+
+- Combined `TranscriptionClient.transcribe`'s `options` and `operationOptions` parameters into a single options bag. `TranscriptionOptions` now extends `OperationOptions`, so callers can pass `abortSignal`, `requestOptions`, `tracingOptions`, and `onResponse` alongside transcription-specific parameters in the same object. The standalone `TranscribeOptions` interface has been removed. Callers that previously passed `(source, options, operationOptions)` should merge both objects into a single `options` argument.
 
 ## 1.0.0-beta.2 (2026-05-13)
 

--- a/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-models-node.api.md
+++ b/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-models-node.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import type { OperationOptions } from '@azure-rest/core-client';
+
 // @public
 export interface ChannelCombinedPhrases {
     channel?: number;
@@ -75,7 +77,7 @@ export interface TranscriptionDiarizationOptions {
 }
 
 // @public
-export interface TranscriptionOptions {
+export interface TranscriptionOptions extends OperationOptions {
     activeChannels?: number[];
     audioUrl?: string;
     diarizationOptions?: TranscriptionDiarizationOptions;

--- a/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-node.api.md
+++ b/sdk/transcription/ai-speech-transcription/review/ai-speech-transcription-node.api.md
@@ -67,16 +67,12 @@ export interface TranscribedWord {
     text: string;
 }
 
-// @public
-export interface TranscribeOptions extends OperationOptions {
-}
-
 // @public (undocumented)
 export class TranscriptionClient {
     constructor(endpoint: string, credential: KeyCredential | TokenCredential, options?: TranscriptionClientOptions);
     readonly pipeline: Pipeline;
-    transcribe(audioUrl: string, options?: Omit<TranscriptionOptions, "audioUrl">, operationOptions?: TranscribeOptions): Promise<TranscriptionResult>;
-    transcribe(audio: Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob, options?: Omit<TranscriptionOptions, "audioUrl">, operationOptions?: TranscribeOptions): Promise<TranscriptionResult>;
+    transcribe(audioUrl: string, options?: Omit<TranscriptionOptions, "audioUrl">): Promise<TranscriptionResult>;
+    transcribe(audio: Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob, options?: Omit<TranscriptionOptions, "audioUrl">): Promise<TranscriptionResult>;
 }
 
 // @public
@@ -91,7 +87,7 @@ export interface TranscriptionDiarizationOptions {
 }
 
 // @public
-export interface TranscriptionOptions {
+export interface TranscriptionOptions extends OperationOptions {
     activeChannels?: number[];
     audioUrl?: string;
     diarizationOptions?: TranscriptionDiarizationOptions;

--- a/sdk/transcription/ai-speech-transcription/src/index.ts
+++ b/sdk/transcription/ai-speech-transcription/src/index.ts
@@ -16,5 +16,5 @@ export type {
   TranscribedPhrase,
   TranscribedWord,
 } from "./models/index.js";
-export type { TranscriptionClientOptions, TranscribeOptions } from "./api/index.js";
+export type { TranscriptionClientOptions } from "./api/index.js";
 export type { FileContents };

--- a/sdk/transcription/ai-speech-transcription/src/models/models.ts
+++ b/sdk/transcription/ai-speech-transcription/src/models/models.ts
@@ -3,6 +3,7 @@
 
 import type { FileContents } from "../static-helpers/multipartHelpers.js";
 import { createFilePartDescriptor } from "../static-helpers/multipartHelpers.js";
+import type { OperationOptions } from "@azure-rest/core-client";
 
 /**
  * This file contains only generated model types and their (de)serializers.
@@ -39,8 +40,8 @@ export function transcriptionContentSerializer(item: TranscriptionContent): any 
   ];
 }
 
-/** Metadata for a transcription request. */
-export interface TranscriptionOptions {
+/** Metadata for a transcription request. Also serves as the optional parameters bag for {@link TranscriptionClient.transcribe}, so it supports standard operation options such as `abortSignal`, `requestOptions`, and `tracingOptions`. */
+export interface TranscriptionOptions extends OperationOptions {
   /** The URL of the audio to be transcribed. The audio must be shorter than 2 hours in audio duration and smaller than 250 MB in size. If both Audio and AudioUrl are provided, Audio is used. */
   audioUrl?: string;
   /** A list of possible locales for the transcription. If not specified, the locale of the speech in the audio is detected automatically from all supported locales. */

--- a/sdk/transcription/ai-speech-transcription/src/transcriptionClient.ts
+++ b/sdk/transcription/ai-speech-transcription/src/transcriptionClient.ts
@@ -4,7 +4,6 @@
 import { createTranscription } from "./api/index.js";
 import type { TranscriptionContext, TranscriptionClientOptions } from "./api/index.js";
 import { transcribe as transcribeOperation } from "./api/operations.js";
-import type { TranscribeOptions } from "./api/options.js";
 import type {
   TranscriptionContent,
   TranscriptionOptions,
@@ -40,31 +39,21 @@ export class TranscriptionClient {
   transcribe(
     audioUrl: string,
     options?: Omit<TranscriptionOptions, "audioUrl">,
-    operationOptions?: TranscribeOptions,
   ): Promise<TranscriptionResult>;
   /** Transcribes audio from a binary source (buffer, stream, or blob). */
   transcribe(
     audio: Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob,
     options?: Omit<TranscriptionOptions, "audioUrl">,
-    operationOptions?: TranscribeOptions,
   ): Promise<TranscriptionResult>;
   transcribe(
     source: string | Uint8Array | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Blob,
     options: Omit<TranscriptionOptions, "audioUrl"> = {},
-    operationOptions: TranscribeOptions = { requestOptions: {} },
   ): Promise<TranscriptionResult> {
-    let body: TranscriptionContent;
-    if (typeof source === "string") {
-      body = {
-        options: { ...options, audioUrl: source },
-      };
-    } else {
-      body = {
-        audio: source,
-        options,
-      };
-    }
+    const body: TranscriptionContent =
+      typeof source === "string"
+        ? { options: { ...options, audioUrl: source } }
+        : { audio: source, options };
 
-    return transcribeOperation(this._client, body, operationOptions);
+    return transcribeOperation(this._client, body, options);
   }
 }


### PR DESCRIPTION
### Packages impacted by this PR
[ai-speech-transcription] 

### Issues associated with this PR


### Describe the problem that is addressed by this PR
Combine transcribe() options into single bag

Address APIView feedback by collapsing transcribe()'s `options` and
`operationOptions` parameters into a single options bag. Callers no longer
need to pass `undefined` to reach operation options like `abortSignal`.

- `TranscriptionOptions` now extends `OperationOptions`, so standard
  operation options (`abortSignal`, `requestOptions`, `tracingOptions`,
  `onResponse`) can be passed alongside transcription-specific parameters.
- Removed the now-redundant public `TranscribeOptions` interface.
- Both `transcribe(audioUrl, ...)` and `transcribe(audio, ...)` overloads
  updated to `(source, options?: Omit<TranscriptionOptions, "audioUrl">)`.
- Body serializer cherry-picks transcription fields, so OperationOptions
  fields stay off the wire.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_
no

### Provide a list of related PRs _(if any)_
na

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
