### PR TITLE
[EngSys] restore browser target to top in warp config

### DIFF
--- a/sdk/agricultureplatform/arm-agricultureplatform/package.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/agricultureplatform/arm-agricultureplatform/warp.config.yml
+++ b/sdk/agricultureplatform/arm-agricultureplatform/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/alertprocessingrules/arm-alertprocessingrules/package.json
+++ b/sdk/alertprocessingrules/arm-alertprocessingrules/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/alertprocessingrules/arm-alertprocessingrules/warp.config.yml
+++ b/sdk/alertprocessingrules/arm-alertprocessingrules/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/alertrulerecommendations/arm-alertrulerecommendations/package.json
+++ b/sdk/alertrulerecommendations/arm-alertrulerecommendations/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/alertrulerecommendations/arm-alertrulerecommendations/warp.config.yml
+++ b/sdk/alertrulerecommendations/arm-alertrulerecommendations/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/alertsmanagement/arm-alertsmanagement/package.json
+++ b/sdk/alertsmanagement/arm-alertsmanagement/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/alertsmanagement/arm-alertsmanagement/warp.config.yml
+++ b/sdk/alertsmanagement/arm-alertsmanagement/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/analysisservices/arm-analysisservices/package.json
+++ b/sdk/analysisservices/arm-analysisservices/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/analysisservices/arm-analysisservices/warp.config.yml
+++ b/sdk/analysisservices/arm-analysisservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/apimanagement/arm-apimanagement/package.json
+++ b/sdk/apimanagement/arm-apimanagement/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/apimanagement/arm-apimanagement/warp.config.yml
+++ b/sdk/apimanagement/arm-apimanagement/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/warp.config.yml
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/appconfiguration/arm-appconfiguration/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/appconfiguration/arm-appconfiguration/warp.config.yml
+++ b/sdk/appconfiguration/arm-appconfiguration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/appcontainers/arm-appcontainers/package.json
+++ b/sdk/appcontainers/arm-appcontainers/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/appcontainers/arm-appcontainers/warp.config.yml
+++ b/sdk/appcontainers/arm-appcontainers/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/applicationinsights/arm-appinsights/package.json
+++ b/sdk/applicationinsights/arm-appinsights/package.json
@@ -94,6 +94,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -101,10 +105,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/applicationinsights/arm-appinsights/warp.config.yml
+++ b/sdk/applicationinsights/arm-appinsights/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/appnetwork/arm-appnetwork/package.json
+++ b/sdk/appnetwork/arm-appnetwork/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/appnetwork/arm-appnetwork/warp.config.yml
+++ b/sdk/appnetwork/arm-appnetwork/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/appservice/arm-appservice-rest/package.json
+++ b/sdk/appservice/arm-appservice-rest/package.json
@@ -104,6 +104,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -111,10 +115,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/appservice/arm-appservice-rest/warp.config.yml
+++ b/sdk/appservice/arm-appservice-rest/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/artifactsigning/arm-artifactsigning/package.json
+++ b/sdk/artifactsigning/arm-artifactsigning/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/artifactsigning/arm-artifactsigning/warp.config.yml
+++ b/sdk/artifactsigning/arm-artifactsigning/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/astro/arm-astro/package.json
+++ b/sdk/astro/arm-astro/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/astro/arm-astro/warp.config.yml
+++ b/sdk/astro/arm-astro/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/attestation/arm-attestation/package.json
+++ b/sdk/attestation/arm-attestation/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/attestation/arm-attestation/warp.config.yml
+++ b/sdk/attestation/arm-attestation/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/authorization/arm-authorization/package.json
+++ b/sdk/authorization/arm-authorization/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/authorization/arm-authorization/warp.config.yml
+++ b/sdk/authorization/arm-authorization/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/automanage/arm-automanage/package.json
+++ b/sdk/automanage/arm-automanage/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/automanage/arm-automanage/warp.config.yml
+++ b/sdk/automanage/arm-automanage/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/avs/arm-avs/package.json
+++ b/sdk/avs/arm-avs/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/avs/arm-avs/warp.config.yml
+++ b/sdk/avs/arm-avs/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/warp.config.yml
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/azurestack/arm-azurestack/package.json
+++ b/sdk/azurestack/arm-azurestack/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/azurestack/arm-azurestack/warp.config.yml
+++ b/sdk/azurestack/arm-azurestack/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/azurestackhci/arm-azurestackhci/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/azurestackhci/arm-azurestackhci/warp.config.yml
+++ b/sdk/azurestackhci/arm-azurestackhci/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/package.json
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/warp.config.yml
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/package.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/warp.config.yml
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/batch/arm-batch/package.json
+++ b/sdk/batch/arm-batch/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/batch/arm-batch/warp.config.yml
+++ b/sdk/batch/arm-batch/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/billing/arm-billing/package.json
+++ b/sdk/billing/arm-billing/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/billing/arm-billing/warp.config.yml
+++ b/sdk/billing/arm-billing/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/billingbenefits/arm-billingbenefits/package.json
+++ b/sdk/billingbenefits/arm-billingbenefits/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/billingbenefits/arm-billingbenefits/warp.config.yml
+++ b/sdk/billingbenefits/arm-billingbenefits/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/botservice/arm-botservice/package.json
+++ b/sdk/botservice/arm-botservice/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/botservice/arm-botservice/warp.config.yml
+++ b/sdk/botservice/arm-botservice/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/carbonoptimization/arm-carbonoptimization/package.json
+++ b/sdk/carbonoptimization/arm-carbonoptimization/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/carbonoptimization/arm-carbonoptimization/warp.config.yml
+++ b/sdk/carbonoptimization/arm-carbonoptimization/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/cdn/arm-cdn/package.json
+++ b/sdk/cdn/arm-cdn/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/cdn/arm-cdn/warp.config.yml
+++ b/sdk/cdn/arm-cdn/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/certificateregistration/arm-certificateregistration/package.json
+++ b/sdk/certificateregistration/arm-certificateregistration/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/certificateregistration/arm-certificateregistration/warp.config.yml
+++ b/sdk/certificateregistration/arm-certificateregistration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/changeanalysis/arm-changeanalysis/package.json
+++ b/sdk/changeanalysis/arm-changeanalysis/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/changeanalysis/arm-changeanalysis/warp.config.yml
+++ b/sdk/changeanalysis/arm-changeanalysis/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/changes/arm-changes/package.json
+++ b/sdk/changes/arm-changes/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/changes/arm-changes/warp.config.yml
+++ b/sdk/changes/arm-changes/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/chaos/arm-chaos/package.json
+++ b/sdk/chaos/arm-chaos/package.json
@@ -104,6 +104,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -111,10 +115,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/chaos/arm-chaos/warp.config.yml
+++ b/sdk/chaos/arm-chaos/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/cloudhealth/arm-cloudhealth/package.json
+++ b/sdk/cloudhealth/arm-cloudhealth/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/cloudhealth/arm-cloudhealth/warp.config.yml
+++ b/sdk/cloudhealth/arm-cloudhealth/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/commerce/arm-commerce/package.json
+++ b/sdk/commerce/arm-commerce/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/commerce/arm-commerce/warp.config.yml
+++ b/sdk/commerce/arm-commerce/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/communication/arm-communication/package.json
+++ b/sdk/communication/arm-communication/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/communication/arm-communication/warp.config.yml
+++ b/sdk/communication/arm-communication/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/compute/arm-compute-rest/package.json
+++ b/sdk/compute/arm-compute-rest/package.json
@@ -105,6 +105,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -112,10 +116,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/compute/arm-compute-rest/warp.config.yml
+++ b/sdk/compute/arm-compute-rest/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/compute/arm-compute/warp.config.yml
+++ b/sdk/compute/arm-compute/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/compute/arm-computerecommender/package.json
+++ b/sdk/compute/arm-computerecommender/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/compute/arm-computerecommender/warp.config.yml
+++ b/sdk/compute/arm-computerecommender/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/computebulkactions/arm-computebulkactions/package.json
+++ b/sdk/computebulkactions/arm-computebulkactions/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/computebulkactions/arm-computebulkactions/warp.config.yml
+++ b/sdk/computebulkactions/arm-computebulkactions/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/computefleet/arm-computefleet/package.json
+++ b/sdk/computefleet/arm-computefleet/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/computefleet/arm-computefleet/warp.config.yml
+++ b/sdk/computefleet/arm-computefleet/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/computelimit/arm-computelimit/package.json
+++ b/sdk/computelimit/arm-computelimit/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/computelimit/arm-computelimit/warp.config.yml
+++ b/sdk/computelimit/arm-computelimit/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/computeschedule/arm-computeschedule/package.json
+++ b/sdk/computeschedule/arm-computeschedule/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/computeschedule/arm-computeschedule/warp.config.yml
+++ b/sdk/computeschedule/arm-computeschedule/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/confidentialledger/arm-confidentialledger/package.json
+++ b/sdk/confidentialledger/arm-confidentialledger/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/confidentialledger/arm-confidentialledger/warp.config.yml
+++ b/sdk/confidentialledger/arm-confidentialledger/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/confluent/arm-confluent/package.json
+++ b/sdk/confluent/arm-confluent/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/confluent/arm-confluent/warp.config.yml
+++ b/sdk/confluent/arm-confluent/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/connectedcache/arm-connectedcache/package.json
+++ b/sdk/connectedcache/arm-connectedcache/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/connectedcache/arm-connectedcache/warp.config.yml
+++ b/sdk/connectedcache/arm-connectedcache/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/connectedvmware/arm-connectedvmware/package.json
+++ b/sdk/connectedvmware/arm-connectedvmware/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/connectedvmware/arm-connectedvmware/warp.config.yml
+++ b/sdk/connectedvmware/arm-connectedvmware/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/consumption/arm-consumption/package.json
+++ b/sdk/consumption/arm-consumption/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/consumption/arm-consumption/warp.config.yml
+++ b/sdk/consumption/arm-consumption/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerinstance/arm-containerinstance/package.json
+++ b/sdk/containerinstance/arm-containerinstance/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/containerinstance/arm-containerinstance/warp.config.yml
+++ b/sdk/containerinstance/arm-containerinstance/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerregistry/arm-containerregistry/package.json
+++ b/sdk/containerregistry/arm-containerregistry/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/containerregistry/arm-containerregistry/warp.config.yml
+++ b/sdk/containerregistry/arm-containerregistry/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerregistry/arm-containerregistrytasks/package.json
+++ b/sdk/containerregistry/arm-containerregistrytasks/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/containerregistry/arm-containerregistrytasks/warp.config.yml
+++ b/sdk/containerregistry/arm-containerregistrytasks/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerservice/arm-containerservice-rest/package.json
+++ b/sdk/containerservice/arm-containerservice-rest/package.json
@@ -104,6 +104,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -111,10 +115,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/containerservice/arm-containerservice-rest/warp.config.yml
+++ b/sdk/containerservice/arm-containerservice-rest/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerservice/arm-containerservice/package.json
+++ b/sdk/containerservice/arm-containerservice/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/containerservice/arm-containerservice/warp.config.yml
+++ b/sdk/containerservice/arm-containerservice/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerservice/arm-containerservicefleet/package.json
+++ b/sdk/containerservice/arm-containerservicefleet/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/containerservice/arm-containerservicefleet/warp.config.yml
+++ b/sdk/containerservice/arm-containerservicefleet/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/containerservice/arm-containerservicesafeguards/package.json
+++ b/sdk/containerservice/arm-containerservicesafeguards/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/containerservice/arm-containerservicesafeguards/warp.config.yml
+++ b/sdk/containerservice/arm-containerservicesafeguards/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/cosmosdb/arm-cosmosdb/package.json
+++ b/sdk/cosmosdb/arm-cosmosdb/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/cosmosdb/arm-cosmosdb/warp.config.yml
+++ b/sdk/cosmosdb/arm-cosmosdb/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/package.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/warp.config.yml
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/cost-management/arm-costmanagement/package.json
+++ b/sdk/cost-management/arm-costmanagement/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/cost-management/arm-costmanagement/warp.config.yml
+++ b/sdk/cost-management/arm-costmanagement/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/customer-insights/arm-customerinsights/package.json
+++ b/sdk/customer-insights/arm-customerinsights/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/customer-insights/arm-customerinsights/warp.config.yml
+++ b/sdk/customer-insights/arm-customerinsights/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dashboard/arm-dashboard/package.json
+++ b/sdk/dashboard/arm-dashboard/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/dashboard/arm-dashboard/warp.config.yml
+++ b/sdk/dashboard/arm-dashboard/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/databasewatcher/arm-databasewatcher/package.json
+++ b/sdk/databasewatcher/arm-databasewatcher/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/databasewatcher/arm-databasewatcher/warp.config.yml
+++ b/sdk/databasewatcher/arm-databasewatcher/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/databoundaries/arm-databoundaries/package.json
+++ b/sdk/databoundaries/arm-databoundaries/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/databoundaries/arm-databoundaries/warp.config.yml
+++ b/sdk/databoundaries/arm-databoundaries/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/databox/arm-databox/package.json
+++ b/sdk/databox/arm-databox/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/databox/arm-databox/warp.config.yml
+++ b/sdk/databox/arm-databox/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/databoxedge/arm-databoxedge/package.json
+++ b/sdk/databoxedge/arm-databoxedge/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/databoxedge/arm-databoxedge/warp.config.yml
+++ b/sdk/databoxedge/arm-databoxedge/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/databricks/arm-databricks/package.json
+++ b/sdk/databricks/arm-databricks/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/databricks/arm-databricks/warp.config.yml
+++ b/sdk/databricks/arm-databricks/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/datacatalog/arm-datacatalog/package.json
+++ b/sdk/datacatalog/arm-datacatalog/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/datacatalog/arm-datacatalog/warp.config.yml
+++ b/sdk/datacatalog/arm-datacatalog/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/datadog/arm-datadog/package.json
+++ b/sdk/datadog/arm-datadog/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/datadog/arm-datadog/warp.config.yml
+++ b/sdk/datadog/arm-datadog/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/datafactory/arm-datafactory/package.json
+++ b/sdk/datafactory/arm-datafactory/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/datafactory/arm-datafactory/warp.config.yml
+++ b/sdk/datafactory/arm-datafactory/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/datalake-analytics/arm-datalake-analytics/package.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/datalake-analytics/arm-datalake-analytics/warp.config.yml
+++ b/sdk/datalake-analytics/arm-datalake-analytics/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/datamigration/arm-datamigration/package.json
+++ b/sdk/datamigration/arm-datamigration/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/datamigration/arm-datamigration/warp.config.yml
+++ b/sdk/datamigration/arm-datamigration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dataprotection/arm-dataprotection/package.json
+++ b/sdk/dataprotection/arm-dataprotection/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/dataprotection/arm-dataprotection/warp.config.yml
+++ b/sdk/dataprotection/arm-dataprotection/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/defendereasm/arm-defendereasm/package.json
+++ b/sdk/defendereasm/arm-defendereasm/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/defendereasm/arm-defendereasm/warp.config.yml
+++ b/sdk/defendereasm/arm-defendereasm/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dell/arm-dell-storage/package.json
+++ b/sdk/dell/arm-dell-storage/package.json
@@ -110,6 +110,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -117,10 +121,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/dell/arm-dell-storage/warp.config.yml
+++ b/sdk/dell/arm-dell-storage/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dependencymap/arm-dependencymap/package.json
+++ b/sdk/dependencymap/arm-dependencymap/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/dependencymap/arm-dependencymap/warp.config.yml
+++ b/sdk/dependencymap/arm-dependencymap/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/deploymentmanager/arm-deploymentmanager/package.json
+++ b/sdk/deploymentmanager/arm-deploymentmanager/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/deploymentmanager/arm-deploymentmanager/warp.config.yml
+++ b/sdk/deploymentmanager/arm-deploymentmanager/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/package.json
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/warp.config.yml
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/devcenter/arm-devcenter/package.json
+++ b/sdk/devcenter/arm-devcenter/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/devcenter/arm-devcenter/warp.config.yml
+++ b/sdk/devcenter/arm-devcenter/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/devhub/arm-devhub/package.json
+++ b/sdk/devhub/arm-devhub/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/devhub/arm-devhub/warp.config.yml
+++ b/sdk/devhub/arm-devhub/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
@@ -105,6 +105,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -112,10 +116,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/warp.config.yml
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/deviceregistry/arm-deviceregistry/package.json
+++ b/sdk/deviceregistry/arm-deviceregistry/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/deviceregistry/arm-deviceregistry/warp.config.yml
+++ b/sdk/deviceregistry/arm-deviceregistry/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/deviceupdate/arm-deviceupdate/package.json
+++ b/sdk/deviceupdate/arm-deviceupdate/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/deviceupdate/arm-deviceupdate/warp.config.yml
+++ b/sdk/deviceupdate/arm-deviceupdate/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/warp.config.yml
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/devspaces/arm-devspaces/package.json
+++ b/sdk/devspaces/arm-devspaces/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/devspaces/arm-devspaces/warp.config.yml
+++ b/sdk/devspaces/arm-devspaces/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/devtestlabs/arm-devtestlabs/package.json
+++ b/sdk/devtestlabs/arm-devtestlabs/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/devtestlabs/arm-devtestlabs/warp.config.yml
+++ b/sdk/devtestlabs/arm-devtestlabs/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/digitaltwins/arm-digitaltwins/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/digitaltwins/arm-digitaltwins/warp.config.yml
+++ b/sdk/digitaltwins/arm-digitaltwins/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/disconnectedoperations/arm-disconnectedoperations/package.json
+++ b/sdk/disconnectedoperations/arm-disconnectedoperations/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/disconnectedoperations/arm-disconnectedoperations/warp.config.yml
+++ b/sdk/disconnectedoperations/arm-disconnectedoperations/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/discovery/arm-discovery/package.json
+++ b/sdk/discovery/arm-discovery/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/discovery/arm-discovery/warp.config.yml
+++ b/sdk/discovery/arm-discovery/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
@@ -91,6 +91,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -98,10 +102,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dns/arm-dns/package.json
+++ b/sdk/dns/arm-dns/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/dns/arm-dns/warp.config.yml
+++ b/sdk/dns/arm-dns/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dnsresolver/arm-dnsresolver/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/dnsresolver/arm-dnsresolver/warp.config.yml
+++ b/sdk/dnsresolver/arm-dnsresolver/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/domainregistration/arm-domainregistration/package.json
+++ b/sdk/domainregistration/arm-domainregistration/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/domainregistration/arm-domainregistration/warp.config.yml
+++ b/sdk/domainregistration/arm-domainregistration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/domainservices/arm-domainservices/package.json
+++ b/sdk/domainservices/arm-domainservices/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/domainservices/arm-domainservices/warp.config.yml
+++ b/sdk/domainservices/arm-domainservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/durabletask/arm-durabletask/package.json
+++ b/sdk/durabletask/arm-durabletask/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/durabletask/arm-durabletask/warp.config.yml
+++ b/sdk/durabletask/arm-durabletask/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/dynatrace/arm-dynatrace/package.json
+++ b/sdk/dynatrace/arm-dynatrace/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/dynatrace/arm-dynatrace/warp.config.yml
+++ b/sdk/dynatrace/arm-dynatrace/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/edgeactions/arm-edgeactions/package.json
+++ b/sdk/edgeactions/arm-edgeactions/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/edgeactions/arm-edgeactions/warp.config.yml
+++ b/sdk/edgeactions/arm-edgeactions/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/edgezones/arm-edgezones/package.json
+++ b/sdk/edgezones/arm-edgezones/package.json
@@ -90,6 +90,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -97,10 +101,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/edgezones/arm-edgezones/warp.config.yml
+++ b/sdk/edgezones/arm-edgezones/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/education/arm-education/package.json
+++ b/sdk/education/arm-education/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/education/arm-education/warp.config.yml
+++ b/sdk/education/arm-education/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/elastic/arm-elastic/package.json
+++ b/sdk/elastic/arm-elastic/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/elastic/arm-elastic/warp.config.yml
+++ b/sdk/elastic/arm-elastic/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/elasticsans/arm-elasticsan/package.json
+++ b/sdk/elasticsans/arm-elasticsan/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/elasticsans/arm-elasticsan/warp.config.yml
+++ b/sdk/elasticsans/arm-elasticsan/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/eventgrid/arm-eventgrid/package.json
+++ b/sdk/eventgrid/arm-eventgrid/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/eventgrid/arm-eventgrid/warp.config.yml
+++ b/sdk/eventgrid/arm-eventgrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/eventhub/arm-eventhub/package.json
+++ b/sdk/eventhub/arm-eventhub/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/eventhub/arm-eventhub/warp.config.yml
+++ b/sdk/eventhub/arm-eventhub/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/extendedlocation/arm-extendedlocation/package.json
+++ b/sdk/extendedlocation/arm-extendedlocation/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/extendedlocation/arm-extendedlocation/warp.config.yml
+++ b/sdk/extendedlocation/arm-extendedlocation/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/fabric/arm-fabric/package.json
+++ b/sdk/fabric/arm-fabric/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/fabric/arm-fabric/warp.config.yml
+++ b/sdk/fabric/arm-fabric/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/features/arm-features/warp.config.yml
+++ b/sdk/features/arm-features/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/fileshares/arm-fileshares/package.json
+++ b/sdk/fileshares/arm-fileshares/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/fileshares/arm-fileshares/warp.config.yml
+++ b/sdk/fileshares/arm-fileshares/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/fluidrelay/arm-fluidrelay/package.json
+++ b/sdk/fluidrelay/arm-fluidrelay/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/fluidrelay/arm-fluidrelay/warp.config.yml
+++ b/sdk/fluidrelay/arm-fluidrelay/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/frontdoor/arm-frontdoor/package.json
+++ b/sdk/frontdoor/arm-frontdoor/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/frontdoor/arm-frontdoor/warp.config.yml
+++ b/sdk/frontdoor/arm-frontdoor/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/graphservices/arm-graphservices/package.json
+++ b/sdk/graphservices/arm-graphservices/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/graphservices/arm-graphservices/warp.config.yml
+++ b/sdk/graphservices/arm-graphservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/guestconfiguration/arm-guestconfiguration/package.json
+++ b/sdk/guestconfiguration/arm-guestconfiguration/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/guestconfiguration/arm-guestconfiguration/warp.config.yml
+++ b/sdk/guestconfiguration/arm-guestconfiguration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hanaonazure/arm-hanaonazure/package.json
+++ b/sdk/hanaonazure/arm-hanaonazure/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/hanaonazure/arm-hanaonazure/warp.config.yml
+++ b/sdk/hanaonazure/arm-hanaonazure/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/warp.config.yml
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hdinsight/arm-hdinsight/package.json
+++ b/sdk/hdinsight/arm-hdinsight/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/hdinsight/arm-hdinsight/warp.config.yml
+++ b/sdk/hdinsight/arm-hdinsight/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/healthbot/arm-healthbot/package.json
+++ b/sdk/healthbot/arm-healthbot/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/healthbot/arm-healthbot/warp.config.yml
+++ b/sdk/healthbot/arm-healthbot/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/healthcareapis/arm-healthcareapis/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/healthcareapis/arm-healthcareapis/warp.config.yml
+++ b/sdk/healthcareapis/arm-healthcareapis/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/warp.config.yml
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/horizondb/arm-horizondb/package.json
+++ b/sdk/horizondb/arm-horizondb/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/horizondb/arm-horizondb/warp.config.yml
+++ b/sdk/horizondb/arm-horizondb/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hybridcompute/arm-hybridcompute/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/hybridcompute/arm-hybridcompute/warp.config.yml
+++ b/sdk/hybridcompute/arm-hybridcompute/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/warp.config.yml
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/package.json
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/warp.config.yml
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/warp.config.yml
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/hybridnetwork/arm-hybridnetwork/package.json
+++ b/sdk/hybridnetwork/arm-hybridnetwork/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/hybridnetwork/arm-hybridnetwork/warp.config.yml
+++ b/sdk/hybridnetwork/arm-hybridnetwork/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/identity/identity/warp.config.yml
+++ b/sdk/identity/identity/warp.config.yml
@@ -3,11 +3,11 @@
 extends: ../../../warp.base.config.yml
 
 targets:
