### PR TITLE
fix(arm-iotoperations): add missing react-native tsconfig for extract-api

### DIFF
--- a/sdk/iotoperations/arm-iotoperations/config/tsconfig.src.react-native.json
+++ b/sdk/iotoperations/arm-iotoperations/config/tsconfig.src.react-native.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../eng/tsconfigs/src.react-native.json",
+  "include": [
+    "../src/index.ts"
+  ]
+}

--- a/sdk/iotoperations/arm-iotoperations/tsconfig.json
+++ b/sdk/iotoperations/arm-iotoperations/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "./config/tsconfig.src.browser.json"
     },
     {
+      "path": "./config/tsconfig.src.react-native.json"
+    },
+    {
       "path": "./config/tsconfig.test.node.json"
     },
     {

--- a/sdk/iotoperations/arm-iotoperations/warp.config.yml
+++ b/sdk/iotoperations/arm-iotoperations/warp.config.yml
@@ -5,6 +5,9 @@ targets:
   - name: browser
     tsconfig: "./config/tsconfig.src.browser.json"
 
+  - name: react-native
+    tsconfig: "./config/tsconfig.src.react-native.json"
+
   - name: esm
     condition: import
     tsconfig: "./config/tsconfig.src.esm.json"


### PR DESCRIPTION
## Problem

The SDK generation pipeline for `@azure/arm-iotoperations` fails with exit code 255 during `dev-tool run extract-api`:

```
[Internal Error] Error parsing api-extractor.json:
The file referenced by "tsconfigFilePath" does not exist: tsconfig.src.json
```

**Root cause:** PR #38557 migrated the package to use `config/` directory tsconfigs but omitted `config/tsconfig.src.react-native.json`. When the TypeSpec emitter regenerates `warp.config.yml` with a `react-native` target during SDK generation, `extract-api.ts` (`getTsconfigFile()`) can't find `config/tsconfig.src.react-native.json` and falls back to `tsconfig.src.json`, which also doesn't exist.

## Fix

- Added `config/tsconfig.src.react-native.json` extending `eng/tsconfigs/src.react-native.json`
- Added `react-native` target to `warp.config.yml` (matching the base config pattern)
- Added react-native reference to `tsconfig.json`

## Related

- Pipeline failure: https://dev.azure.com/azure-sdk/public/_build/results?buildId=6316324
- Spec PR: https://github.com/Azure/azure-rest-api-specs/pull/43276
- Migration PR that missed this: #38557