### PR TITLE
[EngSys] Use .ts extensions for samples-dev relative imports - from claude

### DIFF
--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -368,6 +368,11 @@ export async function createTsconfig(projectInfo: ProjectInfo): Promise<string> 
   delete tsconfig.compilerOptions.inlineSources;
   delete tsconfig.compilerOptions.sourceMap;
   delete tsconfig.compilerOptions.verbatimModuleSyntax;
+  // `allowImportingTsExtensions` is enabled in `samples-dev` so that local samples
+  // can `import "./foo.ts"` and be executed directly with Node's TypeScript loader.
+  // Published samples are compiled with `tsc` and emit `.js` files, so the `.ts`
+  // specifiers are rewritten back to `.js` during publishing — strip this flag.
+  delete tsconfig.compilerOptions.allowImportingTsExtensions;
   tsconfig.include = ["./src"];
   tsconfig.compilerOptions.outDir = "./dist";
   tsconfig.compilerOptions.rootDir = "./src";
@@ -439,6 +444,12 @@ export async function makeSamplesFactory(
         .replace(/\/\*\*(\s+\*)*/s, `/**\n *`)
         // Finally remove empty doc comments.
         .replace(/\s*\/\*\*(\s+\*)*\/\s*/s, "\n\n")
+        // Rewrite relative imports/requires that reference `.ts` files to `.js`,
+        // since published samples are consumed as JavaScript (or compiled with tsc
+        // using `nodenext` resolution, which also expects `.js` specifiers).
+        // The `.ts` form is used in samples-dev sources so that `dev-tool samples run`
+        // can load them directly via Node's TypeScript loader.
+        .replace(/(["'])(\.\.?\/[^"']*?)\.ts\1/g, "$1$2.js$1")
     );
   }
 

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/README.md
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/README.md
@@ -1,0 +1,53 @@
+# Azure Template client library samples for JavaScript
+
+These sample programs show how to use the JavaScript client libraries for Azure Template in some common scenarios.
+
+| **File Name**           | **Description**                                                                                                |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [useUtils.js][useutils] | verifies that relative imports written with a `.ts` extension are rewritten to `.js` in the published samples. |
+
+## Prerequisites
+
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
+
+You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
+
+- [Azure App Configuration][createinstance_azureappconfiguration]
+
+Samples retrieve credentials to access the service endpoint from environment variables. Alternatively, edit the source code to include the appropriate credentials. See each individual sample for details on which environment variables/credentials it requires to function.
+
+Adapting the samples to run in the browser may require some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the dependencies using `npm`:
+
+```bash
+npm install
+```
+
+2. Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.
+
+3. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node useUtils.js
+```
+
+Alternatively, run a single sample with the required environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
+
+```bash
+node useUtils.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[useutils]: https://github.com/Azure/azure-sdk-for-js/blob/main/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/useUtils.js
+[apiref]: https://learn.microsoft.com/javascript/api/
+[freesub]: https://azure.microsoft.com/free/
+[createinstance_azureappconfiguration]: https://learn.microsoft.com/azure/azure-app-configuration/
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/README.md

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@azure-samples/ts-imports-js",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Azure Template client library samples for JavaScript",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
+    "directory": "common/tools/dev-tool/test/samples/files/expectations/ts-imports"
+  },
+  "keywords": [
+    "ts-imports"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/ts-imports",
+  "dependencies": {
+    "ts-imports": "latest",
+    "dotenv": "latest"
+  },
+  "devDependencies": {
+    "cross-env": "latest"
+  }
+}

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/sample.env
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/sample.env
@@ -1,0 +1,2 @@
+# Used in most samples.
+SOME_VARIABLE="<value>"

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/useUtils.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/useUtils.js
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @summary verifies that relative imports written with a `.ts` extension are
+ *  rewritten to `.js` in the published samples.
+ */
+
+const { greet } = require("./utils/helpers.js");
+const { CONSTANT } = require("./utils/constants.js");
+
+async function main() {
+  console.log(greet("world"));
+  console.log("constant:", CONSTANT);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/utils/constants.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/utils/constants.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const CONSTANT = 42;
+
+module.exports = { CONSTANT };

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/utils/helpers.js
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/javascript/utils/helpers.js
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+function greet(name) {
+  return `Hello, ${name}!`;
+}
+
+module.exports = { greet };

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/README.md
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/README.md
@@ -1,0 +1,66 @@
+# Azure Template client library samples for TypeScript
+
+These sample programs show how to use the TypeScript client libraries for Azure Template in some common scenarios.
+
+| **File Name**           | **Description**                                                                                                |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [useUtils.ts][useutils] | verifies that relative imports written with a `.ts` extension are rewritten to `.js` in the published samples. |
+
+## Prerequisites
+
+The sample programs are compatible with [LTS versions of Node.js](https://github.com/nodejs/release#release-schedule).
+
+Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using:
+
+```bash
+npm install -g typescript
+```
+
+You need [an Azure subscription][freesub] and the following Azure resources to run these sample programs:
+
+- [Azure App Configuration][createinstance_azureappconfiguration]
+
+Samples retrieve credentials to access the service endpoint from environment variables. Alternatively, edit the source code to include the appropriate credentials. See each individual sample for details on which environment variables/credentials it requires to function.
+
+Adapting the samples to run in the browser may require some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the dependencies using `npm`:
+
+```bash
+npm install
+```
+
+2. Compile the samples:
+
+```bash
+npm run build
+```
+
+3. Edit the file `sample.env`, adding the correct credentials to access the Azure service and run the samples. Then rename the file from `sample.env` to just `.env`. The sample programs will read this file automatically.
+
+4. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node dist/useUtils.js
+```
+
+Alternatively, run a single sample with the required environment variables set (setting up the `.env` file is not required if you do this), for example (cross-platform):
+
+```bash
+node dist/useUtils.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[useutils]: https://github.com/Azure/azure-sdk-for-js/blob/main/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/useUtils.ts
+[apiref]: https://learn.microsoft.com/javascript/api/
+[freesub]: https://azure.microsoft.com/free/
+[createinstance_azureappconfiguration]: https://learn.microsoft.com/azure/azure-app-configuration/
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/README.md
+[typescript]: https://www.typescriptlang.org/docs/home.html

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/package.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@azure-samples/ts-imports-ts",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Azure Template client library samples for TypeScript",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rimraf dist/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git",
+    "directory": "common/tools/dev-tool/test/samples/files/expectations/ts-imports"
+  },
+  "keywords": [
+    "ts-imports"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/common/tools/dev-tool/test/samples/files/expectations/ts-imports",
+  "dependencies": {
+    "ts-imports": "latest",
+    "dotenv": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "cross-env": "latest",
+    "rimraf": "latest",
+    "typescript": "~6.0.2"
+  }
+}

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/sample.env
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/sample.env
@@ -1,0 +1,2 @@
+# Used in most samples.
+SOME_VARIABLE="<value>"

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/useUtils.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/useUtils.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @summary verifies that relative imports written with a `.ts` extension are
+ *  rewritten to `.js` in the published samples.
+ */
+
+import { greet } from "./utils/helpers.js";
+import { CONSTANT } from "./utils/constants.js";
+
+async function main(): Promise<void> {
+  console.log(greet("world"));
+  console.log("constant:", CONSTANT);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/utils/constants.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/utils/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const CONSTANT = 42;

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/utils/helpers.ts
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/src/utils/helpers.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/tsconfig.json
+++ b/common/tools/dev-tool/test/samples/files/expectations/ts-imports/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "alwaysStrict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/common/tools/dev-tool/test/samples/files/inputs/ts-imports/config.json
+++ b/common/tools/dev-tool/test/samples/files/inputs/ts-imports/config.json
@@ -1,0 +1,10 @@
+{
+  "skipFolder": false,
+  "disableDocsMs": true,
+  "productName": "Azure Template",
+  "productSlugs": [],
+  "apiRefLink": "https://learn.microsoft.com/javascript/api/",
+  "requiredResources": {
+    "Azure App Configuration": "https://learn.microsoft.com/azure/azure-app-configuration/"
+  }
+}

--- a/common/tools/dev-tool/test/samples/files/inputs/ts-imports/sample.env
+++ b/common/tools/dev-tool/test/samples/files/inputs/ts-imports/sample.env
@@ -1,0 +1,2 @@
+# Used in most samples.
+SOME_VARIABLE="<value>"

--- a/common/tools/dev-tool/test/samples/files/inputs/ts-imports/useUtils.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/ts-imports/useUtils.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @summary verifies that relative imports written with a `.ts` extension are
+ *  rewritten to `.js` in the published samples.
+ */
+
+import { greet } from "./utils/helpers.ts";
+import { CONSTANT } from "./utils/constants.ts";
+
+async function main(): Promise<void> {
+  console.log(greet("world"));
+  console.log("constant:", CONSTANT);
+}
+
+main().catch((err) => {
+  console.error("The sample encountered an error:", err);
+});

--- a/common/tools/dev-tool/test/samples/files/inputs/ts-imports/utils/constants.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/ts-imports/utils/constants.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @azsdk-util true
+ */
+
+export const CONSTANT = 42;

--- a/common/tools/dev-tool/test/samples/files/inputs/ts-imports/utils/helpers.ts
+++ b/common/tools/dev-tool/test/samples/files/inputs/ts-imports/utils/helpers.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @azsdk-util true
+ */
+
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/eng/tsconfigs/samples.json
+++ b/eng/tsconfigs/samples.json
@@ -6,7 +6,8 @@
     "noEmit": true,
     "skipLibCheck": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["${configDir}/../samples-dev"]
 }

--- a/sdk/ai/ai-projects/samples-dev/agents/tools/agentComputerUse.ts
+++ b/sdk/ai/ai-projects/samples-dev/agents/tools/agentComputerUse.ts
@@ -25,7 +25,7 @@ import {
   loadScreenshotAssets,
   handleComputerActionAndTakeScreenshot,
   printFinalOutput,
-} from "./computerUseUtil.js";
+} from "./computerUseUtil.ts";
 
 const projectEndpoint = process.env["FOUNDRY_PROJECT_ENDPOINT"] || "<project endpoint>";
 const deploymentName =

--- a/sdk/appconfiguration/app-configuration/samples-dev/updateSyncTokenSample.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/updateSyncTokenSample.ts
@@ -13,7 +13,7 @@
 import { AppConfigurationClient } from "@azure/app-configuration";
 import type { EventGridEvent } from "@azure/eventgrid";
 import { isSystemEvent, EventGridDeserializer } from "@azure/eventgrid";
-import { appConfigTestEvent } from "./testData.js";
+import { appConfigTestEvent } from "./testData.ts";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";

--- a/sdk/attestation/attestation/samples-dev/attestEnclaves.ts
+++ b/sdk/attestation/attestation/samples-dev/attestEnclaves.ts
@@ -25,8 +25,8 @@
  */
 import { AttestationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { writeBanner } from "./utils/helpers.js";
-import { decodeString } from "./utils/base64url.js";
+import { writeBanner } from "./utils/helpers.ts";
+import { decodeString } from "./utils/base64url.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/createAttestationClient.ts
+++ b/sdk/attestation/attestation/samples-dev/createAttestationClient.ts
@@ -25,7 +25,7 @@
 import { AttestationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
 import { X509 } from "jsrsasign";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/getAttestationPolicy.ts
+++ b/sdk/attestation/attestation/samples-dev/getAttestationPolicy.ts
@@ -26,7 +26,7 @@
 
 import { AttestationAdministrationClient, KnownAttestationType } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/getPolicyManagementCertificates.ts
+++ b/sdk/attestation/attestation/samples-dev/getPolicyManagementCertificates.ts
@@ -27,7 +27,7 @@
 import { AttestationAdministrationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
 import { X509 } from "jsrsasign";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/modifyPolicyManagementCertificates.ts
+++ b/sdk/attestation/attestation/samples-dev/modifyPolicyManagementCertificates.ts
@@ -31,9 +31,9 @@
 
 import { AttestationAdministrationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { createRSAKey, createX509Certificate, generateSha1Hash } from "./utils/cryptoUtils.js";
+import { createRSAKey, createX509Certificate, generateSha1Hash } from "./utils/cryptoUtils.ts";
 import { X509 } from "jsrsasign";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
+++ b/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
@@ -36,8 +36,8 @@ import {
   KnownAttestationType,
 } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { writeBanner } from "./utils/helpers.js";
-import { createRSAKey, createX509Certificate, generateSha256Hash } from "./utils/cryptoUtils.js";
+import { writeBanner } from "./utils/helpers.ts";
+import { createRSAKey, createX509Certificate, generateSha256Hash } from "./utils/cryptoUtils.ts";
 import { X509 } from "jsrsasign";
 // Load environment from a .env file if it exists.
 import "dotenv/config";

--- a/sdk/cosmosdb/cosmos/samples-dev/AlterQueryThroughput.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/AlterQueryThroughput.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.js";
+import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.ts";
 import type {
   OfferDefinition,
   Resource,

--- a/sdk/cosmosdb/cosmos/samples-dev/Bulk.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/Bulk.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { OperationInput } from "@azure/cosmos";
 import { BulkOperationType, CosmosClient, PatchOperationType } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/BulkUpdateWithSproc.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/BulkUpdateWithSproc.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.ts";
 import { CosmosClient } from "@azure/cosmos";
 import { randomUUID } from "@azure/core-util";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeed.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeed.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader } from "./Shared/handleError.js";
+import { finish, handleError, logSampleHeader } from "./Shared/handleError.ts";
 import { CosmosClient } from "@azure/cosmos";
 
 const key = process.env.COSMOS_KEY || "<cosmos key>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedHierarchicalPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedHierarchicalPartitionKey.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader } from "../Shared/handleError.js";
+import { finish, handleError, logSampleHeader } from "../Shared/handleError.ts";
 import type { Container, ChangeFeedIteratorOptions } from "@azure/cosmos";
 import {
   CosmosClient,

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorAllVersionsAndDeletes.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorAllVersionsAndDeletes.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.js";
+import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.ts";
 import type {
   Container,
   ChangeFeedIteratorOptions,

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorLatestVersion.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorLatestVersion.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.js";
+import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.ts";
 import type {
   Container,
   ChangeFeedIteratorOptions,

--- a/sdk/cosmosdb/cosmos/samples-dev/ClientSideEncryption.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ClientSideEncryption.ts
@@ -21,7 +21,7 @@ import {
   EncryptionType,
   EncryptionQueryBuilder,
 } from "@azure/cosmos";
-import { finish, handleError, logStep } from "./Shared/handleError.js";
+import { finish, handleError, logStep } from "./Shared/handleError.ts";
 
 const key = process.env.COSMOS_KEY || "<cosmos key>";
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ContainerManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ContainerManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.js";
+import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.ts";
 import type { ContainerDefinition, IndexingPolicy, SpatialIndex } from "@azure/cosmos";
 import {
   CosmosClient,

--- a/sdk/cosmosdb/cosmos/samples-dev/DatabaseManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/DatabaseManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, logStep, logSampleHeader, finish } from "./Shared/handleError.js";
+import { handleError, logStep, logSampleHeader, finish } from "./Shared/handleError.ts";
 import { CosmosClient } from "@azure/cosmos";
 import assert from "node:assert";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/Diagnostics.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, logSampleHeader, finish } from "./Shared/handleError.js";
+import { handleError, logSampleHeader, finish } from "./Shared/handleError.ts";
 import type { OperationInput, Container, GatewayStatistics, Database } from "@azure/cosmos";
 import { CosmosClient, BulkOperationType, PatchOperationType } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/EntraAuth.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/EntraAuth.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { CosmosClient } from "@azure/cosmos";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 
 const key = process.env.COSMOS_KEY || "<cosmos key>";
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ExcludedLocations.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ExcludedLocations.ts
@@ -8,7 +8,7 @@
 import "dotenv/config";
 import type { ChangeFeedIteratorOptions } from "@azure/cosmos";
 import { CosmosClient, BulkOperationType, ChangeFeedStartFrom } from "@azure/cosmos";
-import { handleError, logStep } from "./Shared/handleError.js";
+import { handleError, logStep } from "./Shared/handleError.ts";
 
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";
 const key = process.env.COSMOS_KEY || "<cosmos key>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ExecuteBulkOperations.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ExecuteBulkOperations.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { OperationInput } from "@azure/cosmos";
 import { BulkOperationType, CosmosClient, PatchOperationType } from "@azure/cosmos";
 import { DefaultAzureCredential } from "@azure/identity";

--- a/sdk/cosmosdb/cosmos/samples-dev/HierarchicalPartitioning.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/HierarchicalPartitioning.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, logSampleHeader, finish } from "./Shared/handleError.js";
+import { handleError, logSampleHeader, finish } from "./Shared/handleError.ts";
 import type { PatchOperation, OperationInput } from "@azure/cosmos";
 import {
   CosmosClient,

--- a/sdk/cosmosdb/cosmos/samples-dev/IndexManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/IndexManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { ContainerDefinition } from "@azure/cosmos";
 import { CosmosClient, IndexKind, DataType, IndexingMode } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/ItemManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ItemManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { PatchOperation } from "@azure/cosmos";
 import { CosmosClient, PriorityLevel } from "@azure/cosmos";
 import FamiliesJSON from "./Data/Families.json" with { type: "json" };

--- a/sdk/cosmosdb/cosmos/samples-dev/PriorityLevel.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/PriorityLevel.ts
@@ -7,7 +7,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader, logStep } from "./Shared/handleError.js";
+import { finish, handleError, logSampleHeader, logStep } from "./Shared/handleError.ts";
 import type {
   Container,
   ChangeFeedIteratorOptions,

--- a/sdk/cosmosdb/cosmos/samples-dev/Query/FullTextSearch.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/Query/FullTextSearch.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader } from "./../Shared/handleError.js";
+import { finish, handleError, logSampleHeader } from "./../Shared/handleError.ts";
 import type { IndexingPolicy } from "@azure/cosmos";
 import { CosmosClient } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/SasTokenAuth.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/SasTokenAuth.ts
@@ -8,7 +8,7 @@
 import "dotenv/config";
 import type { SasTokenProperties } from "@azure/cosmos";
 import { CosmosClient, createAuthorizationSasToken, SasTokenPermissionKind } from "@azure/cosmos";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 const masterKey = process.env.COSMOS_KEY || "<cosmos key>";
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";
 const sasToken = "your-sas-token";

--- a/sdk/cosmosdb/cosmos/samples-dev/ServerSideScripts.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ServerSideScripts.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, logStep, finish, handleError } from "./Shared/handleError.js";
+import { logSampleHeader, logStep, finish, handleError } from "./Shared/handleError.ts";
 import type { ErrorResponse, FeedOptions, Item, Resource } from "@azure/cosmos";
 import { CosmosClient } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/ThroughputBucket.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ThroughputBucket.ts
@@ -6,7 +6,7 @@
  */
 import "dotenv/config";
 import { ChangeFeedStartFrom, CosmosClient, type Container } from "@azure/cosmos";
-import { logSampleHeader, handleError, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, logStep } from "./Shared/handleError.ts";
 import { randomUUID } from "@azure/core-util";
 
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples-dev/receiveEventsWithApiSpecificStorage.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples-dev/receiveEventsWithApiSpecificStorage.ts
@@ -16,7 +16,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { EventHubConsumerClient } from "@azure/event-hubs";
 import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
 import { BlobServiceClient } from "@azure/storage-blob";
-import { createCustomPipeline } from "./createCustomPipeline.js";
+import { createCustomPipeline } from "./createCustomPipeline.ts";
 
 import "dotenv/config";
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeBusinessCard.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeBusinessCard.ts
@@ -16,7 +16,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltBusinessCardModel } from "./prebuilt/prebuilt-businessCard.js";
+import { PrebuiltBusinessCardModel } from "./prebuilt/prebuilt-businessCard.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeIdentityDocument.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeIdentityDocument.ts
@@ -16,7 +16,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltIdDocumentModel } from "./prebuilt/prebuilt-idDocument.js";
+import { PrebuiltIdDocumentModel } from "./prebuilt/prebuilt-idDocument.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeInvoice.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeInvoice.ts
@@ -15,7 +15,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltInvoiceModel } from "./prebuilt/prebuilt-invoice.js";
+import { PrebuiltInvoiceModel } from "./prebuilt/prebuilt-invoice.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeReceipt.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeReceipt.ts
@@ -15,7 +15,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltReceiptModel } from "./prebuilt/prebuilt-receipt.js";
+import { PrebuiltReceiptModel } from "./prebuilt/prebuilt-receipt.ts";
 
 import "dotenv/config";
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeW2TaxForm.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeW2TaxForm.ts
@@ -15,7 +15,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltTaxUsW2Model } from "./prebuilt/prebuilt-tax.us.w2.js";
+import { PrebuiltTaxUsW2Model } from "./prebuilt/prebuilt-tax.us.w2.ts";
 import fs from "node:fs";
 import path from "node:path";
 import "dotenv/config";

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractGeneralDocument.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractGeneralDocument.ts
@@ -11,7 +11,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltDocumentModel } from "./prebuilt/prebuilt-document.js";
+import { PrebuiltDocumentModel } from "./prebuilt/prebuilt-document.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractLayout.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractLayout.ts
@@ -12,7 +12,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltLayoutModel } from "./prebuilt/prebuilt-layout.js";
+import { PrebuiltLayoutModel } from "./prebuilt/prebuilt-layout.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/readDocument.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/readDocument.ts
@@ -9,8 +9,8 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltReadModel } from "./prebuilt/prebuilt-read.js";
-import { getTextOfSpans } from "./utils.js";
+import { PrebuiltReadModel } from "./prebuilt/prebuilt-read.ts";
+import { getTextOfSpans } from "./utils.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushSize.ts
+++ b/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushSize.ts
@@ -13,8 +13,8 @@ import {
   SearchIndexingBufferedSender,
 } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchIndexingBufferedSender.

