### PR TITLE
[core] send request body of ArrayBufferView subarray properly

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix an issue in `NodeHttpClient` where we incorrectly send the whole backing buffer when request body is an `ArrayBufferView`.
+
 ### Other Changes
 
 - Set `RestError.response.bodyAsText` when the error response body has `string` type [PR #38059](https://github.com/Azure/azure-sdk-for-js/pull/38059)

--- a/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
@@ -256,7 +256,11 @@ class NodeHttpClient implements HttpClient {
         if (typeof body === "string" || Buffer.isBuffer(body)) {
           req.end(body);
         } else if (isArrayBuffer(body)) {
-          req.end(ArrayBuffer.isView(body) ? Buffer.from(body.buffer, body.byteOffset, body.byteLength) : Buffer.from(body));
+          req.end(
+            ArrayBuffer.isView(body)
+              ? Buffer.from(body.buffer, body.byteOffset, body.byteLength)
+              : Buffer.from(body),
+          );
         } else {
           logger.error("Unrecognized body type", body);
           reject(new RestError("Unrecognized body type"));

--- a/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
+++ b/sdk/core/ts-http-runtime/src/nodeHttpClient.ts
@@ -256,7 +256,7 @@ class NodeHttpClient implements HttpClient {
         if (typeof body === "string" || Buffer.isBuffer(body)) {
           req.end(body);
         } else if (isArrayBuffer(body)) {
-          req.end(ArrayBuffer.isView(body) ? Buffer.from(body.buffer) : Buffer.from(body));
+          req.end(ArrayBuffer.isView(body) ? Buffer.from(body.buffer, body.byteOffset, body.byteLength) : Buffer.from(body));
         } else {
           logger.error("Unrecognized body type", body);
           reject(new RestError("Unrecognized body type"));

--- a/sdk/core/ts-http-runtime/test/public/node/nodeHttpClient.spec.ts
+++ b/sdk/core/ts-http-runtime/test/public/node/nodeHttpClient.spec.ts
@@ -332,6 +332,39 @@ describe("NodeHttpClient", function () {
     assert.strictEqual(response.status, 200);
   });
 
+  it("should send only the ArrayBufferView window for subarray bodies", async function () {
+    const client = createDefaultHttpClient();
+    let sentChunk: unknown;
+    const captureChunkRequest: ClientRequest = {
+      on() {
+        /* no op */
+      },
+      once() {
+        /* no op */
+      },
+      end(chunk: unknown) {
+        sentChunk = chunk;
+      },
+    } as unknown as ClientRequest;
+    vi.mocked(https.request).mockReturnValueOnce(captureChunkRequest);
+
+    const data = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7]);
+    const subarray = data.subarray(2, 6);
+    const request = createPipelineRequest({
+      url: "https://example.com",
+      body: subarray,
+    });
+    const promise = client.sendRequest(request);
+    yieldHttpsResponse(createResponse(200));
+    const response = await promise;
+
+    assert.strictEqual(response.status, 200);
+    assert.isTrue(Buffer.isBuffer(sentChunk), "Expected request body to be a Buffer");
+    assert.deepStrictEqual(Array.from(sentChunk as Buffer), [2, 3, 4, 5]);
+    assert.strictEqual((sentChunk as Buffer).byteLength, subarray.byteLength);
+    assert.strictEqual(request.headers.get("Content-Length"), String(subarray.byteLength));
+  });
+
   it("should handle ArrayBuffer bodies correctly", async function () {
     const client = createDefaultHttpClient();
     vi.mocked(https.request).mockReturnValueOnce(httpRequestChecker);


### PR DESCRIPTION
When the request body is an ArrayBufferView we are incorrectly sending the whole
backing buffer of the view `Buffer.from(body.buffer)`.  This PR fixes the issue
by sending the proper subarray.