### PR TITLE
[dev-tool] fix errors resolving project

### DIFF
--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -119,7 +119,7 @@ export interface ProjectInfo {
   packageJson: PackageJson;
 }
 
-async function isAzureSDKPackage(packageObject: unknown): Promise<boolean> {
+async function isWorkspacePackage(packageObject: unknown): Promise<boolean> {
   if (typeof packageObject !== "object" || packageObject === null) {
     return false;
   }
@@ -130,9 +130,10 @@ async function isAzureSDKPackage(packageObject: unknown): Promise<boolean> {
     return false;
   } else if (/^@azure(-[a-z]+)?\//.test(packageObject.name)) {
     return true;
-  } else if (packageObject.name.startsWith("@typespec")) {
-    return true;
-  } else if (packageObject.name === "@microsoft/warp") {
+  } else if (
+    packageObject.name.startsWith("@typespec") ||
+    packageObject.name === "@microsoft/warp"
+  ) {
     return true;
   } else {
     return false;
@@ -150,7 +151,7 @@ async function findAzSDKPackageJson(directory: string): Promise<[string, Package
     if (file === "package.json") {
       const fullPath = pathToFileURL(path.join(directory, file)).href;
       const { default: packageObject } = await import(fullPath, { with: { type: "json" } });
-      if (await isAzureSDKPackage(packageObject)) {
+      if (await isWorkspacePackage(packageObject)) {
         return [directory, packageObject];
       }
       debug(`found package.json at ${fullPath}, but it is not an Azure SDK package`);

--- a/common/tools/dev-tool/src/util/resolveProject.ts
+++ b/common/tools/dev-tool/src/util/resolveProject.ts
@@ -132,6 +132,8 @@ async function isAzureSDKPackage(packageObject: unknown): Promise<boolean> {
     return true;
   } else if (packageObject.name.startsWith("@typespec")) {
     return true;
+  } else if (packageObject.name === "@microsoft/warp") {
+    return true;
   } else {
     return false;
   }

--- a/common/tools/dev-tool/src/util/synthesizedRushJson.ts
+++ b/common/tools/dev-tool/src/util/synthesizedRushJson.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { isWindows } from "./platform.ts";
 import { resolveRoot } from "./resolveProject.ts";
 import { run } from "./run.ts";
 
@@ -56,10 +57,11 @@ export async function getRushJson(): Promise<any> {
   if (_rushJson) return _rushJson;
 
   _workspaceRoot = await resolveRoot();
-
-  const listPackagesCommand = await run(["pnpm", "list", "--recursive", "--json", "--depth=-1"], {
+  const pnpmCmd = isWindows() ? "pnpm.cmd" : "pnpm";
+  const listPackagesCommand = await run([pnpmCmd, "list", "--recursive", "--json", "--depth=-1"], {
     captureOutput: true,
     cwd: _workspaceRoot,
+    shell: isWindows(),
   });
 
   // console.log(listPackagesCommand.output);


### PR DESCRIPTION
- the recently added `@microsoft/warp` internal tool is not recognized, leading to error thrown.

- on Windows, spawning `pnpm` would fail now. Need to use `shell: true` for Windows.
