### PR TITLE
[dev-tool] Fix samples-dev cross-imports under Node strip-types -- from copilot

### DIFF
--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -327,6 +327,31 @@ function jsonify(value: unknown) {
 }
 
 /**
+ * Rewrites relative `.ts` import/export specifiers in TypeScript sample source
+ * text to use `.js` extensions.
+ *
+ * Samples authored under `samples-dev/` use `.ts` extensions on relative imports
+ * so that Node's native TypeScript loader can resolve sibling sample files when
+ * developers run them directly. Published TypeScript samples, however, are
+ * compiled with `tsc` into `dist/` and must reference the emitted `.js` files
+ * to be runnable. This helper performs that rewrite on the copied sample text.
+ *
+ * Matches the following forms:
+ * - `import ... from "./foo.ts"`
+ * - `import "./foo.ts"`
+ * - `import("./foo.ts")` (dynamic import)
+ * - `export ... from "./foo.ts"`
+ *
+ * @param content - the raw module source text
+ */
+function rewriteRelativeTsImports(content: string): string {
+  return content.replace(
+    /(\b(?:import|export|from)\s*\(?\s*)(['"])(\.\.?\/[^'"]*?)\.ts(['"])/g,
+    "$1$2$3.js$4",
+  );
+}
+
+/**
  * Checks if a file exists.
  * @param filePath - The path to the file
  * @returns Whether the file exists
@@ -368,6 +393,7 @@ export async function createTsconfig(projectInfo: ProjectInfo): Promise<string> 
   delete tsconfig.compilerOptions.inlineSources;
   delete tsconfig.compilerOptions.sourceMap;
   delete tsconfig.compilerOptions.verbatimModuleSyntax;
+  delete tsconfig.compilerOptions.allowImportingTsExtensions;
   tsconfig.include = ["./src"];
   tsconfig.compilerOptions.outDir = "./dist";
   tsconfig.compilerOptions.rootDir = "./src";
@@ -429,7 +455,7 @@ export async function makeSamplesFactory(
   function postProcess(moduleText: string | Buffer): string {
     const content = Buffer.isBuffer(moduleText) ? moduleText.toString("utf8") : moduleText;
     return (
-      content
+      rewriteRelativeTsImports(content)
         .replace(new RegExp(`^\\s*\\*\\s*@${AZSDK_META_TAG_PREFIX}.*\n`, "gm"), "")
         // We also need to clean up extra blank lines that might be left behind by
         // removing azsdk tags. These regular expressions are extremely frustrating

--- a/common/tools/dev-tool/src/util/samples/processor.ts
+++ b/common/tools/dev-tool/src/util/samples/processor.ts
@@ -159,6 +159,7 @@ export async function processSources(
         result.summary === undefined &&
         !importedRelativeModules.has(result.relativeSourcePath.replace(/\.ts$/, "")) &&
         !importedRelativeModules.has(result.relativeSourcePath.replace(/\.ts$/, ".js")) &&
+        !importedRelativeModules.has(result.relativeSourcePath) &&
         !result.azSdkTags.util
       ) {
         fail(

--- a/common/tools/dev-tool/src/util/samples/transforms.ts
+++ b/common/tools/dev-tool/src/util/samples/transforms.ts
@@ -90,7 +90,11 @@ export function importDeclarationToCommonJs(
     factory.createCallExpression(
       factory.createIdentifier("require"),
       /* typeArguments: */ undefined,
-      [factory.createStringLiteral((decl.moduleSpecifier as ts.StringLiteral).text)],
+      [
+        factory.createStringLiteral(
+          convertTsExtensionToJs((decl.moduleSpecifier as ts.StringLiteral).text),
+        ),
+      ],
     );
 
   if (!decl.importClause) {
@@ -240,6 +244,27 @@ export function isNodeBuiltin(moduleSpecifier: string): boolean {
  * @param input - a string to test
  */
 export const isRelativePath = (input: string): boolean => /^\.\.?[/\\]/.test(input);
+
+/**
+ * Rewrites a relative module specifier ending in `.ts` to use `.js` instead.
+ *
+ * Sample sources under `samples-dev/` use `.ts` extensions on relative imports
+ * so that Node's native TypeScript loader can resolve sibling sample files
+ * directly. When publishing the camera-ready samples, both the TypeScript and
+ * JavaScript outputs are emitted as `.js`, so the import specifiers must be
+ * rewritten to match.
+ *
+ * Non-relative specifiers (package imports, node builtins) and specifiers that
+ * are not `.ts` are returned unchanged. `.d.ts` specifiers are also left alone.
+ *
+ * @param specifier - the module specifier to normalize
+ */
+export function convertTsExtensionToJs(specifier: string): string {
+  if (isRelativePath(specifier) && specifier.endsWith(".ts") && !specifier.endsWith(".d.ts")) {
+    return specifier.slice(0, -".ts".length) + ".js";
+  }
+  return specifier;
+}
 
 /**
  * Determines whether a module specifier is a package dependency.

--- a/eng/tsconfigs/samples.json
+++ b/eng/tsconfigs/samples.json
@@ -4,6 +4,7 @@
     "lib": ["ESNext", "DOM"],
     "types": ["node"],
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false

--- a/sdk/ai/ai-projects/samples-dev/agents/tools/agentComputerUse.ts
+++ b/sdk/ai/ai-projects/samples-dev/agents/tools/agentComputerUse.ts
@@ -25,7 +25,7 @@ import {
   loadScreenshotAssets,
   handleComputerActionAndTakeScreenshot,
   printFinalOutput,
-} from "./computerUseUtil.js";
+} from "./computerUseUtil.ts";
 
 const projectEndpoint = process.env["FOUNDRY_PROJECT_ENDPOINT"] || "<project endpoint>";
 const deploymentName =

--- a/sdk/appconfiguration/app-configuration/samples-dev/updateSyncTokenSample.ts
+++ b/sdk/appconfiguration/app-configuration/samples-dev/updateSyncTokenSample.ts
@@ -13,7 +13,7 @@
 import { AppConfigurationClient } from "@azure/app-configuration";
 import type { EventGridEvent } from "@azure/eventgrid";
 import { isSystemEvent, EventGridDeserializer } from "@azure/eventgrid";
-import { appConfigTestEvent } from "./testData.js";
+import { appConfigTestEvent } from "./testData.ts";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";

--- a/sdk/attestation/attestation/samples-dev/attestEnclaves.ts
+++ b/sdk/attestation/attestation/samples-dev/attestEnclaves.ts
@@ -25,8 +25,8 @@
  */
 import { AttestationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { writeBanner } from "./utils/helpers.js";
-import { decodeString } from "./utils/base64url.js";
+import { writeBanner } from "./utils/helpers.ts";
+import { decodeString } from "./utils/base64url.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/createAttestationClient.ts
+++ b/sdk/attestation/attestation/samples-dev/createAttestationClient.ts
@@ -25,7 +25,7 @@
 import { AttestationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
 import { X509 } from "jsrsasign";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/getAttestationPolicy.ts
+++ b/sdk/attestation/attestation/samples-dev/getAttestationPolicy.ts
@@ -26,7 +26,7 @@
 
 import { AttestationAdministrationClient, KnownAttestationType } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/getPolicyManagementCertificates.ts
+++ b/sdk/attestation/attestation/samples-dev/getPolicyManagementCertificates.ts
@@ -27,7 +27,7 @@
 import { AttestationAdministrationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
 import { X509 } from "jsrsasign";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/modifyPolicyManagementCertificates.ts
+++ b/sdk/attestation/attestation/samples-dev/modifyPolicyManagementCertificates.ts
@@ -31,9 +31,9 @@
 
 import { AttestationAdministrationClient } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { createRSAKey, createX509Certificate, generateSha1Hash } from "./utils/cryptoUtils.js";
+import { createRSAKey, createX509Certificate, generateSha1Hash } from "./utils/cryptoUtils.ts";
 import { X509 } from "jsrsasign";
-import { writeBanner } from "./utils/helpers.js";
+import { writeBanner } from "./utils/helpers.ts";
 // Load environment from a .env file if it exists.
 import "dotenv/config";
 

--- a/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
+++ b/sdk/attestation/attestation/samples-dev/setAttestationPolicy.ts
@@ -36,8 +36,8 @@ import {
   KnownAttestationType,
 } from "@azure/attestation";
 import { DefaultAzureCredential } from "@azure/identity";
-import { writeBanner } from "./utils/helpers.js";
-import { createRSAKey, createX509Certificate, generateSha256Hash } from "./utils/cryptoUtils.js";
+import { writeBanner } from "./utils/helpers.ts";
+import { createRSAKey, createX509Certificate, generateSha256Hash } from "./utils/cryptoUtils.ts";
 import { X509 } from "jsrsasign";
 // Load environment from a .env file if it exists.
 import "dotenv/config";

--- a/sdk/cosmosdb/cosmos/samples-dev/AlterQueryThroughput.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/AlterQueryThroughput.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.js";
+import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.ts";
 import type {
   OfferDefinition,
   Resource,

--- a/sdk/cosmosdb/cosmos/samples-dev/Bulk.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/Bulk.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { OperationInput } from "@azure/cosmos";
 import { BulkOperationType, CosmosClient, PatchOperationType } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/BulkUpdateWithSproc.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/BulkUpdateWithSproc.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.ts";
 import { CosmosClient } from "@azure/cosmos";
 import { randomUUID } from "@azure/core-util";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeed.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeed.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader } from "./Shared/handleError.js";
+import { finish, handleError, logSampleHeader } from "./Shared/handleError.ts";
 import { CosmosClient } from "@azure/cosmos";
 
 const key = process.env.COSMOS_KEY || "<cosmos key>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedHierarchicalPartitionKey.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedHierarchicalPartitionKey.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader } from "../Shared/handleError.js";
+import { finish, handleError, logSampleHeader } from "../Shared/handleError.ts";
 import type { Container, ChangeFeedIteratorOptions } from "@azure/cosmos";
 import {
   CosmosClient,

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorAllVersionsAndDeletes.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorAllVersionsAndDeletes.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.js";
+import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.ts";
 import type {
   Container,
   ChangeFeedIteratorOptions,

--- a/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorLatestVersion.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ChangeFeedIterator/ChangeFeedIteratorLatestVersion.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.js";
+import { finish, handleError, logSampleHeader, logStep } from "../Shared/handleError.ts";
 import type {
   Container,
   ChangeFeedIteratorOptions,

--- a/sdk/cosmosdb/cosmos/samples-dev/ClientSideEncryption.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ClientSideEncryption.ts
@@ -21,7 +21,7 @@ import {
   EncryptionType,
   EncryptionQueryBuilder,
 } from "@azure/cosmos";
-import { finish, handleError, logStep } from "./Shared/handleError.js";
+import { finish, handleError, logStep } from "./Shared/handleError.ts";
 
 const key = process.env.COSMOS_KEY || "<cosmos key>";
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ContainerManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ContainerManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.js";
+import { finish, handleError, logStep, logSampleHeader } from "./Shared/handleError.ts";
 import type { ContainerDefinition, IndexingPolicy, SpatialIndex } from "@azure/cosmos";
 import {
   CosmosClient,

--- a/sdk/cosmosdb/cosmos/samples-dev/DatabaseManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/DatabaseManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, logStep, logSampleHeader, finish } from "./Shared/handleError.js";
+import { handleError, logStep, logSampleHeader, finish } from "./Shared/handleError.ts";
 import { CosmosClient } from "@azure/cosmos";
 import assert from "node:assert";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/Diagnostics.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/Diagnostics.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, logSampleHeader, finish } from "./Shared/handleError.js";
+import { handleError, logSampleHeader, finish } from "./Shared/handleError.ts";
 import type { OperationInput, Container, GatewayStatistics, Database } from "@azure/cosmos";
 import { CosmosClient, BulkOperationType, PatchOperationType } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/EntraAuth.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/EntraAuth.ts
@@ -10,7 +10,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { CosmosClient } from "@azure/cosmos";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 
 const key = process.env.COSMOS_KEY || "<cosmos key>";
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ExcludedLocations.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ExcludedLocations.ts
@@ -8,7 +8,7 @@
 import "dotenv/config";
 import type { ChangeFeedIteratorOptions } from "@azure/cosmos";
 import { CosmosClient, BulkOperationType, ChangeFeedStartFrom } from "@azure/cosmos";
-import { handleError, logStep } from "./Shared/handleError.js";
+import { handleError, logStep } from "./Shared/handleError.ts";
 
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";
 const key = process.env.COSMOS_KEY || "<cosmos key>";

--- a/sdk/cosmosdb/cosmos/samples-dev/ExecuteBulkOperations.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ExecuteBulkOperations.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { OperationInput } from "@azure/cosmos";
 import { BulkOperationType, CosmosClient, PatchOperationType } from "@azure/cosmos";
 import { DefaultAzureCredential } from "@azure/identity";

--- a/sdk/cosmosdb/cosmos/samples-dev/HierarchicalPartitioning.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/HierarchicalPartitioning.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { handleError, logSampleHeader, finish } from "./Shared/handleError.js";
+import { handleError, logSampleHeader, finish } from "./Shared/handleError.ts";
 import type { PatchOperation, OperationInput } from "@azure/cosmos";
 import {
   CosmosClient,

--- a/sdk/cosmosdb/cosmos/samples-dev/IndexManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/IndexManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { ContainerDefinition } from "@azure/cosmos";
 import { CosmosClient, IndexKind, DataType, IndexingMode } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/ItemManagement.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ItemManagement.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, finish, logStep } from "./Shared/handleError.ts";
 import type { PatchOperation } from "@azure/cosmos";
 import { CosmosClient, PriorityLevel } from "@azure/cosmos";
 import FamiliesJSON from "./Data/Families.json" with { type: "json" };

--- a/sdk/cosmosdb/cosmos/samples-dev/PriorityLevel.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/PriorityLevel.ts
@@ -7,7 +7,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader, logStep } from "./Shared/handleError.js";
+import { finish, handleError, logSampleHeader, logStep } from "./Shared/handleError.ts";
 import type {
   Container,
   ChangeFeedIteratorOptions,

--- a/sdk/cosmosdb/cosmos/samples-dev/Query/FullTextSearch.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/Query/FullTextSearch.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { finish, handleError, logSampleHeader } from "./../Shared/handleError.js";
+import { finish, handleError, logSampleHeader } from "./../Shared/handleError.ts";
 import type { IndexingPolicy } from "@azure/cosmos";
 import { CosmosClient } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/SasTokenAuth.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/SasTokenAuth.ts
@@ -8,7 +8,7 @@
 import "dotenv/config";
 import type { SasTokenProperties } from "@azure/cosmos";
 import { CosmosClient, createAuthorizationSasToken, SasTokenPermissionKind } from "@azure/cosmos";
-import { handleError, finish, logStep } from "./Shared/handleError.js";
+import { handleError, finish, logStep } from "./Shared/handleError.ts";
 const masterKey = process.env.COSMOS_KEY || "<cosmos key>";
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";
 const sasToken = "your-sas-token";

--- a/sdk/cosmosdb/cosmos/samples-dev/ServerSideScripts.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ServerSideScripts.ts
@@ -6,7 +6,7 @@
  */
 
 import "dotenv/config";
-import { logSampleHeader, logStep, finish, handleError } from "./Shared/handleError.js";
+import { logSampleHeader, logStep, finish, handleError } from "./Shared/handleError.ts";
 import type { ErrorResponse, FeedOptions, Item, Resource } from "@azure/cosmos";
 import { CosmosClient } from "@azure/cosmos";
 

--- a/sdk/cosmosdb/cosmos/samples-dev/ThroughputBucket.ts
+++ b/sdk/cosmosdb/cosmos/samples-dev/ThroughputBucket.ts
@@ -6,7 +6,7 @@
  */
 import "dotenv/config";
 import { ChangeFeedStartFrom, CosmosClient, type Container } from "@azure/cosmos";
-import { logSampleHeader, handleError, logStep } from "./Shared/handleError.js";
+import { logSampleHeader, handleError, logStep } from "./Shared/handleError.ts";
 import { randomUUID } from "@azure/core-util";
 
 const endpoint = process.env.COSMOS_ENDPOINT || "<cosmos endpoint>";

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples-dev/receiveEventsWithApiSpecificStorage.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples-dev/receiveEventsWithApiSpecificStorage.ts
@@ -16,7 +16,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { EventHubConsumerClient } from "@azure/event-hubs";
 import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
 import { BlobServiceClient } from "@azure/storage-blob";
-import { createCustomPipeline } from "./createCustomPipeline.js";
+import { createCustomPipeline } from "./createCustomPipeline.ts";
 
 import "dotenv/config";
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeBusinessCard.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeBusinessCard.ts
@@ -16,7 +16,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltBusinessCardModel } from "./prebuilt/prebuilt-businessCard.js";
+import { PrebuiltBusinessCardModel } from "./prebuilt/prebuilt-businessCard.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeIdentityDocument.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeIdentityDocument.ts
@@ -16,7 +16,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltIdDocumentModel } from "./prebuilt/prebuilt-idDocument.js";
+import { PrebuiltIdDocumentModel } from "./prebuilt/prebuilt-idDocument.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeInvoice.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeInvoice.ts
@@ -15,7 +15,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltInvoiceModel } from "./prebuilt/prebuilt-invoice.js";
+import { PrebuiltInvoiceModel } from "./prebuilt/prebuilt-invoice.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeReceipt.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeReceipt.ts
@@ -15,7 +15,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltReceiptModel } from "./prebuilt/prebuilt-receipt.js";
+import { PrebuiltReceiptModel } from "./prebuilt/prebuilt-receipt.ts";
 
 import "dotenv/config";
 

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeW2TaxForm.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/analyzeW2TaxForm.ts
@@ -15,7 +15,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltTaxUsW2Model } from "./prebuilt/prebuilt-tax.us.w2.js";
+import { PrebuiltTaxUsW2Model } from "./prebuilt/prebuilt-tax.us.w2.ts";
 import fs from "node:fs";
 import path from "node:path";
 import "dotenv/config";

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractGeneralDocument.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractGeneralDocument.ts
@@ -11,7 +11,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltDocumentModel } from "./prebuilt/prebuilt-document.js";
+import { PrebuiltDocumentModel } from "./prebuilt/prebuilt-document.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractLayout.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/extractLayout.ts
@@ -12,7 +12,7 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltLayoutModel } from "./prebuilt/prebuilt-layout.js";
+import { PrebuiltLayoutModel } from "./prebuilt/prebuilt-layout.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/formrecognizer/ai-form-recognizer/samples-dev/readDocument.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples-dev/readDocument.ts
@@ -9,8 +9,8 @@
 
 import { DocumentAnalysisClient } from "@azure/ai-form-recognizer";
 import { DefaultAzureCredential } from "@azure/identity";