--- a/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushTimer.ts
+++ b/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushTimer.ts
@@ -14,8 +14,8 @@ import {
   SearchIndexingBufferedSender,
 } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchIndexingBufferedSender.

--- a/sdk/search/search-documents/samples-dev/bufferedSenderManualFlush.ts
+++ b/sdk/search/search-documents/samples-dev/bufferedSenderManualFlush.ts
@@ -13,8 +13,8 @@ import {
   SearchIndexingBufferedSender,
 } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchIndexingBufferedSender.

--- a/sdk/search/search-documents/samples-dev/searchClientOperations.ts
+++ b/sdk/search/search-documents/samples-dev/searchClientOperations.ts
@@ -9,8 +9,8 @@ import { DefaultAzureCredential } from "@azure/identity";
 import type { SelectFields } from "@azure/search-documents";
 import { GeographyPoint, SearchClient, SearchIndexClient } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchClient.

--- a/sdk/search/search-documents/samples-dev/setup.ts
+++ b/sdk/search/search-documents/samples-dev/setup.ts
@@ -9,7 +9,7 @@
 import type { SearchIndex, SearchIndexClient } from "@azure/search-documents";
 import { KnownAnalyzerNames } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
+import type { Hotel } from "./interfaces.ts";
 
 export const WAIT_TIME = 4000;
 

