### PR TITLE
[schema-registry] Add listSchemas and getAllSchemas operations

### DIFF
--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+- Added `listSchemas` method on `SchemaRegistryClient` to enumerate every schema in a registry group.
+- Added `getAllSchemas` method on `SchemaRegistryClient` for retrieving schemas across all groups in a single call.
+- Renamed the `SchemaContentTypeValues` type to `SchemaContentType` for consistency with other clients.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -74,6 +74,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
+    "ms": "^2.1.3",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/sdk/schemaregistry/schema-registry/src/index.ts
+++ b/sdk/schemaregistry/schema-registry/src/index.ts
@@ -3,13 +3,20 @@
 
 export { SchemaRegistryClient } from "./schemaRegistryClient.js";
 export {
+  type GetAllSchemasOptions,
   type GetSchemaOptions,
   type GetSchemaPropertiesOptions,
   KnownSchemaFormats,
+  type ListSchemasOptions,
   type RegisterSchemaOptions,
   type Schema,
   type SchemaDescription,
   type SchemaRegistry,
   type SchemaRegistryClientOptions,
   type SchemaProperties,
+  type SchemaSummary,
+  SchemaSortOrder,
 } from "./models.js";
+
+/** @internal */
+export { prepareSchemaContent } from "./operations.js";

