### PR TITLE
Bump @azure/arm-containerservicesafeguards to 1.0.0-beta.2

### DIFF
--- a/sdk/containerservice/arm-containerservicesafeguards/CHANGELOG.md
+++ b/sdk/containerservice/arm-containerservicesafeguards/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-07-18)
 
 ### Features Added

--- a/sdk/containerservice/arm-containerservicesafeguards/package.json
+++ b/sdk/containerservice/arm-containerservicesafeguards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-containerservicesafeguards",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for ContainerServiceClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/containerservice/arm-containerservicesafeguards/src/api/containerServiceContext.ts
+++ b/sdk/containerservice/arm-containerservicesafeguards/src/api/containerServiceContext.ts
@@ -27,7 +27,7 @@ export function createContainerService(
 ): ContainerServiceContext {
   const endpointUrl = options.endpoint ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-containerservicesafeguards/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-containerservicesafeguards/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;


### PR DESCRIPTION
This PR bumps `@azure/arm-containerservicesafeguards` from `1.0.0-beta.1` to `1.0.0-beta.2`.

Version 1.0.0-beta.1 was already published but source files were modified since the release tag. The release pipeline's "Check package version" step requires a version bump before re-releasing.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6338122&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=8dd92614-7454-569d-3061-0c20dc3c788d&l=92

### Changes
- **package.json** — version `1.0.0-beta.1` → `1.0.0-beta.2`
- **CHANGELOG.md** — added new `1.0.0-beta.2 (Unreleased)` section
- **src/api/containerServiceContext.ts** — updated userAgent version constant