### PR TITLE
[attestation] migrate to #platform import style

### DIFF
--- a/sdk/attestation/attestation/README.md
+++ b/sdk/attestation/attestation/README.md
@@ -413,7 +413,8 @@ const openEnclaveReport = new Uint8Array(0); // Open enclave report data
 try {
   await client.attestSgxEnclave(openEnclaveReport);
 } catch (error) {
-  console.log(`Exception thrown for invalid request: ${error.message}`);
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(`Exception thrown for invalid request: ${message}`);
 }
 ```
 

--- a/sdk/attestation/attestation/README.md
+++ b/sdk/attestation/attestation/README.md
@@ -413,8 +413,7 @@ const openEnclaveReport = new Uint8Array(0); // Open enclave report data
 try {
   await client.attestSgxEnclave(openEnclaveReport);
 } catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.log(`Exception thrown for invalid request: ${message}`);
+  console.log(`Exception thrown for invalid request: ${error}`);
 }
 ```
 

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -32,9 +32,9 @@
     "lint": "eslint package.json src test",
     "lint:fix": "eslint package.json src test --fix --fix-type [problem,suggestion]",
     "pack": "pnpm pack 2>&1",
-    "test": "npm run test:node && npm run test:browser",
-    "test:browser": "npm run clean && dev-tool run build-package && dev-tool run build-test && dev-tool run test:vitest --browser",
-    "test:node": "dev-tool run build-test --no-browser-test && dev-tool run test:vitest",
+    "test": "tsc -b --noEmit && npm run test:node && npm run test:browser",
+    "test:browser": "dev-tool run test:vitest --browser",
+    "test:node": "dev-tool run test:vitest",
     "update-snippets": "dev-tool run update-snippets"
   },
   "files": [
@@ -130,7 +130,12 @@
   },
   "imports": {
     "#platform/*": {
+      "browser": "./src/*-browser.mts",
       "default": "./src/*.ts"
+    },
+    "#platform/test/utils/*": {
+      "browser": "./test/utils/*-browser.mts",
+      "default": "./test/utils/*.ts"
     }
   }
 }

--- a/sdk/attestation/attestation/src/attestationClient.ts
+++ b/sdk/attestation/attestation/src/attestationClient.ts
@@ -31,7 +31,7 @@ import { bytesToString, stringToBytes } from "./utils/utf8.js";
 import { _attestationResultFromGenerated } from "./models/attestationResult.js";
 import { _attestationSignerFromGenerated } from "./models/attestationSigner.js";
 import { AttestationTokenImpl } from "./models/attestationToken.js";