-  - name: workerd
-    tsconfig: "./config/tsconfig.src.workerd.json"
-
   - name: browser
     tsconfig: "./config/tsconfig.src.browser.json"
+
+  - name: workerd
+    tsconfig: "./config/tsconfig.src.workerd.json"
 
   - name: esm
     condition: import

--- a/sdk/imagebuilder/arm-imagebuilder/package.json
+++ b/sdk/imagebuilder/arm-imagebuilder/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/imagebuilder/arm-imagebuilder/warp.config.yml
+++ b/sdk/imagebuilder/arm-imagebuilder/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/impactreporting/arm-impactreporting/package.json
+++ b/sdk/impactreporting/arm-impactreporting/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/impactreporting/arm-impactreporting/warp.config.yml
+++ b/sdk/impactreporting/arm-impactreporting/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/informatica/arm-informaticadatamanagement/package.json
+++ b/sdk/informatica/arm-informaticadatamanagement/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/informatica/arm-informaticadatamanagement/warp.config.yml
+++ b/sdk/informatica/arm-informaticadatamanagement/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/iotcentral/arm-iotcentral/package.json
+++ b/sdk/iotcentral/arm-iotcentral/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/iotcentral/arm-iotcentral/warp.config.yml
+++ b/sdk/iotcentral/arm-iotcentral/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/warp.config.yml
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/iothub/arm-iothub/package.json
+++ b/sdk/iothub/arm-iothub/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/iothub/arm-iothub/warp.config.yml
+++ b/sdk/iothub/arm-iothub/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/iotoperations/arm-iotoperations/package.json
+++ b/sdk/iotoperations/arm-iotoperations/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/iotoperations/arm-iotoperations/warp.config.yml
+++ b/sdk/iotoperations/arm-iotoperations/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/keyvault/arm-keyvault/package.json
+++ b/sdk/keyvault/arm-keyvault/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/keyvault/arm-keyvault/warp.config.yml
+++ b/sdk/keyvault/arm-keyvault/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/warp.config.yml
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/warp.config.yml
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/warp.config.yml
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/warp.config.yml
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/warp.config.yml
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/warp.config.yml
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/kusto/arm-kusto/package.json
+++ b/sdk/kusto/arm-kusto/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/kusto/arm-kusto/warp.config.yml
+++ b/sdk/kusto/arm-kusto/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/labservices/arm-labservices/package.json
+++ b/sdk/labservices/arm-labservices/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/labservices/arm-labservices/warp.config.yml
+++ b/sdk/labservices/arm-labservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/package.json
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/warp.config.yml
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/largeinstance/arm-largeinstance/package.json
+++ b/sdk/largeinstance/arm-largeinstance/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/largeinstance/arm-largeinstance/warp.config.yml
+++ b/sdk/largeinstance/arm-largeinstance/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/package.json
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/warp.config.yml
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/liftrqumulo/arm-qumulo/package.json
+++ b/sdk/liftrqumulo/arm-qumulo/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/liftrqumulo/arm-qumulo/warp.config.yml
+++ b/sdk/liftrqumulo/arm-qumulo/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/package.json
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/warp.config.yml
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -89,6 +89,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -96,10 +100,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/links/arm-links/warp.config.yml
+++ b/sdk/links/arm-links/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/loadtesting/arm-loadtesting/package.json
+++ b/sdk/loadtesting/arm-loadtesting/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/loadtesting/arm-loadtesting/warp.config.yml
+++ b/sdk/loadtesting/arm-loadtesting/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/locks/arm-locks/warp.config.yml
+++ b/sdk/locks/arm-locks/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/logic/arm-logic/package.json
+++ b/sdk/logic/arm-logic/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/logic/arm-logic/warp.config.yml
+++ b/sdk/logic/arm-logic/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/machinelearning/arm-commitmentplans/package.json
+++ b/sdk/machinelearning/arm-commitmentplans/package.json
@@ -88,6 +88,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -95,10 +99,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/machinelearning/arm-commitmentplans/warp.config.yml
+++ b/sdk/machinelearning/arm-commitmentplans/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/machinelearning/arm-machinelearning/package.json
+++ b/sdk/machinelearning/arm-machinelearning/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/machinelearning/arm-machinelearning/warp.config.yml
+++ b/sdk/machinelearning/arm-machinelearning/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/machinelearning/arm-webservices/package.json
+++ b/sdk/machinelearning/arm-webservices/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/machinelearning/arm-webservices/warp.config.yml
+++ b/sdk/machinelearning/arm-webservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/machinelearning/arm-workspaces/package.json
+++ b/sdk/machinelearning/arm-workspaces/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/machinelearning/arm-workspaces/warp.config.yml
+++ b/sdk/machinelearning/arm-workspaces/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/warp.config.yml
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/warp.config.yml
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/maintenance/arm-maintenance/package.json
+++ b/sdk/maintenance/arm-maintenance/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/maintenance/arm-maintenance/warp.config.yml
+++ b/sdk/maintenance/arm-maintenance/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/managedapplications/arm-managedapplications/warp.config.yml
+++ b/sdk/managedapplications/arm-managedapplications/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/package.json
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/warp.config.yml
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/managedops/arm-managedops/package.json
+++ b/sdk/managedops/arm-managedops/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/managedops/arm-managedops/warp.config.yml
+++ b/sdk/managedops/arm-managedops/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/managementgroups/arm-managementgroups/package.json
+++ b/sdk/managementgroups/arm-managementgroups/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/managementgroups/arm-managementgroups/warp.config.yml
+++ b/sdk/managementgroups/arm-managementgroups/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/managementpartner/arm-managementpartner/package.json
+++ b/sdk/managementpartner/arm-managementpartner/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/managementpartner/arm-managementpartner/warp.config.yml
+++ b/sdk/managementpartner/arm-managementpartner/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/maps/arm-maps/package.json
+++ b/sdk/maps/arm-maps/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/maps/arm-maps/warp.config.yml
+++ b/sdk/maps/arm-maps/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/mariadb/arm-mariadb/package.json
+++ b/sdk/mariadb/arm-mariadb/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/mariadb/arm-mariadb/warp.config.yml
+++ b/sdk/mariadb/arm-mariadb/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/marketplace/arm-marketplace/package.json
+++ b/sdk/marketplace/arm-marketplace/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/marketplace/arm-marketplace/warp.config.yml
+++ b/sdk/marketplace/arm-marketplace/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/marketplaceordering/arm-marketplaceordering/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/marketplaceordering/arm-marketplaceordering/warp.config.yml
+++ b/sdk/marketplaceordering/arm-marketplaceordering/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/migrate/arm-migrate/package.json
+++ b/sdk/migrate/arm-migrate/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/migrate/arm-migrate/warp.config.yml
+++ b/sdk/migrate/arm-migrate/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/migrate/arm-migrationassessment/package.json
+++ b/sdk/migrate/arm-migrationassessment/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/migrate/arm-migrationassessment/warp.config.yml
+++ b/sdk/migrate/arm-migrationassessment/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/package.json
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/warp.config.yml
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/mongocluster/arm-mongocluster/package.json
+++ b/sdk/mongocluster/arm-mongocluster/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/mongocluster/arm-mongocluster/warp.config.yml
+++ b/sdk/mongocluster/arm-mongocluster/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/mongodbatlas/arm-mongodbatlas/package.json
+++ b/sdk/mongodbatlas/arm-mongodbatlas/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/mongodbatlas/arm-mongodbatlas/warp.config.yml
+++ b/sdk/mongodbatlas/arm-mongodbatlas/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/monitor/arm-monitor/package.json
+++ b/sdk/monitor/arm-monitor/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/monitor/arm-monitor/warp.config.yml
+++ b/sdk/monitor/arm-monitor/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/monitor/arm-monitorslis/package.json
+++ b/sdk/monitor/arm-monitorslis/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/monitor/arm-monitorslis/warp.config.yml
+++ b/sdk/monitor/arm-monitorslis/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/msi/arm-msi/package.json
+++ b/sdk/msi/arm-msi/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/msi/arm-msi/warp.config.yml
+++ b/sdk/msi/arm-msi/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/mysql/arm-mysql-flexible/package.json
+++ b/sdk/mysql/arm-mysql-flexible/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/mysql/arm-mysql-flexible/warp.config.yml
+++ b/sdk/mysql/arm-mysql-flexible/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/mysql/arm-mysql/package.json
+++ b/sdk/mysql/arm-mysql/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/mysql/arm-mysql/warp.config.yml
+++ b/sdk/mysql/arm-mysql/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/netapp/arm-netapp/package.json
+++ b/sdk/netapp/arm-netapp/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/netapp/arm-netapp/warp.config.yml
+++ b/sdk/netapp/arm-netapp/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/network/arm-network-rest/package.json
+++ b/sdk/network/arm-network-rest/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/network/arm-network-rest/warp.config.yml
+++ b/sdk/network/arm-network-rest/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/network/arm-network/warp.config.yml
+++ b/sdk/network/arm-network/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/networkcloud/arm-networkcloud/package.json
+++ b/sdk/networkcloud/arm-networkcloud/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/networkcloud/arm-networkcloud/warp.config.yml
+++ b/sdk/networkcloud/arm-networkcloud/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/networkfunction/arm-networkfunction/package.json
+++ b/sdk/networkfunction/arm-networkfunction/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/networkfunction/arm-networkfunction/warp.config.yml
+++ b/sdk/networkfunction/arm-networkfunction/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/newrelicobservability/arm-newrelicobservability/package.json
+++ b/sdk/newrelicobservability/arm-newrelicobservability/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/newrelicobservability/arm-newrelicobservability/warp.config.yml
+++ b/sdk/newrelicobservability/arm-newrelicobservability/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/nginx/arm-nginx/package.json
+++ b/sdk/nginx/arm-nginx/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/nginx/arm-nginx/warp.config.yml
+++ b/sdk/nginx/arm-nginx/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/notificationhubs/arm-notificationhubs/package.json
+++ b/sdk/notificationhubs/arm-notificationhubs/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/notificationhubs/arm-notificationhubs/warp.config.yml
+++ b/sdk/notificationhubs/arm-notificationhubs/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/oep/arm-oep/package.json
+++ b/sdk/oep/arm-oep/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/oep/arm-oep/warp.config.yml
+++ b/sdk/oep/arm-oep/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/package.json
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/warp.config.yml
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/operationalinsights/arm-operationalinsights/package.json
+++ b/sdk/operationalinsights/arm-operationalinsights/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/operationalinsights/arm-operationalinsights/warp.config.yml
+++ b/sdk/operationalinsights/arm-operationalinsights/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/operationsmanagement/arm-operations/package.json
+++ b/sdk/operationsmanagement/arm-operations/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/operationsmanagement/arm-operations/warp.config.yml
+++ b/sdk/operationsmanagement/arm-operations/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/oracledatabase/arm-oracledatabase/package.json
+++ b/sdk/oracledatabase/arm-oracledatabase/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/oracledatabase/arm-oracledatabase/warp.config.yml
+++ b/sdk/oracledatabase/arm-oracledatabase/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/orbital/arm-orbital/package.json
+++ b/sdk/orbital/arm-orbital/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/orbital/arm-orbital/warp.config.yml
+++ b/sdk/orbital/arm-orbital/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/warp.config.yml
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/peering/arm-peering/package.json
+++ b/sdk/peering/arm-peering/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/peering/arm-peering/warp.config.yml
+++ b/sdk/peering/arm-peering/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/pineconevectordb/arm-pineconevectordb/package.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/pineconevectordb/arm-pineconevectordb/warp.config.yml
+++ b/sdk/pineconevectordb/arm-pineconevectordb/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/planetarycomputer/arm-planetarycomputer/package.json
+++ b/sdk/planetarycomputer/arm-planetarycomputer/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/planetarycomputer/arm-planetarycomputer/warp.config.yml
+++ b/sdk/planetarycomputer/arm-planetarycomputer/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/playwright/arm-playwright/package.json
+++ b/sdk/playwright/arm-playwright/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/playwright/arm-playwright/warp.config.yml
+++ b/sdk/playwright/arm-playwright/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
@@ -89,6 +89,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -96,10 +100,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/policy/arm-policy/warp.config.yml
+++ b/sdk/policy/arm-policy/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/policyinsights/arm-policyinsights/package.json
+++ b/sdk/policyinsights/arm-policyinsights/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/policyinsights/arm-policyinsights/warp.config.yml
+++ b/sdk/policyinsights/arm-policyinsights/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/portal/arm-portal/package.json
+++ b/sdk/portal/arm-portal/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/portal/arm-portal/warp.config.yml
+++ b/sdk/portal/arm-portal/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/portalservices/arm-portalservicescopilot/package.json
+++ b/sdk/portalservices/arm-portalservicescopilot/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/portalservices/arm-portalservicescopilot/warp.config.yml
+++ b/sdk/portalservices/arm-portalservicescopilot/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/postgresql/arm-postgresql-flexible/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/postgresql/arm-postgresql-flexible/warp.config.yml
+++ b/sdk/postgresql/arm-postgresql-flexible/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/postgresql/arm-postgresql/package.json
+++ b/sdk/postgresql/arm-postgresql/package.json
@@ -98,6 +98,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -105,10 +109,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/postgresql/arm-postgresql/warp.config.yml
+++ b/sdk/postgresql/arm-postgresql/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/powerbidedicated/arm-powerbidedicated/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/powerbidedicated/arm-powerbidedicated/warp.config.yml
+++ b/sdk/powerbidedicated/arm-powerbidedicated/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/powerbiembedded/arm-powerbiembedded/package.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/package.json
@@ -88,6 +88,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -95,10 +99,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/powerbiembedded/arm-powerbiembedded/warp.config.yml
+++ b/sdk/powerbiembedded/arm-powerbiembedded/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/previewalertrule/arm-previewalertrule/package.json
+++ b/sdk/previewalertrule/arm-previewalertrule/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/previewalertrule/arm-previewalertrule/warp.config.yml
+++ b/sdk/previewalertrule/arm-previewalertrule/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/privatedns/arm-privatedns/package.json
+++ b/sdk/privatedns/arm-privatedns/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/privatedns/arm-privatedns/warp.config.yml
+++ b/sdk/privatedns/arm-privatedns/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/package.json
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/warp.config.yml
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/prometheusrulegroups/arm-prometheusrulegroups/package.json
+++ b/sdk/prometheusrulegroups/arm-prometheusrulegroups/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/prometheusrulegroups/arm-prometheusrulegroups/warp.config.yml
+++ b/sdk/prometheusrulegroups/arm-prometheusrulegroups/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/providerhub/arm-providerhub/package.json
+++ b/sdk/providerhub/arm-providerhub/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/providerhub/arm-providerhub/warp.config.yml
+++ b/sdk/providerhub/arm-providerhub/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/purestorageblock/arm-purestorageblock/package.json
+++ b/sdk/purestorageblock/arm-purestorageblock/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/purestorageblock/arm-purestorageblock/warp.config.yml
+++ b/sdk/purestorageblock/arm-purestorageblock/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/purview/arm-purview/package.json
+++ b/sdk/purview/arm-purview/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/purview/arm-purview/warp.config.yml
+++ b/sdk/purview/arm-purview/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/quantum/arm-quantum/package.json
+++ b/sdk/quantum/arm-quantum/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/quantum/arm-quantum/warp.config.yml
+++ b/sdk/quantum/arm-quantum/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/quota/arm-quota/package.json
+++ b/sdk/quota/arm-quota/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/quota/arm-quota/warp.config.yml
+++ b/sdk/quota/arm-quota/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/recoveryservices/arm-recoveryservices/package.json
+++ b/sdk/recoveryservices/arm-recoveryservices/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/recoveryservices/arm-recoveryservices/warp.config.yml
+++ b/sdk/recoveryservices/arm-recoveryservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/warp.config.yml
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/warp.config.yml
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/warp.config.yml
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/redhatopenshift/arm-redhatopenshift/package.json
+++ b/sdk/redhatopenshift/arm-redhatopenshift/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/redhatopenshift/arm-redhatopenshift/warp.config.yml
+++ b/sdk/redhatopenshift/arm-redhatopenshift/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/redis/arm-rediscache/package.json
+++ b/sdk/redis/arm-rediscache/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/redis/arm-rediscache/warp.config.yml
+++ b/sdk/redis/arm-rediscache/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/redisenterprise/arm-redisenterprisecache/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/redisenterprise/arm-redisenterprisecache/warp.config.yml
+++ b/sdk/redisenterprise/arm-redisenterprisecache/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/relationships/arm-relationships/package.json
+++ b/sdk/relationships/arm-relationships/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/relationships/arm-relationships/warp.config.yml
+++ b/sdk/relationships/arm-relationships/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/relay/arm-relay/package.json
+++ b/sdk/relay/arm-relay/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/relay/arm-relay/warp.config.yml
+++ b/sdk/relay/arm-relay/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/reservations/arm-reservations/package.json
+++ b/sdk/reservations/arm-reservations/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/reservations/arm-reservations/warp.config.yml
+++ b/sdk/reservations/arm-reservations/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resourceconnector/arm-resourceconnector/package.json
+++ b/sdk/resourceconnector/arm-resourceconnector/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/resourceconnector/arm-resourceconnector/warp.config.yml
+++ b/sdk/resourceconnector/arm-resourceconnector/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resourcegraph/arm-resourcegraph/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/package.json
@@ -94,6 +94,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -101,10 +105,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resourcegraph/arm-resourcegraph/warp.config.yml
+++ b/sdk/resourcegraph/arm-resourcegraph/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resourcehealth/arm-resourcehealth/package.json
+++ b/sdk/resourcehealth/arm-resourcehealth/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resourcehealth/arm-resourcehealth/warp.config.yml
+++ b/sdk/resourcehealth/arm-resourcehealth/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resourcemover/arm-resourcemover/package.json
+++ b/sdk/resourcemover/arm-resourcemover/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resourcemover/arm-resourcemover/warp.config.yml
+++ b/sdk/resourcemover/arm-resourcemover/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/warp.config.yml
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resources/arm-resources/warp.config.yml
+++ b/sdk/resources/arm-resources/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resources/arm-resourcesbicep/package.json
+++ b/sdk/resources/arm-resourcesbicep/package.json
@@ -101,6 +101,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -108,10 +112,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/resources/arm-resourcesbicep/warp.config.yml
+++ b/sdk/resources/arm-resourcesbicep/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resources/arm-resourcesdeployments/package.json
+++ b/sdk/resources/arm-resourcesdeployments/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/resources/arm-resourcesdeployments/warp.config.yml
+++ b/sdk/resources/arm-resourcesdeployments/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/package.json
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/warp.config.yml
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/scvmm/arm-scvmm/package.json
+++ b/sdk/scvmm/arm-scvmm/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/scvmm/arm-scvmm/warp.config.yml
+++ b/sdk/scvmm/arm-scvmm/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/search/arm-search/package.json
+++ b/sdk/search/arm-search/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/search/arm-search/warp.config.yml
+++ b/sdk/search/arm-search/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/security/arm-security/package.json
+++ b/sdk/security/arm-security/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/security/arm-security/warp.config.yml
+++ b/sdk/security/arm-security/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/securitydevops/arm-securitydevops/package.json
+++ b/sdk/securitydevops/arm-securitydevops/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/securitydevops/arm-securitydevops/warp.config.yml
+++ b/sdk/securitydevops/arm-securitydevops/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/securityinsight/arm-securityinsight/package.json
+++ b/sdk/securityinsight/arm-securityinsight/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/securityinsight/arm-securityinsight/warp.config.yml
+++ b/sdk/securityinsight/arm-securityinsight/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/selfhelp/arm-selfhelp/package.json
+++ b/sdk/selfhelp/arm-selfhelp/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/selfhelp/arm-selfhelp/warp.config.yml
+++ b/sdk/selfhelp/arm-selfhelp/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/serialconsole/arm-serialconsole/package.json
+++ b/sdk/serialconsole/arm-serialconsole/package.json
@@ -93,6 +93,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -100,10 +104,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/serialconsole/arm-serialconsole/warp.config.yml
+++ b/sdk/serialconsole/arm-serialconsole/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/service-map/arm-servicemap/package.json
+++ b/sdk/service-map/arm-servicemap/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/service-map/arm-servicemap/warp.config.yml
+++ b/sdk/service-map/arm-servicemap/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicebus/arm-servicebus/package.json
+++ b/sdk/servicebus/arm-servicebus/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/servicebus/arm-servicebus/warp.config.yml
+++ b/sdk/servicebus/arm-servicebus/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicefabric/arm-servicefabric-rest/package.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/package.json
@@ -104,6 +104,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -111,10 +115,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/servicefabric/arm-servicefabric-rest/warp.config.yml
+++ b/sdk/servicefabric/arm-servicefabric-rest/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicefabric/arm-servicefabric/package.json
+++ b/sdk/servicefabric/arm-servicefabric/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/servicefabric/arm-servicefabric/warp.config.yml
+++ b/sdk/servicefabric/arm-servicefabric/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/warp.config.yml
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/warp.config.yml
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicegroups/arm-servicegroups/package.json
+++ b/sdk/servicegroups/arm-servicegroups/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/servicegroups/arm-servicegroups/warp.config.yml
+++ b/sdk/servicegroups/arm-servicegroups/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicelinker/arm-servicelinker/package.json
+++ b/sdk/servicelinker/arm-servicelinker/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/servicelinker/arm-servicelinker/warp.config.yml
+++ b/sdk/servicelinker/arm-servicelinker/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/servicenetworking/arm-servicenetworking/package.json
+++ b/sdk/servicenetworking/arm-servicenetworking/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/servicenetworking/arm-servicenetworking/warp.config.yml
+++ b/sdk/servicenetworking/arm-servicenetworking/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/signalr/arm-signalr/package.json
+++ b/sdk/signalr/arm-signalr/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/signalr/arm-signalr/warp.config.yml
+++ b/sdk/signalr/arm-signalr/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/sitemanager/arm-sitemanager/package.json
+++ b/sdk/sitemanager/arm-sitemanager/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/sitemanager/arm-sitemanager/warp.config.yml
+++ b/sdk/sitemanager/arm-sitemanager/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/sphere/arm-sphere/package.json
+++ b/sdk/sphere/arm-sphere/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/sphere/arm-sphere/warp.config.yml
+++ b/sdk/sphere/arm-sphere/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/springappdiscovery/arm-springappdiscovery/package.json
+++ b/sdk/springappdiscovery/arm-springappdiscovery/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/springappdiscovery/arm-springappdiscovery/warp.config.yml
+++ b/sdk/springappdiscovery/arm-springappdiscovery/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/sql/arm-sql/warp.config.yml
+++ b/sdk/sql/arm-sql/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/warp.config.yml
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/standbypool/arm-standbypool/package.json
+++ b/sdk/standbypool/arm-standbypool/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/standbypool/arm-standbypool/warp.config.yml
+++ b/sdk/standbypool/arm-standbypool/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storage/arm-storage/package.json
+++ b/sdk/storage/arm-storage/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storage/arm-storage/warp.config.yml
+++ b/sdk/storage/arm-storage/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storageactions/arm-storageactions/package.json
+++ b/sdk/storageactions/arm-storageactions/package.json
@@ -104,6 +104,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -111,10 +115,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/storageactions/arm-storageactions/warp.config.yml
+++ b/sdk/storageactions/arm-storageactions/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storagecache/arm-storagecache/package.json
+++ b/sdk/storagecache/arm-storagecache/package.json
@@ -92,6 +92,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -99,10 +103,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storagecache/arm-storagecache/warp.config.yml
+++ b/sdk/storagecache/arm-storagecache/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storagediscovery/arm-storagediscovery/package.json
+++ b/sdk/storagediscovery/arm-storagediscovery/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/storagediscovery/arm-storagediscovery/warp.config.yml
+++ b/sdk/storagediscovery/arm-storagediscovery/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storageimportexport/arm-storageimportexport/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storageimportexport/arm-storageimportexport/warp.config.yml
+++ b/sdk/storageimportexport/arm-storageimportexport/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storagemover/arm-storagemover/package.json
+++ b/sdk/storagemover/arm-storagemover/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/storagemover/arm-storagemover/warp.config.yml
+++ b/sdk/storagemover/arm-storagemover/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storagesync/arm-storagesync/package.json
+++ b/sdk/storagesync/arm-storagesync/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storagesync/arm-storagesync/warp.config.yml
+++ b/sdk/storagesync/arm-storagesync/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storsimple1200series/arm-storsimple1200series/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storsimple1200series/arm-storsimple1200series/warp.config.yml
+++ b/sdk/storsimple1200series/arm-storsimple1200series/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/storsimple8000series/arm-storsimple8000series/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/package.json
@@ -96,6 +96,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -103,10 +107,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/storsimple8000series/arm-storsimple8000series/warp.config.yml
+++ b/sdk/storsimple8000series/arm-storsimple8000series/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/streamanalytics/arm-streamanalytics/package.json
+++ b/sdk/streamanalytics/arm-streamanalytics/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/streamanalytics/arm-streamanalytics/warp.config.yml
+++ b/sdk/streamanalytics/arm-streamanalytics/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
@@ -95,6 +95,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -102,10 +106,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/warp.config.yml
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/subscription/arm-subscriptions/package.json
+++ b/sdk/subscription/arm-subscriptions/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/subscription/arm-subscriptions/warp.config.yml
+++ b/sdk/subscription/arm-subscriptions/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/support/arm-support/package.json
+++ b/sdk/support/arm-support/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/support/arm-support/warp.config.yml
+++ b/sdk/support/arm-support/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/synapse/arm-synapse/package.json
+++ b/sdk/synapse/arm-synapse/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/synapse/arm-synapse/warp.config.yml
+++ b/sdk/synapse/arm-synapse/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/templatespecs/arm-templatespecs/package.json
+++ b/sdk/templatespecs/arm-templatespecs/package.json
@@ -94,6 +94,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -101,10 +105,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/templatespecs/arm-templatespecs/warp.config.yml
+++ b/sdk/templatespecs/arm-templatespecs/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/package.json
+++ b/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/package.json
@@ -15,6 +15,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -22,10 +26,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/warp.config.yml
+++ b/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/terraform/arm-terraform/package.json
+++ b/sdk/terraform/arm-terraform/package.json
@@ -100,6 +100,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -107,10 +111,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./models": {

