### PR TITLE
[EngSys] fix pnpm workspace arm catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,14 +10,14 @@ catalogs:
       specifier: 8.1.0
       version: 8.1.0
     '@azure/arm-resources':
-      specifier: 7.0.1
-      version: 7.0.1
+      specifier: 7.0.0
+      version: 7.0.0
     '@azure/arm-storage':
       specifier: 18.5.0
       version: 18.5.0
     '@azure/arm-webpubsub':
-      specifier: 1.2.2
-      version: 1.2.2
+      specifier: 1.2.0
+      version: 1.2.0
   default:
     '@types/node':
       specifier: ^20.19.25
@@ -3427,7 +3427,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: link:../../resources/arm-resources
+        version: 7.0.0
       '@azure/arm-storage':
         specifier: catalog:arm
         version: 18.5.0
@@ -3618,7 +3618,7 @@ importers:
         version: link:../../keyvault/arm-keyvault
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: link:../../resources/arm-resources
+        version: 7.0.0
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -18561,7 +18561,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-resources':
         specifier: catalog:arm
-        version: link:../../resources/arm-resources
+        version: 7.0.0
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -33425,7 +33425,7 @@ importers:
         version: link:../../test-utils/test-utils-vitest
       '@azure/arm-webpubsub':
         specifier: catalog:arm
-        version: link:../arm-webpubsub
+        version: 1.2.0
       '@azure/dev-tool':
         specifier: workspace:^
         version: link:../../../common/tools/dev-tool
@@ -33996,6 +33996,10 @@ packages:
     resolution: {integrity: sha1-xhCsgrCAoBid/WnFP8GwR1gkT9E=}
     engines: {node: '>=14.0.0'}
 
+  '@azure/arm-resources@7.0.0':
+    resolution: {integrity: sha1-BVmrhR0htNdIiB/2pTwv0FfJoDA=}
+    engines: {node: '>=20.0.0'}
+
   '@azure/arm-search@3.3.0':
     resolution: {integrity: sha1-8Tr5mwParu0OYtHg7Hvmh+ZkRks=}
     engines: {node: '>=20.0.0'}
@@ -34006,6 +34010,10 @@ packages:
 
   '@azure/arm-storage@18.5.0':
     resolution: {integrity: sha1-hHzWoKc3k3aMCxqEesNscjBgZrE=}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/arm-webpubsub@1.2.0':
+    resolution: {integrity: sha1-mfACuVCTDGJNhvkWsqXe5eKtOGQ=}
     engines: {node: '>=18.0.0'}
 
   '@azure/communication-common@2.4.0':
@@ -39818,6 +39826,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@azure/arm-resources@7.0.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/arm-search@3.3.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -39845,6 +39865,18 @@ snapshots:
   '@azure/arm-storage@18.5.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/arm-webpubsub@1.2.0':
+    dependencies:
+      '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.10.1
       '@azure/core-client': 1.10.1
       '@azure/core-lro': 2.7.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,8 +32,8 @@ catalogs:
   arm:
     '@azure/arm-cognitiveservices': 8.1.0
     '@azure/arm-storage': 18.5.0
-    '@azure/arm-webpubsub': 1.2.2
-    '@azure/arm-resources': 7.0.1
+    '@azure/arm-webpubsub': 1.2.0
+    '@azure/arm-resources': 7.0.0
   internal:
     '@azure/identity': 4.13.0
     express: ^5.2.1


### PR DESCRIPTION
We keep a `arm` dependency catalog in pnpm-workspace.yaml for stability and to
avoid circular dependencies. The versions of @azure/arm-webpubsub and
@azure/arm-resources in the `arm` catalog has not been published. They caused
installation failures when their in-source version change and they are no longer
linked to workspace version, pnpm tries to download from npmjs but the
unpublished version are not available.

This PR updates them to be published versions.