### PR TITLE
[storage-common] remove top-level `await` from crc64.js

### DIFF
--- a/sdk/storage/storage-common/copyJSFiles.cjs
+++ b/sdk/storage/storage-common/copyJSFiles.cjs
@@ -32,9 +32,15 @@ const cjsSource = esmSource
   .replace(ESM_EXPORT_BLOCK, "module.exports = NativeCRC64;");
 
 fs.writeFileSync('./dist/commonjs/crc64.js', cjsSource);
-fs.cpSync(SRC_GLUE, './dist/commonjs/crc64_glue.js');
 
-for (const dir of ['browser', 'esm', 'react-native']) {
-  fs.cpSync(SRC_CRC64, `./dist/${dir}/crc64.js`);
+const browserSource = esmSource
+      .replace(
+        ESM_COMPAT_BLOCK,
+        `// ESM compatibility block omitted in browsers build as it is NodeJS only.\n`);
+
+fs.writeFileSync('./dist/browser/crc64.js', browserSource);
+fs.writeFileSync('./dist/react-native/crc64.js', browserSource);
+
+for (const dir of ['browser', 'esm', 'commonjs', 'react-native']) {
   fs.cpSync(SRC_GLUE, `./dist/${dir}/crc64_glue.js`);
 }

--- a/sdk/storage/storage-common/copyJSFiles.cjs
+++ b/sdk/storage/storage-common/copyJSFiles.cjs
@@ -24,6 +24,8 @@ if (!ESM_EXPORT_BLOCK.test(esmSource)) {
   );
 }
 
+fs.writeFileSync('./dist/esm/crc64.js', esmSource);
+
 const cjsSource = esmSource
   .replace(
     ESM_COMPAT_BLOCK,

--- a/sdk/storage/storage-common/src/crc64.js
+++ b/sdk/storage/storage-common/src/crc64.js
@@ -8,6 +8,9 @@
 // The detection check below MUST stay byte-for-byte identical to the Emscripten-generated
 // `ENVIRONMENT_IS_NODE` check later in this file; otherwise the polyfill and the Node branch
 // can disagree and the ESM `ReferenceError: require is not defined` bug returns.
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 const __isNode__ =
   typeof process === "object" &&
   typeof process.versions === "object" &&
@@ -16,12 +19,6 @@ let require;
 let __filename;
 let __dirname;
 if (__isNode__) {
-  const _modSpecifier = "node:module";
-  const _urlSpecifier = "node:url";
-  const _pathSpecifier = "node:path";
-  const { createRequire } = await import(_modSpecifier);
-  const { fileURLToPath } = await import(_urlSpecifier);
-  const { dirname } = await import(_pathSpecifier);
   require = createRequire(import.meta.url);
   __filename = fileURLToPath(import.meta.url);
   __dirname = dirname(__filename);


### PR DESCRIPTION
In the bundling scenario where consumer code is ESM but the output format is
`cjs` the top-level `await` is causing problems because some bundler does not
allow that.  This PR removes the top-level awaits by using `import` statements
instead of dynamical imports.  Browser and React Native versions don't need the
compat polyfill so it is omitted for them.