### PR TITLE
[@azure/playwright] Fix invalid snippets.spec.ts and outdated README snippet

### DIFF
--- a/sdk/loadtesting/playwright/README.md
+++ b/sdk/loadtesting/playwright/README.md
@@ -163,16 +163,15 @@ The Azure Playwright reporter is included with the `@azure/playwright` package a
 Add both the HTML reporter and Azure Playwright reporter to your `playwright.service.config.ts`:
 
 ```typescript snippet:configure_reporters
-import { getServiceConfig, PlaywrightReporter } from "@azure/playwright";
 import { defineConfig } from "@playwright/test";
+import { createAzurePlaywrightConfig } from "@azure/playwright";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // <snippet_configure_reporters>
-import { getServiceConfig, PlaywrightReporter } from "@azure/playwright";
-import { defineConfig } from "@playwright/test";
-import { DefaultAzureCredential } from "@azure/identity";
-export default defineConfig(
-  getServiceConfig({
+const playwrightConfig = defineConfig({});
+defineConfig(
+  playwrightConfig,
+  createAzurePlaywrightConfig(playwrightConfig, {
     // Your existing configuration
     credential: new DefaultAzureCredential(),
   }),

--- a/sdk/loadtesting/playwright/test/snippets.spec.ts
+++ b/sdk/loadtesting/playwright/test/snippets.spec.ts
@@ -1,17 +1,19 @@
-import { describe, it, assert } from "vitest";
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+import { describe, it } from "vitest";
+import { createAzurePlaywrightConfig } from "../src/index.js";
+import { defineConfig } from "@playwright/test";
+import { DefaultAzureCredential } from "@azure/identity";
 
 describe("snippets", () => {
   it("configure_reporters", () => {
     // <snippet_configure_reporters>
-    import { getServiceConfig, PlaywrightReporter } from "@azure/playwright";
-    import { defineConfig } from "@playwright/test";
-    import { DefaultAzureCredential } from "@azure/identity";
+    const playwrightConfig = defineConfig({});
 
-    export default defineConfig(
-      getServiceConfig({
+    defineConfig(
+      playwrightConfig,
+      createAzurePlaywrightConfig(playwrightConfig, {
         // Your existing configuration
         credential: new DefaultAzureCredential(),
       }),


### PR DESCRIPTION
### Packages impacted by this PR

@azure/playwright

### Issues associated with this PR

None.

### Describe the problem that is addressed by this PR

`sdk/loadtesting/playwright/test/snippets.spec.ts` currently fails to type-check, which blocks `npm test` for the package and therefore blocks any release.

**The exact error:**

```
test/snippets.spec.ts(9,5): error TS1232: An import declaration can only be used at the top level of a namespace or module.
test/snippets.spec.ts(10,5): error TS1232: An import declaration can only be used at the top level of a namespace or module.
test/snippets.spec.ts(11,5): error TS1232: An import declaration can only be used at the top level of a namespace or module.
test/snippets.spec.ts(13,5): error TS1258: A default export must be at the top level of a file or module declaration.
```

**Two issues compound here:**

1. **Invalid TypeScript** — the file places `import` and `export default` statements **inside** an `it()` arrow-function body, which is illegal at non-top-level scope.

2. **References APIs that no longer exist** — the snippet imports `getServiceConfig` and `PlaywrightReporter` from `@azure/playwright`. `getServiceConfig` was renamed to `createAzurePlaywrightConfig` in #35686 (Aug 2025), and `PlaywrightReporter` is not exported (the reporter is referenced as the string `"@azure/playwright/reporter"`).

The matching `<snippet_configure_reporters>` block in `README.md` displays the same outdated code, so any customer copy-pasting the documented example would also see a compile error against today's `@azure/playwright`.

### Timeline — when did this break and why did it surface now?

This is a latent bug that surfaced only after the recent config-folder migration:

- **2025-06-04 (#34674)** — `snippets.spec.ts` is introduced when `@azure/playwright` is onboarded under `sdk/loadtesting/`. The snippet uses `getServiceConfig`.
- **2025-08-26 (#35686)** — `getServiceConfig` is renamed to `createAzurePlaywrightConfig`. `snippets.spec.ts` and `README.md` are not updated. `npm test` continues to pass because the old test script (`npm run test:node && npm run test:browser`) does not run `tsc -b --noEmit` against the snippets file.
- **2026-01-06 (#36974)** — README is updated for reporting docs; the snippet markers are reorganized but the body still references the renamed/removed symbols.
- **2026-05-06 (df9ce05b8c, `Properly migrate 71 packages to config folder structure`)** — config files move under `config/` AND the package's test script is changed to `tsc -b --noEmit && npm run test:node && npm run test:browser`. From this commit onward, `snippets.spec.ts` is included in the type-check, the broken code is finally exercised, and `npm test` (and therefore release) fails.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The dev-tool `update-snippets` command extracts the body of each `it(name, () => { ... })` in `snippets.spec.ts` and writes it into the `<snippet_name>` markers in `README.md`. The fix here:

1. Moves the imports to the top of `snippets.spec.ts` (legal TS).
2. Replaces the body with valid code using the actual SDK API: `createAzurePlaywrightConfig(playwrightConfig, { credential, ... })`.
3. Runs `npm run update-snippets` so the README block is regenerated automatically rather than hand-edited.

Hand-editing the README was rejected because the package already owns `update-snippets` as the canonical regeneration tool; running it ensures spec and docs stay in sync and matches the convention used by other packages in the monorepo.

### Are there test cases added in this PR? _(If not, why?)_

No new tests. This PR fixes a broken file so the existing test suite (`npm test`) goes from failing (TS compile errors) to passing:

```
Before: test/snippets.spec.ts(9,5): error TS1232 ...
After:  Test Files  12 passed (12) | Tests  194 passed | 1 skipped (195)
```

### Provide a list of related PRs _(if any)_

The same package's #38693 (adds `sourceType` option) is currently blocked on this fix.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A.

### Checklists
- [x] Added impacted package name to the issue description
- [x] Does this PR needs any fixes in the SDK Generator? -- No, hand-authored fix.
- [x] Added a changelog (if necessary) -- not needed; this is an internal test/doc fix with no API or behavior change.
