### PR TITLE
[Confidential Ledger] Fix incorrect Content-Type for user PATCH endpoints

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.2-beta.6 (Unreleased)
 
+### Bugs Fixed
+
+- Fixed incorrect `Content-Type` header for user management PATCH operations. The SDK now automatically sets `Content-Type: application/merge-patch+json` for PATCH requests to `/app/users/{userId}` and `/app/ledgerUsers/{userId}`, which the service requires for API versions after `2022-04-20-preview`. Previously, omitting the `contentType` parameter caused the SDK to default to `application/json`, resulting in an `UnsupportedContentType` error from the service.
+
 ### Features Added
 
 - Added redirect URL caching for write operations. When the Confidential Ledger load balancer issues a 307/308 redirect, the target (primary node) URL is cached so subsequent write requests skip the load balancer, reducing latency. Read requests (GET/HEAD) continue to always go through the load balancer. The cache is automatically invalidated on server errors (5xx) or transport failures.

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
@@ -36,7 +36,7 @@ export default function createClient(
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
       : `${userAgentInfo}`;
-  options = {
+  const updatedOptions = {
     ...options,
     userAgentOptions: {
       userAgentPrefix,
@@ -48,7 +48,7 @@ export default function createClient(
       scopes: options.credentials?.scopes ?? ["https://confidential-ledger.azure.com/.default"],
     },
   };
-  const client = getClient(endpointUrl, credentials, options) as ConfidentialLedgerClient;
+  const client = getClient(endpointUrl, credentials, updatedOptions) as ConfidentialLedgerClient;
 
   // Replace the default redirect policy with one that preserves headers (including
   // Authorization) on redirects, but ONLY for targets that remain within the trust
@@ -302,13 +302,13 @@ function isTrustedRedirectTarget(target: URL, ledgerHostname: string, ledgerPort
 /**
  * Regex matching the path portion of user management endpoints that require
  * the "application/merge-patch+json" content type on PATCH requests.
- * Matches /app/users/{userId} and /app/ledgerUsers/{userId}.
+ * Matches /app/users/\{userId\} and /app/ledgerUsers/\{userId\}.
  */
 const usersPatchPathRe = /\/app\/(?:users|ledgerUsers)\/[^/?#]+\/?$/i;
 
 /**
  * Pipeline policy that ensures PATCH requests to user management endpoints
- * (/app/users/{userId} and /app/ledgerUsers/{userId}) use the
+ * (/app/users/\{userId\} and /app/ledgerUsers/\{userId\}) use the
  * "application/merge-patch+json" content type required by the service.
  *
  * The generated parameter types declare contentType as optional, so when

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
@@ -323,11 +323,8 @@ function confidentialLedgerMergePatchContentTypePolicy(): PipelinePolicy {
   return {
     name: "confidentialLedgerMergePatchContentTypePolicy",
     sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
-      if (request.method === "PATCH") {
-        const pathStart = request.url.indexOf("/", request.url.indexOf("://") + 3);
-        const queryStart = request.url.indexOf("?", pathStart);
-        const path = queryStart === -1 ? request.url.slice(pathStart) : request.url.slice(pathStart, queryStart);
-
+      if (request.method.toUpperCase() === "PATCH") {
+        const path = new URL(request.url).pathname;
         if (usersPatchPathRe.test(path)) {
           request.headers.set("Content-Type", "application/merge-patch+json");
         }

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedger.ts
@@ -62,6 +62,14 @@ export default function createClient(
     afterPhase: "Retry",
   });
 
+  // Ensure PATCH requests to user management endpoints send the correct
+  // Content-Type. The service requires "application/merge-patch+json" for
+  // /app/users/{userId} and /app/ledgerUsers/{userId}, but the generated
+  // parameter types declare contentType as optional — so when callers omit it,
+  // @azure-rest/core-client defaults to "application/json" which the service
+  // rejects with UnsupportedContentType (415).
+  client.pipeline.addPolicy(confidentialLedgerMergePatchContentTypePolicy());
+
   client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
   client.pipeline.addPolicy({
     name: "ClientApiVersionPolicy",
@@ -289,6 +297,44 @@ function isTrustedRedirectTarget(target: URL, ledgerHostname: string, ledgerPort
   const host = canonicalHostname(target.hostname);
   if (host === ledgerHostname) return true;
   return host.endsWith("." + ledgerHostname);
+}
+
+/**
+ * Regex matching the path portion of user management endpoints that require
+ * the "application/merge-patch+json" content type on PATCH requests.
+ * Matches /app/users/{userId} and /app/ledgerUsers/{userId}.
+ */
+const usersPatchPathRe = /\/app\/(?:users|ledgerUsers)\/[^/?#]+\/?$/i;
+
+/**
+ * Pipeline policy that ensures PATCH requests to user management endpoints
+ * (/app/users/{userId} and /app/ledgerUsers/{userId}) use the
+ * "application/merge-patch+json" content type required by the service.
+ *
+ * The generated parameter types declare contentType as optional, so when
+ * callers omit it the framework defaults to "application/json", which TPAL
+ * rejects for api-versions after 2022-04-20-preview. This policy corrects the
+ * header transparently so callers don't need to remember to set it.
+ *
+ * Other PATCH endpoints (e.g. /app/roles, /app/userDefinedEndpoints/runtimeOptions)
+ * are intentionally excluded — those accept "application/json".
+ */
+function confidentialLedgerMergePatchContentTypePolicy(): PipelinePolicy {
+  return {
+    name: "confidentialLedgerMergePatchContentTypePolicy",
+    sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+      if (request.method === "PATCH") {
+        const pathStart = request.url.indexOf("/", request.url.indexOf("://") + 3);
+        const queryStart = request.url.indexOf("?", pathStart);
+        const path = queryStart === -1 ? request.url.slice(pathStart) : request.url.slice(pathStart, queryStart);
+
+        if (usersPatchPathRe.test(path)) {
+          request.headers.set("Content-Type", "application/merge-patch+json");
+        }
+      }
+      return next(request);
+    },
+  };
 }
 
 async function handleRedirect(

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerMergePatchContentType.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerMergePatchContentType.spec.ts
@@ -17,9 +17,7 @@ function getMergePatchPolicy(ledgerEndpoint: string): PipelinePolicy {
   };
   const client = createClient(ledgerEndpoint, fakeCredential);
   const policies = client.pipeline.getOrderedPolicies();
-  const policy = policies.find(
-    (p) => p.name === "confidentialLedgerMergePatchContentTypePolicy",
-  );
+  const policy = policies.find((p) => p.name === "confidentialLedgerMergePatchContentTypePolicy");
   assert.ok(
     policy,
     "confidentialLedgerMergePatchContentTypePolicy should be present in the pipeline",
@@ -68,9 +66,7 @@ describe("Confidential Ledger Merge-Patch Content-Type Policy", () => {
     };
     const client = createClient(ledgerEndpoint, fakeCredential);
     const policies = client.pipeline.getOrderedPolicies();
-    const policy = policies.find(
-      (p) => p.name === "confidentialLedgerMergePatchContentTypePolicy",
-    );
+    const policy = policies.find((p) => p.name === "confidentialLedgerMergePatchContentTypePolicy");
     assert.ok(policy, "Policy should be present");
   });
 
@@ -302,11 +298,7 @@ describe("Confidential Ledger Merge-Patch Content-Type Policy", () => {
 
     await policy.sendRequest(request, next);
 
-    assert.equal(
-      capturedContentTypes[0],
-      JSON_CT,
-      "GET should preserve original Content-Type",
-    );
+    assert.equal(capturedContentTypes[0], JSON_CT, "GET should preserve original Content-Type");
   });
 
   it("should NOT change Content-Type for DELETE /app/users/{userId}", async () => {
@@ -321,11 +313,7 @@ describe("Confidential Ledger Merge-Patch Content-Type Policy", () => {
 
     await policy.sendRequest(request, next);
 
-    assert.equal(
-      capturedContentTypes[0],
-      JSON_CT,
-      "DELETE should preserve original Content-Type",
-    );
+    assert.equal(capturedContentTypes[0], JSON_CT, "DELETE should preserve original Content-Type");
   });
 
   it("should NOT change Content-Type for POST /app/users/{userId}", async () => {
@@ -341,11 +329,7 @@ describe("Confidential Ledger Merge-Patch Content-Type Policy", () => {
 
     await policy.sendRequest(request, next);
 
-    assert.equal(
-      capturedContentTypes[0],
-      JSON_CT,
-      "POST should preserve original Content-Type",
-    );
+    assert.equal(capturedContentTypes[0], JSON_CT, "POST should preserve original Content-Type");
   });
 
   it("should NOT change Content-Type for PUT /app/users/{userId}", async () => {
@@ -361,10 +345,6 @@ describe("Confidential Ledger Merge-Patch Content-Type Policy", () => {
 
     await policy.sendRequest(request, next);
 
-    assert.equal(
-      capturedContentTypes[0],
-      JSON_CT,
-      "PUT should preserve original Content-Type",
-    );
+    assert.equal(capturedContentTypes[0], JSON_CT, "PUT should preserve original Content-Type");
   });
 });

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerMergePatchContentType.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerMergePatchContentType.spec.ts
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, assert, vi } from "vitest";
+import type { PipelinePolicy, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import createClient from "../../src/confidentialLedger.js";
+
+/**
+ * Helper to extract the merge-patch content type policy from a client's pipeline.
+ */
+function getMergePatchPolicy(ledgerEndpoint: string): PipelinePolicy {
+  const fakeCredential = {
+    getToken: vi
+      .fn()
+      .mockResolvedValue({ token: "fake-token", expiresOnTimestamp: Date.now() + 3600000 }),
+  };
+  const client = createClient(ledgerEndpoint, fakeCredential);
+  const policies = client.pipeline.getOrderedPolicies();
+  const policy = policies.find(
+    (p) => p.name === "confidentialLedgerMergePatchContentTypePolicy",
+  );
+  assert.ok(
+    policy,
+    "confidentialLedgerMergePatchContentTypePolicy should be present in the pipeline",
+  );
+  return policy!;
+}
+
+/**
+ * Helper that creates a mock SendRequest which snapshots the Content-Type
+ * header at the moment `next` is called. We snapshot (copy the string value)
+ * rather than capturing the request object reference, because the policy
+ * mutates the request *before* calling next — if we only kept a reference we
+ * would see whatever the final mutated state is, not what was actually
+ * dispatched to the network layer.
+ */
+function createMockNext(): {
+  next: SendRequest;
+  /** Content-Type value seen by the downstream pipeline for each call. */
+  capturedContentTypes: (string | undefined)[];
+} {
+  const capturedContentTypes: (string | undefined)[] = [];
+  const next: SendRequest = async (req) => {
+    capturedContentTypes.push(req.headers.get("Content-Type") ?? undefined);
+    return {
+      status: 200,
+      headers: createHttpHeaders(),
+      request: req,
+    } as PipelineResponse;
+  };
+  return { next, capturedContentTypes };
+}
+
+const MERGE_PATCH = "application/merge-patch+json";
+const JSON_CT = "application/json";
+
+describe("Confidential Ledger Merge-Patch Content-Type Policy", () => {
+  const ledgerEndpoint = "https://test-ledger.confidential-ledger.azure.com";
+
+  // ─── Pipeline integration ──────────────────────────────────────────
+
+  it("should be present in the pipeline", () => {
+    const fakeCredential = {
+      getToken: vi
+        .fn()
+        .mockResolvedValue({ token: "fake-token", expiresOnTimestamp: Date.now() + 3600000 }),
+    };
+    const client = createClient(ledgerEndpoint, fakeCredential);
+    const policies = client.pipeline.getOrderedPolicies();
+    const policy = policies.find(
+      (p) => p.name === "confidentialLedgerMergePatchContentTypePolicy",
+    );
+    assert.ok(policy, "Policy should be present");
+  });
+
+  // ─── Positive cases: PATCH to user endpoints MUST get merge-patch ──
+
+  it("should override application/json to merge-patch for PATCH /app/users/{userId}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes.length, 1, "next should be called exactly once");
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should override application/json to merge-patch for PATCH /app/ledgerUsers/{userId}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/ledgerUsers/user@contoso.com`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRoles: ["Reader"] }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes.length, 1);
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should ADD merge-patch when no Content-Type is set (the real-world SDK default)", async () => {
+    // This is the actual bug scenario: @azure-rest/core-client defaults to
+    // application/json at a lower layer, but at policy evaluation time the
+    // header may be absent. The policy must set it regardless.
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "PATCH",
+      // Intentionally no Content-Type header
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should be idempotent when Content-Type is already merge-patch", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": MERGE_PATCH }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should handle userId with special characters (percent-encoded)", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/user%40contoso.com`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should handle URL with query parameters", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123?api-version=2024-12-09-preview`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should handle redirected URL (subdomain) for user PATCH", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: "https://node-1.test-ledger.confidential-ledger.azure.com/app/ledgerUsers/abc-123",
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRoles: ["Reader"] }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  it("should handle trailing slash on user path", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123/`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], MERGE_PATCH);
+  });
+
+  // ─── Negative: other PATCH endpoints must keep application/json ────
+
+  it("should NOT change Content-Type for PATCH /app/roles", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/roles`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify([{ roleName: "TestRole", roleActions: [] }]),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], JSON_CT);
+  });
+
+  it("should NOT change Content-Type for PATCH /app/userDefinedEndpoints/runtimeOptions", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/userDefinedEndpoints/runtimeOptions`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ logExceptionDetails: true }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], JSON_CT);
+  });
+
+  it("should NOT match /app/users (list endpoint, no userId segment)", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], JSON_CT);
+  });
+
+  it("should NOT match /app/users/{userId}/subresource (extra path segments)", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123/permissions`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], JSON_CT);
+  });
+
+  it("should NOT match look-alike paths like /app/usersExtra/{id}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/usersExtra/abc-123`,
+      method: "PATCH",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(capturedContentTypes[0], JSON_CT);
+  });
+
+  // ─── Negative: non-PATCH HTTP methods must not be affected ─────────
+
+  it("should NOT change Content-Type for GET /app/users/{userId}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "GET",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(
+      capturedContentTypes[0],
+      JSON_CT,
+      "GET should preserve original Content-Type",
+    );
+  });
+
+  it("should NOT change Content-Type for DELETE /app/users/{userId}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "DELETE",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(
+      capturedContentTypes[0],
+      JSON_CT,
+      "DELETE should preserve original Content-Type",
+    );
+  });
+
+  it("should NOT change Content-Type for POST /app/users/{userId}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "POST",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(
+      capturedContentTypes[0],
+      JSON_CT,
+      "POST should preserve original Content-Type",
+    );
+  });
+
+  it("should NOT change Content-Type for PUT /app/users/{userId}", async () => {
+    const policy = getMergePatchPolicy(ledgerEndpoint);
+    const { next, capturedContentTypes } = createMockNext();
+
+    const request = createPipelineRequest({
+      url: `${ledgerEndpoint}/app/users/abc-123`,
+      method: "PUT",
+      headers: createHttpHeaders({ "Content-Type": JSON_CT }),
+      body: JSON.stringify({ assignedRole: "Reader" }),
+    });
+
+    await policy.sendRequest(request, next);
+
+    assert.equal(
+      capturedContentTypes[0],
+      JSON_CT,
+      "PUT should preserve original Content-Type",
+    );
+  });
+});

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectCaching.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectCaching.spec.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert, vi } from "vitest";
-import type { PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
+import type { PipelinePolicy, PipelineResponse, SendRequest } from "@azure/core-rest-pipeline";
 import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
 import createClient from "../../src/confidentialLedger.js";
 
 /**
  * Helper to extract the custom redirect policy from a client's pipeline.
  */
-function getRedirectPolicy(ledgerEndpoint: string) {
+function getRedirectPolicy(ledgerEndpoint: string): PipelinePolicy {
   const fakeCredential = {
     getToken: vi
       .fn()

--- a/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectTrust.spec.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/test/public/confidentialLedgerRedirectTrust.spec.ts
@@ -32,7 +32,7 @@ function getRedirectPolicy(ledgerEndpoint: string): PipelinePolicy {
  * Helper to create a write request with a Bearer token. The token text is
  * checked in assertions to verify it never leaks to untrusted targets.
  */
-function writeRequest(url: string) {
+function writeRequest(url: string): PipelineRequest {
   return createPipelineRequest({
     url,
     method: "POST",


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/confidential-ledger`

### Issues associated with this PR

https://msazure.visualstudio.com/One/_workitems/edit/38104668

### Describe the problem that is addressed by this PR

The JS SDK sends `Content-Type: application/json` for PATCH requests to `/app/users/{userId}` and `/app/ledgerUsers/{userId}`. The Confidential Ledger service (TPAL) requires `application/merge-patch+json` for these endpoints on API versions after `2022-04-20-preview`, and rejects the request with `UnsupportedContentType`.

The root cause is that the TypeSpec RLC emitter (`@azure-tools/typespec-ts`) generates `contentType` as an optional parameter. When callers omit it, `@azure-rest/core-client` defaults to `application/json` instead of the only valid content type.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Three approaches were considered:

1. **Pipeline policy (chosen)**: A `confidentialLedgerMergePatchContentTypePolicy` intercepts PATCH requests matching `/app/(users|ledgerUsers)/{userId}` and sets the correct Content-Type header. This is transparent to callers, ships immediately, and follows the same pattern already used in this SDK for the redirect policy and API version policy.

2. **Make `contentType` required in the generated types**: This would be a breaking API change that forces all existing callers to update their code.

3. **Fix the TypeSpec emitter**: The correct long-term fix, but would take weeks to ship through the codegen pipeline. A codegen issue should be filed separately.

Other PATCH endpoints (`/app/roles`, `/app/userDefinedEndpoints/runtimeOptions`) are intentionally excluded because those accept `application/json`.

### Are there test cases added in this PR? _(If not, why?)_

Yes, 18 unit tests in `test/public/confidentialLedgerMergePatchContentType.spec.ts`:

**Positive cases (9):**
- PATCH `/app/users/{userId}` overrides `application/json` to `application/merge-patch+json`
- PATCH `/app/ledgerUsers/{userId}` overrides correctly
- No Content-Type header set (the real-world SDK default bug scenario), policy adds the header
- Idempotent when Content-Type is already `application/merge-patch+json`
- Percent-encoded userId, query parameters, trailing slash, subdomain (redirected URL)

**Negative cases (9):**
- PATCH `/app/roles` preserves `application/json`
- PATCH `/app/userDefinedEndpoints/runtimeOptions` preserves `application/json`
- `/app/users` (list, no userId) not matched
- `/app/users/{userId}/subresource` (extra path segments) not matched
- `/app/usersExtra/{id}` (look-alike prefix) not matched
- GET, DELETE, POST, PUT to `/app/users/{userId}` all preserve original Content-Type

All existing tests (50 redirect policy/trust/caching tests) continue to pass.

### Provide a list of related PRs _(if any)_

N/A. A follow-up codegen issue should be filed against `@azure-tools/typespec-ts` for the long-term fix.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)