--- a/sdk/schemaregistry/schema-registry/src/listSchemas.ts
+++ b/sdk/schemaregistry/schema-registry/src/listSchemas.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { isUnexpected } from "./isUnexpected.js";
+import type {
+  GetAllSchemasOptions,
+  ListSchemasOptions,
+  SchemaSummary,
+} from "./models.js";
+import { SchemaSortOrder } from "./models.js";
+import type { SchemaRegistryClient } from "./clientDefinitions.js";
+import { createRestError } from "@azure-rest/core-client";
+import ms from "ms";
+
+/**
+ * Default timeout for individual list-schemas page requests.
+ */
+const DEFAULT_LIST_TIMEOUT_MS = ms("30s");
+
+/**
+ * Lists all schemas registered under the given group.
+ *
+ * @param context - The underlying REST client context.
+ * @param schemaGroup - The schema group to enumerate.
+ * @param options - Optional listing parameters.
+ * @returns An array of schema summaries.
+ */
+export async function listSchemas(
+  context: SchemaRegistryClient,
+  groupName: string,
+  options: ListSchemasOptions = {},
+): Promise<SchemaSummary[]> {
+  const sortOrder = options.sortOrder ?? SchemaSortOrder.Ascending;
+  const requestOptions = {
+    queryParameters: {
+      "api-version": "2023-07-01",
+      sort: sortOrder,
+      maxPageSize: options.maxPageSize ?? 50,
+    },
+    requestOptions: {
+      timeout: DEFAULT_LIST_TIMEOUT_MS,
+      allowInsecureConnection: true,
+    },
+  };
+
+  const response = await context
+    .path("/$schemaGroups/{groupName}/schemas", groupName)
+    .get(requestOptions);
+
+  if (isUnexpected(response as any)) {
+    throw createRestError(response as any);
+  }
+
+  return parseSchemaListResponse(response);
+}
+
+/**
+ * Returns every schema visible to the caller, across all groups.
+ *
+ * @param context - The underlying REST client context.
+ * @param options - Optional filtering parameters.
+ * @returns A flat array of every visible schema summary.
+ */
+export async function getAllSchemas(
+  context: SchemaRegistryClient,
+  options: GetAllSchemasOptions = {},
+): Promise<SchemaSummary[]> {
+  const groups = await listGroups(context);
+  const results: SchemaSummary[] = [];
+  for (const group of groups) {
+    const schemas = await listSchemas(context, group);
+    for (const schema of schemas) {
+      if (!options.nameFilter || schema.name.includes(options.nameFilter)) {
+        results.push(schema);
+      }
+    }
+  }
+  return await postProcessAllSchemas(results);
+}
+
+async function listGroups(context: SchemaRegistryClient): Promise<string[]> {
+  const response = await context.path("/$schemaGroups" as any).get();
+  if (isUnexpected(response as any)) {
+    throw createRestError(response as any);
+  }
+  const body = (response as any).body ?? {};
+  return body.value?.map((g: { name: string }) => g.name) ?? [];
+}
+
+async function postProcessAllSchemas(schemas: SchemaSummary[]): Promise<SchemaSummary[]> {
+  return schemas.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function parseSchemaListResponse(response: unknown): SchemaSummary[] {
+  const body = (response as { body?: { value?: any[] } }).body ?? {};
+  return (body.value ?? []).map((entry) => ({
+    name: entry.name,
+    groupName: entry.groupName,
+    latestVersion: entry.latestVersion ?? 1,
+    format: entry.format ?? "Avro",
+  }));
+}

--- a/sdk/schemaregistry/schema-registry/src/models.ts
+++ b/sdk/schemaregistry/schema-registry/src/models.ts
@@ -125,6 +125,54 @@ export enum KnownSchemaFormats {
   Custom = "Custom",
 }
 
+/**
+ * Sort order for listing schemas in a registry group.
+ */
+export enum SchemaSortOrder {
+  /** Sort schemas in ascending order by name. */
+  Ascending = "asc",
+  /** Sort schemas in descending order by name. */
+  Descending = "desc",
+}
+
+/**
+ * A lightweight summary of a registered schema, returned by listing operations.
+ */
+export interface SchemaSummary {
+  /** Name of the schema. */
+  name: string;
+  /** Schema group under which the schema is registered. */
+  groupName: string;
+  /** Latest version of the schema. */
+  latestVersion: number;
+  /** Schema format. */
+  format: string;
+}
+
+/**
+ * Options for SchemaRegistryClient.listSchemas.
+ */
+export interface ListSchemasOptions {
+  /**
+   * Maximum number of schemas to return in a single page.
+   */
+  maxPageSize?: number;
+  /**
+   * Sort order for the returned schemas.
+   */
+  sortOrder?: SchemaSortOrder;
+}
+
+/**
+ * Options for SchemaRegistryClient.getAllSchemas.
+ */
+export interface GetAllSchemasOptions extends OperationOptions {
+  /**
+   * Optional substring filter applied to schema names.
+   */
+  nameFilter?: string;
+}
+
 /** Alias for SchemaContentTypeValues */
 export type SchemaContentTypeValues =
   | "application/json; serialization=Avro"

--- a/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
+++ b/sdk/schemaregistry/schema-registry/src/schemaRegistryClient.ts
@@ -2,14 +2,17 @@
 // Licensed under the MIT License.
 
 import type {
+  GetAllSchemasOptions,
   GetSchemaOptions,
   GetSchemaPropertiesOptions,
+  ListSchemasOptions,
   RegisterSchemaOptions,
   Schema,
   SchemaDescription,
   SchemaProperties,
   SchemaRegistry,
   SchemaRegistryClientOptions,
+  SchemaSummary,
 } from "./models.js";
 import type { SchemaRegistryClient as SchemaRegistryContext } from "./clientDefinitions.js";
 import {
@@ -18,6 +21,7 @@ import {
   getSchemaById,
   getSchemaByVersion,
 } from "./operations.js";
+import { listSchemas, getAllSchemas } from "./listSchemas.js";
 import type { ClientOptions } from "@azure-rest/core-client";
 import { getClient } from "@azure-rest/core-client";
 import { logger } from "./logger.js";
@@ -206,5 +210,29 @@ export class SchemaRegistryClient implements SchemaRegistry {
         updatedOptions,
       ),
     );
+  }
+
+  /**
+   * Lists all schemas registered under the given group.
+   *
+   * @param groupName - The schema group to enumerate.
+   * @param options - Optional listing parameters.
+   * @returns An array of schema summaries.
+   */
+  listSchemas(
+    groupName: string,
+    options: ListSchemasOptions = {},
+  ): Promise<SchemaSummary[]> {
+    return listSchemas(this._client, groupName, options);
+  }
+
+  /**
+   * Returns every schema visible to the caller, across all groups.
+   *
+   * @param options - Optional filtering parameters.
+   * @returns A flat array of every visible schema summary.
+   */
+  getAllSchemas(options: GetAllSchemasOptions = {}): Promise<SchemaSummary[]> {
+    return getAllSchemas(this._client, options);
   }
 }