--- a/sdk/terraform/arm-terraform/warp.config.yml
+++ b/sdk/terraform/arm-terraform/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/warp.config.yml
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/trafficmanager/arm-trafficmanager/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/trafficmanager/arm-trafficmanager/warp.config.yml
+++ b/sdk/trafficmanager/arm-trafficmanager/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/trustedsigning/arm-trustedsigning/package.json
+++ b/sdk/trustedsigning/arm-trustedsigning/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/trustedsigning/arm-trustedsigning/warp.config.yml
+++ b/sdk/trustedsigning/arm-trustedsigning/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/visualstudio/arm-visualstudio/package.json
+++ b/sdk/visualstudio/arm-visualstudio/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/visualstudio/arm-visualstudio/warp.config.yml
+++ b/sdk/visualstudio/arm-visualstudio/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
@@ -97,6 +97,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -104,10 +108,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/warp.config.yml
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/voiceservices/arm-voiceservices/package.json
+++ b/sdk/voiceservices/arm-voiceservices/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/voiceservices/arm-voiceservices/warp.config.yml
+++ b/sdk/voiceservices/arm-voiceservices/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/web-pubsub/arm-webpubsub/package.json
+++ b/sdk/web-pubsub/arm-webpubsub/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/web-pubsub/arm-webpubsub/warp.config.yml
+++ b/sdk/web-pubsub/arm-webpubsub/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/workloadorchestration/arm-workloadorchestration/package.json
+++ b/sdk/workloadorchestration/arm-workloadorchestration/package.json
@@ -103,6 +103,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -110,10 +114,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/workloadorchestration/arm-workloadorchestration/warp.config.yml
+++ b/sdk/workloadorchestration/arm-workloadorchestration/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/workloads/arm-workloads/package.json
+++ b/sdk/workloads/arm-workloads/package.json
@@ -99,6 +99,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -106,10 +110,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     }
   },

--- a/sdk/workloads/arm-workloads/warp.config.yml
+++ b/sdk/workloads/arm-workloads/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"

--- a/sdk/workloads/arm-workloadssapvirtualinstance/package.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/package.json
@@ -102,6 +102,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -109,10 +113,6 @@
       "require": {
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
-      },
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
       }
     },
     "./api": {

--- a/sdk/workloads/arm-workloadssapvirtualinstance/warp.config.yml
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/warp.config.yml
@@ -2,6 +2,9 @@
 extends: ../../../warp.base.config.yml
 
 targets:
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"
@@ -10,6 +13,3 @@ targets:
     condition: require
     tsconfig: "./config/tsconfig.src.cjs.json"
     moduleType: commonjs
-
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"


### PR DESCRIPTION
It turns out that the order of targets in warp.config.yml determines the order
of exports in the `package.json` after build. This PR restores browser target to
be the top target so that the export order is the same as pre config/ migration.

***NO_CI***