--- a/sdk/search/search-documents/samples-dev/stickySession.ts
+++ b/sdk/search/search-documents/samples-dev/stickySession.ts
@@ -10,8 +10,8 @@ import { DefaultAzureCredential } from "@azure/identity";
 import type { SearchClient } from "@azure/search-documents";
 import { odata, SearchIndexClient } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, WAIT_TIME } from "./setup.ts";
 
 /**
  * If you're querying a replicated index, Azure AI Search may target any replica with your queries.

--- a/sdk/search/search-documents/samples-dev/vectorSearch.ts
+++ b/sdk/search/search-documents/samples-dev/vectorSearch.ts
@@ -8,9 +8,9 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { GeographyPoint, SearchClient, SearchIndexClient } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, WAIT_TIME } from "./setup.js";
-import { fancyStayEnVector, fancyStayFrVector, luxuryQueryVector } from "./vectors.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, WAIT_TIME } from "./setup.ts";
+import { fancyStayEnVector, fancyStayFrVector, luxuryQueryVector } from "./vectors.ts";
 
 /**
  * This sample is to demonstrate the use of SearchClient's vector search feature.

--- a/sdk/storage/storage-blob/samples-dev/errorsAndResponses.ts
+++ b/sdk/storage/storage-blob/samples-dev/errorsAndResponses.ts
@@ -8,7 +8,7 @@
 
 import { BlobServiceClient } from "@azure/storage-blob";
 
-import { streamToBuffer } from "./utils/stream.js";
+import { streamToBuffer } from "./utils/stream.ts";
 
 // Load the .env file if it exists
 import "dotenv/config";

--- a/sdk/storage/storage-blob/samples-dev/snapshots.ts
+++ b/sdk/storage/storage-blob/samples-dev/snapshots.ts
@@ -23,7 +23,7 @@
 
 import { ContainerClient, StorageSharedKeyCredential } from "@azure/storage-blob";
 
-import { streamToBuffer } from "./utils/stream.js";
+import { streamToBuffer } from "./utils/stream.ts";
 
 // Load the .env file if it exists
 import "dotenv/config";

--- a/tsconfig.samples.base.json
+++ b/tsconfig.samples.base.json
@@ -2,7 +2,8 @@
   "extends": ["./tsconfig", "./tsconfig.nonlib"],
   "compilerOptions": {
     "types": ["node"],
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["${configDir}/samples-dev"]
 }


### PR DESCRIPTION
## Summary

Fixes #38822.

- Switched relative imports in `samples-dev` from `.js` to `.ts` so that `dev-tool samples run`, which now loads samples directly via Node's TypeScript loader (Node 22.18+), can resolve them.
- Added `allowImportingTsExtensions: true` to the shared `tsconfig.samples.base.json` so `tsc -p tsconfig.samples.json` continues to accept `samples-dev/**/*.ts` sources.
- Updated `dev-tool samples publish` so the resulting `samples/` tree continues to use `.js` specifiers: relative `.ts` imports are rewritten to `.js` in both the TypeScript output (which is compiled with `tsc` using `nodenext` resolution) and the JavaScript (CommonJS) output. The generated `tsconfig.json` also strips `allowImportingTsExtensions`.
- Added a `ts-imports` test fixture under `common/tools/dev-tool/test/samples/files/` that exercises the rewrite for both kinds of published output.

## Test plan

- [x] `pnpm test` in `common/tools/dev-tool` (46 tests pass, including the new `ts-imports` fixture).
- [x] Manually published the attestation package's samples and confirmed `samples/v1/typescript/src/*.ts` and `samples/v1/javascript/*.js` both reference `./utils/*.js`.
- [x] Loaded an attestation sample directly with Node's TS loader and confirmed the original `ERR_MODULE_NOT_FOUND` on `./utils/helpers.js` no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)