### PR TITLE
fix(arm-iotoperations): regenerate SDK with latest emitter

### DIFF
--- a/sdk/iotoperations/arm-iotoperations/CHANGELOG.md
+++ b/sdk/iotoperations/arm-iotoperations/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Regenerated SDK with latest TypeSpec emitter (v0.53.2)
+
 ## 2.0.0 (2026-04-16)
 
 ### Features Added

--- a/sdk/iotoperations/arm-iotoperations/metadata.json
+++ b/sdk/iotoperations/arm-iotoperations/metadata.json
@@ -2,7 +2,7 @@
   "apiVersions": {
     "Microsoft.IoTOperations": "2026-03-01"
   },
-  "emitterVersion": "0.52.1",
+  "emitterVersion": "0.53.2",
   "crossLanguageDefinitions": {
     "CrossLanguagePackageId": "Microsoft.IoTOperations",
     "CrossLanguageDefinitionId": {

--- a/sdk/iotoperations/arm-iotoperations/package.json
+++ b/sdk/iotoperations/arm-iotoperations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-iotoperations",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generated SDK for IoTOperationsClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/iotoperations/arm-iotoperations/package.json
+++ b/sdk/iotoperations/arm-iotoperations/package.json
@@ -344,8 +344,10 @@
   "module": "./dist/esm/index.js",
   "browser": "./dist/browser/index.js",
   "imports": {
-    "#platform/*": {
-      "default": "./src/*.ts"
+    "#platform/*.js": {
+      "browser": "./src/*-browser.mjs",
+      "react-native": "./src/*-react-native.mjs",
+      "default": "./src/*.js"
     }
   }
 }

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-akriConnector-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-akriConnector-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, akriConnectorTemplateName: string, connectorName: string, options?: AkriConnectorDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-akriConnectorTemplate-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-akriConnectorTemplate-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, akriConnectorTemplateName: string, options?: AkriConnectorTemplateDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-akriService-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-akriService-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, akriServiceName: string, options?: AkriServiceDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-broker-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-broker-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, brokerName: string, options?: BrokerDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-brokerAuthentication-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-brokerAuthentication-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, brokerName: string, authenticationName: string, options?: BrokerAuthenticationDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-brokerAuthorization-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-brokerAuthorization-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, brokerName: string, authorizationName: string, options?: BrokerAuthorizationDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-brokerListener-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-brokerListener-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, brokerName: string, listenerName: string, options?: BrokerListenerDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflow-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflow-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, dataflowProfileName: string, dataflowName: string, options?: DataflowDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflowEndpoint-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflowEndpoint-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, dataflowEndpointName: string, options?: DataflowEndpointDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflowGraph-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflowGraph-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, dataflowProfileName: string, dataflowGraphName: string, options?: DataflowGraphDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflowProfile-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-dataflowProfile-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, dataflowProfileName: string, options?: DataflowProfileDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-instance-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-instance-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, options?: InstanceDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-node.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { ClientOptions } from '@azure-rest/core-client';
-import type { TokenCredential } from '@azure/core-auth';
+import { Client } from '@azure-rest/core-client';
+import { ClientOptions } from '@azure-rest/core-client';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export function createIoTOperations(credential: TokenCredential, subscriptionId: string, options?: IoTOperationsClientOptionalParams): IoTOperationsContext;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-operations-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-operations-node.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
 
 // @public
 export function list(context: IoTOperationsContext, options?: OperationsListOptionalParams): PagedAsyncIterableIterator<Operation>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-registryEndpoint-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-api-registryEndpoint-node.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import type { Client } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PollerLike } from '@azure/core-lro';
+import { Client } from '@azure-rest/core-client';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PollerLike } from '@azure/core-lro';
 
 // @public
 export function $delete(context: IoTOperationsContext, resourceGroupName: string, instanceName: string, registryEndpointName: string, options?: RegistryEndpointDeleteOptionalParams): PollerLike<OperationState<void>, void>;