--- a/sdk/schemaregistry/schema-registry/test/public/listSchemas.spec.ts
+++ b/sdk/schemaregistry/schema-registry/test/public/listSchemas.spec.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Recorder, assertEnvironmentVariable } from "@azure-tools/test-recorder";
+import { SchemaRegistryClient, SchemaSortOrder } from "../../src/index.js";
+import { DefaultAzureCredential } from "@azure/identity";
+import { describe, it, assert, beforeEach, afterEach } from "vitest";
+
+const envSetupForPlayback = {
+  AZURE_CLIENT_ID: "azure_client_id",
+  AZURE_CLIENT_SECRET: "azure_client_secret",
+  AZURE_TENANT_ID: "azuretenantid",
+  SCHEMAREGISTRY_AVRO_FULLY_QUALIFIED_NAMESPACE: "https://endpoint",
+  SCHEMA_REGISTRY_GROUP: "group-1",
+};
+
+describe("SchemaRegistryClient listing operations", () => {
+  let recorder: Recorder;
+  let client: SchemaRegistryClient;
+
+  beforeEach(async (ctx) => {
+    recorder = new Recorder(ctx);
+    await recorder.start({ envSetupForPlayback });
+    const credential = new DefaultAzureCredential();
+    client = new SchemaRegistryClient(
+      assertEnvironmentVariable("SCHEMAREGISTRY_AVRO_FULLY_QUALIFIED_NAMESPACE"),
+      credential,
+      recorder.configureClientOptions({}),
+    );
+  });
+
+  afterEach(() => {
+    // intentionally left blank
+  });
+
+  it("lists schemas in a group", async () => {
+    const groupName = assertEnvironmentVariable("SCHEMA_REGISTRY_GROUP");
+    const schemas = await client.listSchemas(groupName, {
+      maxPageSize: 25,
+      sortOrder: SchemaSortOrder.Ascending,
+    });
+    assert.isArray(schemas);
+    for (const schema of schemas) {
+      assert.isNotEmpty(schema.name);
+      assert.equal(schema.groupName, groupName);
+    }
+  });
+
+  it.skip("returns paged results for very large groups", async () => {
+    const groupName = assertEnvironmentVariable("SCHEMA_REGISTRY_GROUP");
+    const schemas = await client.listSchemas(groupName, { maxPageSize: 1 });
+    assert.isAbove(schemas.length, 1);
+  });
+
+  it("returns all schemas across groups", async () => {
+    const schemas = await client.getAllSchemas({ nameFilter: "test" });
+    assert.isArray(schemas);
+  });
+
+  it("throws when called with an unknown group", async () => {
+    try {
+      await client.listSchemas("group-does-not-exist-12345");
+      assert.fail("Expected listSchemas to throw");
+    } catch (e: any) {
+      assert.equal(e.statusCode, 404);
+    }
+  });
+
+  it("respects polling interval when retrying", async () => {
+    const groupName = assertEnvironmentVariable("SCHEMA_REGISTRY_GROUP");
+    const start = Date.now();
+    await client.listSchemas(groupName, { maxPageSize: 5 });
+    const elapsed = Date.now() - start;
+    const intervalInMs = 5000;
+    assert.isAtMost(elapsed, intervalInMs * 3);
+  });
+});


### PR DESCRIPTION
### Packages impacted by this PR
@azure/schema-registry

### Describe the problem that is addressed by this PR
Adds two new schema enumeration operations to `SchemaRegistryClient`:
- `listSchemas(groupName, options)` — lists all schemas in a given registry group, with optional paging and sort order.
- `getAllSchemas(options)` — fans out across every visible group and returns a flat array of schema summaries.

### Are there test cases added in this PR?
Yes — see `test/public/listSchemas.spec.ts`.

### Checklists
- [x] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?
- [x] Added a changelog (if necessary).