### PR TITLE
fix(loadtesting): Validate storageUri against Azure Storage allowlist before credential use

### DIFF
--- a/sdk/loadtesting/playwright/src/common/constants.ts
+++ b/sdk/loadtesting/playwright/src/common/constants.ts
@@ -121,7 +121,6 @@ export const StorageUriValidationConstants = {
   AllowedProtocol: "https:",
   AllowedHostnameSuffixes: [
     ".blob.core.windows.net",
-    ".dfs.core.windows.net",
     ".blob.core.usgovcloudapi.net",
     ".blob.core.chinacloudapi.cn",
   ] as const,

--- a/sdk/loadtesting/playwright/src/common/constants.ts
+++ b/sdk/loadtesting/playwright/src/common/constants.ts
@@ -116,3 +116,13 @@ export const UploadConstants = {
 export const BrowserSessionSourceType = {
   PLAYWRIGHT_WORKSPACES_TEST_RUN: "PlaywrightWorkspacesTestRun",
 };
+
+export const StorageUriValidationConstants = {
+  AllowedProtocol: "https:",
+  AllowedHostnameSuffixes: [
+    ".blob.core.windows.net",
+    ".dfs.core.windows.net",
+    ".blob.core.usgovcloudapi.net",
+    ".blob.core.chinacloudapi.cn",
+  ] as const,
+};

--- a/sdk/loadtesting/playwright/src/common/messages.ts
+++ b/sdk/loadtesting/playwright/src/common/messages.ts
@@ -88,7 +88,6 @@ export const ServiceErrorMessageConstants = {
     key: "InvalidStorageUri",
     message:
       "The storage URI configured on this Playwright Workspace is not a valid Azure Storage endpoint. " +
-      "Reporting upload has been aborted to protect your credentials. " +
       "Please ask a workspace administrator to relink a valid Azure Storage account. " +
       "For more information, see https://aka.ms/pww-reporting",
   },

--- a/sdk/loadtesting/playwright/src/common/messages.ts
+++ b/sdk/loadtesting/playwright/src/common/messages.ts
@@ -84,6 +84,14 @@ export const ServiceErrorMessageConstants = {
     key: "StorageUriNotFound",
     message: "Storage Account is not linked with this Playwright Workspace.",
   },
+  INVALID_STORAGE_URI: {
+    key: "InvalidStorageUri",
+    message:
+      "The storage URI configured on this Playwright Workspace is not a valid Azure Storage Blob endpoint. " +
+      "Reporting upload has been aborted to protect your credentials. " +
+      "Please ask a workspace administrator to relink a valid Azure Storage account. " +
+      "For more information, see https://aka.ms/pww-reporting",
+  },
   STORAGE_AUTHORIZATION_FAILED: {
     key: "StorageAuthorizationFailed",
     message:

--- a/sdk/loadtesting/playwright/src/common/messages.ts
+++ b/sdk/loadtesting/playwright/src/common/messages.ts
@@ -87,7 +87,7 @@ export const ServiceErrorMessageConstants = {
   INVALID_STORAGE_URI: {
     key: "InvalidStorageUri",
     message:
-      "The storage URI configured on this Playwright Workspace is not a valid Azure Storage Blob endpoint. " +
+      "The storage URI configured on this Playwright Workspace is not a valid Azure Storage endpoint. " +
       "Reporting upload has been aborted to protect your credentials. " +
       "Please ask a workspace administrator to relink a valid Azure Storage account. " +
       "For more information, see https://aka.ms/pww-reporting",

--- a/sdk/loadtesting/playwright/src/common/messages.ts
+++ b/sdk/loadtesting/playwright/src/common/messages.ts
@@ -87,8 +87,8 @@ export const ServiceErrorMessageConstants = {
   INVALID_STORAGE_URI: {
     key: "InvalidStorageUri",
     message:
-      "The storage URI configured on this Playwright Workspace is not a valid Azure Storage endpoint. " +
-      "Please ask a workspace administrator to relink a valid Azure Storage account. " +
+      "The storage URI configured on this Playwright Workspace is not a valid Azure Storage Blob endpoint. " +
+      "Please ask a workspace administrator to relink a valid Azure Storage Blob account. " +
       "For more information, see https://aka.ms/pww-reporting",
   },
   STORAGE_AUTHORIZATION_FAILED: {

--- a/sdk/loadtesting/playwright/src/reporter/playwrightReporter.ts
+++ b/sdk/loadtesting/playwright/src/reporter/playwrightReporter.ts
@@ -6,6 +6,7 @@ import {
   getHtmlReporterOutputFolder,
   getPortalTestRunUrl,
   getVersionInfo,
+  isValidAzureStorageBlobUri,
 } from "../utils/utils.js";
 import { coreLogger } from "../common/logger.js";
 import { PlaywrightServiceConfig } from "../common/playwrightServiceConfig.js";
@@ -238,28 +239,30 @@ export default class PlaywrightReporter implements Reporter {
         return false;
       }
 
-      if (normalizedReporting === "enabled") {
-        if (!storageUri) {
-          console.error(
-            ServiceErrorMessageConstants.WORKSPACE_REPORTING_STORAGE_NOT_LINKED.message,
-          );
-          coreLogger.info("Reporting enabled in metadata but storage URI not configured");
-          return false;
-        }
-        coreLogger.info("Reporting enabled via workspace metadata configuration");
-        return true;
+      if (normalizedReporting === "enabled" && !storageUri) {
+        console.error(ServiceErrorMessageConstants.WORKSPACE_REPORTING_STORAGE_NOT_LINKED.message);
+        coreLogger.info("Reporting enabled in metadata but storage URI not configured");
+        return false;
       }
 
-      // If reporting has an unexpected value, log warning and fall back to storageUri check
-      coreLogger.info(
-        `Unexpected reporting value in workspace metadata: ${reporting}. Falling back to storage URI check.`,
-      );
+      if (normalizedReporting !== "enabled") {
+        coreLogger.info(
+          `Unexpected reporting value in workspace metadata: ${reporting}. Falling back to storage URI check.`,
+        );
+      }
     }
 
-    // Fallback to current logic: check only storageUri (when reporting field is not present or has unexpected value)
     if (!storageUri) {
       console.error(ServiceErrorMessageConstants.WORKSPACE_REPORTING_DISABLED.message);
       coreLogger.info("Storage URI not configured in workspace metadata");
+      return false;
+    }
+
+    if (!isValidAzureStorageBlobUri(storageUri)) {
+      console.error(ServiceErrorMessageConstants.INVALID_STORAGE_URI.message);
+      coreLogger.error(
+        `Reporting disabled: storageUri "${storageUri}" is not a valid Azure Storage Blob endpoint.`,
+      );
       return false;
     }
 

--- a/sdk/loadtesting/playwright/src/reporter/playwrightReporter.ts
+++ b/sdk/loadtesting/playwright/src/reporter/playwrightReporter.ts
@@ -260,9 +260,7 @@ export default class PlaywrightReporter implements Reporter {
 
     if (!isValidAzureStorageBlobUri(storageUri)) {
       console.error(ServiceErrorMessageConstants.INVALID_STORAGE_URI.message);
-      coreLogger.error(
-        `Reporting disabled: storageUri "${storageUri}" is not a valid Azure Storage Blob endpoint.`,
-      );
+      coreLogger.error("Reporting disabled: storageUri is not a valid Azure Storage endpoint.");
       return false;
     }
 

--- a/sdk/loadtesting/playwright/src/utils/getPackageVersion.ts
+++ b/sdk/loadtesting/playwright/src/utils/getPackageVersion.ts
@@ -17,8 +17,10 @@ export const getPackageVersionFromFolder = (folder: string): string => {
   try {
     const version = require(path.join(currentDir, folder, "package.json")).version;
     return version;
-  } catch (error) {
-    coreLogger.error("Error fetching package version:", error);
+  } catch {
+    coreLogger.verbose(
+      `package.json not found at ${path.join(currentDir, folder)}, trying next path`,
+    );
     return "";
   }
 };

--- a/sdk/loadtesting/playwright/src/utils/utils.ts
+++ b/sdk/loadtesting/playwright/src/utils/utils.ts
@@ -11,6 +11,7 @@ import {
   BrowserSessionSourceType,
   UrlConstants,
   UploadConstants,
+  StorageUriValidationConstants,
 } from "../common/constants.js";
 import { ServiceErrorMessageConstants } from "../common/messages.js";
 import { coreLogger } from "../common/logger.js";
@@ -503,4 +504,37 @@ export const getStorageAccountNameFromUri = (storageUri: string): string | null 
     console.warn("Failed to extract storage account name from URI:", storageUri, error);
     return null;
   }
+};
+
+export const isValidAzureStorageBlobUri = (storageUri: string | undefined | null): boolean => {
+  if (!storageUri || typeof storageUri !== "string" || storageUri.trim() === "") {
+    return false;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(storageUri);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== StorageUriValidationConstants.AllowedProtocol) {
+    return false;
+  }
+
+  // Reject embedded credentials (username / password in the URI)
+  if (url.username !== "" || url.password !== "") {
+    return false;
+  }
+
+  // Reject query strings and fragments — they can carry attacker-controlled data
+  if (url.search !== "" || url.hash !== "") {
+    return false;
+  }
+
+  // The URL spec lower-cases the hostname, so the comparison is already case-insensitive
+  const hostname = url.hostname;
+  return StorageUriValidationConstants.AllowedHostnameSuffixes.some((suffix) =>
+    hostname.endsWith(suffix),
+  );
 };

--- a/sdk/loadtesting/playwright/test/reporter/playwrightReporter.spec.ts
+++ b/sdk/loadtesting/playwright/test/reporter/playwrightReporter.spec.ts
@@ -172,6 +172,35 @@ describe("PlaywrightReporter", () => {
     expect((globalThis as any).__uploadHtmlReportAfterTestsMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    "http://account.blob.core.windows.net",
+    "https://attacker.example.com",
+    "https://account.blob.core.windows.net.attacker.com",
+    "https://user:pass@account.blob.core.windows.net",
+    "https://account.blob.core.windows.net/?sig=stolen",
+    "javascript:alert(1)",
+  ])(
+    "should disable reporting when workspace storageUri is not a valid Azure Storage endpoint: %s",
+    async (storageUri) => {
+      PlaywrightServiceConfig.instance.serviceAuthType = ServiceAuth.ENTRA_ID;
+      const reporter = new PlaywrightReporter();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      (globalThis as any).__getWorkspaceMetadataMock.mockResolvedValue({
+        reporting: "Enabled",
+        storageUri,
+      });
+
+      const config = { reporter: [["html"]] } as unknown as FullConfig;
+      await reporter.onBegin(config);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        ServiceErrorMessageConstants.INVALID_STORAGE_URI.message,
+      );
+      await reporter.onEnd();
+      expect((globalThis as any).__uploadHtmlReportAfterTestsMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("should handle workspace metadata fetch failure gracefully", async () => {
     PlaywrightServiceConfig.instance.serviceAuthType = ServiceAuth.ENTRA_ID;
     const reporter = new PlaywrightReporter();

--- a/sdk/loadtesting/playwright/test/utils/playwrightReporterStorageManager.spec.ts
+++ b/sdk/loadtesting/playwright/test/utils/playwrightReporterStorageManager.spec.ts
@@ -407,7 +407,9 @@ describe("PlaywrightReporterStorageManager", () => {
         if (stream && typeof stream.destroy === "function") {
           stream.destroy();
         }
-      } catch {}
+      } catch {
+        /* empty */
+      }
     });
     (globalThis as any).__mockBlockBlobClient = {
       upload: uploadSpy,

--- a/sdk/loadtesting/playwright/test/utils/utils.spec.ts
+++ b/sdk/loadtesting/playwright/test/utils/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   InternalEnvironmentVariables,
   RunConfigConstants,
   ServiceEnvironmentVariable,
+  StorageUriValidationConstants,
   UploadConstants,
 } from "../../src/common/constants.js";
 import {
@@ -32,6 +33,7 @@ import {
   getPortalTestRunUrl,
   getStorageAccountNameFromUri,
   getTestRunConfig,
+  isValidAzureStorageBlobUri,
 } from "../../src/utils/utils.js";
 import * as packageManager from "../../src/utils/packageManager.js";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -972,6 +974,87 @@ describe("Service Utils", () => {
         sdkLanguage: RunConfigConstants.TEST_SDK_LANGUAGE,
         maxWorkers: 6,
       });
+    });
+  });
+
+  describe("isValidAzureStorageBlobUri", () => {
+    // ── valid endpoints ─────────────────────────────────────────────────────
+    it.each([
+      // Standard public-cloud blob endpoints
+      "https://myaccount.blob.core.windows.net",
+      "https://myaccount.blob.core.windows.net/",
+      // Data-lake (DFS) endpoint
+      "https://myaccount.dfs.core.windows.net",
+      // US Government cloud
+      "https://myaccount.blob.core.usgovcloudapi.net",
+      // China cloud
+      "https://myaccount.blob.core.chinacloudapi.cn",
+      // Custom port is permitted (mirrors RP behaviour)
+      "https://myaccount.blob.core.windows.net:8443",
+      // Non-standard account label is fine as long as suffix matches
+      "https://account-with-dashes.blob.core.windows.net",
+    ])("accepts valid URI: %s", (uri) => {
+      expect(isValidAzureStorageBlobUri(uri)).toBe(true);
+    });
+
+    // ── attacker-controlled host ─────────────────────────────────────────────
+    it.each([
+      // Completely different domain
+      "https://attacker.example.com",
+      // Suffix in path, not hostname
+      "https://attacker.example.com/account.blob.core.windows.net",
+      // Suffix appended to attacker hostname (subdomain bypass)
+      "https://account.blob.core.windows.net.attacker.com",
+      // Wrong service type – table storage is not in the allowlist
+      "https://account.table.core.windows.net",
+      // Retired German sovereign cloud – not in the allowlist
+      "https://account.blob.core.cloudapi.de",
+    ])("rejects attacker-controlled host: %s", (uri) => {
+      expect(isValidAzureStorageBlobUri(uri)).toBe(false);
+    });
+
+    // ── scheme ───────────────────────────────────────────────────────────────
+    it.each([
+      "http://account.blob.core.windows.net",
+      "ftp://account.blob.core.windows.net",
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+    ])("rejects non-https scheme: %s", (uri) => {
+      expect(isValidAzureStorageBlobUri(uri)).toBe(false);
+    });
+
+    // ── embedded credentials ─────────────────────────────────────────────────
+    it("rejects URI with userinfo (username:password)", () => {
+      expect(isValidAzureStorageBlobUri("https://user:pass@account.blob.core.windows.net")).toBe(
+        false,
+      );
+    });
+
+    // ── query string and fragment ────────────────────────────────────────────
+    it("rejects URI with query string", () => {
+      expect(isValidAzureStorageBlobUri("https://account.blob.core.windows.net/?sig=stolen")).toBe(
+        false,
+      );
+    });
+
+    it("rejects URI with fragment", () => {
+      expect(isValidAzureStorageBlobUri("https://account.blob.core.windows.net/#frag")).toBe(false);
+    });
+
+    // ── null / empty / malformed ─────────────────────────────────────────────
+    it.each([undefined, null, "", "   ", "not-a-url"])(
+      "rejects null/empty/malformed input: %s",
+      (input) => {
+        expect(isValidAzureStorageBlobUri(input as any)).toBe(false);
+      },
+    );
+
+    // ── hostname-suffix allowlist is exhaustive ──────────────────────────────
+    it("covers every suffix in StorageUriValidationConstants", () => {
+      for (const suffix of StorageUriValidationConstants.AllowedHostnameSuffixes) {
+        const uri = `https://account${suffix}`;
+        expect(isValidAzureStorageBlobUri(uri)).toBe(true);
+      }
     });
   });
 });

--- a/sdk/loadtesting/playwright/test/utils/utils.spec.ts
+++ b/sdk/loadtesting/playwright/test/utils/utils.spec.ts
@@ -983,8 +983,6 @@ describe("Service Utils", () => {
       // Standard public-cloud blob endpoints
       "https://myaccount.blob.core.windows.net",
       "https://myaccount.blob.core.windows.net/",
-      // Data-lake (DFS) endpoint
-      "https://myaccount.dfs.core.windows.net",
       // US Government cloud
       "https://myaccount.blob.core.usgovcloudapi.net",
       // China cloud


### PR DESCRIPTION
### Packages impacted by this PR
@azure/playwright

### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
