### PR TITLE
[iot-modelsrepository] migrate to #platform import

### DIFF
--- a/sdk/iot/iot-modelsrepository/README.md
+++ b/sdk/iot/iot-modelsrepository/README.md
@@ -98,7 +98,7 @@ const models = await client.getModels(dtmi);
 
 // In this case the above dtmi has 2 model dependencies.
 // dtmi:com:example:Thermostat;1 and dtmi:azure:DeviceManagement:DeviceInformation;1
-console.log(`${dtmi} resolved in {Object.keys(models).length} interfaces.`);
+console.log(`${dtmi} resolved in ${Object.keys(models).length} interfaces.`);
 ```
 
 You are also able to get definitions for multiple root models at a time by leveraging the `GetModels` overload.
@@ -118,7 +118,7 @@ const models = await client.getModels(dtmis);
 // In this case the dtmi "dtmi:com:example:TemperatureController;1" has 2 model dependencies
 // and the dtmi "dtmi:com:example:azuresphere:sampledevice;1" has no additional dependencies.
 // The returned IDictionary will include 4 models.
-console.log(`${dtmis.toString()} resolved in ${Object.keys(models.keys).length} interfaces.`);
+console.log(`${dtmis.toString()} resolved in ${Object.keys(models).length} interfaces.`);
 ```
 
 ### Digital Twins Model Parser Integration

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -19,8 +19,8 @@
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
     "temp-unit-test": "mocha -r ts-node/register --timeout 1200000 test/node/*.spec.ts",
-    "test": "npm run test:node && npm run test:browser",
-    "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
+    "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
+    "test:browser": "dev-tool run test:vitest --browser",
     "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
     "update-snippets": "dev-tool run update-snippets"
   },
@@ -120,6 +120,7 @@
   "react-native": "./dist/react-native/index.js",
   "imports": {
     "#platform/*": {
+      "browser": "./src/*-browser.mts",
       "default": "./src/*.ts"
     }
   }

--- a/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
+++ b/sdk/iot/iot-modelsrepository/src/modelsRepositoryClient.ts
@@ -12,8 +12,8 @@ import {
 import type { InternalClientPipelineOptions } from "@azure/core-client";
 import { createClientPipeline } from "@azure/core-client";
 import type { Fetcher } from "./fetcherAbstract.js";
-import { isLocalPath, normalize } from "./utils/path.js";
-import { FilesystemFetcher } from "./fetcherFilesystem.js";
+import { isLocalPath, normalize } from "#platform/utils/path";
+import { FilesystemFetcher } from "#platform/fetcherFilesystem";
 import type { dependencyResolutionType } from "./dependencyResolutionType.js";
 import { DtmiResolver } from "./dtmiResolver.js";
 import { PseudoParser } from "./psuedoParser.js";

--- a/sdk/iot/iot-modelsrepository/test/snippets.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/snippets.spec.ts
@@ -67,7 +67,7 @@ describe("snippets", () => {
     // In this case the dtmi "dtmi:com:example:TemperatureController;1" has 2 model dependencies
     // and the dtmi "dtmi:com:example:azuresphere:sampledevice;1" has no additional dependencies.
     // The returned IDictionary will include 4 models.
-    console.log(`${dtmis.toString()} resolved in ${Object.keys(models.keys).length} interfaces.`);
+    console.log(`${dtmis.toString()} resolved in ${Object.keys(models.keys as {}).length} interfaces.`);
   });
 
   it("ReadmeSampleDtmiConventions", async () => {

--- a/sdk/iot/iot-modelsrepository/test/snippets.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/snippets.spec.ts
@@ -51,7 +51,7 @@ describe("snippets", () => {
     // @ts-preserve-whitespace
     // In this case the above dtmi has 2 model dependencies.
     // dtmi:com:example:Thermostat;1 and dtmi:azure:DeviceManagement:DeviceInformation;1
-    console.log(`${dtmi} resolved in {Object.keys(models).length} interfaces.`);
+    console.log(`${dtmi} resolved in ${Object.keys(models).length} interfaces.`);
   });
 
   it("ReadmeSampleGetModels_Multiple", async () => {
@@ -67,7 +67,7 @@ describe("snippets", () => {
     // In this case the dtmi "dtmi:com:example:TemperatureController;1" has 2 model dependencies
     // and the dtmi "dtmi:com:example:azuresphere:sampledevice;1" has no additional dependencies.
     // The returned IDictionary will include 4 models.
-    console.log(`${dtmis.toString()} resolved in ${Object.keys(models.keys as {}).length} interfaces.`);
+    console.log(`${dtmis.toString()} resolved in ${Object.keys(models).length} interfaces.`);
   });
 
   it("ReadmeSampleDtmiConventions", async () => {

--- a/sdk/iot/iot-modelsrepository/vitest.browser.config.ts
+++ b/sdk/iot/iot-modelsrepository/vitest.browser.config.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import viteConfig from "../../../vitest.browser.shared.config.ts";
-
-export default viteConfig;
+export { default } from "../../../eng/vitestconfigs/browser.config.ts";


### PR DESCRIPTION
- update imports
- update testing NPM scripts
- fix snippets compilation error of

>test/snippets.spec.ts:70:64 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(o: {}): string[]', gave the following error.
    Argument of type 'unknown' is not assignable to parameter of type '{}'.
  Overload 2 of 2, '(o: object): string[]', gave the following error.
    Argument of type 'unknown' is not assignable to parameter of type 'object'.
>
>70     console.log(`${dtmis.toString()} resolved in ${Object.keys(models.keys).length} interfaces.`);