### PR TITLE
[EngSys] bump package versions for 6 ARM SDK packages

### DIFF
--- a/sdk/artifactsigning/arm-artifactsigning/CHANGELOG.md
+++ b/sdk/artifactsigning/arm-artifactsigning/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Release History
+
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
     
 ## 1.0.0 (2026-02-11)
 

--- a/sdk/artifactsigning/arm-artifactsigning/package.json
+++ b/sdk/artifactsigning/arm-artifactsigning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-artifactsigning",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for CodeSigningClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/artifactsigning/arm-artifactsigning/src/api/codeSigningContext.ts
+++ b/sdk/artifactsigning/arm-artifactsigning/src/api/codeSigningContext.ts
@@ -36,7 +36,7 @@ export function createCodeSigning(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-artifactsigning/1.0.0`;
+  const userAgentInfo = `azsdk-js-arm-artifactsigning/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/computelimit/arm-computelimit/CHANGELOG.md
+++ b/sdk/computelimit/arm-computelimit/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Release History
+
+## 1.1.0 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
     
 ## 1.0.0 (2026-04-22)
 

--- a/sdk/computelimit/arm-computelimit/package.json
+++ b/sdk/computelimit/arm-computelimit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-computelimit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A generated SDK for ComputeLimitClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/computelimit/arm-computelimit/src/api/computeLimitContext.ts
+++ b/sdk/computelimit/arm-computelimit/src/api/computeLimitContext.ts
@@ -36,7 +36,7 @@ export function createComputeLimit(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-computelimit/1.0.0`;
+  const userAgentInfo = `azsdk-js-arm-computelimit/1.1.0`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/computeschedule/arm-computeschedule/CHANGELOG.md
+++ b/sdk/computeschedule/arm-computeschedule/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.2.0-beta.1 (2025-08-28)
 
 Compared with version 1.1.0

--- a/sdk/computeschedule/arm-computeschedule/package.json
+++ b/sdk/computeschedule/arm-computeschedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-computeschedule",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "A generated SDK for ComputeScheduleClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/computeschedule/arm-computeschedule/src/api/computeScheduleContext.ts
+++ b/sdk/computeschedule/arm-computeschedule/src/api/computeScheduleContext.ts
@@ -34,7 +34,7 @@ export function createComputeSchedule(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-computeschedule/1.2.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-computeschedule/1.2.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/CHANGELOG.md
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 6.0.0-beta.4 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 6.0.0-beta.3 (2025-10-13)
 Compared with version 5.1.0
 

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-deviceprovisioningservices",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-beta.4",
   "description": "A generated SDK for IotDpsClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/src/api/iotDpsContext.ts
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/src/api/iotDpsContext.ts
@@ -36,7 +36,7 @@ export function createIotDps(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-deviceprovisioningservices/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-deviceprovisioningservices/6.0.0-beta.4`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/resourceconnector/arm-resourceconnector/CHANGELOG.md
+++ b/sdk/resourceconnector/arm-resourceconnector/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0-beta.1 (2026-01-12)
 Compared with version 1.0.0
 

--- a/sdk/resourceconnector/arm-resourceconnector/package.json
+++ b/sdk/resourceconnector/arm-resourceconnector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-resourceconnector",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A generated SDK for ResourceConnectorManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/resourceconnector/arm-resourceconnector/src/api/resourceConnectorManagementContext.ts
+++ b/sdk/resourceconnector/arm-resourceconnector/src/api/resourceConnectorManagementContext.ts
@@ -36,7 +36,7 @@ export function createResourceConnectorManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-resourceconnector/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-resourceconnector/2.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/workloadorchestration/arm-workloadorchestration/CHANGELOG.md
+++ b/sdk/workloadorchestration/arm-workloadorchestration/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-09-02)
 
 ### Features Added

--- a/sdk/workloadorchestration/arm-workloadorchestration/package.json
+++ b/sdk/workloadorchestration/arm-workloadorchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-workloadorchestration",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for WorkloadOrchestrationManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/workloadorchestration/arm-workloadorchestration/src/api/workloadOrchestrationManagementContext.ts
+++ b/sdk/workloadorchestration/arm-workloadorchestration/src/api/workloadOrchestrationManagementContext.ts
@@ -34,7 +34,7 @@ export function createWorkloadOrchestrationManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-workloadorchestration/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-workloadorchestration/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;


### PR DESCRIPTION
## Summary

Bump versions for 6 ARM management SDK packages to fix `Build Analyze` CI failures. These packages had source changes after their published npm versions without corresponding version bumps.

| Package | Old Version | New Version | Bump Type |
|---|---|---|---|
| \@azure/arm-computelimit\ | 1.0.0 | **1.1.0** | Minor (new features) |
| \@azure/arm-artifactsigning\ | 1.0.0 | **1.0.1** | Patch (type-only exports) |
| \@azure/arm-workloadorchestration\ | 1.0.0-beta.1 | **1.0.0-beta.2** | Beta increment |
| \@azure/arm-resourceconnector\ | 2.0.0-beta.1 | **2.0.0-beta.2** | Beta increment |
| \@azure/arm-computeschedule\ | 1.2.0-beta.1 | **1.2.0-beta.2** | Beta increment |
| \@azure/arm-deviceprovisioningservices\ | 6.0.0-beta.3 | **6.0.0-beta.4** | Beta increment |

Each package has both `package.json` and `CHANGELOG.md` updated with an `(Unreleased)` section.

Fixes #38592