### PR TITLE
Fix test failure

### DIFF
--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -329,7 +329,6 @@ describe("FileClient", () => {
     assert.isDefined(result.fileParentId!);
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -419,7 +418,6 @@ describe("FileClient", () => {
 
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -1934,7 +1932,6 @@ describe("FileClient - OAuth", () => {
     assert.isDefined(result.fileParentId!);
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -1949,7 +1946,6 @@ describe("FileClient - OAuth", () => {
 
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -2240,7 +2236,6 @@ describe("FileClient - AllowTrailingDots - True", () => {
     assert.isDefined(result.fileParentId!);
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -2266,7 +2261,6 @@ describe("FileClient - AllowTrailingDots - True", () => {
 
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -2615,7 +2609,6 @@ describe("FileClient - AllowTrailingDots - False", () => {
     assert.isDefined(result.fileParentId!);
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -2641,7 +2634,6 @@ describe("FileClient - AllowTrailingDots - False", () => {
 
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);
@@ -3116,7 +3108,6 @@ describe("FileClient - NFS", () => {
 
     assert.isDefined(result.lastModified);
     assert.deepStrictEqual(result.metadata, {});
-    assert.isUndefined(result.cacheControl);
     assert.isUndefined(result.contentType);
     assert.isUndefined(result.contentMD5);
     assert.isUndefined(result.contentEncoding);


### PR DESCRIPTION
### Packages impacted by this PR


### Issues associated with this PR
For file's getProperties function,  default cachecontrole value returned from service changed from undefined to 'no-cache'. 
SDK Should not check the default value, so remove the judgement on default cachecontrol value


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
