### PR TITLE
[storage] bump blob-changefeed version

### DIFF
--- a/sdk/storage/storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/storage-blob-changefeed/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 12.0.0-beta.6 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 12.0.0-preview.5 (Unreleased)
 
 ### Features Added

--- a/sdk/storage/storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/storage-blob-changefeed/CHANGELOG.md
@@ -1,16 +1,6 @@
 # Release History
 
-## 12.0.0-beta.6 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 12.0.0-preview.5 (Unreleased)
+## 12.0.1-beta.1 (Unreleased)
 
 ### Features Added
 

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob-changefeed",
   "sdk-type": "client",
-  "version": "12.0.0-preview.5",
+  "version": "12.0.0-beta.6",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob Change Feed",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob-changefeed",
   "sdk-type": "client",
-  "version": "12.0.0-beta.6",
+  "version": "12.0.1-beta.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob Change Feed",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/storage/storage-blob-changefeed/src/utils/constants.ts
+++ b/sdk/storage/storage-blob-changefeed/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.0-beta.6";
+export const SDK_VERSION: string = "12.0.1-beta.1";
 
 export const CHANGE_FEED_CONTAINER_NAME: string = "$blobchangefeed";
 export const CHANGE_FEED_META_SEGMENT_PATH: string = "meta/segments.json";

--- a/sdk/storage/storage-blob-changefeed/src/utils/constants.ts
+++ b/sdk/storage/storage-blob-changefeed/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.0-preview.5";
+export const SDK_VERSION: string = "12.0.0-beta.6";
 
 export const CHANGE_FEED_CONTAINER_NAME: string = "$blobchangefeed";
 export const CHANGE_FEED_META_SEGMENT_PATH: string = "meta/segments.json";


### PR DESCRIPTION
as 12.0.0-preview.5 has been published already.  This PR also changes to use `-beta` instead of `-preview` suffix which we stopped using a while ago.