-import { Uint8ArrayFromInput } from "./utils/buffer.js";
+import { Uint8ArrayFromInput } from "#platform/utils/buffer";
 import { tracingClient } from "./generated/tracing.js";
 
 /**

--- a/sdk/attestation/attestation/src/utils/buffer-browser.mts
+++ b/sdk/attestation/attestation/src/utils/buffer-browser.mts
@@ -2,15 +2,7 @@
 // Licensed under the MIT License.
 
 async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
-  if ("arrayBuffer" in blob) {
-    return blob.arrayBuffer();
-  }
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as ArrayBuffer);
-    reader.onerror = () => reject;
-    reader.readAsArrayBuffer(blob);
-  });
+  return blob.arrayBuffer();
 }
 
 /**

--- a/sdk/attestation/attestation/src/utils/buffer-browser.mts
+++ b/sdk/attestation/attestation/src/utils/buffer-browser.mts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-async function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
-  return blob.arrayBuffer();
-}
-
 /**
  * Converts an attestation input from Uint8Array/Buffer/Blob to Uint8Array.
  *
@@ -20,7 +16,7 @@ export async function Uint8ArrayFromInput(
 
   // If this is not a Uint8Array, assume it's a blob and retrieve an ArrayBuffer from the blob.
   if ((input as any).byteLength === undefined) {
-    return new Uint8Array(await blobToArrayBuffer(input as Blob));
+    return new Uint8Array(await (input as Blob).arrayBuffer());
   }
 
   // We eliminated the 'Blob' case above, so we know this must be either a Buffer or Uint8Array.

--- a/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
+++ b/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
@@ -9,7 +9,7 @@ import {
   createRecordedClient,
   recorderOptions,
 } from "../utils/recordedClient.js";
-import * as base64url from "../utils/base64url.js";
+import * as base64url from "../utils/base64url-browser.mjs";
 
 import { KnownAttestationType } from "../../src/index.js";
 import { describe, it, assert, expect, beforeEach, afterEach } from "vitest";

--- a/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
+++ b/sdk/attestation/attestation/test/browser/attestationTests.browser.spec.ts
@@ -9,7 +9,7 @@ import {
   createRecordedClient,
   recorderOptions,
 } from "../utils/recordedClient.js";
-import * as base64url from "../utils/base64url-browser.mjs";
+import * as base64url from "#platform/test/utils/base64url";
 
 import { KnownAttestationType } from "../../src/index.js";
 import { describe, it, assert, expect, beforeEach, afterEach } from "vitest";

--- a/sdk/attestation/attestation/test/public/attestationTests.spec.ts
+++ b/sdk/attestation/attestation/test/public/attestationTests.spec.ts
@@ -8,7 +8,7 @@ import {
   createRecordedClient,
   recorderOptions,
 } from "../utils/recordedClient.js";
-import * as base64url from "../utils/base64url.js";
+import * as base64url from "#platform/test/utils/base64url";
 
 import { KnownAttestationType } from "../../src/index.js";
 import { describe, it, assert, expect, beforeEach, afterEach } from "vitest";

--- a/sdk/attestation/attestation/test/snippets.spec.ts
+++ b/sdk/attestation/attestation/test/snippets.spec.ts
@@ -153,7 +153,8 @@ describe("snippets", () => {
     try {
       await client.attestSgxEnclave(openEnclaveReport);
     } catch (error) {
-      console.log(`Exception thrown for invalid request: ${error.message}`);
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`Exception thrown for invalid request: ${message}`);
     }
   });
 

--- a/sdk/attestation/attestation/test/snippets.spec.ts
+++ b/sdk/attestation/attestation/test/snippets.spec.ts
@@ -153,8 +153,7 @@ describe("snippets", () => {
     try {
       await client.attestSgxEnclave(openEnclaveReport);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.log(`Exception thrown for invalid request: ${message}`);
+      console.log(`Exception thrown for invalid request: ${error}`);
     }
   });
 

--- a/sdk/attestation/attestation/test/utils/base64url-browser.mts
+++ b/sdk/attestation/attestation/test/utils/base64url-browser.mts
@@ -7,7 +7,7 @@
  * Decodes a base64 string into a byte array.
  * @param value - the base64 string to decode
  */
-function decodeStringFromBase64(value: string): Uint8Array {
+function decodeStringFromBase64(value: string): Uint8Array<ArrayBuffer> {
   const byteString = atob(value);
   const arr = new Uint8Array(byteString.length);
   for (let i = 0; i < byteString.length; i++) {
@@ -30,7 +30,7 @@ function fixPadding(unpadded: string): string {
  * Decodes a base64url string into a byte array.
  * @param value - the base64url string to decode
  */
-export function decodeString(value: string): Uint8Array {
+export function decodeString(value: string): Uint8Array<ArrayBuffer> {
   const encoded = value.replace(/-/g, "+").replace(/_/g, "/");
   const paddedEncoded = fixPadding(encoded);
   return decodeStringFromBase64(paddedEncoded);

--- a/sdk/attestation/attestation/vitest.browser.config.ts
+++ b/sdk/attestation/attestation/vitest.browser.config.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import viteConfig from "../../../vitest.browser.shared.config.ts";
-
-export default viteConfig;
+export { default } from "../../../eng/vitestconfigs/browser.config.ts";


### PR DESCRIPTION
- update package.json to include browser, and test/utils/ in #platform imports
- Blob.arrayBuffer is now available everywhere on our supported platforms thus
removing the fallback
- fix error in snippets