### PR TITLE
[EngSys] Increment version for packages with modified published versions

### DIFF
--- a/sdk/advisor/arm-advisor/CHANGELOG.md
+++ b/sdk/advisor/arm-advisor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 3.2.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.2.0 (2023-08-03)
 
 ### Features Added

--- a/sdk/advisor/arm-advisor/package.json
+++ b/sdk/advisor/arm-advisor/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AdvisorManagementClient.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/advisor/arm-advisor/src/advisorManagementClient.ts
+++ b/sdk/advisor/arm-advisor/src/advisorManagementClient.ts
@@ -72,7 +72,7 @@ export class AdvisorManagementClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-advisor/3.2.0`;
+    const packageDetails = `azsdk-js-arm-advisor/3.2.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/ai/ai-agents/CHANGELOG.md
+++ b/sdk/ai/ai-agents/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.2.0-beta.2 (2025-09-26)
 
 ### Features Added

--- a/sdk/ai/ai-agents/package.json
+++ b/sdk/ai/ai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ai-agents",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.3",
   "description": "Azure AI Agents client library.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/ai/ai-agents/src/constants.ts
+++ b/sdk/ai/ai-agents/src/constants.ts
@@ -4,7 +4,7 @@
 /**
  * Current version of the `@azure/ai-agents` package.
  */