--- a/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-node.api.md
+++ b/sdk/iotoperations/arm-iotoperations/review/arm-iotoperations-node.api.md
@@ -4,14 +4,16 @@
 
 ```ts
 
-import type { AbortSignalLike } from '@azure/abort-controller';
-import type { ClientOptions } from '@azure-rest/core-client';
-import type { OperationOptions } from '@azure-rest/core-client';
-import type { OperationState } from '@azure/core-lro';
-import type { PathUncheckedResponse } from '@azure-rest/core-client';
-import type { Pipeline } from '@azure/core-rest-pipeline';
-import type { PollerLike } from '@azure/core-lro';
-import type { TokenCredential } from '@azure/core-auth';
+import { AbortSignalLike } from '@azure/abort-controller';
+import { ClientOptions } from '@azure-rest/core-client';
+import { isRestError } from '@azure/core-rest-pipeline';
+import { OperationOptions } from '@azure-rest/core-client';
+import { OperationState } from '@azure/core-lro';
+import { PathUncheckedResponse } from '@azure-rest/core-client';
+import { Pipeline } from '@azure/core-rest-pipeline';
+import { PollerLike } from '@azure/core-lro';
+import { RestError } from '@azure/core-rest-pipeline';
+import { TokenCredential } from '@azure/core-auth';
 
 // @public
 export type ActionType = string;
@@ -1579,6 +1581,8 @@ export interface IoTOperationsClientOptionalParams extends ClientOptions {
     cloudSetting?: AzureSupportedClouds;
 }
 
+export { isRestError }
+
 // @public
 export type KafkaAuthMethod = string;
 
@@ -2263,6 +2267,8 @@ export interface ResourceHealthStatus {
     readonly reasonCode?: string;
     readonly status?: ResourceHealthState;
 }
+
+export { RestError }
 
 // @public
 export function restorePoller<TResponse extends PathUncheckedResponse, TResult>(client: IoTOperationsClient, serializedState: string, sourceOperation: (...args: any[]) => PollerLike<OperationState<TResult>, TResult>, options?: RestorePollerOptions<TResult>): PollerLike<OperationState<TResult>, TResult>;

--- a/sdk/iotoperations/arm-iotoperations/src/api/akriConnector/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/akriConnector/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  AkriConnectorResource,
-  _AkriConnectorResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  AkriConnectorResource,
   akriConnectorResourceSerializer,
   akriConnectorResourceDeserializer,
+  _AkriConnectorResourceListResult,
   _akriConnectorResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   AkriConnectorListByTemplateOptionalParams,
   AkriConnectorDeleteOptionalParams,
   AkriConnectorCreateOrUpdateOptionalParams,
   AkriConnectorGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByTemplateSend(
   context: Client,
@@ -128,11 +132,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a AkriConnectorResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/akriConnector/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/akriConnector/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface AkriConnectorListByTemplateOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/akriConnectorTemplate/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/akriConnectorTemplate/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  AkriConnectorTemplateResource,
-  _AkriConnectorTemplateResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  AkriConnectorTemplateResource,
   akriConnectorTemplateResourceSerializer,
   akriConnectorTemplateResourceDeserializer,
+  _AkriConnectorTemplateResourceListResult,
   _akriConnectorTemplateResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   AkriConnectorTemplateListByInstanceResourceOptionalParams,
   AkriConnectorTemplateDeleteOptionalParams,
   AkriConnectorTemplateCreateOrUpdateOptionalParams,
   AkriConnectorTemplateGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByInstanceResourceSend(
   context: Client,
@@ -116,11 +120,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a AkriConnectorTemplateResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/akriConnectorTemplate/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/akriConnectorTemplate/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface AkriConnectorTemplateListByInstanceResourceOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/akriService/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/akriService/operations.ts
@@ -1,27 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type { AkriServiceResource, _AkriServiceResourceListResult } from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  AkriServiceResource,
   akriServiceResourceSerializer,
   akriServiceResourceDeserializer,
+  _AkriServiceResourceListResult,
   _akriServiceResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   AkriServiceListByInstanceResourceOptionalParams,
   AkriServiceDeleteOptionalParams,
   AkriServiceCreateOrUpdateOptionalParams,
   AkriServiceGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByInstanceResourceSend(
   context: Client,
@@ -113,11 +120,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a AkriServiceResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/akriService/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/akriService/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface AkriServiceListByInstanceResourceOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/broker/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/broker/operations.ts
@@ -1,27 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type { BrokerResource, _BrokerResourceListResult } from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  BrokerResource,
   brokerResourceSerializer,
   brokerResourceDeserializer,
+  _BrokerResourceListResult,
   _brokerResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   BrokerListByResourceGroupOptionalParams,
   BrokerDeleteOptionalParams,
   BrokerCreateOrUpdateOptionalParams,
   BrokerGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -113,11 +120,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a BrokerResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/broker/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/broker/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface BrokerListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthentication/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthentication/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  BrokerAuthenticationResource,
-  _BrokerAuthenticationResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  BrokerAuthenticationResource,
   brokerAuthenticationResourceSerializer,
   brokerAuthenticationResourceDeserializer,
+  _BrokerAuthenticationResourceListResult,
   _brokerAuthenticationResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   BrokerAuthenticationListByResourceGroupOptionalParams,
   BrokerAuthenticationDeleteOptionalParams,
   BrokerAuthenticationCreateOrUpdateOptionalParams,
   BrokerAuthenticationGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -121,11 +125,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a BrokerAuthenticationResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthentication/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthentication/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface BrokerAuthenticationListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthorization/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthorization/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  BrokerAuthorizationResource,
-  _BrokerAuthorizationResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  BrokerAuthorizationResource,
   brokerAuthorizationResourceSerializer,
   brokerAuthorizationResourceDeserializer,
+  _BrokerAuthorizationResourceListResult,
   _brokerAuthorizationResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   BrokerAuthorizationListByResourceGroupOptionalParams,
   BrokerAuthorizationDeleteOptionalParams,
   BrokerAuthorizationCreateOrUpdateOptionalParams,
   BrokerAuthorizationGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -121,11 +125,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a BrokerAuthorizationResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthorization/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/brokerAuthorization/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface BrokerAuthorizationListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/brokerListener/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/brokerListener/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  BrokerListenerResource,
-  _BrokerListenerResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  BrokerListenerResource,
   brokerListenerResourceSerializer,
   brokerListenerResourceDeserializer,
+  _BrokerListenerResourceListResult,
   _brokerListenerResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   BrokerListenerListByResourceGroupOptionalParams,
   BrokerListenerDeleteOptionalParams,
   BrokerListenerCreateOrUpdateOptionalParams,
   BrokerListenerGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -121,11 +125,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a BrokerListenerResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/brokerListener/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/brokerListener/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface BrokerListenerListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflow/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflow/operations.ts
@@ -1,27 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type { DataflowResource, _DataflowResourceListResult } from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  DataflowResource,
   dataflowResourceSerializer,
   dataflowResourceDeserializer,
+  _DataflowResourceListResult,
   _dataflowResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   DataflowListByResourceGroupOptionalParams,
   DataflowDeleteOptionalParams,
   DataflowCreateOrUpdateOptionalParams,
   DataflowGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -125,11 +132,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a DataflowResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflow/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflow/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface DataflowListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflowEndpoint/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflowEndpoint/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  DataflowEndpointResource,
-  _DataflowEndpointResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  DataflowEndpointResource,
   dataflowEndpointResourceSerializer,
   dataflowEndpointResourceDeserializer,
+  _DataflowEndpointResourceListResult,
   _dataflowEndpointResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   DataflowEndpointListByResourceGroupOptionalParams,
   DataflowEndpointDeleteOptionalParams,
   DataflowEndpointCreateOrUpdateOptionalParams,
   DataflowEndpointGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -116,11 +120,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a DataflowEndpointResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflowEndpoint/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflowEndpoint/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface DataflowEndpointListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflowGraph/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflowGraph/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  DataflowGraphResource,
-  _DataflowGraphResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  DataflowGraphResource,
   dataflowGraphResourceSerializer,
   dataflowGraphResourceDeserializer,
+  _DataflowGraphResourceListResult,
   _dataflowGraphResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   DataflowGraphListByDataflowProfileOptionalParams,
   DataflowGraphDeleteOptionalParams,
   DataflowGraphCreateOrUpdateOptionalParams,
   DataflowGraphGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByDataflowProfileSend(
   context: Client,
@@ -128,11 +132,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a DataflowGraphResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflowGraph/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflowGraph/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface DataflowGraphListByDataflowProfileOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflowProfile/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflowProfile/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  DataflowProfileResource,
-  _DataflowProfileResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  DataflowProfileResource,
   dataflowProfileResourceSerializer,
   dataflowProfileResourceDeserializer,
+  _DataflowProfileResourceListResult,
   _dataflowProfileResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   DataflowProfileListByResourceGroupOptionalParams,
   DataflowProfileDeleteOptionalParams,
   DataflowProfileCreateOrUpdateOptionalParams,
   DataflowProfileGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByResourceGroupSend(
   context: Client,
@@ -116,11 +120,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a DataflowProfileResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/dataflowProfile/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/dataflowProfile/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface DataflowProfileListByResourceGroupOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/instance/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/instance/operations.ts
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  InstanceResource,
-  InstancePatchModel,
-  _InstanceResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  InstanceResource,
   instanceResourceSerializer,
   instanceResourceDeserializer,
+  InstancePatchModel,
   instancePatchModelSerializer,
+  _InstanceResourceListResult,
   _instanceResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   InstanceListBySubscriptionOptionalParams,
   InstanceListByResourceGroupOptionalParams,
   InstanceDeleteOptionalParams,
@@ -26,9 +26,13 @@ import type {
   InstanceCreateOrUpdateOptionalParams,
   InstanceGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listBySubscriptionSend(
   context: Client,
@@ -163,11 +167,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a InstanceResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/instance/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/instance/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface InstanceListBySubscriptionOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/ioTOperationsContext.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/ioTOperationsContext.ts
@@ -34,7 +34,7 @@ export function createIoTOperations(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-iotoperations/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-iotoperations/2.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/iotoperations/arm-iotoperations/src/api/ioTOperationsContext.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/ioTOperationsContext.ts
@@ -3,11 +3,9 @@
 
 import { logger } from "../logger.js";
 import { KnownVersions } from "../models/models.js";
-import type { AzureSupportedClouds } from "../static-helpers/cloudSettingHelpers.js";
-import { getArmEndpoint } from "../static-helpers/cloudSettingHelpers.js";
-import type { Client, ClientOptions } from "@azure-rest/core-client";
-import { getClient } from "@azure-rest/core-client";
-import type { TokenCredential } from "@azure/core-auth";
+import { AzureSupportedClouds, getArmEndpoint } from "../static-helpers/cloudSettingHelpers.js";
+import { Client, ClientOptions, getClient } from "@azure-rest/core-client";
+import { TokenCredential } from "@azure/core-auth";
 
 /** Microsoft.IoTOperations Resource Provider management API. */
 export interface IoTOperationsContext extends Client {
@@ -36,7 +34,7 @@ export function createIoTOperations(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-iotoperations/2.0.0`;
+  const userAgentInfo = `azsdk-js-arm-iotoperations/1.0.0-beta.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;
@@ -44,7 +42,9 @@ export function createIoTOperations(
     ...options,
     userAgentOptions: { userAgentPrefix },
     loggingOptions: { logger: options.loggingOptions?.logger ?? logger.info },
-    credentials: { scopes: options.credentials?.scopes ?? [`${endpointUrl}/.default`] },
+    credentials: {
+      scopes: options.credentials?.scopes ?? ["https://management.azure.com/.default"],
+    },
   };
   const clientContext = getClient(endpointUrl, credential, updatedOptions);
   const apiVersion = options.apiVersion;

--- a/sdk/iotoperations/arm-iotoperations/src/api/operations/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/operations/operations.ts
@@ -1,18 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type { _OperationListResult, Operation } from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
+  _OperationListResult,
   _operationListResultDeserializer,
+  Operation,
   errorResponseDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type { OperationsListOptionalParams } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
+import { OperationsListOptionalParams } from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
 
 export function _listSend(
   context: Client,

--- a/sdk/iotoperations/arm-iotoperations/src/api/operations/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/operations/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface OperationsListOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/api/registryEndpoint/operations.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/registryEndpoint/operations.ts
@@ -1,30 +1,34 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext as Client } from "../index.js";
-import type {
-  RegistryEndpointResource,
-  _RegistryEndpointResourceListResult,
-} from "../../models/models.js";
+import { IoTOperationsContext as Client } from "../index.js";
 import {
   errorResponseDeserializer,
+  RegistryEndpointResource,
   registryEndpointResourceSerializer,
   registryEndpointResourceDeserializer,
+  _RegistryEndpointResourceListResult,
   _registryEndpointResourceListResultDeserializer,
 } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import { buildPagedAsyncIterator } from "../../static-helpers/pagingHelpers.js";
+import {
+  PagedAsyncIterableIterator,
+  buildPagedAsyncIterator,
+} from "../../static-helpers/pagingHelpers.js";
 import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
 import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
-import type {
+import {
   RegistryEndpointListByInstanceResourceOptionalParams,
   RegistryEndpointDeleteOptionalParams,
   RegistryEndpointCreateOrUpdateOptionalParams,
   RegistryEndpointGetOptionalParams,
 } from "./options.js";
-import type { StreamableMethod, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError, operationOptionsToRequestParameters } from "@azure-rest/core-client";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 export function _listByInstanceResourceSend(
   context: Client,
@@ -116,11 +120,6 @@ export async function _$deleteDeserialize(result: PathUncheckedResponse): Promis
 }
 
 /** Delete a RegistryEndpointResource */
-/**
- *  @fixme delete is a reserved word that cannot be used as an operation name.
- *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
- *         to the operation to override the generated name.
- */
 export function $delete(
   context: Client,
   resourceGroupName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/api/registryEndpoint/options.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/api/registryEndpoint/options.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { OperationOptions } from "@azure-rest/core-client";
+import { OperationOptions } from "@azure-rest/core-client";
 
 /** Optional parameters. */
 export interface RegistryEndpointListByInstanceResourceOptionalParams extends OperationOptions {}

--- a/sdk/iotoperations/arm-iotoperations/src/classic/akriConnector/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/akriConnector/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByTemplate,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/akriConnector/operations.js";
-import type {
+import {
   AkriConnectorListByTemplateOptionalParams,
   AkriConnectorDeleteOptionalParams,
   AkriConnectorCreateOrUpdateOptionalParams,
   AkriConnectorGetOptionalParams,
 } from "../../api/akriConnector/options.js";
-import type { AkriConnectorResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { AkriConnectorResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a AkriConnector operations. */
 export interface AkriConnectorOperations {
@@ -28,11 +28,6 @@ export interface AkriConnectorOperations {
     options?: AkriConnectorListByTemplateOptionalParams,
   ) => PagedAsyncIterableIterator<AkriConnectorResource>;
   /** Delete a AkriConnectorResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/akriConnectorTemplate/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/akriConnectorTemplate/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByInstanceResource,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/akriConnectorTemplate/operations.js";
-import type {
+import {
   AkriConnectorTemplateListByInstanceResourceOptionalParams,
   AkriConnectorTemplateDeleteOptionalParams,
   AkriConnectorTemplateCreateOrUpdateOptionalParams,
   AkriConnectorTemplateGetOptionalParams,
 } from "../../api/akriConnectorTemplate/options.js";
-import type { AkriConnectorTemplateResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { AkriConnectorTemplateResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a AkriConnectorTemplate operations. */
 export interface AkriConnectorTemplateOperations {
@@ -27,11 +27,6 @@ export interface AkriConnectorTemplateOperations {
     options?: AkriConnectorTemplateListByInstanceResourceOptionalParams,
   ) => PagedAsyncIterableIterator<AkriConnectorTemplateResource>;
   /** Delete a AkriConnectorTemplateResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/akriService/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/akriService/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByInstanceResource,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/akriService/operations.js";
-import type {
+import {
   AkriServiceListByInstanceResourceOptionalParams,
   AkriServiceDeleteOptionalParams,
   AkriServiceCreateOrUpdateOptionalParams,
   AkriServiceGetOptionalParams,
 } from "../../api/akriService/options.js";
-import type { AkriServiceResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { AkriServiceResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a AkriService operations. */
 export interface AkriServiceOperations {
@@ -27,11 +27,6 @@ export interface AkriServiceOperations {
     options?: AkriServiceListByInstanceResourceOptionalParams,
   ) => PagedAsyncIterableIterator<AkriServiceResource>;
   /** Delete a AkriServiceResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/broker/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/broker/index.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import { listByResourceGroup, $delete, createOrUpdate, get } from "../../api/broker/operations.js";
-import type {
+import {
   BrokerListByResourceGroupOptionalParams,
   BrokerDeleteOptionalParams,
   BrokerCreateOrUpdateOptionalParams,
   BrokerGetOptionalParams,
 } from "../../api/broker/options.js";
-import type { BrokerResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { BrokerResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a Broker operations. */
 export interface BrokerOperations {
@@ -22,11 +22,6 @@ export interface BrokerOperations {
     options?: BrokerListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<BrokerResource>;
   /** Delete a BrokerResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/brokerAuthentication/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/brokerAuthentication/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByResourceGroup,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/brokerAuthentication/operations.js";
-import type {
+import {
   BrokerAuthenticationListByResourceGroupOptionalParams,
   BrokerAuthenticationDeleteOptionalParams,
   BrokerAuthenticationCreateOrUpdateOptionalParams,
   BrokerAuthenticationGetOptionalParams,
 } from "../../api/brokerAuthentication/options.js";
-import type { BrokerAuthenticationResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { BrokerAuthenticationResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a BrokerAuthentication operations. */
 export interface BrokerAuthenticationOperations {
@@ -28,11 +28,6 @@ export interface BrokerAuthenticationOperations {
     options?: BrokerAuthenticationListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<BrokerAuthenticationResource>;
   /** Delete a BrokerAuthenticationResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/brokerAuthorization/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/brokerAuthorization/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByResourceGroup,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/brokerAuthorization/operations.js";
-import type {
+import {
   BrokerAuthorizationListByResourceGroupOptionalParams,
   BrokerAuthorizationDeleteOptionalParams,
   BrokerAuthorizationCreateOrUpdateOptionalParams,
   BrokerAuthorizationGetOptionalParams,
 } from "../../api/brokerAuthorization/options.js";
-import type { BrokerAuthorizationResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { BrokerAuthorizationResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a BrokerAuthorization operations. */
 export interface BrokerAuthorizationOperations {
@@ -28,11 +28,6 @@ export interface BrokerAuthorizationOperations {
     options?: BrokerAuthorizationListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<BrokerAuthorizationResource>;
   /** Delete a BrokerAuthorizationResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/brokerListener/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/brokerListener/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByResourceGroup,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/brokerListener/operations.js";
-import type {
+import {
   BrokerListenerListByResourceGroupOptionalParams,
   BrokerListenerDeleteOptionalParams,
   BrokerListenerCreateOrUpdateOptionalParams,
   BrokerListenerGetOptionalParams,
 } from "../../api/brokerListener/options.js";
-import type { BrokerListenerResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { BrokerListenerResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a BrokerListener operations. */
 export interface BrokerListenerOperations {
@@ -28,11 +28,6 @@ export interface BrokerListenerOperations {
     options?: BrokerListenerListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<BrokerListenerResource>;
   /** Delete a BrokerListenerResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/dataflow/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/dataflow/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByResourceGroup,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/dataflow/operations.js";
-import type {
+import {
   DataflowListByResourceGroupOptionalParams,
   DataflowDeleteOptionalParams,
   DataflowCreateOrUpdateOptionalParams,
   DataflowGetOptionalParams,
 } from "../../api/dataflow/options.js";
-import type { DataflowResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { DataflowResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a Dataflow operations. */
 export interface DataflowOperations {
@@ -28,11 +28,6 @@ export interface DataflowOperations {
     options?: DataflowListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<DataflowResource>;
   /** Delete a DataflowResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/dataflowEndpoint/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/dataflowEndpoint/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByResourceGroup,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/dataflowEndpoint/operations.js";
-import type {
+import {
   DataflowEndpointListByResourceGroupOptionalParams,
   DataflowEndpointDeleteOptionalParams,
   DataflowEndpointCreateOrUpdateOptionalParams,
   DataflowEndpointGetOptionalParams,
 } from "../../api/dataflowEndpoint/options.js";
-import type { DataflowEndpointResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { DataflowEndpointResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a DataflowEndpoint operations. */
 export interface DataflowEndpointOperations {
@@ -27,11 +27,6 @@ export interface DataflowEndpointOperations {
     options?: DataflowEndpointListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<DataflowEndpointResource>;
   /** Delete a DataflowEndpointResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/dataflowGraph/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/dataflowGraph/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByDataflowProfile,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/dataflowGraph/operations.js";
-import type {
+import {
   DataflowGraphListByDataflowProfileOptionalParams,
   DataflowGraphDeleteOptionalParams,
   DataflowGraphCreateOrUpdateOptionalParams,
   DataflowGraphGetOptionalParams,
 } from "../../api/dataflowGraph/options.js";
-import type { DataflowGraphResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { DataflowGraphResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a DataflowGraph operations. */
 export interface DataflowGraphOperations {
@@ -28,11 +28,6 @@ export interface DataflowGraphOperations {
     options?: DataflowGraphListByDataflowProfileOptionalParams,
   ) => PagedAsyncIterableIterator<DataflowGraphResource>;
   /** Delete a DataflowGraphResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/dataflowProfile/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/dataflowProfile/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByResourceGroup,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/dataflowProfile/operations.js";
-import type {
+import {
   DataflowProfileListByResourceGroupOptionalParams,
   DataflowProfileDeleteOptionalParams,
   DataflowProfileCreateOrUpdateOptionalParams,
   DataflowProfileGetOptionalParams,
 } from "../../api/dataflowProfile/options.js";
-import type { DataflowProfileResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { DataflowProfileResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a DataflowProfile operations. */
 export interface DataflowProfileOperations {
@@ -27,11 +27,6 @@ export interface DataflowProfileOperations {
     options?: DataflowProfileListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<DataflowProfileResource>;
   /** Delete a DataflowProfileResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/instance/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/instance/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listBySubscription,
   listByResourceGroup,
@@ -10,7 +10,7 @@ import {
   createOrUpdate,
   get,
 } from "../../api/instance/operations.js";
-import type {
+import {
   InstanceListBySubscriptionOptionalParams,
   InstanceListByResourceGroupOptionalParams,
   InstanceDeleteOptionalParams,
@@ -18,9 +18,9 @@ import type {
   InstanceCreateOrUpdateOptionalParams,
   InstanceGetOptionalParams,
 } from "../../api/instance/options.js";
-import type { InstanceResource, InstancePatchModel } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { InstanceResource, InstancePatchModel } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a Instance operations. */
 export interface InstanceOperations {
@@ -34,11 +34,6 @@ export interface InstanceOperations {
     options?: InstanceListByResourceGroupOptionalParams,
   ) => PagedAsyncIterableIterator<InstanceResource>;
   /** Delete a InstanceResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/classic/operations/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/operations/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import { list } from "../../api/operations/operations.js";
-import type { OperationsListOptionalParams } from "../../api/operations/options.js";
-import type { Operation } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { OperationsListOptionalParams } from "../../api/operations/options.js";
+import { Operation } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
 
 /** Interface representing a Operations operations. */
 export interface OperationsOperations {

--- a/sdk/iotoperations/arm-iotoperations/src/classic/registryEndpoint/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/classic/registryEndpoint/index.ts
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
+import { IoTOperationsContext } from "../../api/ioTOperationsContext.js";
 import {
   listByInstanceResource,
   $delete,
   createOrUpdate,
   get,
 } from "../../api/registryEndpoint/operations.js";
-import type {
+import {
   RegistryEndpointListByInstanceResourceOptionalParams,
   RegistryEndpointDeleteOptionalParams,
   RegistryEndpointCreateOrUpdateOptionalParams,
   RegistryEndpointGetOptionalParams,
 } from "../../api/registryEndpoint/options.js";
-import type { RegistryEndpointResource } from "../../models/models.js";
-import type { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
-import type { PollerLike, OperationState } from "@azure/core-lro";
+import { RegistryEndpointResource } from "../../models/models.js";
+import { PagedAsyncIterableIterator } from "../../static-helpers/pagingHelpers.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
 
 /** Interface representing a RegistryEndpoint operations. */
 export interface RegistryEndpointOperations {
@@ -27,11 +27,6 @@ export interface RegistryEndpointOperations {
     options?: RegistryEndpointListByInstanceResourceOptionalParams,
   ) => PagedAsyncIterableIterator<RegistryEndpointResource>;
   /** Delete a RegistryEndpointResource */
-  /**
-   *  @fixme delete is a reserved word that cannot be used as an operation name.
-   *         Please add @clientName("clientName") or @clientName("<JS-Specific-Name>", "javascript")
-   *         to the operation to override the generated name.
-   */
   delete: (
     resourceGroupName: string,
     instanceName: string,

--- a/sdk/iotoperations/arm-iotoperations/src/index.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/index.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { AzureSupportedClouds } from "./static-helpers/cloudSettingHelpers.js";
-import { AzureClouds } from "./static-helpers/cloudSettingHelpers.js";
-import type {
+import { AzureClouds, AzureSupportedClouds } from "./static-helpers/cloudSettingHelpers.js";
+import {
   PageSettings,
   ContinuablePage,
   PagedAsyncIterableIterator,
@@ -451,3 +450,4 @@ export type {
 export type { PageSettings, ContinuablePage, PagedAsyncIterableIterator };
 export { AzureClouds };
 export type { AzureSupportedClouds };
+export { RestError, isRestError } from "@azure/core-rest-pipeline";

--- a/sdk/iotoperations/arm-iotoperations/src/ioTOperationsClient.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/ioTOperationsClient.ts
@@ -1,38 +1,54 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsContext, IoTOperationsClientOptionalParams } from "./api/index.js";
-import { createIoTOperations } from "./api/index.js";
-import type { AkriConnectorOperations } from "./classic/akriConnector/index.js";
-import { _getAkriConnectorOperations } from "./classic/akriConnector/index.js";
-import type { AkriConnectorTemplateOperations } from "./classic/akriConnectorTemplate/index.js";
-import { _getAkriConnectorTemplateOperations } from "./classic/akriConnectorTemplate/index.js";
-import type { AkriServiceOperations } from "./classic/akriService/index.js";
-import { _getAkriServiceOperations } from "./classic/akriService/index.js";
-import type { BrokerOperations } from "./classic/broker/index.js";
-import { _getBrokerOperations } from "./classic/broker/index.js";
-import type { BrokerAuthenticationOperations } from "./classic/brokerAuthentication/index.js";
-import { _getBrokerAuthenticationOperations } from "./classic/brokerAuthentication/index.js";
-import type { BrokerAuthorizationOperations } from "./classic/brokerAuthorization/index.js";
-import { _getBrokerAuthorizationOperations } from "./classic/brokerAuthorization/index.js";
-import type { BrokerListenerOperations } from "./classic/brokerListener/index.js";
-import { _getBrokerListenerOperations } from "./classic/brokerListener/index.js";
-import type { DataflowOperations } from "./classic/dataflow/index.js";
-import { _getDataflowOperations } from "./classic/dataflow/index.js";
-import type { DataflowEndpointOperations } from "./classic/dataflowEndpoint/index.js";
-import { _getDataflowEndpointOperations } from "./classic/dataflowEndpoint/index.js";
-import type { DataflowGraphOperations } from "./classic/dataflowGraph/index.js";
-import { _getDataflowGraphOperations } from "./classic/dataflowGraph/index.js";
-import type { DataflowProfileOperations } from "./classic/dataflowProfile/index.js";
-import { _getDataflowProfileOperations } from "./classic/dataflowProfile/index.js";
-import type { InstanceOperations } from "./classic/instance/index.js";
-import { _getInstanceOperations } from "./classic/instance/index.js";
-import type { OperationsOperations } from "./classic/operations/index.js";
-import { _getOperationsOperations } from "./classic/operations/index.js";
-import type { RegistryEndpointOperations } from "./classic/registryEndpoint/index.js";
-import { _getRegistryEndpointOperations } from "./classic/registryEndpoint/index.js";
-import type { TokenCredential } from "@azure/core-auth";
-import type { Pipeline } from "@azure/core-rest-pipeline";
+import {
+  IoTOperationsContext,
+  IoTOperationsClientOptionalParams,
+  createIoTOperations,
+} from "./api/index.js";
+import {
+  AkriConnectorOperations,
+  _getAkriConnectorOperations,
+} from "./classic/akriConnector/index.js";
+import {
+  AkriConnectorTemplateOperations,
+  _getAkriConnectorTemplateOperations,
+} from "./classic/akriConnectorTemplate/index.js";
+import { AkriServiceOperations, _getAkriServiceOperations } from "./classic/akriService/index.js";
+import { BrokerOperations, _getBrokerOperations } from "./classic/broker/index.js";
+import {
+  BrokerAuthenticationOperations,
+  _getBrokerAuthenticationOperations,
+} from "./classic/brokerAuthentication/index.js";
+import {
+  BrokerAuthorizationOperations,
+  _getBrokerAuthorizationOperations,
+} from "./classic/brokerAuthorization/index.js";
+import {
+  BrokerListenerOperations,
+  _getBrokerListenerOperations,
+} from "./classic/brokerListener/index.js";
+import { DataflowOperations, _getDataflowOperations } from "./classic/dataflow/index.js";
+import {
+  DataflowEndpointOperations,
+  _getDataflowEndpointOperations,
+} from "./classic/dataflowEndpoint/index.js";
+import {
+  DataflowGraphOperations,
+  _getDataflowGraphOperations,
+} from "./classic/dataflowGraph/index.js";
+import {
+  DataflowProfileOperations,
+  _getDataflowProfileOperations,
+} from "./classic/dataflowProfile/index.js";
+import { InstanceOperations, _getInstanceOperations } from "./classic/instance/index.js";
+import { OperationsOperations, _getOperationsOperations } from "./classic/operations/index.js";
+import {
+  RegistryEndpointOperations,
+  _getRegistryEndpointOperations,
+} from "./classic/registryEndpoint/index.js";
+import { TokenCredential } from "@azure/core-auth";
+import { Pipeline } from "@azure/core-rest-pipeline";
 
 export type { IoTOperationsClientOptionalParams } from "./api/ioTOperationsContext.js";
 

--- a/sdk/iotoperations/arm-iotoperations/src/restorePollerHelpers.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/restorePollerHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { IoTOperationsClient } from "./ioTOperationsClient.js";
+import { IoTOperationsClient } from "./ioTOperationsClient.js";
 import { _$deleteDeserialize, _createOrUpdateDeserialize } from "./api/akriService/operations.js";
 import {
   _$deleteDeserialize as _$deleteDeserializeAkriConnector,
@@ -52,10 +52,14 @@ import {
   _createOrUpdateDeserialize as _createOrUpdateDeserializeInstance,
 } from "./api/instance/operations.js";
 import { getLongRunningPoller } from "./static-helpers/pollingHelpers.js";
-import type { OperationOptions, PathUncheckedResponse } from "@azure-rest/core-client";
-import type { AbortSignalLike } from "@azure/abort-controller";
-import type { PollerLike, OperationState, ResourceLocationConfig } from "@azure/core-lro";
-import { deserializeState } from "@azure/core-lro";
+import { OperationOptions, PathUncheckedResponse } from "@azure-rest/core-client";
+import { AbortSignalLike } from "@azure/abort-controller";
+import {
+  PollerLike,
+  OperationState,
+  deserializeState,
+  ResourceLocationConfig,
+} from "@azure/core-lro";
 
 export interface RestorePollerOptions<
   TResult,

--- a/sdk/iotoperations/arm-iotoperations/src/static-helpers/pagingHelpers.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/static-helpers/pagingHelpers.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { Client, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError } from "@azure-rest/core-client";
+import { Client, createRestError, PathUncheckedResponse } from "@azure-rest/core-client";
 import { RestError } from "@azure/core-rest-pipeline";
 
 /**
@@ -262,9 +261,7 @@ function addApiVersionToUrl(url: string, apiVersion: string): string {
   const urlObj = new URL(url, "https://microsoft.com");
   if (!urlObj.searchParams.get("api-version")) {
     // Append one if there is no apiVersion
-    return `${url}${
-      Array.from(urlObj.searchParams.keys()).length > 0 ? "&" : "?"
-    }api-version=${apiVersion}`;
+    return `${url}${urlObj.search ? "&" : "?"}api-version=${apiVersion}`;
   }
   return url;
 }

--- a/sdk/iotoperations/arm-iotoperations/src/static-helpers/pollingHelpers.ts
+++ b/sdk/iotoperations/arm-iotoperations/src/static-helpers/pollingHelpers.ts
@@ -1,18 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type {
+import {
   PollerLike,
   OperationState,
   ResourceLocationConfig,
   RunningOperation,
+  createHttpPoller,
   OperationResponse,
 } from "@azure/core-lro";
-import { createHttpPoller } from "@azure/core-lro";
 
-import type { Client, PathUncheckedResponse } from "@azure-rest/core-client";
-import { createRestError } from "@azure-rest/core-client";
-import type { AbortSignalLike } from "@azure/abort-controller";
+import { Client, PathUncheckedResponse, createRestError } from "@azure-rest/core-client";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 export interface GetLongRunningPollerOptions<TResponse> {
   /** Delay to wait until next poll, in milliseconds. */
@@ -142,9 +141,7 @@ function addApiVersionToUrl(url: string, apiVersion: string): string {
   const urlObj = new URL(url, "https://microsoft.com");
   if (!urlObj.searchParams.get("api-version")) {
     // Append one if there is no apiVersion
-    return `${url}${
-      Array.from(urlObj.searchParams.keys()).length > 0 ? "&" : "?"
-    }api-version=${apiVersion}`;
+    return `${url}${urlObj.search ? "&" : "?"}api-version=${apiVersion}`;
   }
   return url;
 }

--- a/sdk/iotoperations/arm-iotoperations/warp.config.yml
+++ b/sdk/iotoperations/arm-iotoperations/warp.config.yml
@@ -1,5 +1,24 @@
+# warp.config.yml — build configuration
 
-extends: ../../../warp.base.config.yml
+exports:
+  "./package.json": "./package.json"
+  ".": "./src/index.ts"
+  "./api": "./src/api/index.ts"
+  "./api/akriService": "./src/api/akriService/index.ts"
+  "./api/akriConnector": "./src/api/akriConnector/index.ts"
+  "./api/akriConnectorTemplate": "./src/api/akriConnectorTemplate/index.ts"
+  "./api/registryEndpoint": "./src/api/registryEndpoint/index.ts"
+  "./api/dataflowGraph": "./src/api/dataflowGraph/index.ts"
+  "./api/dataflowEndpoint": "./src/api/dataflowEndpoint/index.ts"
+  "./api/dataflow": "./src/api/dataflow/index.ts"
+  "./api/dataflowProfile": "./src/api/dataflowProfile/index.ts"
+  "./api/brokerAuthorization": "./src/api/brokerAuthorization/index.ts"
+  "./api/brokerAuthentication": "./src/api/brokerAuthentication/index.ts"
+  "./api/brokerListener": "./src/api/brokerListener/index.ts"
+  "./api/broker": "./src/api/broker/index.ts"
+  "./api/instance": "./src/api/instance/index.ts"
+  "./api/operations": "./src/api/operations/index.ts"
+  "./models": "./src/models/index.ts"
 
 targets:
   - name: browser


### PR DESCRIPTION
## Problem

The SDK generation pipeline for `@azure/arm-iotoperations` fails during `extract-api` because `tsconfig.src.react-native.json` doesn't exist after the config/ migration (#38557).

## Fix

Regenerated the SDK using the latest TypeSpec emitter (v0.53.2, bumped in #38588), which no longer generates react-native targets for management packages (per https://github.com/Azure/autorest.typescript/pull/3943).

This replaces the manual react-native tsconfig fix in #38598 with a proper regeneration as recommended by @jeremymeng in https://github.com/Azure/azure-sdk-for-js/pull/38598#issuecomment-4490845845.

## Changes

- Regenerated SDK source code with latest emitter
- `warp.config.yml` no longer includes a `react-native` target
- No `config/tsconfig.src.react-native.json` needed
- Formatted code with prettier

## Related

- Reviewer comment: https://github.com/Azure/azure-sdk-for-js/pull/38598#issuecomment-4490845845
- Emitter version bump: #38588
- Emitter fix: https://github.com/Azure/autorest.typescript/pull/3943
- Original (superseded) PR: #38598