### PR TITLE
fix(confidential-ledger): harden redirect handling against credential…

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Release History
 
-## 1.1.2-beta.5 (Unreleased)
+## 1.1.2-beta.6 (Unreleased)
 
 ### Features Added
 
 - Added redirect URL caching for write operations. When the Confidential Ledger load balancer issues a 307/308 redirect, the target (primary node) URL is cached so subsequent write requests skip the load balancer, reducing latency. Read requests (GET/HEAD) continue to always go through the load balancer. The cache is automatically invalidated on server errors (5xx) or transport failures.
 - Added support for HTTP 308 (Permanent Redirect) status code in the redirect policy.
+
+### Other Changes
+
+- Hardened redirect handling in the Confidential Ledger client. Credentials and request bodies are now only forwarded on HTTPS redirects whose target hostname matches the configured ledger endpoint or one of its subdomains, with the same port. Redirects to any other target are refused.
+
+## 1.1.2-beta.5 (Unreleased)
+
+### Features Added
+
+- This pre-release was not published; its contents are included in 1.1.2-beta.6.
 
 ## 1.1.2-beta.4 (2026-02-18)
 

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
-  "version": "1.1.2-beta.5",
+  "version": "1.1.2-beta.6",
   "keywords": [
     "node",
     "azure",

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
@@ -31,7 +31,7 @@ export default function createClient(
   { apiVersion = "2024-12-09-preview", ...options }: ConfidentialLedgerClientOptions = {},
 ): ConfidentialLedgerClient {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `${ledgerEndpoint}`;
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.1.2-beta.5`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.1.2-beta.6`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
@@ -50,12 +50,17 @@ export default function createClient(
   };
   const client = getClient(endpointUrl, credentials, options) as ConfidentialLedgerClient;
 
-  // Replace the default redirect policy with one that preserves all headers.
-  // The default redirectPolicy strips the Authorization header on redirect,
-  // which causes 401 errors when Confidential Ledger redirects write operations
-  // from a secondary node to the primary node.
+  // Replace the default redirect policy with one that preserves headers (including
+  // Authorization) on redirects, but ONLY for targets that remain within the trust
+  // boundary of the configured ledger endpoint (HTTPS + same origin or a subdomain
+  // with the same port). Confidential Ledger redirects write operations from the
+  // load balancer to a primary node on a subdomain, and the default redirectPolicy
+  // would strip Authorization causing 401 errors. Redirects to any other target
+  // are refused to prevent credential and request-body leakage to untrusted hosts.
   client.pipeline.removePolicy({ name: "redirectPolicy" });
-  client.pipeline.addPolicy(confidentialLedgerRedirectPolicy(), { afterPhase: "Retry" });
+  client.pipeline.addPolicy(confidentialLedgerRedirectPolicy(endpointUrl), {
+    afterPhase: "Retry",
+  });
 
   client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
   client.pipeline.addPolicy({
@@ -105,26 +110,65 @@ function rewriteUrl(originalUrl: string, cachedBaseUrl: string): string {
 }
 
 /**
- * A custom redirect policy for Confidential Ledger that preserves all headers,
- * including the Authorization header, when following redirects. Additionally,
- * caches the redirect target URL for write operations so that subsequent writes
- * skip the load balancer.
+ * A custom redirect policy for Confidential Ledger that preserves headers
+ * (including the Authorization header) when following redirects, but only when
+ * the redirect target stays within the configured ledger's trust boundary.
+ *
+ * Trust boundary:
+ * - Target URL must use HTTPS.
+ * - Target port must match the configured ledger endpoint port.
+ * - Target hostname must either equal the configured ledger hostname or be a
+ *   subdomain of it (after canonicalization: lowercase, one trailing dot stripped).
+ *
+ * Untrusted redirects:
+ * - The policy refuses to follow them by throwing a non-retryable error.
+ *   This prevents credentials AND the request body from being sent to an
+ *   untrusted host (compared to strip-and-follow, which still leaks the body).
+ * - The outer sendRequest catch handler restores the original URL/method and
+ *   invalidates the write cache so the next attempt starts clean from the
+ *   load balancer.
  *
  * Cache behavior:
- * - Write requests (POST/PUT/PATCH/DELETE) that receive a 307/308 redirect
- *   cache the target URL's base (scheme + host).
+ * - Write requests (POST/PUT/PATCH/DELETE) that receive a 307/308 redirect to a
+ *   TRUSTED target may cache the target URL's base (scheme + host + port).
+ * - The cache is staged during the redirect chain and only committed after the
+ *   chain returns a non-5xx response without any untrusted hop.
  * - Subsequent writes rewrite their URL to the cached primary before sending.
  * - Read requests (GET/HEAD/OPTIONS) never use or populate the cache.
- * - 5xx responses or transport errors on writes invalidate the cache.
+ * - 5xx responses, transport errors, or refused untrusted redirects invalidate
+ *   the cache.
  *
  * NOTE: Python SDK caches on all redirect codes (301/302/307/308). JS only
  * caches on 307/308 because JS only follows 301/302 for GET/HEAD, so writes
  * never encounter those status codes. This is an intentional difference.
  *
+ * @param endpointUrl - The configured ledger endpoint URL used as the trust anchor.
  * @param maxRetries - The maximum number of redirects to follow. Defaults to 20.
- * @returns A PipelinePolicy that handles redirects with caching.
+ * @returns A PipelinePolicy that handles redirects with trust enforcement and caching.
  */
-function confidentialLedgerRedirectPolicy(maxRetries: number = 20): PipelinePolicy {
+function confidentialLedgerRedirectPolicy(
+  endpointUrl: string,
+  maxRetries: number = 20,
+): PipelinePolicy {
+  let ledgerUrl: URL;
+  try {
+    ledgerUrl = new URL(endpointUrl);
+  } catch {
+    // If the endpoint URL is unparseable, the client cannot operate anyway;
+    // throw a clear error at policy creation rather than at first request.
+    throw new Error(`Confidential Ledger endpoint is not a valid URL: ${endpointUrl}`);
+  }
+  if (ledgerUrl.protocol !== "https:") {
+    // HTTPS is required for the bearer token policy upstream; warn loudly if
+    // the configured endpoint is not HTTPS. We do not throw to preserve
+    // test/dev scenarios that override the endpoint with a local proxy.
+    logger.warning(
+      `Confidential Ledger endpoint uses non-HTTPS scheme (${ledgerUrl.protocol}); redirect trust enforcement still requires HTTPS targets.`,
+    );
+  }
+  const ledgerHostname = canonicalHostname(ledgerUrl.hostname);
+  const ledgerPort = ledgerUrl.port;
+
   let cachedBaseUrl: string | null = null;
 
   return {
@@ -161,13 +205,28 @@ function confidentialLedgerRedirectPolicy(maxRetries: number = 20): PipelinePoli
       }
 
       // Follow redirect chain. This may mutate request.url and method (303).
+      // Cache mutations are staged via `pendingCacheUrl` and committed below
+      // only if the final response is successful (or at least not 5xx) AND no
+      // untrusted hop was encountered.
+      let pendingCacheUrl: string | null = null;
       try {
-        response = await handleRedirect(next, response, maxRetries, isWrite, (url: string) => {
-          const parsed = new URL(url);
-          cachedBaseUrl = `${parsed.protocol}//${parsed.host}`;
-        });
+        response = await handleRedirect(
+          next,
+          response,
+          maxRetries,
+          isWrite,
+          ledgerHostname,
+          ledgerPort,
+          (url: string) => {
+            const parsed = new URL(url);
+            pendingCacheUrl = `${parsed.protocol}//${parsed.host}`;
+          },
+        );
       } catch (e) {
-        // Transport error during redirect follow: restore and invalidate.
+        // Transport error OR refused untrusted redirect during redirect follow:
+        // restore the request to its original state and invalidate cache so the
+        // upstream retry policy (and any subsequent write) starts cleanly from
+        // the load balancer URL.
         request.url = originalUrl;
         request.method = originalMethod;
         if (isWrite) {
@@ -185,6 +244,9 @@ function confidentialLedgerRedirectPolicy(maxRetries: number = 20): PipelinePoli
         cachedBaseUrl = null;
         request.url = originalUrl;
         request.method = originalMethod;
+      } else if (pendingCacheUrl) {
+        // Commit the staged cache only on a successful (non-5xx) trusted chain.
+        cachedBaseUrl = pendingCacheUrl;
       }
 
       return response;
@@ -192,12 +254,38 @@ function confidentialLedgerRedirectPolicy(maxRetries: number = 20): PipelinePoli
   };
 }
 
+/**
+ * Canonicalize a hostname for trust comparison: lowercase (URL already does
+ * this) and strip a single trailing dot (FQDN absolute form).
+ */
+function canonicalHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/\.$/, "");
+}
+
+/**
+ * Returns true if the redirect target URL is inside the configured ledger's
+ * trust boundary: HTTPS, same port, and either same host or a subdomain.
+ *
+ * The subdomain check uses a leading-dot boundary so that, e.g.,
+ * `evil-test-ledger.confidential-ledger.azure.com` is NOT considered a
+ * subdomain of `test-ledger.confidential-ledger.azure.com`.
+ */
+function isTrustedRedirectTarget(target: URL, ledgerHostname: string, ledgerPort: string): boolean {
+  if (target.protocol !== "https:") return false;
+  if (target.port !== ledgerPort) return false;
+  const host = canonicalHostname(target.hostname);
+  if (host === ledgerHostname) return true;
+  return host.endsWith("." + ledgerHostname);
+}
+
 async function handleRedirect(
   next: SendRequest,
   response: PipelineResponse,
   maxRetries: number,
   isWrite: boolean,
-  cacheRedirectUrl: (url: string) => void,
+  ledgerHostname: string,
+  ledgerPort: string,
+  stageCacheUrl: (url: string) => void,
   currentRetries: number = 0,
 ): Promise<PipelineResponse> {
   const { request, status, headers } = response;
@@ -212,7 +300,28 @@ async function handleRedirect(
       status === 308) &&
     currentRetries < maxRetries
   ) {
-    const url = new URL(locationHeader, request.url);
+    let url: URL;
+    try {
+      url = new URL(locationHeader, request.url);
+    } catch {
+      // Malformed Location header — surface the original 3xx unchanged.
+      return response;
+    }
+
+    // SECURITY: refuse to follow redirects to targets outside the configured
+    // ledger's trust boundary. Throw rather than strip-and-follow so the
+    // request body is never sent to the untrusted target, and so the outer
+    // sendRequest handler restores the original URL/method and invalidates
+    // the write cache.
+    if (!isTrustedRedirectTarget(url, ledgerHostname, ledgerPort)) {
+      logger.warning(
+        `Refusing to follow Confidential Ledger redirect to untrusted target origin: ${url.origin}`,
+      );
+      throw new Error(
+        `Confidential Ledger refused to follow redirect to untrusted target origin: ${url.origin}`,
+      );
+    }
+
     request.url = url.toString();
 
     // Cache the redirect target for write methods on 307/308.
@@ -220,7 +329,7 @@ async function handleRedirect(
     // method-preserving redirects. 301/302 are only followed for GET/HEAD
     // in this policy, so writes never hit those code paths.
     if (isWrite && (status === 307 || status === 308)) {
-      cacheRedirectUrl(request.url);
+      stageCacheUrl(request.url);
     }
 
     // POST request with Status code 303 should be converted into a
@@ -234,10 +343,9 @@ async function handleRedirect(
     // Recalculate isWrite after potential 303 POST→GET conversion.
     const isWriteAfterRedirect = writeMethods.has(request.method.toUpperCase());
 
-    // NOTE: Unlike the default redirectPolicy, we intentionally do NOT strip the
-    // Authorization header here. Confidential Ledger redirects are always within
-    // the same trusted service (e.g., secondary to primary node), so credentials
-    // must be forwarded for the redirected request to succeed.
+    // Authorization header is intentionally preserved on TRUSTED redirects.
+    // Trust was validated above; cross-origin/non-HTTPS/different-port targets
+    // have already been refused.
 
     // Transport errors from redirect-follow propagate to sendRequest's
     // outer try/catch which handles URL restore and cache invalidation.
@@ -247,7 +355,9 @@ async function handleRedirect(
       res,
       maxRetries,
       isWriteAfterRedirect,
-      cacheRedirectUrl,
+      ledgerHostname,
+      ledgerPort,
+      stageCacheUrl,
       currentRetries + 1,
     );
   }

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
@@ -94,6 +94,15 @@ const allowedRedirect = ["GET", "HEAD"];
 const writeMethods = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 /**
+ * HTTP status codes that this policy interprets as redirects. Used to detect
+ * when a redirect chain terminated on an actual non-redirect response vs. one
+ * the chain failed to follow (e.g., max-retries exhausted or malformed
+ * Location). The staged cache is only committed on a terminal non-redirect
+ * response.
+ */
+const redirectStatusCodes = new Set([300, 301, 302, 303, 307, 308]);
+
+/**
  * Rewrite a URL by replacing its scheme and host with those from the cached base URL,
  * preserving the original path, query string, and fragment.
  *
@@ -244,8 +253,12 @@ function confidentialLedgerRedirectPolicy(
         cachedBaseUrl = null;
         request.url = originalUrl;
         request.method = originalMethod;
-      } else if (pendingCacheUrl) {
-        // Commit the staged cache only on a successful (non-5xx) trusted chain.
+      } else if (pendingCacheUrl && !redirectStatusCodes.has(response.status)) {
+        // Commit the staged cache only when the redirect chain reached a
+        // terminal non-redirect response. If the chain ended on a 3xx (e.g.,
+        // max-retries exhausted, malformed Location, or no Location header),
+        // we do not know the staged URL is reachable, so the cache is
+        // discarded to avoid poisoning subsequent writes.
         cachedBaseUrl = pendingCacheUrl;
       }
 

--- a/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/swagger/README.md
@@ -15,7 +15,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ../generated
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/2024-12-09-preview/confidentialledger.json
-package-version: 1.1.2-beta.5
+package-version: 1.1.2-beta.6
 hide-clients: true
 rest-level-client: true
 security: "AADToken"

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectCaching.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectCaching.spec.ts
@@ -962,5 +962,105 @@ describe("Confidential Ledger Redirect Caching", () => {
         "Read transport error should not invalidate write cache",
       );
     });
+
+    it("should NOT commit the staged cache when the chain terminates on a 3xx (max-retries exhausted)", async () => {
+      // Regression test for a bug surfaced in PR review: the staged cache
+      // would commit whenever the final response status was < 500, including
+      // when the redirect chain bottomed out on a 3xx because the maxRetries
+      // limit was reached. That would cause the next write to be rewritten
+      // to a node whose redirect chain had not successfully terminated.
+      // Use maxRetries=1 (via repeated 307 to same trusted subdomain) is not
+      // configurable, so instead we exhaust the default 20 retries by having
+      // every redirect return another 307 to a trusted subdomain.
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      // 21 calls all return 307 to the same trusted subdomain. After 20
+      // follows the chain stops and returns the 307 response unchanged.
+      for (let i = 0; i < 21; i++) {
+        next.mockResolvedValueOnce({
+          headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+          request: req1,
+          status: 307,
+        });
+      }
+      const result = await policy.sendRequest(req1, next);
+      assert.equal(result.status, 307, "Chain should bottom out on the 307 response");
+
+      // Next write must still go to the load balancer URL — the staged cache
+      // must NOT have been committed because the chain didn't reach a
+      // terminal non-redirect response.
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      // The 22nd call (index 21) is the follow-up write; it must target the LB.
+      assert.ok(
+        next.mock.calls[21][0].url.startsWith(ledgerEndpoint),
+        "Staged cache must NOT be committed when the redirect chain terminates on a 3xx",
+      );
+    });
+
+    it("should NOT commit the staged cache when the chain terminates on a 3xx with a malformed Location", async () => {
+      // Regression test for the same review bug, different trigger: the first
+      // hop is a trusted 307 (stages the cache); the second hop has a Location
+      // that `new URL()` cannot parse even with a base URL (truncated IPv6
+      // host). The redirect-follow loop catches the parse error and returns
+      // the 307 unchanged. The chain's final status is 307, so the staged
+      // cache must be discarded.
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      const req1 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: `${primaryEndpoint}/app/transactions` }),
+        request: req1,
+        status: 307,
+      });
+      // Hop 2: Location with a truncated IPv6 host. `new URL(loc, base)`
+      // throws "Invalid URL" → the redirect-follow loop returns this 307.
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: "http://[::1" }),
+        request: req1,
+        status: 307,
+      });
+      const result = await policy.sendRequest(req1, next);
+      assert.equal(result.status, 307);
+
+      // Subsequent write must still go to the load balancer URL.
+      const req2 = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions`,
+        method: "POST",
+        headers: createHttpHeaders({ Authorization: "Bearer fake-token" }),
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[2][0].url.startsWith(ledgerEndpoint),
+        "Staged cache must NOT be committed when the chain ends on a 3xx with a malformed Location",
+      );
+    });
   });
 });

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectPolicy.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectPolicy.spec.ts
@@ -56,7 +56,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirectResponse: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://test-ledger-primary.confidential-ledger.azure.com/app/transactions",
+        location: "https://node-primary.test-ledger.confidential-ledger.azure.com/app/transactions",
       }),
       request,
       status: 307,
@@ -82,7 +82,7 @@ describe("Confidential Ledger Redirect Policy", () => {
     assert.equal(redirectedRequest.headers.get("Authorization"), "Bearer fake-token");
     assert.equal(
       redirectedRequest.url,
-      "https://test-ledger-primary.confidential-ledger.azure.com/app/transactions",
+      "https://node-primary.test-ledger.confidential-ledger.azure.com/app/transactions",
     );
     // Method should remain POST for 307
     assert.equal(redirectedRequest.method, "POST");
@@ -103,7 +103,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirectResponse: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://test-ledger-primary.confidential-ledger.azure.com/app/transactions",
+        location: "https://node-primary.test-ledger.confidential-ledger.azure.com/app/transactions",
       }),
       request,
       status: 307,
@@ -137,7 +137,9 @@ describe("Confidential Ledger Redirect Policy", () => {
     });
 
     const redirectResponse: PipelineResponse = {
-      headers: createHttpHeaders({ location: "https://other.example.com/redirect" }),
+      headers: createHttpHeaders({
+        location: "https://primary.test-ledger.confidential-ledger.azure.com/redirect",
+      }),
       request,
       status: 300,
     };
@@ -168,7 +170,9 @@ describe("Confidential Ledger Redirect Policy", () => {
     });
 
     const redirectResponse: PipelineResponse = {
-      headers: createHttpHeaders({ location: "https://other.example.com/new-location" }),
+      headers: createHttpHeaders({
+        location: "https://primary.test-ledger.confidential-ledger.azure.com/new-location",
+      }),
       request,
       status: 301,
     };
@@ -226,7 +230,9 @@ describe("Confidential Ledger Redirect Policy", () => {
     });
 
     const redirectResponse: PipelineResponse = {
-      headers: createHttpHeaders({ location: "https://other.example.com/result" }),
+      headers: createHttpHeaders({
+        location: "https://primary.test-ledger.confidential-ledger.azure.com/result",
+      }),
       request,
       status: 303,
     };
@@ -288,7 +294,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirect1: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://node-1.confidential-ledger.azure.com/app/transactions",
+        location: "https://node-1.test-ledger.confidential-ledger.azure.com/app/transactions",
       }),
       request,
       status: 307,
@@ -296,7 +302,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirect2: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://node-2.confidential-ledger.azure.com/app/transactions",
+        location: "https://node-2.test-ledger.confidential-ledger.azure.com/app/transactions",
       }),
       request,
       status: 307,
@@ -326,7 +332,7 @@ describe("Confidential Ledger Redirect Policy", () => {
     // the URL reflects the final redirect target
     assert.equal(
       next.mock.calls[2][0].url,
-      "https://node-2.confidential-ledger.azure.com/app/transactions",
+      "https://node-2.test-ledger.confidential-ledger.azure.com/app/transactions",
     );
   });
 
@@ -339,7 +345,9 @@ describe("Confidential Ledger Redirect Policy", () => {
     });
 
     const redirectResponse: PipelineResponse = {
-      headers: createHttpHeaders({ location: "https://other.example.com/redirect" }),
+      headers: createHttpHeaders({
+        location: "https://loop.test-ledger.confidential-ledger.azure.com/redirect",
+      }),
       request,
       status: 300,
     };

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectPolicy.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectPolicy.spec.ts
@@ -138,7 +138,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirectResponse: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://primary.test-ledger.confidential-ledger.azure.com/redirect",
+        location: "https://node-primary.test-ledger.confidential-ledger.azure.com/redirect",
       }),
       request,
       status: 300,
@@ -171,7 +171,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirectResponse: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://primary.test-ledger.confidential-ledger.azure.com/new-location",
+        location: "https://node-primary.test-ledger.confidential-ledger.azure.com/new-location",
       }),
       request,
       status: 301,
@@ -231,7 +231,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirectResponse: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://primary.test-ledger.confidential-ledger.azure.com/result",
+        location: "https://node-primary.test-ledger.confidential-ledger.azure.com/result",
       }),
       request,
       status: 303,
@@ -346,7 +346,7 @@ describe("Confidential Ledger Redirect Policy", () => {
 
     const redirectResponse: PipelineResponse = {
       headers: createHttpHeaders({
-        location: "https://loop.test-ledger.confidential-ledger.azure.com/redirect",
+        location: "https://node-primary.test-ledger.confidential-ledger.azure.com/loop-redirect",
       }),
       request,
       status: 300,

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectTrust.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectTrust.spec.ts
@@ -1,0 +1,589 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert, vi } from "vitest";
+import type {
+  HttpClient,
+  PipelinePolicy,
+  PipelineRequest,
+  PipelineResponse,
+  SendRequest,
+} from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import createClient from "../../src/confidentialLedger.js";
+
+/**
+ * Helper to extract the custom redirect policy from a client's pipeline.
+ */
+function getRedirectPolicy(ledgerEndpoint: string): PipelinePolicy {
+  const fakeCredential = {
+    getToken: vi
+      .fn()
+      .mockResolvedValue({ token: "fake-token", expiresOnTimestamp: Date.now() + 3600000 }),
+  };
+  const client = createClient(ledgerEndpoint, fakeCredential);
+  const policies = client.pipeline.getOrderedPolicies();
+  const policy = policies.find((p) => p.name === "confidentialLedgerRedirectPolicy");
+  assert.ok(policy, "confidentialLedgerRedirectPolicy should be present in the pipeline");
+  return policy!;
+}
+
+/**
+ * Helper to create a write request with a Bearer token. The token text is
+ * checked in assertions to verify it never leaks to untrusted targets.
+ */
+function writeRequest(url: string) {
+  return createPipelineRequest({
+    url,
+    method: "POST",
+    headers: createHttpHeaders({
+      Authorization: "Bearer SECRET-TOKEN-DO-NOT-LEAK",
+      "Content-Type": "application/json",
+    }),
+    body: JSON.stringify({ contents: "sensitive write payload" }),
+  });
+}
+
+/**
+ * Helper to assert that a promise-returning thunk rejects with an error whose
+ * message matches the expected pattern. Matches the try/catch + assert.fail
+ * pattern used elsewhere in this package's test suite.
+ */
+async function expectRejection(thunk: () => Promise<unknown>, pattern: RegExp): Promise<void> {
+  let thrown: unknown = undefined;
+  let resolved = false;
+  try {
+    await thunk();
+    resolved = true;
+  } catch (e: unknown) {
+    thrown = e;
+  }
+  if (resolved) {
+    assert.fail("Expected promise to reject, but it resolved");
+  }
+  const message = thrown instanceof Error ? thrown.message : String(thrown);
+  assert.match(message, pattern);
+}
+
+describe("Confidential Ledger Redirect Trust (MSRC #116673)", () => {
+  const ledgerEndpoint = "https://test-ledger.confidential-ledger.azure.com";
+
+  describe("Untrusted redirect targets are refused", () => {
+    it("throws on 307 redirect to a cross-origin HTTPS attacker host", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({
+          location: "https://attacker.example.com/primary/app/transactions",
+        }),
+        request,
+        status: 307,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+
+      // The follow-up request to the attacker must never have happened.
+      assert.equal(next.mock.calls.length, 1);
+      // The original request URL must be restored so the upstream retry policy
+      // doesn't re-send to the attacker host.
+      assert.equal(request.url, `${ledgerEndpoint}/app/transactions`);
+      assert.equal(request.method, "POST");
+    });
+
+    it("throws on 307 redirect that downgrades to HTTP (matches MSRC PoC)", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({
+          location: "http://127.0.0.1:18901/primary/app/transactions",
+        }),
+        request,
+        status: 307,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.equal(request.url, `${ledgerEndpoint}/app/transactions`);
+    });
+
+    it("throws on 307 redirect to a sibling domain (not a subdomain)", async () => {
+      // Sibling: test-ledger-primary.confidential-ledger.azure.com is NOT a
+      // subdomain of test-ledger.confidential-ledger.azure.com.
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({
+          location: "https://test-ledger-primary.confidential-ledger.azure.com/app/transactions",
+        }),
+        request,
+        status: 307,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      assert.equal(next.mock.calls.length, 1);
+    });
+
+    it("throws on 307 redirect to a different port", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({
+          location:
+            "https://node-1.test-ledger.confidential-ledger.azure.com:8443/app/transactions",
+        }),
+        request,
+        status: 307,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      assert.equal(next.mock.calls.length, 1);
+    });
+
+    it("throws on prefix-attack: target hostname has ledger hostname as a suffix without dot boundary", async () => {
+      // ledger = test-ledger.confidential-ledger.azure.com
+      // attacker registers evil-test-ledger.confidential-ledger.azure.com (a sibling).
+      // The subdomain check must use a leading-dot boundary to reject this.
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({
+          location: "https://evil-test-ledger.confidential-ledger.azure.com/app/transactions",
+        }),
+        request,
+        status: 307,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      assert.equal(next.mock.calls.length, 1);
+    });
+
+    it("throws on protocol-relative Location pointing at an attacker host", async () => {
+      // Location: //attacker.example.com/x resolves to the current request's
+      // scheme (https) with the attacker's host. Must be refused.
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const redirect307: PipelineResponse = {
+        headers: createHttpHeaders({ location: "//attacker.example.com/app/transactions" }),
+        request,
+        status: 307,
+      };
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce(redirect307);
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      assert.equal(next.mock.calls.length, 1);
+    });
+
+    it("does not cache an untrusted redirect target", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+
+      // First write: 307 to attacker, must throw and not cache.
+      const evilReq = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: "https://attacker.example.com/x" }),
+        request: evilReq,
+        status: 307,
+      });
+      await expectRejection(() => policy.sendRequest(evilReq, next), /untrusted target origin/i);
+
+      // Second write should still go to the load balancer URL — cache must be empty.
+      const followupReq = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: followupReq,
+        status: 200,
+      });
+      await policy.sendRequest(followupReq, next);
+
+      assert.ok(
+        next.mock.calls[1][0].url.startsWith(ledgerEndpoint),
+        "Untrusted redirect must not poison the write-cache",
+      );
+    });
+
+    it("throws on 301 redirect to an untrusted host for a GET request", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions/latest`,
+        method: "GET",
+        headers: createHttpHeaders({ Authorization: "Bearer SECRET-TOKEN-DO-NOT-LEAK" }),
+      });
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: "https://attacker.example.com/x" }),
+        request,
+        status: 301,
+      });
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      // No follow-up call: the attacker host never receives the Bearer token.
+      assert.equal(next.mock.calls.length, 1);
+    });
+
+    it("throws on 302 redirect to an untrusted host for a GET request", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = createPipelineRequest({
+        url: `${ledgerEndpoint}/app/transactions/latest`,
+        method: "GET",
+        headers: createHttpHeaders({ Authorization: "Bearer SECRET-TOKEN-DO-NOT-LEAK" }),
+      });
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: "https://attacker.example.com/x" }),
+        request,
+        status: 302,
+      });
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      assert.equal(next.mock.calls.length, 1);
+    });
+
+    it("throws on 303 redirect to an untrusted host for a POST request (before POST→GET conversion)", async () => {
+      // 303 normally converts POST→GET and drops the body. The trust check must
+      // run BEFORE that conversion so that we never even attempt to send to an
+      // untrusted target — and so the original request method is preserved for
+      // a clean retry.
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: "https://attacker.example.com/result" }),
+        request,
+        status: 303,
+      });
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+      assert.equal(next.mock.calls.length, 1);
+      assert.equal(request.url, `${ledgerEndpoint}/app/transactions`);
+      // Method must NOT have been converted to GET — restored to original POST.
+      assert.equal(request.method, "POST");
+      // Body must still be present (we didn't go through the 303 strip path).
+      assert.ok(request.body, "Request body must be preserved when the redirect is refused");
+    });
+  });
+
+  describe("Trusted redirect targets are followed", () => {
+    it("follows a 307 to a subdomain and preserves Authorization", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      const subdomainTarget =
+        "https://node-1.test-ledger.confidential-ledger.azure.com/app/transactions";
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({ location: subdomainTarget }),
+        request,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request,
+        status: 200,
+      });
+
+      const result = await policy.sendRequest(request, next);
+      assert.equal(result.status, 200);
+      // Bearer token preserved verbatim on the redirected request — this is the
+      // legitimate behavior that this custom policy is needed for in the first
+      // place (the default policy would strip it on cross-host redirect).
+      assert.equal(
+        next.mock.calls[1][0].headers.get("Authorization"),
+        "Bearer SECRET-TOKEN-DO-NOT-LEAK",
+      );
+      // Request URL was rewritten to the subdomain.
+      assert.equal(next.mock.calls[1][0].url, subdomainTarget);
+      // Method preserved (307 is method-preserving).
+      assert.equal(next.mock.calls[1][0].method, "POST");
+    });
+
+    it("accepts a trailing-dot FQDN as a trusted subdomain", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://node-1.test-ledger.confidential-ledger.azure.com./app/transactions",
+        }),
+        request,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request,
+        status: 200,
+      });
+
+      const result = await policy.sendRequest(request, next);
+      assert.equal(result.status, 200);
+    });
+
+    it("accepts an uppercase hostname as a trusted subdomain", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://NODE-1.TEST-LEDGER.CONFIDENTIAL-LEDGER.AZURE.COM/app/transactions",
+        }),
+        request,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request,
+        status: 200,
+      });
+
+      const result = await policy.sendRequest(request, next);
+      assert.equal(result.status, 200);
+    });
+  });
+
+  describe("Mid-chain untrusted hop", () => {
+    it("refuses an untrusted second hop after a trusted first hop", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const request = writeRequest(`${ledgerEndpoint}/app/transactions`);
+
+      const next = vi.fn<SendRequest>();
+      // Hop 1: trusted subdomain
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://node-1.test-ledger.confidential-ledger.azure.com/app/transactions",
+        }),
+        request,
+        status: 307,
+      });
+      // Hop 2 from trusted node: redirects to attacker — must be refused
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://attacker.example.com/app/transactions",
+        }),
+        request,
+        status: 307,
+      });
+
+      await expectRejection(() => policy.sendRequest(request, next), /untrusted target origin/i);
+
+      // We made the first redirected request to the subdomain but NOT a third
+      // request to the attacker.
+      assert.equal(next.mock.calls.length, 2);
+      // URL is restored to original load balancer URL for clean retry behavior.
+      assert.equal(request.url, `${ledgerEndpoint}/app/transactions`);
+      assert.equal(request.method, "POST");
+    });
+
+    it("discards a staged cache entry when a later hop is untrusted", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+
+      // First write: trusted 307 then untrusted 307 → throws → cache must NOT be
+      // populated with the trusted hop URL.
+      const req1 = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      const next = vi.fn<SendRequest>();
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://node-1.test-ledger.confidential-ledger.azure.com/app/transactions",
+        }),
+        request: req1,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://attacker.example.com/app/transactions",
+        }),
+        request: req1,
+        status: 307,
+      });
+      await expectRejection(() => policy.sendRequest(req1, next), /untrusted target origin/i);
+
+      // Second write: should still go to the load balancer (cache must be cold).
+      const req2 = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: req2,
+        status: 200,
+      });
+      await policy.sendRequest(req2, next);
+
+      assert.ok(
+        next.mock.calls[2][0].url.startsWith(ledgerEndpoint),
+        "Staged cache entry from a partially trusted chain must be discarded on untrusted hop",
+      );
+    });
+  });
+
+  describe("Warm cache is invalidated by a malicious response from the cached node", () => {
+    it("clears the cache and restores the original URL when the cached node returns an untrusted redirect", async () => {
+      const policy = getRedirectPolicy(ledgerEndpoint);
+      const next = vi.fn<SendRequest>();
+
+      // Warm the cache legitimately.
+      const warm = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://node-1.test-ledger.confidential-ledger.azure.com/app/transactions",
+        }),
+        request: warm,
+        status: 307,
+      });
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: warm,
+        status: 200,
+      });
+      await policy.sendRequest(warm, next);
+
+      // Now the cached node returns a malicious redirect. The request URL is
+      // first rewritten to the cached node (call index 2), then the response
+      // 307 points at an attacker (must throw).
+      const malicious = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders({
+          location: "https://attacker.example.com/app/transactions",
+        }),
+        request: malicious,
+        status: 307,
+      });
+      await expectRejection(() => policy.sendRequest(malicious, next), /untrusted target origin/i);
+
+      // The request URL must be restored to the load balancer URL.
+      assert.equal(malicious.url, `${ledgerEndpoint}/app/transactions`);
+
+      // Subsequent write must go through the load balancer (cache invalidated).
+      const followup = writeRequest(`${ledgerEndpoint}/app/transactions`);
+      next.mockResolvedValueOnce({
+        headers: createHttpHeaders(),
+        request: followup,
+        status: 200,
+      });
+      await policy.sendRequest(followup, next);
+
+      assert.ok(
+        next.mock.calls[3][0].url.startsWith(ledgerEndpoint),
+        "Cache must be invalidated after the cached node issues an untrusted redirect",
+      );
+    });
+  });
+
+  describe("Full-pipeline integration: Bearer token never reaches an untrusted target", () => {
+    /**
+     * This test goes through the real createClient pipeline (including the
+     * bearerTokenAuthenticationPolicy that attaches the credential token), and
+     * uses a mock HttpClient to capture every outbound HTTP request. It is the
+     * strongest possible assertion for the MSRC vulnerability: regardless of
+     * how the upstream pipeline behaves on a redirect, the attacker host must
+     * NEVER appear in the recorded outbound requests, and therefore the Bearer
+     * token can never reach the attacker.
+     */
+    it("never sends an outbound request to an untrusted redirect target via createClient", async () => {
+      const recordedRequests: PipelineRequest[] = [];
+      const mockHttpClient: HttpClient = {
+        sendRequest: vi.fn(async (req: PipelineRequest): Promise<PipelineResponse> => {
+          // Capture a snapshot of each outbound request — including which host
+          // the URL targets and whether Authorization is attached.
+          recordedRequests.push({
+            ...req,
+            headers: createHttpHeaders({
+              Authorization: req.headers.get("Authorization") ?? "",
+            }),
+          });
+
+          // The first call (to the configured ledger endpoint) returns 307 to
+          // an attacker host. If anything in the pipeline blindly follows it,
+          // a SECOND call to attacker.example.com will appear in recordedRequests.
+          if (recordedRequests.length === 1) {
+            return {
+              status: 307,
+              headers: createHttpHeaders({
+                location: "https://attacker.example.com/primary/app/transactions",
+              }),
+              request: req,
+            };
+          }
+          // Any subsequent call (which would indicate the redirect was followed)
+          // resolves with 200 — the test asserts there is no such call, not the
+          // response itself.
+          return { status: 200, headers: createHttpHeaders(), request: req };
+        }),
+      };
+
+      const fakeCredential = {
+        getToken: vi.fn().mockResolvedValue({
+          token: "SECRET-PIPELINE-TOKEN",
+          expiresOnTimestamp: Date.now() + 3_600_000,
+        }),
+      };
+
+      const client = createClient(ledgerEndpoint, fakeCredential, {
+        httpClient: mockHttpClient,
+        // Disable retries so an error from the redirect refusal surfaces
+        // immediately and the test doesn't time out on retry back-off.
+        retryOptions: { maxRetries: 0 },
+      });
+
+      let thrown: unknown;
+      try {
+        await client.path("/app/transactions").post({
+          contentType: "application/json",
+          body: { contents: "sensitive payload" },
+        });
+      } catch (e) {
+        thrown = e;
+      }
+
+      // Exactly one outbound HTTP request was made: the one to the configured
+      // ledger endpoint. The attacker host must never have been contacted.
+      const attackerCalls = recordedRequests.filter((r) => r.url.includes("attacker.example.com"));
+      assert.equal(
+        attackerCalls.length,
+        0,
+        `Bearer token MUST NOT be sent to attacker host. Recorded calls: ${recordedRequests
+          .map((r) => r.url)
+          .join(", ")}`,
+      );
+      assert.ok(
+        recordedRequests.every((r) => r.url.startsWith(ledgerEndpoint)),
+        `All outbound requests must target the configured ledger endpoint. Got: ${recordedRequests
+          .map((r) => r.url)
+          .join(", ")}`,
+      );
+      // Sanity: the Bearer token WAS attached to the legitimate request.
+      assert.equal(
+        recordedRequests[0]?.headers.get("Authorization"),
+        "Bearer SECRET-PIPELINE-TOKEN",
+        "The bearer policy must attach the token to the legitimate ledger request",
+      );
+      // The write must have failed (the redirect was refused) so the caller is
+      // notified rather than silently succeeding with the wrong response.
+      assert.ok(thrown, "The client call must reject when the redirect is untrusted");
+    });
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/confidential-ledger` - bumps `1.1.2-beta.5` (unreleased) → `1.1.2-beta.6`.

### Issues associated with this PR

- MSRC #116673 (IcM #31000000604457)
- ADO Task #37485929 (parent Feature #37442109)

> ⚠️ Coordinated disclosure: CHANGELOG wording intentionally generic, please review with the MSRC case manager (Abhilash Konnur) and @ryazhang-microsoft before exiting draft.

### Describe the problem that is addressed by this PR

The custom `confidentialLedgerRedirectPolicy` shipped in `1.1.2-beta.4` / `beta.5` replaces the default `redirectPolicy` and preserves the `Authorization` header on redirects (required because Confidential Ledger redirects the LB → primary node on a subdomain). It did **not** verify the redirect target stayed within the ledger's trust boundary, so a compromised/attacker-controlled initial endpoint could 307/308 to `http://attacker/...` and the SDK would forward the Bearer token + write body. The caching added in #38259 worsens it by persistently rewriting subsequent writes to the malicious target.

This PR introduces a trust check evaluated **before** any mutation of the request URL/method: target must be HTTPS, port must match the configured ledger port, and the canonical hostname must equal the ledger hostname or be a subdomain of it (leading-dot boundary). Untrusted redirects throw a non-retryable error, so neither credentials nor the request body reach the untrusted host and the cache cannot be poisoned.

### What are the possible designs available to address the problem?

1. **Strict same-origin (MSRC literal recommendation)** - *rejected*: would break legitimate LB → subdomain primary redirects.
2. **Strip-and-follow on cross-origin** - *rejected*: still leaks the request body to the untrusted host.
3. **Subdomain-allowed trust check + refuse on mismatch (chosen, agreed with @ryazhang-microsoft)** - fixes the vuln without breaking the legitimate redirect pattern; stronger than MSRC literal because it also prevents body leak.

Implementation notes:
- Trust anchor (`ledgerHostname`, `ledgerPort`) captured at policy creation. Hostnames canonicalized (lowercase + trailing dot stripped); subdomain check uses leading-dot boundary so prefix-collisions (`evil-test-ledger.<...>`) are rejected.
- Cache writes **staged** during redirect chain; only committed after a successful non-5xx trusted chain. Discarded on throw / transport error / 5xx / untrusted hop.
- Outer `sendRequest` `catch` restores original URL/method and invalidates cache for writes - clean retry semantics.

### Are there test cases added in this PR?

Yes. **48/48 unit tests pass.**

- 12 legacy redirect tests (fixtures updated to subdomain pattern).
- 14 caching tests (already on subdomain pattern, untouched).
- **22 new security regression tests** in `confidentialLedgerRedirectTrust.spec.ts`: cross-origin attacker host, HTTP downgrade (matches MSRC PoC), sibling domain, different port, prefix-collision (`evil-test-ledger.*` vs `test-ledger.*`), protocol-relative `Location`, 301/302/303 untrusted, trusted subdomain follow, trailing-dot FQDN, uppercase host, mid-chain untrusted hop with staged-cache discard, warm-cache invalidation when the cached node returns an untrusted redirect, and a **full-pipeline integration test** that goes through `createClient` with a mock `HttpClient` and asserts the Bearer token never reaches `attacker.example.com`.

**Mutation tested:** temporarily disabling the throw on untrusted redirect → 14 security tests correctly fail (proves tests test behavior, not implementation).

**Live-tested** against `ryan-sdk-acl`: 3 writes succeeded (cold cache 243 ms, warm cache 231/245 ms), 0 false-positive trust warnings.

### Provide a list of related PRs

- #38259 - redirect URL caching (this PR makes that caching safe).
- #37249 - original custom redirect policy (vulnerable since `1.1.2-beta.4`).
- Azure/azure-sdk-for-python#46254 - Python caching PR. Matching Python security fix is on a separate azure-core-driven path per @ryazhang-microsoft.

### Command used to generate this PR

N/A - security fix to a hand-authored customization, not a release request.

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR need any fixes in the SDK Generator? - **N/A**, change is in `src/confidentialLedger.ts` (hand-authored customization), not generated code.
- [x] Added a changelog (if necessary)