### PR TITLE
[lint][arm-notificationhubs] restore linting options

### DIFF
--- a/sdk/notificationhubs/arm-notificationhubs/eslint.config.mjs
+++ b/sdk/notificationhubs/arm-notificationhubs/eslint.config.mjs
@@ -9,6 +9,10 @@ export default [
         "@azure/azure-sdk/ts-package-json-engine-is-present": "warn",
         "@azure/azure-sdk/ts-package-json-files-required": "off",
         "@azure/azure-sdk/ts-package-json-main-is-cjs": "off",
+        "@azure/azure-sdk/github-source-headers": "off",
+        "@typescript-eslint/no-use-before-define": "warn",
+        eqeqeq: "warn",
+        "prefer-const": "warn",
         "tsdoc/syntax": "warn"
       }
     }


### PR DESCRIPTION
This is a follow-up to the migration PR
https://github.com/Azure/azure-sdk-for-js/pull/38557.  Linting failed because
some linting options of arm-notificationhubs got removed.  This PR restores them.