-import { PrebuiltReadModel } from "./prebuilt/prebuilt-read.js";
-import { getTextOfSpans } from "./utils.js";
+import { PrebuiltReadModel } from "./prebuilt/prebuilt-read.ts";
+import { getTextOfSpans } from "./utils.ts";
 import "dotenv/config";
 
 async function main(): Promise<void> {

--- a/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushSize.ts
+++ b/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushSize.ts
@@ -13,8 +13,8 @@ import {
   SearchIndexingBufferedSender,
 } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchIndexingBufferedSender.

--- a/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushTimer.ts
+++ b/sdk/search/search-documents/samples-dev/bufferedSenderAutoFlushTimer.ts
@@ -14,8 +14,8 @@ import {
   SearchIndexingBufferedSender,
 } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchIndexingBufferedSender.

--- a/sdk/search/search-documents/samples-dev/bufferedSenderManualFlush.ts
+++ b/sdk/search/search-documents/samples-dev/bufferedSenderManualFlush.ts
@@ -13,8 +13,8 @@ import {
   SearchIndexingBufferedSender,
 } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, documentKeyRetriever, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchIndexingBufferedSender.

--- a/sdk/search/search-documents/samples-dev/searchClientOperations.ts
+++ b/sdk/search/search-documents/samples-dev/searchClientOperations.ts
@@ -9,8 +9,8 @@ import { DefaultAzureCredential } from "@azure/identity";
 import type { SelectFields } from "@azure/search-documents";
 import { GeographyPoint, SearchClient, SearchIndexClient } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, WAIT_TIME } from "./setup.ts";
 
 /**
  * This sample is to demonstrate the use of SearchClient.

--- a/sdk/search/search-documents/samples-dev/setup.ts
+++ b/sdk/search/search-documents/samples-dev/setup.ts
@@ -9,7 +9,7 @@
 import type { SearchIndex, SearchIndexClient } from "@azure/search-documents";
 import { KnownAnalyzerNames } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
+import type { Hotel } from "./interfaces.ts";
 
 export const WAIT_TIME = 4000;
 

--- a/sdk/search/search-documents/samples-dev/stickySession.ts
+++ b/sdk/search/search-documents/samples-dev/stickySession.ts
@@ -10,8 +10,8 @@ import { DefaultAzureCredential } from "@azure/identity";
 import type { SearchClient } from "@azure/search-documents";
 import { odata, SearchIndexClient } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, WAIT_TIME } from "./setup.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, WAIT_TIME } from "./setup.ts";
 
 /**
  * If you're querying a replicated index, Azure AI Search may target any replica with your queries.

--- a/sdk/search/search-documents/samples-dev/vectorSearch.ts
+++ b/sdk/search/search-documents/samples-dev/vectorSearch.ts
@@ -8,9 +8,9 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { GeographyPoint, SearchClient, SearchIndexClient } from "@azure/search-documents";
 import "dotenv/config";
-import type { Hotel } from "./interfaces.js";
-import { createIndex, delay, WAIT_TIME } from "./setup.js";
-import { fancyStayEnVector, fancyStayFrVector, luxuryQueryVector } from "./vectors.js";
+import type { Hotel } from "./interfaces.ts";
+import { createIndex, delay, WAIT_TIME } from "./setup.ts";
+import { fancyStayEnVector, fancyStayFrVector, luxuryQueryVector } from "./vectors.ts";
 
 /**
  * This sample is to demonstrate the use of SearchClient's vector search feature.

--- a/sdk/storage/storage-blob/samples-dev/errorsAndResponses.ts
+++ b/sdk/storage/storage-blob/samples-dev/errorsAndResponses.ts
@@ -8,7 +8,7 @@
 
 import { BlobServiceClient } from "@azure/storage-blob";
 
-import { streamToBuffer } from "./utils/stream.js";
+import { streamToBuffer } from "./utils/stream.ts";
 
 // Load the .env file if it exists
 import "dotenv/config";

--- a/sdk/storage/storage-blob/samples-dev/snapshots.ts
+++ b/sdk/storage/storage-blob/samples-dev/snapshots.ts
@@ -23,7 +23,7 @@
 
 import { ContainerClient, StorageSharedKeyCredential } from "@azure/storage-blob";
 
-import { streamToBuffer } from "./utils/stream.js";
+import { streamToBuffer } from "./utils/stream.ts";
 
 // Load the .env file if it exists
 import "dotenv/config";

--- a/tsconfig.samples.base.json
+++ b/tsconfig.samples.base.json
@@ -2,7 +2,8 @@
   "extends": ["./tsconfig", "./tsconfig.nonlib"],
   "compilerOptions": {
     "types": ["node"],
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["${configDir}/samples-dev"]
 }


### PR DESCRIPTION
Fixes #38822

### Problem

After #37255 migrated `dev-tool` to run TypeScript natively via Node's strip-types loader, `dev-tool samples run` started failing with `ERR_MODULE_NOT_FOUND` on any sample that imports a sibling helper:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../samples-dev/utils/helpers.js' imported from .../samples-dev/createAttestationClient.ts
```

Node's strip-types loader requires `.js` import specifiers to resolve to a real `.js` file on disk, but only `.ts` files exist in `samples-dev/`. The previous `tsx` loader rewrote the extensions transparently; Node strip-types does not.

### Fix

* Rewrite all 47 affected `samples-dev/**/*.ts` files to use `.ts` relative import specifiers (which Node strip-types accepts natively).
* Add `allowImportingTsExtensions: true` to both shared samples type-check configs — `tsconfig.samples.base.json` and `eng/tsconfigs/samples.json` (the latter is still used by packages such as `@azure/search-documents` via `config/tsconfig.samples.json`) — so `samples-dev/` continues to type-check cleanly.
* Teach `dev-tool samples publish` to rewrite `.ts` → `.js` for both the TypeScript and JavaScript camera-ready outputs:
  * `generation.ts` – new `rewriteRelativeTsImports` helper invoked from `postProcess`.
  * `transforms.ts` – new `convertTsExtensionToJs` helper wired into `importDeclarationToCommonJs`.
  * `generation.ts` – `createTsconfig` now strips `allowImportingTsExtensions` so the published `samples/.../tsconfig.json` still compiles with stock `tsc`.
* Teach `samples processor` to treat a relative `.ts` path as also satisfying the "imported by any other module" rule.

### Verification

* `dev-tool samples run samples-dev` no longer fails with `ERR_MODULE_NOT_FOUND` (verified on `@azure/attestation`).
* `dev-tool samples publish -f` on affected packages produces import lines that are byte-identical to what's already committed in `samples/` (TS uses `./utils/helpers.js`, JS uses `require("./utils/helpers.js")`) — so no regeneration of the published `samples/` is required as part of this PR.
* All 45 `dev-tool` unit tests pass; `tsc` clean; lint clean.

### Notes

* I deliberately did not regenerate the committed `samples/` folders for the affected packages — running publish against the current `main` shows pre-existing drift (formatting changes, removed files, etc.) that is unrelated to this fix.