### PR TITLE
Prepare Key Vault Certificates release

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.10.4 (Unreleased)
+## 4.10.4 (2026-05-26)
 
 ### Features Added
 


### PR DESCRIPTION
## Description
- Finalizes the @azure/keyvault-certificates 4.10.4 changelog entry for release.
- @azure/keyvault-secrets is already stable in the current branch and has no pending release diff.

## Validation
- `git diff --check`

Build note: attempted `pnpm --filter @azure/keyvault-certificates build`, but local dependencies are not installed (`node_modules` missing; `rimraf` unavailable).