-export const SDK_VERSION = `1.2.0-beta.2`;
+export const SDK_VERSION = `1.2.0-beta.3`;
 
 /**
  * The package name of the `@azure/ai-agents` package.

--- a/sdk/appservice/arm-appservice/CHANGELOG.md
+++ b/sdk/appservice/arm-appservice/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 18.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 18.0.0 (2025-11-18)
 The App Service has been divided into three separate services: App Service, Domain Registration, and Certificate Registration. APIs for Domain Registration are available in the @azure/arm-domainregistration package, and APIs for Certificate Registration are provided in the @azure/arm-certificateregistration package.
 

--- a/sdk/appservice/arm-appservice/package.json
+++ b/sdk/appservice/arm-appservice/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for WebSiteManagementClient.",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/appservice/arm-appservice/src/webSiteManagementClient.ts
+++ b/sdk/appservice/arm-appservice/src/webSiteManagementClient.ts
@@ -177,7 +177,7 @@ export class WebSiteManagementClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-appservice/18.0.0`;
+    const packageDetails = `azsdk-js-arm-appservice/18.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/avs/arm-avs/CHANGELOG.md
+++ b/sdk/avs/arm-avs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 7.1.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 7.1.0 (2025-12-19)
 
 ### Features Added

--- a/sdk/avs/arm-avs/package.json
+++ b/sdk/avs/arm-avs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-avs",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "A generated SDK for AzureVMwareSolutionAPI.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/avs/arm-avs/src/api/azureVMwareSolutionAPIContext.ts
+++ b/sdk/avs/arm-avs/src/api/azureVMwareSolutionAPIContext.ts
@@ -36,7 +36,7 @@ export function createAzureVMwareSolutionAPI(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-avs/7.1.0`;
+  const userAgentInfo = `azsdk-js-arm-avs/7.1.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/CHANGELOG.md
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-08-14)
 
 ### Features Added

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/package.json
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-azurestackhcivm",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for AzureStackHCIVMManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/src/api/azureStackHcivmManagementContext.ts
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/src/api/azureStackHcivmManagementContext.ts
@@ -34,7 +34,7 @@ export function createAzureStackHCIVMManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-azurestackhcivm/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-azurestackhcivm/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/carbonoptimization/arm-carbonoptimization/CHANGELOG.md
+++ b/sdk/carbonoptimization/arm-carbonoptimization/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-07-11)
 
 ### Features Added

--- a/sdk/carbonoptimization/arm-carbonoptimization/package.json
+++ b/sdk/carbonoptimization/arm-carbonoptimization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-carbonoptimization",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for CarbonOptimizationManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/carbonoptimization/arm-carbonoptimization/src/api/carbonOptimizationManagementContext.ts
+++ b/sdk/carbonoptimization/arm-carbonoptimization/src/api/carbonOptimizationManagementContext.ts
@@ -27,7 +27,7 @@ export function createCarbonOptimizationManagement(
 ): CarbonOptimizationManagementContext {
   const endpointUrl = options.endpoint ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-carbonoptimization/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-carbonoptimization/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/compute/arm-computerecommender/CHANGELOG.md
+++ b/sdk/compute/arm-computerecommender/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-09-25)
 
 ### Features Added

--- a/sdk/compute/arm-computerecommender/package.json
+++ b/sdk/compute/arm-computerecommender/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-computerecommender",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for ComputeRecommenderManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/compute/arm-computerecommender/src/api/computeRecommenderManagementContext.ts
+++ b/sdk/compute/arm-computerecommender/src/api/computeRecommenderManagementContext.ts
@@ -36,7 +36,7 @@ export function createComputeRecommenderManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-computerecommender/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-computerecommender/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/computebulkactions/arm-computebulkactions/CHANGELOG.md
+++ b/sdk/computebulkactions/arm-computebulkactions/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2026-02-24)
 
 ### Features Added

--- a/sdk/computebulkactions/arm-computebulkactions/package.json
+++ b/sdk/computebulkactions/arm-computebulkactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-computebulkactions",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for ComputeBulkActionsClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/computebulkactions/arm-computebulkactions/src/api/computeBulkActionsContext.ts
+++ b/sdk/computebulkactions/arm-computebulkactions/src/api/computeBulkActionsContext.ts
@@ -36,7 +36,7 @@ export function createComputeBulkActions(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-computebulkactions/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-computebulkactions/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/computefleet/arm-computefleet/CHANGELOG.md
+++ b/sdk/computefleet/arm-computefleet/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0-beta.1 (2025-09-15)
 Compared with version 1.0.0
 

--- a/sdk/computefleet/arm-computefleet/package.json
+++ b/sdk/computefleet/arm-computefleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-computefleet",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "A generated SDK for AzureFleetClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/computefleet/arm-computefleet/src/api/azureFleetContext.ts
+++ b/sdk/computefleet/arm-computefleet/src/api/azureFleetContext.ts
@@ -32,7 +32,7 @@ export function createAzureFleet(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-computefleet/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-computefleet/2.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/connectedcache/arm-connectedcache/CHANGELOG.md
+++ b/sdk/connectedcache/arm-connectedcache/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.2 (2026-02-25)
 Compared with version 1.0.0-beta.1
 

--- a/sdk/connectedcache/arm-connectedcache/package.json
+++ b/sdk/connectedcache/arm-connectedcache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-connectedcache",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "A generated SDK for ConnectedCacheClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/connectedcache/arm-connectedcache/src/api/connectedCacheContext.ts
+++ b/sdk/connectedcache/arm-connectedcache/src/api/connectedCacheContext.ts
@@ -36,7 +36,7 @@ export function createConnectedCache(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-connectedcache/1.0.0-beta.2`;
+  const userAgentInfo = `azsdk-js-arm-connectedcache/1.0.0-beta.3`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/connectedvmware/arm-connectedvmware/CHANGELOG.md
+++ b/sdk/connectedvmware/arm-connectedvmware/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2023-10-24)
 
 ### Features Added

--- a/sdk/connectedvmware/arm-connectedvmware/package.json
+++ b/sdk/connectedvmware/arm-connectedvmware/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AzureArcVMwareManagementServiceAPI.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/connectedvmware/arm-connectedvmware/src/azureArcVMwareManagementServiceAPI.ts
+++ b/sdk/connectedvmware/arm-connectedvmware/src/azureArcVMwareManagementServiceAPI.ts
@@ -92,7 +92,7 @@ export class AzureArcVMwareManagementServiceAPI extends coreClient.ServiceClient
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-connectedvmware/1.0.0`;
+    const packageDetails = `azsdk-js-arm-connectedvmware/1.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/containerservice/arm-containerservicesafeguards/CHANGELOG.md
+++ b/sdk/containerservice/arm-containerservicesafeguards/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-07-18)
 
 ### Features Added

--- a/sdk/containerservice/arm-containerservicesafeguards/package.json
+++ b/sdk/containerservice/arm-containerservicesafeguards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-containerservicesafeguards",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for ContainerServiceClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/containerservice/arm-containerservicesafeguards/src/api/containerServiceContext.ts
+++ b/sdk/containerservice/arm-containerservicesafeguards/src/api/containerServiceContext.ts
@@ -27,7 +27,7 @@ export function createContainerService(
 ): ContainerServiceContext {
   const endpointUrl = options.endpoint ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-containerservicesafeguards/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-containerservicesafeguards/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/dashboard/arm-dashboard/CHANGELOG.md
+++ b/sdk/dashboard/arm-dashboard/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0 (2025-10-21)
 
 ### Features Added

--- a/sdk/dashboard/arm-dashboard/package.json
+++ b/sdk/dashboard/arm-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-dashboard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generated SDK for DashboardManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/dashboard/arm-dashboard/src/api/dashboardManagementContext.ts
+++ b/sdk/dashboard/arm-dashboard/src/api/dashboardManagementContext.ts
@@ -36,7 +36,7 @@ export function createDashboardManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-dashboard/2.0.0`;
+  const userAgentInfo = `azsdk-js-arm-dashboard/2.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/databasewatcher/arm-databasewatcher/CHANGELOG.md
+++ b/sdk/databasewatcher/arm-databasewatcher/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-03-03)
 
 ### Features Added

--- a/sdk/databasewatcher/arm-databasewatcher/package.json
+++ b/sdk/databasewatcher/arm-databasewatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-databasewatcher",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for DatabaseWatcherClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/databasewatcher/arm-databasewatcher/src/api/databaseWatcherContext.ts
+++ b/sdk/databasewatcher/arm-databasewatcher/src/api/databaseWatcherContext.ts
@@ -28,7 +28,7 @@ export function createDatabaseWatcher(
 ): DatabaseWatcherContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-databasewatcher/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-databasewatcher/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/datadog/arm-datadog/CHANGELOG.md
+++ b/sdk/datadog/arm-datadog/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 3.1.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.1.0 (2023-10-09)
     
 ### Features Added

--- a/sdk/datadog/arm-datadog/package.json
+++ b/sdk/datadog/arm-datadog/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MicrosoftDatadogClient.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/datadog/arm-datadog/src/microsoftDatadogClient.ts
+++ b/sdk/datadog/arm-datadog/src/microsoftDatadogClient.ts
@@ -66,7 +66,7 @@ export class MicrosoftDatadogClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-datadog/3.1.0`;
+    const packageDetails = `azsdk-js-arm-datadog/3.1.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/datamigration/arm-datamigration/CHANGELOG.md
+++ b/sdk/datamigration/arm-datamigration/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 3.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.0.0 (2025-09-26)
 
 ### Features Added

--- a/sdk/datamigration/arm-datamigration/package.json
+++ b/sdk/datamigration/arm-datamigration/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DataMigrationManagementClient.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/datamigration/arm-datamigration/src/dataMigrationManagementClient.ts
+++ b/sdk/datamigration/arm-datamigration/src/dataMigrationManagementClient.ts
@@ -76,7 +76,7 @@ export class DataMigrationManagementClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-datamigration/3.0.0`;
+    const packageDetails = `azsdk-js-arm-datamigration/3.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/defendereasm/arm-defendereasm/CHANGELOG.md
+++ b/sdk/defendereasm/arm-defendereasm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2023-08-16)
 
 ### Features Added

--- a/sdk/defendereasm/arm-defendereasm/package.json
+++ b/sdk/defendereasm/arm-defendereasm/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for EasmMgmtClient.",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/defendereasm/arm-defendereasm/src/easmMgmtClient.ts
+++ b/sdk/defendereasm/arm-defendereasm/src/easmMgmtClient.ts
@@ -55,7 +55,7 @@ export class EasmMgmtClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-defendereasm/1.0.0-beta.1`;
+    const packageDetails = `azsdk-js-arm-defendereasm/1.0.0-beta.2`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/dell/arm-dell-storage/CHANGELOG.md
+++ b/sdk/dell/arm-dell-storage/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2026-01-20)
 
 ### Features Added

--- a/sdk/dell/arm-dell-storage/package.json
+++ b/sdk/dell/arm-dell-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-dell-storage",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for StorageClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/dell/arm-dell-storage/src/api/storageContext.ts
+++ b/sdk/dell/arm-dell-storage/src/api/storageContext.ts
@@ -36,7 +36,7 @@ export function createStorage(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-dell-storage/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-dell-storage/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/dependencymap/arm-dependencymap/CHANGELOG.md
+++ b/sdk/dependencymap/arm-dependencymap/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-04-14)
 
 ### Features Added

--- a/sdk/dependencymap/arm-dependencymap/package.json
+++ b/sdk/dependencymap/arm-dependencymap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-dependencymap",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for DependencyMapClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/dependencymap/arm-dependencymap/src/api/dependencyMapContext.ts
+++ b/sdk/dependencymap/arm-dependencymap/src/api/dependencyMapContext.ts
@@ -30,7 +30,7 @@ export function createDependencyMap(
 ): DependencyMapContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-dependencymap/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-dependencymap/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/CHANGELOG.md
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2024-11-25)
 
 ### Features Added

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-devopsinfrastructure",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for DevOpsInfrastructureClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/src/api/devOpsInfrastructureContext.ts
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/src/api/devOpsInfrastructureContext.ts
@@ -21,7 +21,7 @@ export function createDevOpsInfrastructure(
 ): DevOpsInfrastructureContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `https://management.azure.com`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-devopsinfrastructure/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-devopsinfrastructure/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/dynatrace/arm-dynatrace/CHANGELOG.md
+++ b/sdk/dynatrace/arm-dynatrace/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0 (2023-08-15)
     
 ### Features Added

--- a/sdk/dynatrace/arm-dynatrace/package.json
+++ b/sdk/dynatrace/arm-dynatrace/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DynatraceObservability.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/dynatrace/arm-dynatrace/src/dynatraceObservability.ts
+++ b/sdk/dynatrace/arm-dynatrace/src/dynatraceObservability.ts
@@ -60,7 +60,7 @@ export class DynatraceObservability extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-dynatrace/2.0.0`;
+    const packageDetails = `azsdk-js-arm-dynatrace/2.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/edgeactions/arm-edgeactions/CHANGELOG.md
+++ b/sdk/edgeactions/arm-edgeactions/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2026-02-10)
 
 ### Features Added

--- a/sdk/edgeactions/arm-edgeactions/package.json
+++ b/sdk/edgeactions/arm-edgeactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-edgeactions",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for CdnClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/edgeactions/arm-edgeactions/src/api/edgeActionsManagementContext.ts
+++ b/sdk/edgeactions/arm-edgeactions/src/api/edgeActionsManagementContext.ts
@@ -34,7 +34,7 @@ export function createEdgeActionsManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-edgeactions/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-edgeactions/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/elasticsans/arm-elasticsan/CHANGELOG.md
+++ b/sdk/elasticsans/arm-elasticsan/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0 (2026-02-25)
 
 ### Features Added

--- a/sdk/elasticsans/arm-elasticsan/package.json
+++ b/sdk/elasticsans/arm-elasticsan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-elasticsan",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generated SDK for ElasticSanManagement.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/elasticsans/arm-elasticsan/src/api/elasticSanManagementContext.ts
+++ b/sdk/elasticsans/arm-elasticsan/src/api/elasticSanManagementContext.ts
@@ -36,7 +36,7 @@ export function createElasticSanManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-elasticsan/2.0.0`;
+  const userAgentInfo = `azsdk-js-arm-elasticsan/2.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/CHANGELOG.md
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0 (2025-07-04)
     
 ### Features Added

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-hardwaresecuritymodules",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generated SDK for AzureDedicatedHSMResourceProvider.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/src/api/azureDedicatedHSMResourceProviderContext.ts
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/src/api/azureDedicatedHSMResourceProviderContext.ts
@@ -30,7 +30,7 @@ export function createAzureDedicatedHSMResourceProvider(
 ): AzureDedicatedHSMResourceProviderContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-hardwaresecuritymodules/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-hardwaresecuritymodules/2.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/CHANGELOG.md
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2024-11-25)
 
 ### Features Added

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-healthdataaiservices",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for HealthDataAIServicesClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/src/api/healthDataAIServicesContext.ts
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/src/api/healthDataAIServicesContext.ts
@@ -21,7 +21,7 @@ export function createHealthDataAIServices(
 ): HealthDataAIServicesContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `https://management.azure.com`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-healthdataaiservices/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-healthdataaiservices/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/CHANGELOG.md
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0-beta.2 (2025-07-31)
 
 ### Features Added

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-hybridconnectivity",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "A generated SDK for HybridConnectivityManagementAPI.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/src/api/hybridConnectivityManagementAPIContext.ts
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/src/api/hybridConnectivityManagementAPIContext.ts
@@ -34,7 +34,7 @@ export function createHybridConnectivityManagementAPI(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-hybridconnectivity/2.0.0-beta.2`;
+  const userAgentInfo = `azsdk-js-arm-hybridconnectivity/2.0.0-beta.3`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/impactreporting/arm-impactreporting/CHANGELOG.md
+++ b/sdk/impactreporting/arm-impactreporting/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-02-20)
 
 ### Features Added

--- a/sdk/impactreporting/arm-impactreporting/package.json
+++ b/sdk/impactreporting/arm-impactreporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-impactreporting",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for ImpactClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/impactreporting/arm-impactreporting/src/api/impactContext.ts
+++ b/sdk/impactreporting/arm-impactreporting/src/api/impactContext.ts
@@ -28,7 +28,7 @@ export function createImpact(
 ): ImpactContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-impactreporting/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-impactreporting/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/CHANGELOG.md
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0 (2025-09-01)
 
 ### Features Added

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-iotfirmwaredefense",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generated SDK for IoTFirmwareDefenseClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/src/api/ioTFirmwareDefenseContext.ts
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/src/api/ioTFirmwareDefenseContext.ts
@@ -34,7 +34,7 @@ export function createIoTFirmwareDefense(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-iotfirmwaredefense/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-iotfirmwaredefense/2.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/CHANGELOG.md
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-05-12)
 
 ### Features Added

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/package.json
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-lambdatesthyperexecute",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for HyperExecuteClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/src/api/hyperExecuteContext.ts
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/src/api/hyperExecuteContext.ts
@@ -28,7 +28,7 @@ export function createHyperExecute(
 ): HyperExecuteContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-lambdatesthyperexecute/1.0.0`;
+  const userAgentInfo = `azsdk-js-arm-lambdatesthyperexecute/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/CHANGELOG.md
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-06-06)
 
 ### Features Added

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/package.json
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-arizeaiobservabilityeval",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for ObservabilityEvalClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/src/api/observabilityEvalContext.ts
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/src/api/observabilityEvalContext.ts
@@ -28,7 +28,7 @@ export function createObservabilityEval(
 ): ObservabilityEvalContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-arizeaiobservabilityeval/1.0.0`;
+  const userAgentInfo = `azsdk-js-arm-arizeaiobservabilityeval/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/machinelearning/arm-machinelearning/CHANGELOG.md
+++ b/sdk/machinelearning/arm-machinelearning/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 3.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.0.0 (2024-08-15)
     
 ### Features Added

--- a/sdk/machinelearning/arm-machinelearning/package.json
+++ b/sdk/machinelearning/arm-machinelearning/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AzureMachineLearningServicesManagementClient.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/machinelearning/arm-machinelearning/src/azureMachineLearningServicesManagementClient.ts
+++ b/sdk/machinelearning/arm-machinelearning/src/azureMachineLearningServicesManagementClient.ts
@@ -149,7 +149,7 @@ export class AzureMachineLearningServicesManagementClient extends coreClient.Ser
         credential: credentials,
       };
 
-    const packageDetails = `azsdk-js-arm-machinelearning/3.0.0`;
+    const packageDetails = `azsdk-js-arm-machinelearning/3.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/managedapplications/arm-managedapplications/CHANGELOG.md
+++ b/sdk/managedapplications/arm-managedapplications/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 3.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.0.0 (2023-09-06)
     
 ### Features Added

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ApplicationClient.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/managedapplications/arm-managedapplications/src/applicationClient.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/applicationClient.ts
@@ -84,7 +84,7 @@ export class ApplicationClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-managedapplications/3.0.0`;
+    const packageDetails = `azsdk-js-arm-managedapplications/3.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/mongodbatlas/arm-mongodbatlas/CHANGELOG.md
+++ b/sdk/mongodbatlas/arm-mongodbatlas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-07-02)
 
 ### Features Added

--- a/sdk/mongodbatlas/arm-mongodbatlas/package.json
+++ b/sdk/mongodbatlas/arm-mongodbatlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-mongodbatlas",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for AtlasClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/mongodbatlas/arm-mongodbatlas/src/api/atlasContext.ts
+++ b/sdk/mongodbatlas/arm-mongodbatlas/src/api/atlasContext.ts
@@ -28,7 +28,7 @@ export function createAtlas(
 ): AtlasContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-mongodbatlas/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-mongodbatlas/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/monitor/monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/monitor-ingestion/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.2.0 (2025-07-16)
 
 ### Features Added

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -107,7 +107,12 @@
     "node": ">=20.0.0"
   },
   "//metadata": {
-    "constantPaths": []
+    "constantPaths": [
+      {
+        "path": "src/api/logsIngestionContext.ts",
+        "prefix": "const userAgentInfo"
+      }
+    ]
   },
   "//sampleConfiguration": {
     "skipFolder": false,

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-ingestion",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Azure Monitor Ingestion library",
   "keywords": [
     "azure",
@@ -107,20 +107,7 @@
     "node": ">=20.0.0"
   },
   "//metadata": {
-    "constantPaths": [
-      {
-        "path": "src/generated/generatedMonitorIngestionClientContext.ts",
-        "prefix": "packageDetails"
-      },
-      {
-        "path": "src/constants.ts",
-        "prefix": "SDK_VERSION"
-      },
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
-    ]
+    "constantPaths": []
   },
   "//sampleConfiguration": {
     "skipFolder": false,

--- a/sdk/monitor/monitor-ingestion/src/api/logsIngestionContext.ts
+++ b/sdk/monitor/monitor-ingestion/src/api/logsIngestionContext.ts
@@ -36,7 +36,7 @@ export function createLogsIngestion(
 ): LogsIngestionContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? String(endpoint);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-monitor-ingestion/1.2.0`;
+  const userAgentInfo = `azsdk-js-monitor-ingestion/1.2.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/monitor/monitor-query-logs/CHANGELOG.md
+++ b/sdk/monitor/monitor-query-logs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-07-29)
 
 ### Features Added

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-query-logs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An isomorphic client library for querying Azure Monitor's Logs data sources.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/monitor/monitor-query-logs/src/api/monitorQueryLogsContext.ts
+++ b/sdk/monitor/monitor-query-logs/src/api/monitorQueryLogsContext.ts
@@ -30,7 +30,7 @@ export function createMonitorQueryLogs(
   const apiVersion = options.apiVersion ?? "v1";
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `${endpointParam}/${apiVersion}`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-monitor-query-logs/1.0.0`;
+  const userAgentInfo = `azsdk-js-monitor-query-logs/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/monitor/monitor-query-metrics/CHANGELOG.md
+++ b/sdk/monitor/monitor-query-metrics/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-07-31)
 
 ### Features Added

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/monitor-query-metrics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An isomorphic client library for querying Azure Monitor's Metrics data sources.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -83,6 +83,14 @@
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/api/metricsContext.ts",
+        "prefix": "const userAgentInfo"
+      }
+    ]
+  },
   "//sampleConfiguration": {
     "skipFolder": false,
     "productName": "Monitor Query Metrics",

--- a/sdk/monitor/monitor-query-metrics/src/api/metricsContext.ts
+++ b/sdk/monitor/monitor-query-metrics/src/api/metricsContext.ts
@@ -27,7 +27,7 @@ export function createMetrics(
 ): MetricsContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-monitor-query-metrics/1.0.0`;
+  const userAgentInfo = `azsdk-js-monitor-query-metrics/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} ${userAgentInfo}`
     : `${userAgentInfo}`;

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/CHANGELOG.md
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-06-04)
 
 ### Features Added

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/package.json
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-onlineexperimentation",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for OnlineExperimentationClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/src/api/onlineExperimentationContext.ts
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/src/api/onlineExperimentationContext.ts
@@ -30,7 +30,7 @@ export function createOnlineExperimentation(
 ): OnlineExperimentationContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-onlineexperimentation/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-onlineexperimentation/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/oracledatabase/arm-oracledatabase/CHANGELOG.md
+++ b/sdk/oracledatabase/arm-oracledatabase/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 3.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 3.0.0 (2025-09-25)
 
 ### Features Added

--- a/sdk/oracledatabase/arm-oracledatabase/package.json
+++ b/sdk/oracledatabase/arm-oracledatabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-oracledatabase",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A generated SDK for OracleDatabaseManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/oracledatabase/arm-oracledatabase/src/api/oracleDatabaseManagementContext.ts
+++ b/sdk/oracledatabase/arm-oracledatabase/src/api/oracleDatabaseManagementContext.ts
@@ -34,7 +34,7 @@ export function createOracleDatabaseManagement(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-oracledatabase/3.0.0`;
+  const userAgentInfo = `azsdk-js-arm-oracledatabase/3.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/CHANGELOG.md
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.2.0 (2025-11-11)
 
 ### Features Added

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PaloAltoNetworksCloudngfw.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/src/paloAltoNetworksCloudngfw.ts
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/src/paloAltoNetworksCloudngfw.ts
@@ -92,7 +92,7 @@ export class PaloAltoNetworksCloudngfw extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-paloaltonetworksngfw/1.2.0`;
+    const packageDetails = `azsdk-js-arm-paloaltonetworksngfw/1.2.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/pineconevectordb/arm-pineconevectordb/CHANGELOG.md
+++ b/sdk/pineconevectordb/arm-pineconevectordb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.2 (2025-03-25)
 Compared with version 1.0.0-beta.1
     

--- a/sdk/pineconevectordb/arm-pineconevectordb/package.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-pineconevectordb",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "A generated SDK for VectorDbClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/pineconevectordb/arm-pineconevectordb/src/api/vectorDbContext.ts
+++ b/sdk/pineconevectordb/arm-pineconevectordb/src/api/vectorDbContext.ts
@@ -28,7 +28,7 @@ export function createVectorDb(
 ): VectorDbContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-pineconevectordb/1.0.0-beta.2`;
+  const userAgentInfo = `azsdk-js-arm-pineconevectordb/1.0.0-beta.3`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/policyinsights/arm-policyinsights/CHANGELOG.md
+++ b/sdk/policyinsights/arm-policyinsights/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 6.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 6.0.0 (2025-01-09)
 Compared with version 5.0.0
     

--- a/sdk/policyinsights/arm-policyinsights/package.json
+++ b/sdk/policyinsights/arm-policyinsights/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PolicyInsightsClient.",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/policyinsights/arm-policyinsights/src/policyInsightsClient.ts
+++ b/sdk/policyinsights/arm-policyinsights/src/policyInsightsClient.ts
@@ -78,7 +78,7 @@ export class PolicyInsightsClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-policyinsights/6.0.0`;
+    const packageDetails = `azsdk-js-arm-policyinsights/6.0.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/portalservices/arm-portalservicescopilot/CHANGELOG.md
+++ b/sdk/portalservices/arm-portalservicescopilot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-04-14)
 
 ### Features Added

--- a/sdk/portalservices/arm-portalservicescopilot/package.json
+++ b/sdk/portalservices/arm-portalservicescopilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-portalservicescopilot",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for PortalServicesClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/portalservices/arm-portalservicescopilot/src/api/portalServicesContext.ts
+++ b/sdk/portalservices/arm-portalservicescopilot/src/api/portalServicesContext.ts
@@ -27,7 +27,7 @@ export function createPortalServices(
 ): PortalServicesContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-portalservicescopilot/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-portalservicescopilot/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/purestorageblock/arm-purestorageblock/CHANGELOG.md
+++ b/sdk/purestorageblock/arm-purestorageblock/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-06-30)
 
 ### Features Added

--- a/sdk/purestorageblock/arm-purestorageblock/package.json
+++ b/sdk/purestorageblock/arm-purestorageblock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-purestorageblock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for BlockClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/purestorageblock/arm-purestorageblock/src/api/blockContext.ts
+++ b/sdk/purestorageblock/arm-purestorageblock/src/api/blockContext.ts
@@ -28,7 +28,7 @@ export function createBlock(
 ): BlockContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-purestorageblock/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-purestorageblock/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/quota/arm-quota/CHANGELOG.md
+++ b/sdk/quota/arm-quota/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.0.0 (2025-09-24)
 
 ### Features Added

--- a/sdk/quota/arm-quota/package.json
+++ b/sdk/quota/arm-quota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-quota",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A generated SDK for AzureQuotaExtensionAPI.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/quota/arm-quota/src/api/azureQuotaExtensionAPIContext.ts
+++ b/sdk/quota/arm-quota/src/api/azureQuotaExtensionAPIContext.ts
@@ -36,7 +36,7 @@ export function createAzureQuotaExtensionAPI(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-quota/2.0.0`;
+  const userAgentInfo = `azsdk-js-arm-quota/2.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/recoveryservices/arm-recoveryservices/CHANGELOG.md
+++ b/sdk/recoveryservices/arm-recoveryservices/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 7.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 7.0.0 (2025-09-29)
 
 ### Features Added

--- a/sdk/recoveryservices/arm-recoveryservices/package.json
+++ b/sdk/recoveryservices/arm-recoveryservices/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-recoveryservices",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "A generated SDK for RecoveryServicesClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/recoveryservices/arm-recoveryservices/src/api/recoveryServicesContext.ts
+++ b/sdk/recoveryservices/arm-recoveryservices/src/api/recoveryServicesContext.ts
@@ -34,7 +34,7 @@ export function createRecoveryServices(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-recoveryservices/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-recoveryservices/7.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/CHANGELOG.md
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-06-03)
 
 ### Features Added

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-recoveryservicesdatareplication",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for DataReplicationClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/src/api/azureSiteRecoveryManagementServiceAPIContext.ts
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/src/api/azureSiteRecoveryManagementServiceAPIContext.ts
@@ -30,7 +30,7 @@ export function createAzureSiteRecoveryManagementServiceAPI(
 ): AzureSiteRecoveryManagementServiceAPIContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-recoveryservicesdatareplication/1.0.0`;
+  const userAgentInfo = `azsdk-js-arm-recoveryservicesdatareplication/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/resourcemover/arm-resourcemover/CHANGELOG.md
+++ b/sdk/resourcemover/arm-resourcemover/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 2.2.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.2.0 (2023-10-24)
     
 ### Features Added

--- a/sdk/resourcemover/arm-resourcemover/package.json
+++ b/sdk/resourcemover/arm-resourcemover/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ResourceMoverServiceAPI.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/resourcemover/arm-resourcemover/src/resourceMoverServiceAPI.ts
+++ b/sdk/resourcemover/arm-resourcemover/src/resourceMoverServiceAPI.ts
@@ -74,7 +74,7 @@ export class ResourceMoverServiceAPI extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-resourcemover/2.2.0`;
+    const packageDetails = `azsdk-js-arm-resourcemover/2.2.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/servicenetworking/arm-servicenetworking/CHANGELOG.md
+++ b/sdk/servicenetworking/arm-servicenetworking/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 2.1.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.1.0-beta.1 (2025-04-23)
 Compared with version 2.0.0
     

--- a/sdk/servicenetworking/arm-servicenetworking/package.json
+++ b/sdk/servicenetworking/arm-servicenetworking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-servicenetworking",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "A generated SDK for ServiceNetworkingClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/servicenetworking/arm-servicenetworking/src/api/serviceNetworkingManagementContext.ts
+++ b/sdk/servicenetworking/arm-servicenetworking/src/api/serviceNetworkingManagementContext.ts
@@ -30,7 +30,7 @@ export function createServiceNetworkingManagement(
 ): ServiceNetworkingManagementContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-servicenetworking/2.1.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-servicenetworking/2.1.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/signalr/arm-signalr/CHANGELOG.md
+++ b/sdk/signalr/arm-signalr/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 6.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 6.0.0-beta.2 (2023-10-09)
     
 ### Features Added

--- a/sdk/signalr/arm-signalr/package.json
+++ b/sdk/signalr/arm-signalr/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SignalRManagementClient.",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0-beta.3",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/signalr/arm-signalr/src/signalRManagementClient.ts
+++ b/sdk/signalr/arm-signalr/src/signalRManagementClient.ts
@@ -70,7 +70,7 @@ export class SignalRManagementClient extends coreClient.ServiceClient {
       credential: credentials
     };
 
-    const packageDetails = `azsdk-js-arm-signalr/6.0.0-beta.2`;
+    const packageDetails = `azsdk-js-arm-signalr/6.0.0-beta.3`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/sitemanager/arm-sitemanager/CHANGELOG.md
+++ b/sdk/sitemanager/arm-sitemanager/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-08-29)
 
 ### Features Added

--- a/sdk/sitemanager/arm-sitemanager/package.json
+++ b/sdk/sitemanager/arm-sitemanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-sitemanager",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for EdgeClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/sitemanager/arm-sitemanager/src/api/edgeContext.ts
+++ b/sdk/sitemanager/arm-sitemanager/src/api/edgeContext.ts
@@ -34,7 +34,7 @@ export function createEdge(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-sitemanager/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-sitemanager/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/sql/arm-sql/CHANGELOG.md
+++ b/sdk/sql/arm-sql/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 11.0.0-beta.5 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 11.0.0-beta.4 (2025-09-24)
 Compared with version 10.0.0
 

--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SqlManagementClient.",
-  "version": "11.0.0-beta.4",
+  "version": "11.0.0-beta.5",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/sdk/sql/arm-sql/src/sqlManagementClient.ts
+++ b/sdk/sql/arm-sql/src/sqlManagementClient.ts
@@ -344,7 +344,7 @@ export class SqlManagementClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-arm-sql/11.0.0-beta.4`;
+    const packageDetails = `azsdk-js-arm-sql/11.0.0-beta.5`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storageactions/arm-storageactions/CHANGELOG.md
+++ b/sdk/storageactions/arm-storageactions/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-07-03)
 
 ### Features Added

--- a/sdk/storageactions/arm-storageactions/package.json
+++ b/sdk/storageactions/arm-storageactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-storageactions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for StorageActionsManagementClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/storageactions/arm-storageactions/src/api/storageActionsManagementContext.ts
+++ b/sdk/storageactions/arm-storageactions/src/api/storageActionsManagementContext.ts
@@ -30,7 +30,7 @@ export function createStorageActionsManagement(
 ): StorageActionsManagementContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-storageactions/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-storageactions/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/storagediscovery/arm-storagediscovery/CHANGELOG.md
+++ b/sdk/storagediscovery/arm-storagediscovery/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0 (2025-09-30)
 
 ### Features Added

--- a/sdk/storagediscovery/arm-storagediscovery/package.json
+++ b/sdk/storagediscovery/arm-storagediscovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-storagediscovery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated SDK for StorageDiscoveryClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/storagediscovery/arm-storagediscovery/src/api/storageDiscoveryContext.ts
+++ b/sdk/storagediscovery/arm-storagediscovery/src/api/storageDiscoveryContext.ts
@@ -36,7 +36,7 @@ export function createStorageDiscovery(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-storagediscovery/1.0.0`;
+  const userAgentInfo = `azsdk-js-arm-storagediscovery/1.0.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/terraform/arm-terraform/CHANGELOG.md
+++ b/sdk/terraform/arm-terraform/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2024-11-18)
 
 ### Features Added

--- a/sdk/terraform/arm-terraform/package.json
+++ b/sdk/terraform/arm-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-terraform",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for AzureTerraformClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/terraform/arm-terraform/src/api/azureTerraformContext.ts
+++ b/sdk/terraform/arm-terraform/src/api/azureTerraformContext.ts
@@ -23,7 +23,7 @@ export function createAzureTerraform(
 ): AzureTerraformContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `https://management.azure.com`;
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-terraform/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-terraform/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;


### PR DESCRIPTION
## Summary

Ran `check-package-version` from `eng/tools/ci-runner` across all SDK service directories. For each package whose currently-released version is already published on npm **and** has source modifications since its release tag, bumped the version using `npx dev-tool package increment-version` (no direct edits to version fields).

54 packages received version bumps. The 16 packages whose release tags could not be found on the remote were intentionally skipped (they need manual review).

## Bumped packages (54)

| Package | Old | New |
|---|---|---|
| @azure/ai-agents | 1.2.0-beta.2 | 1.2.0-beta.3 |
| @azure/arm-advisor | 3.2.0 | 3.2.1 |
| @azure/arm-appservice | 18.0.0 | 18.0.1 |
| @azure/arm-arizeaiobservabilityeval | 1.0.0 | 1.0.1 |
| @azure/arm-avs | 7.1.0 | 7.1.1 |
| @azure/arm-azurestackhcivm | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-carbonoptimization | 1.0.0 | 1.0.1 |
| @azure/arm-computebulkactions | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-computefleet | 2.0.0-beta.1 | 2.0.0-beta.2 |
| @azure/arm-computerecommender | 1.0.0 | 1.0.1 |
| @azure/arm-connectedcache | 1.0.0-beta.2 | 1.0.0-beta.3 |
| @azure/arm-connectedvmware | 1.0.0 | 1.0.1 |
| @azure/arm-containerservicesafeguards | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-dashboard | 2.0.0 | 2.0.1 |
| @azure/arm-databasewatcher | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-datadog | 3.1.0 | 3.1.1 |
| @azure/arm-datamigration | 3.0.0 | 3.0.1 |
| @azure/arm-defendereasm | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-dell-storage | 1.0.0 | 1.0.1 |
| @azure/arm-dependencymap | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-devopsinfrastructure | 1.0.0 | 1.0.1 |
| @azure/arm-dynatrace | 2.0.0 | 2.0.1 |
| @azure/arm-edgeactions | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-elasticsan | 2.0.0 | 2.0.1 |
| @azure/arm-hardwaresecuritymodules | 2.0.0 | 2.0.1 |
| @azure/arm-healthdataaiservices | 1.0.0 | 1.0.1 |
| @azure/arm-hybridconnectivity | 2.0.0-beta.2 | 2.0.0-beta.3 |
| @azure/arm-impactreporting | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-iotfirmwaredefense | 2.0.0 | 2.0.1 |
| @azure/arm-lambdatesthyperexecute | 1.0.0 | 1.0.1 |
| @azure/arm-machinelearning | 3.0.0 | 3.0.1 |
| @azure/arm-managedapplications | 3.0.0 | 3.0.1 |
| @azure/arm-mongodbatlas | 1.0.0 | 1.0.1 |
| @azure/arm-onlineexperimentation | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-oracledatabase | 3.0.0 | 3.0.1 |
| @azure/arm-paloaltonetworksngfw | 1.2.0 | 1.2.1 |
| @azure/arm-pineconevectordb | 1.0.0-beta.2 | 1.0.0-beta.3 |
| @azure/arm-policyinsights | 6.0.0 | 6.0.1 |
| @azure/arm-portalservicescopilot | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/arm-purestorageblock | 1.0.0 | 1.0.1 |
| @azure/arm-quota | 2.0.0 | 2.0.1 |
| @azure/arm-recoveryservices | 7.0.0 | 7.0.1 |
| @azure/arm-recoveryservicesdatareplication | 1.0.0 | 1.0.1 |
| @azure/arm-resourcemover | 2.2.0 | 2.2.1 |
| @azure/arm-servicenetworking | 2.1.0-beta.1 | 2.1.0-beta.2 |
| @azure/arm-signalr | 6.0.0-beta.2 | 6.0.0-beta.3 |
| @azure/arm-sitemanager | 1.0.0 | 1.0.1 |
| @azure/arm-sql | 11.0.0-beta.4 | 11.0.0-beta.5 |
| @azure/arm-storageactions | 1.0.0 | 1.0.1 |
| @azure/arm-storagediscovery | 1.0.0 | 1.0.1 |
| @azure/arm-terraform | 1.0.0-beta.1 | 1.0.0-beta.2 |
| @azure/monitor-ingestion | 1.2.0 | 1.2.1 |
| @azure/monitor-query-logs | 1.0.0 | 1.0.1 |
| @azure/monitor-query-metrics | 1.0.0 | 1.0.1 |
