### PR TITLE
docs: add "Use with AI tools" section to all library READMEs

### DIFF
--- a/sdk/advisor/arm-advisor/README.md
+++ b/sdk/advisor/arm-advisor/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AdvisorManagementClient` is the primary interface for developers using the Azure AdvisorManagement client library. Explore the methods on this client object to understand the different features of the Azure AdvisorManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/agricultureplatform/arm-agricultureplatform/README.md
+++ b/sdk/agricultureplatform/arm-agricultureplatform/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AgriculturePlatformClient` is the primary interface for developers using the Azure AgriculturePlatform client library. Explore the methods on this client object to understand the different features of the Azure AgriculturePlatform service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/agrifood/agrifood-farming-rest/README.md
+++ b/sdk/agrifood/agrifood-farming-rest/README.md
@@ -154,6 +154,10 @@ for await (const party of parties) {
 
 For additional samples, please refer to the [samples folder][samples_folder]
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/agrifood/arm-agrifood/README.md
+++ b/sdk/agrifood/arm-agrifood/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AgriFoodMgmtClient` is the primary interface for developers using the Azure AgriFoodMgmt client library. Explore the methods on this client object to understand the different features of the Azure AgriFoodMgmt service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/ai/ai-agents/README.md
+++ b/sdk/ai/ai-agents/README.md
@@ -784,6 +784,10 @@ await client.deleteAgent(agent.id);
 console.log(`Deleted agent, agent ID: ${agent.id}`);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Exceptions

--- a/sdk/ai/ai-inference-rest/README.md
+++ b/sdk/ai/ai-inference-rest/README.md
@@ -599,6 +599,10 @@ const getWeatherFunc = (location: string, unit: string): string => {
 };
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/ai/ai-projects/README.md
+++ b/sdk/ai/ai-projects/README.md
@@ -1403,6 +1403,10 @@ Trace context propagation is enabled by default. To disable it, pass `traceConte
 
 Only enable trace context propagation after carefully reviewing your observability, privacy, and security requirements.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Exceptions

--- a/sdk/alertprocessingrules/arm-alertprocessingrules/README.md
+++ b/sdk/alertprocessingrules/arm-alertprocessingrules/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AlertProcessingRulesManagementClient` is the primary interface for developers using the Azure AlertProcessingRulesManagement client library. Explore the methods on this client object to understand the different features of the Azure AlertProcessingRulesManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/alertrulerecommendations/arm-alertrulerecommendations/README.md
+++ b/sdk/alertrulerecommendations/arm-alertrulerecommendations/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AlertRuleRecommendationsManagementClient` is the primary interface for developers using the Azure AlertRuleRecommendationsManagement client library. Explore the methods on this client object to understand the different features of the Azure AlertRuleRecommendationsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/alertsmanagement/arm-alertsmanagement/README.md
+++ b/sdk/alertsmanagement/arm-alertsmanagement/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AlertsManagementClient` is the primary interface for developers using the Azure AlertsManagement client library. Explore the methods on this client object to understand the different features of the Azure AlertsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/analysisservices/arm-analysisservices/README.md
+++ b/sdk/analysisservices/arm-analysisservices/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureAnalysisServices` is the primary interface for developers using the AzureAnalysisServices client library. Explore the methods on this client object to understand the different features of the AzureAnalysisServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/apicenter/arm-apicenter/README.md
+++ b/sdk/apicenter/arm-apicenter/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureAPICenter` is the primary interface for developers using the AzureApiCenter client library. Explore the methods on this client object to understand the different features of the AzureApiCenter service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/apimanagement/arm-apimanagement/README.md
+++ b/sdk/apimanagement/arm-apimanagement/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ApiManagementClient` is the primary interface for developers using the Azure ApiManagement client library. Explore the methods on this client object to understand the different features of the Azure ApiManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/README.md
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AppComplianceAutomationToolForMicrosoft365` is the primary interface for developers using the Azure AppComplianceAutomationToolForMicrosoft365 client library. Explore the methods on this client object to understand the different features of the Azure AppComplianceAutomationToolForMicrosoft365 service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -335,6 +335,10 @@ const recoverSnapshot = await client.recoverSnapshot("testsnapshot");
 console.log("Snapshot updated status is:", recoverSnapshot.status);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appconfiguration/arm-appconfiguration/README.md
+++ b/sdk/appconfiguration/arm-appconfiguration/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AppConfigurationManagementClient` is the primary interface for developers using the Azure AppConfigurationManagement client library. Explore the methods on this client object to understand the different features of the Azure AppConfigurationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appcontainers/arm-appcontainers/README.md
+++ b/sdk/appcontainers/arm-appcontainers/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerAppsAPIClient` is the primary interface for developers using the Azure ContainerAppsAPI client library. Explore the methods on this client object to understand the different features of the Azure ContainerAppsAPI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/applicationinsights/arm-appinsights/README.md
+++ b/sdk/applicationinsights/arm-appinsights/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ApplicationInsightsManagementClient` is the primary interface for developers using the Azure ApplicationInsightsManagement client library. Explore the methods on this client object to understand the different features of the Azure ApplicationInsightsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appnetwork/arm-appnetwork/README.md
+++ b/sdk/appnetwork/arm-appnetwork/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AppLinkClient` is the primary interface for developers using the Azure AppLink client library. Explore the methods on this client object to understand the different features of the Azure AppLink service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/README.md
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WebSiteManagementClient` is the primary interface for developers using the Azure WebSiteManagement client library. Explore the methods on this client object to understand the different features of the Azure WebSiteManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appservice/arm-appservice-rest/README.md
+++ b/sdk/appservice/arm-appservice-rest/README.md
@@ -92,6 +92,10 @@ for await (const item of res) {
 console.log(result);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/appservice/arm-appservice/README.md
+++ b/sdk/appservice/arm-appservice/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WebSiteManagementClient` is the primary interface for developers using the Azure WebSiteManagement client library. Explore the methods on this client object to understand the different features of the Azure WebSiteManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/artifactsigning/arm-artifactsigning/README.md
+++ b/sdk/artifactsigning/arm-artifactsigning/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CodeSigningClient` is the primary interface for developers using the Azure CodeSigningManagement client library. Explore the methods on this client object to understand the different features of the Azure CodeSigningManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/astro/arm-astro/README.md
+++ b/sdk/astro/arm-astro/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AstroManagementClient` is the primary interface for developers using the Azure AstroManagement client library. Explore the methods on this client object to understand the different features of the Azure AstroManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/attestation/arm-attestation/README.md
+++ b/sdk/attestation/arm-attestation/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AttestationManagementClient` is the primary interface for developers using the Azure AttestationManagement client library. Explore the methods on this client object to understand the different features of the Azure AttestationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/attestation/attestation/README.md
+++ b/sdk/attestation/attestation/README.md
@@ -396,6 +396,10 @@ const attestationSigners = await client.getAttestationSigners();
 console.log(`There are ${attestationSigners.length} signers`);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Most Attestation service operations will raise exceptions defined in [Azure Core](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/README.md). The attestation service APIs will throw a `RestError` on failure with helpful error codes. Many of these errors are recoverable.

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/README.md
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AuthorizationManagementClient` is the primary interface for developers using the Azure AuthorizationManagement client library. Explore the methods on this client object to understand the different features of the Azure AuthorizationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/authorization/arm-authorization/README.md
+++ b/sdk/authorization/arm-authorization/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AuthorizationManagementClient` is the primary interface for developers using the Azure AuthorizationManagement client library. Explore the methods on this client object to understand the different features of the Azure AuthorizationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/automanage/arm-automanage/README.md
+++ b/sdk/automanage/arm-automanage/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AutomanageClient` is the primary interface for developers using the Azure Automanage client library. Explore the methods on this client object to understand the different features of the Azure Automanage service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/automation/arm-automation/README.md
+++ b/sdk/automation/arm-automation/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AutomationClient` is the primary interface for developers using the Azure Automation client library. Explore the methods on this client object to understand the different features of the Azure Automation service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/avs/arm-avs/README.md
+++ b/sdk/avs/arm-avs/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureVMwareSolutionAPI` is the primary interface for developers using the AzureVMwareSolutionAPI client library. Explore the methods on this client object to understand the different features of the AzureVMwareSolutionAPI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/README.md
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ExternalIdentitiesConfigurationClient` is the primary interface for developers using the Azure ExternalIdentitiesConfiguration client library. Explore the methods on this client object to understand the different features of the Azure ExternalIdentitiesConfiguration service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/azurestack/arm-azurestack/README.md
+++ b/sdk/azurestack/arm-azurestack/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureStackManagementClient` is the primary interface for developers using the AzureStackManagement client library. Explore the methods on this client object to understand the different features of the AzureStackManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/azurestackhci/arm-azurestackhci/README.md
+++ b/sdk/azurestackhci/arm-azurestackhci/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureStackHCIClient` is the primary interface for developers using the AzureStackHCI client library. Explore the methods on this client object to understand the different features of the AzureStackHCI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/README.md
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureStackHCIVMManagementClient` is the primary interface for developers using the AzureStackHCIVMManagement client library. Explore the methods on this client object to understand the different features of the AzureStackHCIVMManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/README.md
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BareMetalInfrastructureClient` is the primary interface for developers using the Azure bareMetalInfrastructure client library. Explore the methods on this client object to understand the different features of the Azure bareMetalInfrastructure service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/batch/arm-batch/README.md
+++ b/sdk/batch/arm-batch/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BatchManagementClient` is the primary interface for developers using the Azure BatchManagement client library. Explore the methods on this client object to understand the different features of the Azure BatchManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/batch/batch-rest/README.md
+++ b/sdk/batch/batch-rest/README.md
@@ -61,6 +61,10 @@ const credential = new AzureNamedKeyCredential("<account name>", "<account key>"
 const batchClient = createClient("<account endpoint>", credential);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/batch/batch/README.md
+++ b/sdk/batch/batch/README.md
@@ -94,6 +94,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BatchClient` is the primary interface for developers using the Azure Batch client library. Explore the methods on this client object to understand the different features of the Azure Batch service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/billing/arm-billing/README.md
+++ b/sdk/billing/arm-billing/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BillingManagementClient` is the primary interface for developers using the Azure BillingManagement client library. Explore the methods on this client object to understand the different features of the Azure BillingManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/billingbenefits/arm-billingbenefits/README.md
+++ b/sdk/billingbenefits/arm-billingbenefits/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BillingBenefitsRP` is the primary interface for developers using the Azure BillingBenefitsRP client library. Explore the methods on this client object to understand the different features of the Azure BillingBenefitsRP service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/botservice/arm-botservice/README.md
+++ b/sdk/botservice/arm-botservice/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureBotService` is the primary interface for developers using the Azure Bot client library. Explore the methods on this client object to understand the different features of the Azure Bot service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/carbonoptimization/arm-carbonoptimization/README.md
+++ b/sdk/carbonoptimization/arm-carbonoptimization/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CarbonOptimizationManagementClient` is the primary interface for developers using the Azure CarbonOptimizationManagement client library. Explore the methods on this client object to understand the different features of the Azure CarbonOptimizationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cdn/arm-cdn/README.md
+++ b/sdk/cdn/arm-cdn/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CdnManagementClient` is the primary interface for developers using the Azure CdnManagement client library. Explore the methods on this client object to understand the different features of the Azure CdnManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/certificateregistration/arm-certificateregistration/README.md
+++ b/sdk/certificateregistration/arm-certificateregistration/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CertificateRegistrationManagementClient` is the primary interface for developers using the Azure CertificateRegistrationManagement client library. Explore the methods on this client object to understand the different features of the Azure CertificateRegistrationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/changes/arm-changes/README.md
+++ b/sdk/changes/arm-changes/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ChangesClient` is the primary interface for developers using the Azure Changes client library. Explore the methods on this client object to understand the different features of the Azure Changes service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/chaos/arm-chaos/README.md
+++ b/sdk/chaos/arm-chaos/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ChaosManagementClient` is the primary interface for developers using the Azure ChaosManagement client library. Explore the methods on this client object to understand the different features of the Azure ChaosManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cloudhealth/arm-cloudhealth/README.md
+++ b/sdk/cloudhealth/arm-cloudhealth/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CloudHealthClient` is the primary interface for developers using the Azure CloudHealth client library. Explore the methods on this client object to understand the different features of the Azure CloudHealth service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cognitivelanguage/ai-language-conversations/README.md
+++ b/sdk/cognitivelanguage/ai-language-conversations/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ConversationAnalysisClient` is the primary interface for developers using the Azure ConversationAnalysis client library. Explore the methods on this client object to understand the different features of the Azure ConversationAnalysis service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cognitivelanguage/ai-language-text/README.md
+++ b/sdk/cognitivelanguage/ai-language-text/README.md
@@ -238,6 +238,10 @@ if (result.error !== undefined) {
 - [Custom Single-lable Classfication](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/cognitivelanguage/ai-language-text/samples-dev/customSingleLabelClassification.ts)
 - [Custom Multi-lable Classfication](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/cognitivelanguage/ai-language-text/samples-dev/customMultiLabelClassification.ts)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cognitiveservices/arm-cognitiveservices/README.md
+++ b/sdk/cognitiveservices/arm-cognitiveservices/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CognitiveServicesManagementClient` is the primary interface for developers using the Azure CognitiveServicesManagement client library. Explore the methods on this client object to understand the different features of the Azure CognitiveServicesManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/README.md
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `UsageManagementClient` is the primary interface for developers using the Azure UsageManagement client library. Explore the methods on this client object to understand the different features of the Azure UsageManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/commerce/arm-commerce/README.md
+++ b/sdk/commerce/arm-commerce/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `UsageManagementClient` is the primary interface for developers using the Azure UsageManagement client library. Explore the methods on this client object to understand the different features of the Azure UsageManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/arm-communication/README.md
+++ b/sdk/communication/arm-communication/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CommunicationServiceManagementClient` is the primary interface for developers using the Azure CommunicationServiceManagement client library. Explore the methods on this client object to understand the different features of the Azure CommunicationServiceManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-alpha-ids/README.md
+++ b/sdk/communication/communication-alpha-ids/README.md
@@ -94,6 +94,10 @@ const configuration = await client.getDynamicAlphaIdConfiguration();
 console.log(`Usage of Alpha IDs is currently ${configuration.enabled ? "enabled" : "disabled"}`);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-call-automation/README.md
+++ b/sdk/communication/communication-call-automation/README.md
@@ -98,6 +98,10 @@ const myFile: FileSource = { url: "https://<FILE-SOURCE>/<SOME-FILE>.wav", kind:
 const response = await callConnection.getCallMedia().playToAll([myFile]);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-chat/README.md
+++ b/sdk/communication/communication-chat/README.md
@@ -293,6 +293,10 @@ chatClient.on("realTimeNotificationDisconnected", () => {
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-common/README.md
+++ b/sdk/communication/communication-common/README.md
@@ -168,6 +168,10 @@ const entraTokenCredentialOptions: EntraCommunicationTokenCredentialOptions = {
 const credential = new AzureCommunicationTokenCredential(entraTokenCredentialOptions);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 - **Invalid token specified**: Make sure the token you are passing to the `AzureCommunicationTokenCredential` constructor or to the `tokenRefresher` callback is a bare JWT token string. E.g. if you're using the [Azure Communication Identity library][invalid_token_sdk] or [REST API][invalid_token_rest] to obtain the token, make sure you're passing just the `token` part of the response object.

--- a/sdk/communication/communication-email/README.md
+++ b/sdk/communication/communication-email/README.md
@@ -226,6 +226,10 @@ const poller = await client.beginSend(message);
 const response = await poller.pollUntilDone();
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-identity/README.md
+++ b/sdk/communication/communication-identity/README.md
@@ -262,6 +262,10 @@ const { token, expiresOn } = await client.getTokenForTeamsUser({
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-job-router-rest/README.md
+++ b/sdk/communication/communication-job-router-rest/README.md
@@ -422,6 +422,10 @@ const closeJob = await routerClient
   });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-messages-rest/README.md
+++ b/sdk/communication/communication-messages-rest/README.md
@@ -397,6 +397,10 @@ if (!isUnexpected(result)) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-phone-numbers/README.md
+++ b/sdk/communication/communication-phone-numbers/README.md
@@ -510,6 +510,10 @@ const client = new SipRoutingClient("<endpoint-from-resource>", credential);
 await client.deleteTrunk("sbc.one.domain.com");
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-recipient-verification/README.md
+++ b/sdk/communication/communication-recipient-verification/README.md
@@ -157,6 +157,10 @@ for await (const verification of verifications) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-rooms/README.md
+++ b/sdk/communication/communication-rooms/README.md
@@ -266,6 +266,10 @@ const client = new RoomsClient("<endpoint-from-resource>", credential);
 await client.deleteRoom("<room-id>");
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-short-codes/README.md
+++ b/sdk/communication/communication-short-codes/README.md
@@ -289,6 +289,10 @@ for await (const shortCodeCost of shortCodeCosts) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-sms/README.md
+++ b/sdk/communication/communication-sms/README.md
@@ -202,6 +202,10 @@ for (const optOutRemoveResult of optOutRemoveResults) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 SMS operations will throw an exception if the request to the server fails.

--- a/sdk/communication/communication-tiering/README.md
+++ b/sdk/communication/communication-tiering/README.md
@@ -115,6 +115,10 @@ const tierInfo = await client.getTierByResourceId(resourceId);
 console.log(tierInfo);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/communication/communication-toll-free-verification/README.md
+++ b/sdk/communication/communication-toll-free-verification/README.md
@@ -95,6 +95,10 @@ const campaignBrief = await client.getCampaignBrief("63215741-b596-4eb4-a9c0-b29
 console.log(campaignBrief);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/README.md
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ComputeManagementClient` is the primary interface for developers using the Azure ComputeManagement client library. Explore the methods on this client object to understand the different features of the Azure ComputeManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/compute/arm-compute-rest/README.md
+++ b/sdk/compute/arm-compute-rest/README.md
@@ -92,6 +92,10 @@ for await (const item of pageData) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/compute/arm-compute/README.md
+++ b/sdk/compute/arm-compute/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ComputeManagementClient` is the primary interface for developers using the Azure ComputeManagement client library. Explore the methods on this client object to understand the different features of the Azure ComputeManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/compute/arm-computerecommender/README.md
+++ b/sdk/compute/arm-computerecommender/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ComputeRecommenderManagementClient` is the primary interface for developers using the Azure ComputeRecommenderResourceProvider client library. Explore the methods on this client object to understand the different features of the Azure ComputeRecommenderResourceProvider service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/computebulkactions/arm-computebulkactions/README.md
+++ b/sdk/computebulkactions/arm-computebulkactions/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ComputeBulkActionsClient` is the primary interface for developers using the Azure ComputeBulkActions client library. Explore the methods on this client object to understand the different features of the Azure ComputeBulkActions service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/computefleet/arm-computefleet/README.md
+++ b/sdk/computefleet/arm-computefleet/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureFleetClient` is the primary interface for developers using the AzureFleet client library. Explore the methods on this client object to understand the different features of the AzureFleet service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/computelimit/arm-computelimit/README.md
+++ b/sdk/computelimit/arm-computelimit/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ComputeLimitClient` is the primary interface for developers using the Azure ComputeLimit client library. Explore the methods on this client object to understand the different features of the Azure ComputeLimit service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/computeschedule/arm-computeschedule/README.md
+++ b/sdk/computeschedule/arm-computeschedule/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ComputeScheduleClient` is the primary interface for developers using the Azure ComputeSchedule client library. Explore the methods on this client object to understand the different features of the Azure ComputeSchedule service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/confidentialledger/arm-confidentialledger/README.md
+++ b/sdk/confidentialledger/arm-confidentialledger/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ConfidentialLedgerClient` is the primary interface for developers using the Azure ConfidentialLedger client library. Explore the methods on this client object to understand the different features of the Azure ConfidentialLedger service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/confidentialledger/confidential-ledger-rest/README.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/README.md
@@ -457,6 +457,10 @@ Object.keys(enclaveQuotes.body.enclaveQuotes).forEach((key) => {
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/confluent/arm-confluent/README.md
+++ b/sdk/confluent/arm-confluent/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ConfluentManagementClient` is the primary interface for developers using the Azure ConfluentManagement client library. Explore the methods on this client object to understand the different features of the Azure ConfluentManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/connectedcache/arm-connectedcache/README.md
+++ b/sdk/connectedcache/arm-connectedcache/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ConnectedCacheClient` is the primary interface for developers using the Azure ConnectedCache client library. Explore the methods on this client object to understand the different features of the Azure ConnectedCache service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/connectedvmware/arm-connectedvmware/README.md
+++ b/sdk/connectedvmware/arm-connectedvmware/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureArcVMwareManagementServiceAPI` is the primary interface for developers using the Azure Arc VMware Management client library. Explore the methods on this client object to understand the different features of the Azure Arc VMware Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/consumption/arm-consumption/README.md
+++ b/sdk/consumption/arm-consumption/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ConsumptionManagementClient` is the primary interface for developers using the Azure ConsumptionManagement client library. Explore the methods on this client object to understand the different features of the Azure ConsumptionManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerinstance/arm-containerinstance/README.md
+++ b/sdk/containerinstance/arm-containerinstance/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerInstanceManagementClient` is the primary interface for developers using the Azure ContainerInstanceManagement client library. Explore the methods on this client object to understand the different features of the Azure ContainerInstanceManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerregistry/arm-containerregistry/README.md
+++ b/sdk/containerregistry/arm-containerregistry/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerRegistryManagementClient` is the primary interface for developers using the Azure ContainerRegistryManagement client library. Explore the methods on this client object to understand the different features of the Azure ContainerRegistryManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerregistry/arm-containerregistrytasks/README.md
+++ b/sdk/containerregistry/arm-containerregistrytasks/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerRegistryTasksManagementClient` is the primary interface for developers using the Azure ContainerRegistryTasksManagement client library. Explore the methods on this client object to understand the different features of the Azure ContainerRegistryTasksManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerregistry/container-registry/README.md
+++ b/sdk/containerregistry/container-registry/README.md
@@ -335,6 +335,10 @@ for (const layer of (downloadResult.manifest as OciImageManifest).layers) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 For infomation about troubleshooting, refer to the [troubleshooting guide].

--- a/sdk/containerservice/arm-containerservice-rest/README.md
+++ b/sdk/containerservice/arm-containerservice-rest/README.md
@@ -75,6 +75,10 @@ for await (const item of result) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerservice/arm-containerservice/README.md
+++ b/sdk/containerservice/arm-containerservice/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerServiceClient` is the primary interface for developers using the Azure ContainerService client library. Explore the methods on this client object to understand the different features of the Azure ContainerService service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerservice/arm-containerservicefleet/README.md
+++ b/sdk/containerservice/arm-containerservicefleet/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerServiceFleetClient` is the primary interface for developers using the Azure ContainerServiceFleet client library. Explore the methods on this client object to understand the different features of the Azure ContainerServiceFleet service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/containerservice/arm-containerservicesafeguards/README.md
+++ b/sdk/containerservice/arm-containerservicesafeguards/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ContainerServiceClient` is the primary interface for developers using the Azure ContainerServiceDeploymentSafeguards client library. Explore the methods on this client object to understand the different features of the Azure ContainerServiceDeploymentSafeguards service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/contentsafety/ai-content-safety-rest/README.md
+++ b/sdk/contentsafety/ai-content-safety-rest/README.md
@@ -615,6 +615,10 @@ if (isUnexpected(removeBlockItem)) {
 console.log("Removed blockItem: ", blockItemText);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/contentunderstanding/ai-content-understanding/README.md
+++ b/sdk/contentunderstanding/ai-content-understanding/README.md
@@ -382,6 +382,10 @@ console.log(text);
 See the [advanced sample][js_cu_sample_to_llm_input] for output options (fields-only,
 markdown-only, custom metadata), multi-page content ranges, and multi-segment video.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Common issues

--- a/sdk/core/abort-controller/README.md
+++ b/sdk/core/abort-controller/README.md
@@ -74,6 +74,10 @@ doAsyncWork({ abortSignal: signal });
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-amqp/README.md
+++ b/sdk/core/core-amqp/README.md
@@ -34,6 +34,10 @@ Some of the key features of Azure Core AMQP library are:
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 The core-amqp library depends on the [rhea-promise](https://github.com/amqp/rhea-promise) library for managing connections, and for sending and receiving events over the [AMQP](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-complete-v1.0-os.pdf) protocol.

--- a/sdk/core/core-auth/README.md
+++ b/sdk/core/core-auth/README.md
@@ -70,6 +70,10 @@ console.log(credential.signature); // prints: "signature2"
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-client-rest/README.md
+++ b/sdk/core/core-client-rest/README.md
@@ -29,6 +29,10 @@ You can build and run the tests locally by executing `npm run test`. Explore the
 
 Learn more about [AutoRest](https://github.com/Azure/autorest) and the [autorest.typescript extension](https://github.com/Azure/autorest.typescript) for generating a compatible client on top of this package.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-client/README.md
+++ b/sdk/core/core-client/README.md
@@ -41,6 +41,10 @@ You can build and run the tests locally by executing `npm run test`. Explore the
 
 Learn more about [AutoRest](https://github.com/Azure/autorest) and the [autorest.typescript extension](https://github.com/Azure/autorest.typescript) for generating a compatible client on top of this package.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-lro/README.md
+++ b/sdk/core/core-lro/README.md
@@ -62,6 +62,10 @@ A function that returns an object of type `PollerLike`. This poller behaves as f
 
 Examples can be found in the `samples` folder.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -55,6 +55,10 @@ And using the types:
 
 Try out this package in your application when dealing with async iterable iterators and provide feedback!
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Log an issue at https://github.com/Azure/azure-sdk-for-js/issues

--- a/sdk/core/core-rest-pipeline/README.md
+++ b/sdk/core/core-rest-pipeline/README.md
@@ -167,6 +167,10 @@ Examples can be found in the `samples` folder.
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-sse/README.md
+++ b/sdk/core/core-sse/README.md
@@ -31,6 +31,10 @@ Examples can be found in the `samples` folder.
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-tracing/README.md
+++ b/sdk/core/core-tracing/README.md
@@ -24,6 +24,10 @@ Examples can be found in the `samples` folder.
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-util/README.md
+++ b/sdk/core/core-util/README.md
@@ -29,6 +29,10 @@ Examples can be found in the `samples` folder.
 
 Look at usage in dependent client SDKs.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/core-xml/README.md
+++ b/sdk/core/core-xml/README.md
@@ -29,6 +29,10 @@ Examples can be found in the `samples-dev` folder and can be ran using `npm run 
 
 See `@azure/core-client` for actual usage.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/logger/README.md
+++ b/sdk/core/logger/README.md
@@ -113,6 +113,10 @@ a location other than stderr.
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/core/ts-http-runtime/README.md
+++ b/sdk/core/ts-http-runtime/README.md
@@ -168,6 +168,10 @@ Examples can be found in the `samples` folder.
 
 You can build and run the tests locally by executing `npm run test`. Explore the `test` folder to see advanced usage and behavior of the public classes.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/cosmosdb/arm-cosmosdb/README.md
+++ b/sdk/cosmosdb/arm-cosmosdb/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CosmosDBManagementClient` is the primary interface for developers using the Azure CosmosDBManagement client library. Explore the methods on this client object to understand the different features of the Azure CosmosDBManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cosmosdb/cosmos/README.md
+++ b/sdk/cosmosdb/cosmos/README.md
@@ -632,6 +632,10 @@ try {
 
 It's important to properly handle these errors to ensure that your application can gracefully recover from any failures and continue functioning as expected. More details about some of these errors and their possible solutions can be found [here](https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications#should-my-application-retry-on-errors).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### General

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/README.md
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CosmosDBForPostgreSQL` is the primary interface for developers using the Azure CosmosDbForPostgreSQL client library. Explore the methods on this client object to understand the different features of the Azure CosmosDbForPostgreSQL service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/cost-management/arm-costmanagement/README.md
+++ b/sdk/cost-management/arm-costmanagement/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CostManagementClient` is the primary interface for developers using the Azure CostManagement client library. Explore the methods on this client object to understand the different features of the Azure CostManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/customer-insights/arm-customerinsights/README.md
+++ b/sdk/customer-insights/arm-customerinsights/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CustomerInsightsManagementClient` is the primary interface for developers using the Azure CustomerInsightsManagement client library. Explore the methods on this client object to understand the different features of the Azure CustomerInsightsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dashboard/arm-dashboard/README.md
+++ b/sdk/dashboard/arm-dashboard/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DashboardManagementClient` is the primary interface for developers using the Azure DashboardManagement client library. Explore the methods on this client object to understand the different features of the Azure DashboardManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/databasewatcher/arm-databasewatcher/README.md
+++ b/sdk/databasewatcher/arm-databasewatcher/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DatabaseWatcherClient` is the primary interface for developers using the Azure DatabaseWatcher client library. Explore the methods on this client object to understand the different features of the Azure DatabaseWatcher service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/databoundaries/arm-databoundaries/README.md
+++ b/sdk/databoundaries/arm-databoundaries/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataboundariesManegementClient` is the primary interface for developers using the Azure DataboundariesManegement client library. Explore the methods on this client object to understand the different features of the Azure DataboundariesManegement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/databox/arm-databox/README.md
+++ b/sdk/databox/arm-databox/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataBoxManagementClient` is the primary interface for developers using the Azure DataBoxManagement client library. Explore the methods on this client object to understand the different features of the Azure DataBoxManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/README.md
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataBoxEdgeManagementClient` is the primary interface for developers using the Azure DataBoxEdgeManagement client library. Explore the methods on this client object to understand the different features of the Azure DataBoxEdgeManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/databoxedge/arm-databoxedge/README.md
+++ b/sdk/databoxedge/arm-databoxedge/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataBoxEdgeManagementClient` is the primary interface for developers using the Azure DataBoxEdgeManagement client library. Explore the methods on this client object to understand the different features of the Azure DataBoxEdgeManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/databricks/arm-databricks/README.md
+++ b/sdk/databricks/arm-databricks/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureDatabricksManagementClient` is the primary interface for developers using the AzureDatabricksManagement client library. Explore the methods on this client object to understand the different features of the AzureDatabricksManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/datacatalog/arm-datacatalog/README.md
+++ b/sdk/datacatalog/arm-datacatalog/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataCatalogRestClient` is the primary interface for developers using the Azure DataCatalogRest client library. Explore the methods on this client object to understand the different features of the Azure DataCatalogRest service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/datadog/arm-datadog/README.md
+++ b/sdk/datadog/arm-datadog/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftDatadogClient` is the primary interface for developers using the Azure MicrosoftDatadog client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftDatadog service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/datafactory/arm-datafactory/README.md
+++ b/sdk/datafactory/arm-datafactory/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataFactoryManagementClient` is the primary interface for developers using the Azure DataFactoryManagement client library. Explore the methods on this client object to understand the different features of the Azure DataFactoryManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/datalake-analytics/arm-datalake-analytics/README.md
+++ b/sdk/datalake-analytics/arm-datalake-analytics/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataLakeAnalyticsAccountManagementClient` is the primary interface for developers using the Azure DataLakeAnalyticsAccountManagement client library. Explore the methods on this client object to understand the different features of the Azure DataLakeAnalyticsAccountManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/datamigration/arm-datamigration/README.md
+++ b/sdk/datamigration/arm-datamigration/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataMigrationManagementClient` is the primary interface for developers using the Azure DataMigrationManagement client library. Explore the methods on this client object to understand the different features of the Azure DataMigrationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dataprotection/arm-dataprotection/README.md
+++ b/sdk/dataprotection/arm-dataprotection/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataProtectionClient` is the primary interface for developers using the Azure Data Protection client library. Explore the methods on this client object to understand the different features of the Azure Data Protection service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/defendereasm/arm-defendereasm/README.md
+++ b/sdk/defendereasm/arm-defendereasm/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EasmMgmtClient` is the primary interface for developers using the Azure EasmMgmt client library. Explore the methods on this client object to understand the different features of the Azure EasmMgmt service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dell/arm-dell-storage/README.md
+++ b/sdk/dell/arm-dell-storage/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageClient` is the primary interface for developers using the Azure Storage client library. Explore the methods on this client object to understand the different features of the Azure Storage service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dependencymap/arm-dependencymap/README.md
+++ b/sdk/dependencymap/arm-dependencymap/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DependencyMapClient` is the primary interface for developers using the Azure DependencyMap client library. Explore the methods on this client object to understand the different features of the Azure DependencyMap service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/README.md
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DesktopVirtualizationAPIClient` is the primary interface for developers using the Azure Desktop Virtualization API client library. Explore the methods on this client object to understand the different features of the Azure Desktop Virtualization API service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/devcenter/arm-devcenter/README.md
+++ b/sdk/devcenter/arm-devcenter/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DevCenterClient` is the primary interface for developers using the Azure DevCenter client library. Explore the methods on this client object to understand the different features of the Azure DevCenter service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/devcenter/developer-devcenter-rest/README.md
+++ b/sdk/devcenter/developer-devcenter-rest/README.md
@@ -73,6 +73,10 @@ Dev Boxes refer to managed developer machines running in Azure. Dev Boxes are pr
 
 Environments refer to templated developer environments, which combine a template (Catalog Item) and parameters, as well as an Environment Type which defines permissions and where the resources are deployed.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/devhub/arm-devhub/README.md
+++ b/sdk/devhub/arm-devhub/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DeveloperHubServiceClient` is the primary interface for developers using the Azure DeveloperHubService client library. Explore the methods on this client object to understand the different features of the Azure DeveloperHubService service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `IotDpsClient` is the primary interface for developers using the Azure iotDps client library. Explore the methods on this client object to understand the different features of the Azure iotDps service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/deviceregistry/arm-deviceregistry/README.md
+++ b/sdk/deviceregistry/arm-deviceregistry/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DeviceRegistryManagementClient` is the primary interface for developers using the Azure DeviceRegistryManagement client library. Explore the methods on this client object to understand the different features of the Azure DeviceRegistryManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/deviceupdate/arm-deviceupdate/README.md
+++ b/sdk/deviceupdate/arm-deviceupdate/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DeviceUpdate` is the primary interface for developers using the Azure DeviceUpdate client library. Explore the methods on this client object to understand the different features of the Azure DeviceUpdate service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/deviceupdate/iot-device-update-rest/README.md
+++ b/sdk/deviceupdate/iot-device-update-rest/README.md
@@ -81,6 +81,10 @@ const result = await client.path("/deviceupdate/{instanceId}/management/devices"
 console.log(result);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/README.md
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DevOpsInfrastructureClient` is the primary interface for developers using the Azure DevOpsInfrastructure client library. Explore the methods on this client object to understand the different features of the Azure DevOpsInfrastructure service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/devspaces/arm-devspaces/README.md
+++ b/sdk/devspaces/arm-devspaces/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DevSpacesManagementClient` is the primary interface for developers using the Azure DevSpacesManagement client library. Explore the methods on this client object to understand the different features of the Azure DevSpacesManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/devtestlabs/arm-devtestlabs/README.md
+++ b/sdk/devtestlabs/arm-devtestlabs/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DevTestLabsClient` is the primary interface for developers using the Azure DevTestLabs client library. Explore the methods on this client object to understand the different features of the Azure DevTestLabs service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/digitaltwins/arm-digitaltwins/README.md
+++ b/sdk/digitaltwins/arm-digitaltwins/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureDigitalTwinsManagementClient` is the primary interface for developers using the AzureDigitalTwinsManagement client library. Explore the methods on this client object to understand the different features of the AzureDigitalTwinsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/digitaltwins/digital-twins-core/README.md
+++ b/sdk/digitaltwins/digital-twins-core/README.md
@@ -465,6 +465,10 @@ const response = await serviceClient.publishComponentTelemetry(
 Additional examples can be found in the
 [samples directory](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/digitaltwins/digital-twins-core/samples).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/disconnectedoperations/arm-disconnectedoperations/README.md
+++ b/sdk/disconnectedoperations/arm-disconnectedoperations/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DisconnectedOperationsManagementClient` is the primary interface for developers using the Azure DisconnectedOperationsManagement client library. Explore the methods on this client object to understand the different features of the Azure DisconnectedOperationsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/discovery/arm-discovery/README.md
+++ b/sdk/discovery/arm-discovery/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DiscoveryClient` is the primary interface for developers using the Azure Discovery client library. Explore the methods on this client object to understand the different features of the Azure Discovery service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/README.md
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DnsManagementClient` is the primary interface for developers using the Azure DnsManagement client library. Explore the methods on this client object to understand the different features of the Azure DnsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dns/arm-dns/README.md
+++ b/sdk/dns/arm-dns/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DnsManagementClient` is the primary interface for developers using the Azure DnsManagement client library. Explore the methods on this client object to understand the different features of the Azure DnsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dnsresolver/arm-dnsresolver/README.md
+++ b/sdk/dnsresolver/arm-dnsresolver/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DnsResolverManagementClient` is the primary interface for developers using the Azure DnsResolverManagement client library. Explore the methods on this client object to understand the different features of the Azure DnsResolverManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/documentintelligence/ai-document-intelligence-rest/README.md
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/README.md
@@ -494,6 +494,10 @@ for await (const model of paginate(client, response)) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/documenttranslator/ai-document-translator-rest/README.md
+++ b/sdk/documenttranslator/ai-document-translator-rest/README.md
@@ -173,6 +173,10 @@ Please refer to the samples folder to see code samples, including:
 - [List Supported Formats](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/documenttranslator/ai-document-translator-rest/samples/v1/typescript/src/listFormats.ts)
 - [Translate documents](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/documenttranslator/ai-document-translator-rest/samples/v1/typescript/src/translateFromBlob.ts)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/domainregistration/arm-domainregistration/README.md
+++ b/sdk/domainregistration/arm-domainregistration/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DomainRegistrationManagementClient` is the primary interface for developers using the Azure TopLevelDomains API client library. Explore the methods on this client object to understand the different features of the Azure TopLevelDomains API service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/domainservices/arm-domainservices/README.md
+++ b/sdk/domainservices/arm-domainservices/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DomainServicesResourceProvider` is the primary interface for developers using the Azure Domain client library. Explore the methods on this client object to understand the different features of the Azure Domain service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/durabletask/arm-durabletask/README.md
+++ b/sdk/durabletask/arm-durabletask/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DurableTaskClient` is the primary interface for developers using the Azure DurableTask client library. Explore the methods on this client object to understand the different features of the Azure DurableTask service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/dynatrace/arm-dynatrace/README.md
+++ b/sdk/dynatrace/arm-dynatrace/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DynatraceObservability` is the primary interface for developers using the Azure DynatraceObservability client library. Explore the methods on this client object to understand the different features of the Azure DynatraceObservability service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/easm/defender-easm-rest/README.md
+++ b/sdk/easm/defender-easm-rest/README.md
@@ -40,6 +40,10 @@ After setup, you can choose which type of [credential](https://github.com/Azure/
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
 can be used to authenticate the client.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/edgeactions/arm-edgeactions/README.md
+++ b/sdk/edgeactions/arm-edgeactions/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EdgeActionsManagementClient` is the primary interface for developers using the Azure Cdn client library. Explore the methods on this client object to understand the different features of the Azure Cdn service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/edgeorder/arm-edgeorder/README.md
+++ b/sdk/edgeorder/arm-edgeorder/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EdgeOrderClient` is the primary interface for developers using the Azure EdgeOrder client library. Explore the methods on this client object to understand the different features of the Azure EdgeOrder service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/edgezones/arm-edgezones/README.md
+++ b/sdk/edgezones/arm-edgezones/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EdgeZonesClient` is the primary interface for developers using the Azure EdgeZones client library. Explore the methods on this client object to understand the different features of the Azure EdgeZones service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/education/arm-education/README.md
+++ b/sdk/education/arm-education/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EducationManagementClient` is the primary interface for developers using the Azure EducationManagement client library. Explore the methods on this client object to understand the different features of the Azure EducationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/elastic/arm-elastic/README.md
+++ b/sdk/elastic/arm-elastic/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftElastic` is the primary interface for developers using the Azure MicrosoftElastic client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftElastic service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/elasticsans/arm-elasticsan/README.md
+++ b/sdk/elasticsans/arm-elasticsan/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ElasticSanManagement` is the primary interface for developers using the Azure ElasticSanManagement client library. Explore the methods on this client object to understand the different features of the Azure ElasticSanManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/entra/functions-authentication-events/README.md
+++ b/sdk/entra/functions-authentication-events/README.md
@@ -206,6 +206,10 @@ To Test Token Augmentation, please do the following.
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 - Visual Studio Code

--- a/sdk/eventgrid/arm-eventgrid/README.md
+++ b/sdk/eventgrid/arm-eventgrid/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EventGridManagementClient` is the primary interface for developers using the Azure EventGridManagement client library. Explore the methods on this client object to understand the different features of the Azure EventGridManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventgrid/eventgrid-namespaces/README.md
+++ b/sdk/eventgrid/eventgrid-namespaces/README.md
@@ -180,6 +180,10 @@ const cloudEvent = {
 await client.sendEvents(cloudEvent);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventgrid/eventgrid-systemevents/README.md
+++ b/sdk/eventgrid/eventgrid-systemevents/README.md
@@ -49,6 +49,10 @@ npm install @azure/eventgrid-systemevents
 
 This package provides a list of System Events that could be used to publish events to EventGrid.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventgrid/eventgrid/README.md
+++ b/sdk/eventgrid/eventgrid/README.md
@@ -288,6 +288,10 @@ if (
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/README.md
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EventHubManagementClient` is the primary interface for developers using the Azure EventHubManagement client library. Explore the methods on this client object to understand the different features of the Azure EventHubManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventhub/arm-eventhub/README.md
+++ b/sdk/eventhub/arm-eventhub/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EventHubManagementClient` is the primary interface for developers using the Azure EventHubManagement client library. Explore the methods on this client object to understand the different features of the Azure EventHubManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -515,6 +515,10 @@ await client.getPartitionProperties(partitionId);
 await client.close();
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### AMQP Dependencies

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/README.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/README.md
@@ -146,6 +146,10 @@ await subscription.close();
 await consumerClient.close();
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/eventhub/eventhubs-checkpointstore-table/README.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/README.md
@@ -146,6 +146,10 @@ await subscription.close();
 await consumerClient.close();
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/extendedlocation/arm-extendedlocation/README.md
+++ b/sdk/extendedlocation/arm-extendedlocation/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CustomLocationsManagementClient` is the primary interface for developers using the Azure CustomLocationsManagement client library. Explore the methods on this client object to understand the different features of the Azure CustomLocationsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/fabric/arm-fabric/README.md
+++ b/sdk/fabric/arm-fabric/README.md
@@ -78,6 +78,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `FabricClient` is the primary interface for developers using the Azure Fabric client library. Explore the methods on this client object to understand the different features of the Azure Fabric service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/face/ai-vision-face-rest/README.md
+++ b/sdk/face/ai-vision-face-rest/README.md
@@ -457,6 +457,10 @@ if (isUnexpected(getLivenessSessionResultResponse)) {
 console.log(getLivenessSessionResultResponse.body);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### General

--- a/sdk/features/arm-features/README.md
+++ b/sdk/features/arm-features/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `FeatureClient` is the primary interface for developers using the Azure Feature client library. Explore the methods on this client object to understand the different features of the Azure Feature service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/fileshares/arm-fileshares/README.md
+++ b/sdk/fileshares/arm-fileshares/README.md
@@ -133,6 +133,10 @@ const result = await client.fileShares.createOrUpdate("myResourceGroup", "myFile
 console.log(result);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/fluidrelay/arm-fluidrelay/README.md
+++ b/sdk/fluidrelay/arm-fluidrelay/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `FluidRelayManagementClient` is the primary interface for developers using the Azure FluidRelayManagement client library. Explore the methods on this client object to understand the different features of the Azure FluidRelayManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -626,6 +626,10 @@ await client.deleteDocumentModel(modelIdToDelete);
 
 Similar methods `listDocumentClassifiers` and `getDocumentClassifier` are available for listing and getting information about custom classifiers in addition to `deleteDocumentClassifier` for deleting custom classifiers.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 For assistance with troubleshooting, see the [troubleshooting guide][trouble-shooting].

--- a/sdk/frontdoor/arm-frontdoor/README.md
+++ b/sdk/frontdoor/arm-frontdoor/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `FrontDoorManagementClient` is the primary interface for developers using the Azure FrontDoorManagement client library. Explore the methods on this client object to understand the different features of the Azure FrontDoorManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/graphservices/arm-graphservices/README.md
+++ b/sdk/graphservices/arm-graphservices/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `GraphServices` is the primary interface for developers using the Azure GraphServices client library. Explore the methods on this client object to understand the different features of the Azure GraphServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/guestconfiguration/arm-guestconfiguration/README.md
+++ b/sdk/guestconfiguration/arm-guestconfiguration/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `GuestConfigurationClient` is the primary interface for developers using the Azure GuestConfiguration client library. Explore the methods on this client object to understand the different features of the Azure GuestConfiguration service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hanaonazure/arm-hanaonazure/README.md
+++ b/sdk/hanaonazure/arm-hanaonazure/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HanaManagementClient` is the primary interface for developers using the Azure HanaManagement client library. Explore the methods on this client object to understand the different features of the Azure HanaManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/README.md
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureDedicatedHSMResourceProvider` is the primary interface for developers using the Azure HardwareSecurityModules client library. Explore the methods on this client object to understand the different features of the Azure HardwareSecurityModules service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hdinsight/arm-hdinsight/README.md
+++ b/sdk/hdinsight/arm-hdinsight/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HDInsightManagementClient` is the primary interface for developers using the Azure HDInsightManagement client library. Explore the methods on this client object to understand the different features of the Azure HDInsightManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/healthbot/arm-healthbot/README.md
+++ b/sdk/healthbot/arm-healthbot/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HealthbotClient` is the primary interface for developers using the Azure Healthbot client library. Explore the methods on this client object to understand the different features of the Azure Healthbot service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/healthcareapis/arm-healthcareapis/README.md
+++ b/sdk/healthcareapis/arm-healthcareapis/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HealthcareApisManagementClient` is the primary interface for developers using the Azure HealthcareApisManagement client library. Explore the methods on this client object to understand the different features of the Azure HealthcareApisManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/README.md
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HealthDataAIServicesClient` is the primary interface for developers using the Azure HealthDataAIServices client library. Explore the methods on this client object to understand the different features of the Azure HealthDataAIServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/healthdataaiservices/health-deidentification-rest/README.md
+++ b/sdk/healthdataaiservices/health-deidentification-rest/README.md
@@ -203,6 +203,10 @@ console.log(finalOutput.body);
 
 Find a bug, or have feedback? Raise an issue with the [Health Deidentification][github_issue_label] label.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 - **Unable to Access Source or Target Storage**

--- a/sdk/horizondb/arm-horizondb/README.md
+++ b/sdk/horizondb/arm-horizondb/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HorizonDbClient` is the primary interface for developers using the Azure HorizonDb client library. Explore the methods on this client object to understand the different features of the Azure HorizonDb service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hybridcompute/arm-hybridcompute/README.md
+++ b/sdk/hybridcompute/arm-hybridcompute/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HybridComputeManagementClient` is the primary interface for developers using the Azure HybridComputeManagement client library. Explore the methods on this client object to understand the different features of the Azure HybridComputeManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/README.md
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HybridConnectivityManagementAPI` is the primary interface for developers using the Azure HybridConnectivityManagementAPI client library. Explore the methods on this client object to understand the different features of the Azure HybridConnectivityManagementAPI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/README.md
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HybridContainerServiceClient` is the primary interface for developers using the Azure HybridContainerService client library. Explore the methods on this client object to understand the different features of the Azure HybridContainerService service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/README.md
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ConnectedKubernetesClient` is the primary interface for developers using the Azure ConnectedKubernetes client library. Explore the methods on this client object to understand the different features of the Azure ConnectedKubernetes service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/hybridnetwork/arm-hybridnetwork/README.md
+++ b/sdk/hybridnetwork/arm-hybridnetwork/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HybridNetworkManagementClient` is the primary interface for developers using the Azure HybridNetworkManagement client library. Explore the methods on this client object to understand the different features of the Azure HybridNetworkManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/identity/identity-broker/README.md
+++ b/sdk/identity/identity-broker/README.md
@@ -145,6 +145,10 @@ const scope = "https://graph.microsoft.com/.default";
 console.log((await credential.getToken(scope)).token.substr(0, 10), "...");
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 See the Azure Identity [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/TROUBLESHOOTING.md) for details on how to diagnose various failure scenarios.

--- a/sdk/identity/identity-cache-persistence/README.md
+++ b/sdk/identity/identity-cache-persistence/README.md
@@ -60,6 +60,10 @@ const scope = "https://graph.microsoft.com/.default";
 console.log((await credential.getToken(scope)).token.substring(0, 10), "...");
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/identity/identity-vscode/README.md
+++ b/sdk/identity/identity-vscode/README.md
@@ -95,6 +95,10 @@ const credential = new DefaultAzureCredential();
 console.log("Token:", await credential.getToken("https://graph.microsoft.com/.default"));
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -305,6 +305,10 @@ The Azure Identity library offers both in-memory and persistent disk caching. Fo
 
 An authentication broker is an application that runs on a user’s machine and manages the authentication handshakes and token maintenance for connected accounts. Currently, only the Windows Web Account Manager (WAM) is supported. Broker authentication is used by `DefaultAzureCredential` to enable secure sign-in via the WAM. To enable support, use the [`@azure/identity-broker`][azure_identity_broker] package. For details on authenticating using WAM, see the [broker plugin documentation][azure_identity_broker_readme].
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 For assistance with troubleshooting, see the [troubleshooting guide](https://aka.ms/azsdk/js/identity/troubleshoot).

--- a/sdk/imagebuilder/arm-imagebuilder/README.md
+++ b/sdk/imagebuilder/arm-imagebuilder/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ImageBuilderClient` is the primary interface for developers using the Azure ImageBuilder client library. Explore the methods on this client object to understand the different features of the Azure ImageBuilder service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/impactreporting/arm-impactreporting/README.md
+++ b/sdk/impactreporting/arm-impactreporting/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ImpactClient` is the primary interface for developers using the Azure Impact client library. Explore the methods on this client object to understand the different features of the Azure Impact service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/informatica/arm-informaticadatamanagement/README.md
+++ b/sdk/informatica/arm-informaticadatamanagement/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `InformaticaDataManagement` is the primary interface for developers using the Azure InformaticaDataManagement client library. Explore the methods on this client object to understand the different features of the Azure InformaticaDataManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/README.md
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/README.md
@@ -80,6 +80,10 @@ await keyClient.getKey("MyKeyName", {
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/iot/iot-modelsrepository/README.md
+++ b/sdk/iot/iot-modelsrepository/README.md
@@ -172,6 +172,10 @@ console.log(fullyQualifiedModelPath);
 
 ---
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 - If you run into an error, first make sure the model you are access exists at the location you are attempting to get it from.

--- a/sdk/iotcentral/arm-iotcentral/README.md
+++ b/sdk/iotcentral/arm-iotcentral/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `IotCentralClient` is the primary interface for developers using the Azure IotCentral client library. Explore the methods on this client object to understand the different features of the Azure IotCentral service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/README.md
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `IoTFirmwareDefenseClient` is the primary interface for developers using the Azure IoTFirmwareDefense client library. Explore the methods on this client object to understand the different features of the Azure IoTFirmwareDefense service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/README.md
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `IotHubClient` is the primary interface for developers using the Azure iotHub client library. Explore the methods on this client object to understand the different features of the Azure iotHub service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/iothub/arm-iothub/README.md
+++ b/sdk/iothub/arm-iothub/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `IotHubClient` is the primary interface for developers using the Azure iotHub client library. Explore the methods on this client object to understand the different features of the Azure iotHub service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/iotoperations/arm-iotoperations/README.md
+++ b/sdk/iotoperations/arm-iotoperations/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `IoTOperationsClient` is the primary interface for developers using the Azure IoTOperations client library. Explore the methods on this client object to understand the different features of the Azure IoTOperations service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/README.md
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `KeyVaultManagementClient` is the primary interface for developers using the Azure KeyVaultManagement client library. Explore the methods on this client object to understand the different features of the Azure KeyVaultManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/keyvault/arm-keyvault/README.md
+++ b/sdk/keyvault/arm-keyvault/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `KeyVaultManagementClient` is the primary interface for developers using the Azure KeyVaultManagement client library. Explore the methods on this client object to understand the different features of the Azure KeyVaultManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/keyvault/keyvault-admin/README.md
+++ b/sdk/keyvault/keyvault-admin/README.md
@@ -116,6 +116,10 @@ We have samples both in JavaScript and TypeScript that show the access control a
 - [Readme for JavaScript samples](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/samples/v4/javascript/README.md)
 - [Readme for TypeScript samples](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/samples/v4/typescript/README.md)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 See our [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-admin/TROUBLESHOOTING.md) for details on how to diagnose various failure scenarios.

--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -610,6 +610,10 @@ for await (const page of client.listPropertiesOfCertificateVersions(certificateN
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/keyvault/keyvault-common/README.md
+++ b/sdk/keyvault/keyvault-common/README.md
@@ -29,6 +29,10 @@ For examples, please see our [Key Vault client libraries](#key-vault-client-libr
 
 For information on next steps, please see our [Key Vault client libraries](#key-vault-client-libraries).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, directly or indirectly, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -732,6 +732,10 @@ const unwrapResult = await cryptographyClient.unwrapKey("RSA-OAEP", wrapResult.r
 console.log("unwrap result: ", unwrapResult.result);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 See our [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-keys/TROUBLESHOOTING.md) for details on how to diagnose various failure scenarios.

--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -452,6 +452,10 @@ for await (const page of client.listPropertiesOfSecretVersions(secretName).byPag
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 See our [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/keyvault/keyvault-secrets/TROUBLESHOOTING.md) for details on how to diagnose various failure scenarios.

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ExtensionsClient` is the primary interface for developers using the Azure Extensions client library. Explore the methods on this client object to understand the different features of the Azure Extensions service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ExtensionTypesClient` is the primary interface for developers using the Azure ExtensionTypes client library. Explore the methods on this client object to understand the different features of the Azure ExtensionTypes service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `FluxConfigurationClient` is the primary interface for developers using the Azure FluxConfiguration client library. Explore the methods on this client object to understand the different features of the Azure FluxConfiguration service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PrivateLinkScopesClient` is the primary interface for developers using the Azure PrivateLinkScopes client library. Explore the methods on this client object to understand the different features of the Azure PrivateLinkScopes service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SourceControlConfigurationClient` is the primary interface for developers using the Azure SourceControlConfiguration client library. Explore the methods on this client object to understand the different features of the Azure SourceControlConfiguration service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/README.md
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/README.md
@@ -76,6 +76,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `KubernetesRuntimeClient` is the primary interface for developers using the Azure KubernetesRuntime client library. Explore the methods on this client object to understand the different features of the Azure KubernetesRuntime service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/kusto/arm-kusto/README.md
+++ b/sdk/kusto/arm-kusto/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `KustoManagementClient` is the primary interface for developers using the Azure KustoManagement client library. Explore the methods on this client object to understand the different features of the Azure KustoManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/labservices/arm-labservices/README.md
+++ b/sdk/labservices/arm-labservices/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `LabServicesClient` is the primary interface for developers using the Azure LabServices client library. Explore the methods on this client object to understand the different features of the Azure LabServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/README.md
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HyperExecuteClient` is the primary interface for developers using the Azure HyperExecute client library. Explore the methods on this client object to understand the different features of the Azure HyperExecute service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/largeinstance/arm-largeinstance/README.md
+++ b/sdk/largeinstance/arm-largeinstance/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `LargeInstanceManagementClient` is the primary interface for developers using the Azure LargeInstanceManagement client library. Explore the methods on this client object to understand the different features of the Azure LargeInstanceManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/README.md
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ObservabilityEvalClient` is the primary interface for developers using the Azure ObservabilityEval client library. Explore the methods on this client object to understand the different features of the Azure ObservabilityEval service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/liftrqumulo/arm-qumulo/README.md
+++ b/sdk/liftrqumulo/arm-qumulo/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `QumuloStorage` is the primary interface for developers using the Azure QumuloStorage client library. Explore the methods on this client object to understand the different features of the Azure QumuloStorage service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/README.md
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WeightsAndBiasesClient` is the primary interface for developers using the Azure WeightsAndBiases client library. Explore the methods on this client object to understand the different features of the Azure WeightsAndBiases service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/links/arm-links/README.md
+++ b/sdk/links/arm-links/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ManagementLinkClient` is the primary interface for developers using the Azure ManagementLink client library. Explore the methods on this client object to understand the different features of the Azure ManagementLink service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/loadtesting/arm-loadtesting/README.md
+++ b/sdk/loadtesting/arm-loadtesting/README.md
@@ -207,6 +207,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `LoadTestClient` is the primary interface for developers using the Azure LoadTest client library. Explore the methods on this client object to understand the different features of the Azure LoadTest service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/loadtesting/load-testing-rest/README.md
+++ b/sdk/loadtesting/load-testing-rest/README.md
@@ -237,6 +237,10 @@ for (const timeSeries of metricsResult.body.value) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/README.md
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ManagementLockClient` is the primary interface for developers using the Azure ManagementLock client library. Explore the methods on this client object to understand the different features of the Azure ManagementLock service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/locks/arm-locks/README.md
+++ b/sdk/locks/arm-locks/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ManagementLockClient` is the primary interface for developers using the Azure ManagementLock client library. Explore the methods on this client object to understand the different features of the Azure ManagementLock service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/logic/arm-logic/README.md
+++ b/sdk/logic/arm-logic/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `LogicManagementClient` is the primary interface for developers using the Azure LogicManagement client library. Explore the methods on this client object to understand the different features of the Azure LogicManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/machinelearning/arm-commitmentplans/README.md
+++ b/sdk/machinelearning/arm-commitmentplans/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureMLCommitmentPlansManagementClient` is the primary interface for developers using the Azure ML Commitment Plans Management client library. Explore the methods on this client object to understand the different features of the Azure ML Commitment Plans Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/machinelearning/arm-machinelearning/README.md
+++ b/sdk/machinelearning/arm-machinelearning/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureMachineLearningServicesManagementClient` is the primary interface for developers using the AzureMachineLearningServicesManagement client library. Explore the methods on this client object to understand the different features of the AzureMachineLearningServicesManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/machinelearning/arm-webservices/README.md
+++ b/sdk/machinelearning/arm-webservices/README.md
@@ -90,6 +90,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureMLWebServicesManagementClient` is the primary interface for developers using the Azure ML Web Services Management client library. Explore the methods on this client object to understand the different features of the Azure ML Web Services Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/machinelearning/arm-workspaces/README.md
+++ b/sdk/machinelearning/arm-workspaces/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MachineLearningWorkspacesManagementClient` is the primary interface for developers using the Azure Machine Learning Workspaces Management client library. Explore the methods on this client object to understand the different features of the Azure Machine Learning Workspaces Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MachineLearningComputeManagementClient` is the primary interface for developers using the Azure Machine Learning Compute Management client library. Explore the methods on this client object to understand the different features of the Azure Machine Learning Compute Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MLTeamAccountManagementClient` is the primary interface for developers using the Azure ML Team Account Management client library. Explore the methods on this client object to understand the different features of the Azure ML Team Account Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maintenance/arm-maintenance/README.md
+++ b/sdk/maintenance/arm-maintenance/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MaintenanceManagementClient` is the primary interface for developers using the Azure MaintenanceManagement client library. Explore the methods on this client object to understand the different features of the Azure MaintenanceManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/managedapplications/arm-managedapplications/README.md
+++ b/sdk/managedapplications/arm-managedapplications/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ApplicationClient` is the primary interface for developers using the Azure Application client library. Explore the methods on this client object to understand the different features of the Azure Application service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/README.md
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureNetworkFabricManagementServiceAPI` is the primary interface for developers using the AzureNetworkFabricManagementServiceAPI client library. Explore the methods on this client object to understand the different features of the AzureNetworkFabricManagementServiceAPI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/managedops/arm-managedops/README.md
+++ b/sdk/managedops/arm-managedops/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ManagedOpsClient` is the primary interface for developers using the Azure ManagedOps client library. Explore the methods on this client object to understand the different features of the Azure ManagedOps service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/managementgroups/arm-managementgroups/README.md
+++ b/sdk/managementgroups/arm-managementgroups/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ManagementGroupsAPI` is the primary interface for developers using the Azure ManagementGroupsAPI client library. Explore the methods on this client object to understand the different features of the Azure ManagementGroupsAPI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/managementpartner/arm-managementpartner/README.md
+++ b/sdk/managementpartner/arm-managementpartner/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ACEProvisioningManagementPartnerAPI` is the primary interface for developers using the Azure AceProvisioningManagementPartnerApi client library. Explore the methods on this client object to understand the different features of the Azure AceProvisioningManagementPartnerApi service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maps/arm-maps/README.md
+++ b/sdk/maps/arm-maps/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureMapsManagementClient` is the primary interface for developers using the AzureMapsManagement client library. Explore the methods on this client object to understand the different features of the AzureMapsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maps/maps-common/README.md
+++ b/sdk/maps/maps-common/README.md
@@ -27,6 +27,10 @@ For examples, please see our [Maps client libraries](#maps-client-libraries).
 
 For information on next steps, please see our [Maps client libraries](#maps-client-libraries).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 If you run into issues while using this library, directly or indirectly, please feel free to [file an issue](https://github.com/Azure/azure-sdk-for-js/issues/new).

--- a/sdk/maps/maps-geolocation-rest/README.md
+++ b/sdk/maps/maps-geolocation-rest/README.md
@@ -165,6 +165,10 @@ if (!result.body.countryRegion) {
 console.log(`The country code for the IP address is ${result.body.countryRegion.isoCode}`);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maps/maps-render-rest/README.md
+++ b/sdk/maps/maps-render-rest/README.md
@@ -246,6 +246,10 @@ console.log(
 );
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maps/maps-route-rest/README.md
+++ b/sdk/maps/maps-route-rest/README.md
@@ -281,6 +281,10 @@ routeDirectionsResult.body.optimizedWaypoints.forEach(
 );
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maps/maps-search-rest/README.md
+++ b/sdk/maps/maps-search-rest/README.md
@@ -283,6 +283,10 @@ main().catch((err) => {
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/maps/maps-timezone-rest/README.md
+++ b/sdk/maps/maps-timezone-rest/README.md
@@ -269,6 +269,10 @@ if (isUnexpected(response)) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/mariadb/arm-mariadb/README.md
+++ b/sdk/mariadb/arm-mariadb/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MariaDBManagementClient` is the primary interface for developers using the Azure MariaDBManagement client library. Explore the methods on this client object to understand the different features of the Azure MariaDBManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/marketplace/arm-marketplace/README.md
+++ b/sdk/marketplace/arm-marketplace/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MarketplaceClient` is the primary interface for developers using the Azure Marketplace client library. Explore the methods on this client object to understand the different features of the Azure Marketplace service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/marketplaceordering/arm-marketplaceordering/README.md
+++ b/sdk/marketplaceordering/arm-marketplaceordering/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MarketplaceOrderingAgreements` is the primary interface for developers using the Azure MarketplaceOrderingAgreements client library. Explore the methods on this client object to understand the different features of the Azure MarketplaceOrderingAgreements service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/migrate/arm-migrate/README.md
+++ b/sdk/migrate/arm-migrate/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureMigrateV2` is the primary interface for developers using the AzureMigrateV2 client library. Explore the methods on this client object to understand the different features of the AzureMigrateV2 service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/migrate/arm-migrationassessment/README.md
+++ b/sdk/migrate/arm-migrationassessment/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureMigrateAssessmentService` is the primary interface for developers using the Azure Migrate Assessment client library. Explore the methods on this client object to understand the different features of the Azure Migrate Assessment service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/README.md
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WorkloadsClient` is the primary interface for developers using the Azure Workloads client library. Explore the methods on this client object to understand the different features of the Azure Workloads service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/mongocluster/arm-mongocluster/README.md
+++ b/sdk/mongocluster/arm-mongocluster/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MongoClusterManagementClient` is the primary interface for developers using the Azure MongoClusterManagement client library. Explore the methods on this client object to understand the different features of the Azure MongoClusterManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/mongodbatlas/arm-mongodbatlas/README.md
+++ b/sdk/mongodbatlas/arm-mongodbatlas/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AtlasClient` is the primary interface for developers using the Azure Atlas client library. Explore the methods on this client object to understand the different features of the Azure Atlas service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/README.md
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MonitorClient` is the primary interface for developers using the Azure Monitor client library. Explore the methods on this client object to understand the different features of the Azure Monitor service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/monitor/arm-monitor/README.md
+++ b/sdk/monitor/arm-monitor/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MonitorClient` is the primary interface for developers using the Azure Monitor client library. Explore the methods on this client object to understand the different features of the Azure Monitor service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/monitor/arm-monitorslis/README.md
+++ b/sdk/monitor/arm-monitorslis/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MonitorClient` is the primary interface for developers using the Azure Monitor client library. Explore the methods on this client object to understand the different features of the Azure Monitor service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/monitor/arm-monitorworkspaces/README.md
+++ b/sdk/monitor/arm-monitorworkspaces/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MonitorClient` is the primary interface for developers using the Azure Monitor client library. Explore the methods on this client object to understand the different features of the Azure Monitor service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/monitor/monitor-ingestion/README.md
+++ b/sdk/monitor/monitor-ingestion/README.md
@@ -220,6 +220,10 @@ try {
 
 Logs uploaded using the Monitor Ingestion client library can be retrieved using the [Monitor Query client library][monitor_query].
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 For details on diagnosing various failure scenarios, see our [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-ingestion/TROUBLESHOOTING.md).

--- a/sdk/monitor/monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/README.md
@@ -138,6 +138,10 @@ For more information on the OpenTelemetry project, please review the [**OpenTele
 
 By default, custom dimension values are truncated to 64KB. This protects against unexpectedly large payloads.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Enable debug logging

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -570,6 +570,10 @@ try {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Self-diagnostics

--- a/sdk/monitor/monitor-query-logs/README.md
+++ b/sdk/monitor/monitor-query-logs/README.md
@@ -593,6 +593,10 @@ Because the structure of the `visualization` payload varies by query, a `Record<
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 To diagnose various failure scenarios, see the [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query-logs/TROUBLESHOOTING.md).

--- a/sdk/monitor/monitor-query-metrics/README.md
+++ b/sdk/monitor/monitor-query-metrics/README.md
@@ -205,6 +205,10 @@ for (const resource of result) {
 
 For an inventory of metrics and dimensions available for each Azure resource type, see [Supported metrics with Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-supported).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 To diagnose various failure scenarios, see the [troubleshooting guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-query-metrics/TROUBLESHOOTING.md).

--- a/sdk/msi/arm-msi/README.md
+++ b/sdk/msi/arm-msi/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ManagedServiceIdentityClient` is the primary interface for developers using the Azure ManagedServiceIdentity client library. Explore the methods on this client object to understand the different features of the Azure ManagedServiceIdentity service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/mysql/arm-mysql-flexible/README.md
+++ b/sdk/mysql/arm-mysql-flexible/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MySQLManagementFlexibleServerClient` is the primary interface for developers using the Azure MySQLManagementFlexibleServer client library. Explore the methods on this client object to understand the different features of the Azure MySQLManagementFlexibleServer service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/mysql/arm-mysql/README.md
+++ b/sdk/mysql/arm-mysql/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MySQLManagementClient` is the primary interface for developers using the Azure MySQLManagement client library. Explore the methods on this client object to understand the different features of the Azure MySQLManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/netapp/arm-netapp/README.md
+++ b/sdk/netapp/arm-netapp/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NetAppManagementClient` is the primary interface for developers using the Azure NetAppManagement client library. Explore the methods on this client object to understand the different features of the Azure NetAppManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/README.md
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NetworkManagementClient` is the primary interface for developers using the Azure NetworkManagement client library. Explore the methods on this client object to understand the different features of the Azure NetworkManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/network/arm-network-rest/README.md
+++ b/sdk/network/arm-network-rest/README.md
@@ -92,6 +92,10 @@ for await (const page of pageData.byPage()) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/network/arm-network/README.md
+++ b/sdk/network/arm-network/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NetworkManagementClient` is the primary interface for developers using the Azure NetworkManagement client library. Explore the methods on this client object to understand the different features of the Azure NetworkManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/networkcloud/arm-networkcloud/README.md
+++ b/sdk/networkcloud/arm-networkcloud/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NetworkCloud` is the primary interface for developers using the Azure NetworkCloud client library. Explore the methods on this client object to understand the different features of the Azure NetworkCloud service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/networkfunction/arm-networkfunction/README.md
+++ b/sdk/networkfunction/arm-networkfunction/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureTrafficCollectorClient` is the primary interface for developers using the AzureTrafficCollector client library. Explore the methods on this client object to understand the different features of the AzureTrafficCollector service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/newrelicobservability/arm-newrelicobservability/README.md
+++ b/sdk/newrelicobservability/arm-newrelicobservability/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NewRelicObservability` is the primary interface for developers using the Azure NewRelicObservability client library. Explore the methods on this client object to understand the different features of the Azure NewRelicObservability service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/nginx/arm-nginx/README.md
+++ b/sdk/nginx/arm-nginx/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NginxManagementClient` is the primary interface for developers using the Azure NginxManagement client library. Explore the methods on this client object to understand the different features of the Azure NginxManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/notificationhubs/arm-notificationhubs/README.md
+++ b/sdk/notificationhubs/arm-notificationhubs/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `NotificationHubsManagementClient` is the primary interface for developers using the Azure NotificationHubsManagement client library. Explore the methods on this client object to understand the different features of the Azure NotificationHubsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/notificationhubs/notification-hubs/README.md
+++ b/sdk/notificationhubs/notification-hubs/README.md
@@ -629,6 +629,10 @@ console.log(`Correlation ID: ${result.correlationId}`);
 console.log(`Notification ID: ${result.notificationId}`);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ## React Native Support

--- a/sdk/oep/arm-oep/README.md
+++ b/sdk/oep/arm-oep/README.md
@@ -85,6 +85,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `OpenEnergyPlatformManagementServiceAPIs` is the primary interface for developers using the Azure Open Energy Platform Management client library. Explore the methods on this client object to understand the different features of the Azure Open Energy Platform Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/README.md
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `OnlineExperimentationClient` is the primary interface for developers using the Azure OnlineExperimentation client library. Explore the methods on this client object to understand the different features of the Azure OnlineExperimentation service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/onlineexperimentation/onlineexperimentation-rest/README.md
+++ b/sdk/onlineexperimentation/onlineexperimentation-rest/README.md
@@ -83,6 +83,10 @@ for await (const metric of paginate(client, listResponse)) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/openai/openai/README.md
+++ b/sdk/openai/openai/README.md
@@ -221,6 +221,10 @@ for await (const event of events) {
 
 ## Next steps
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Refer to the official [OpenAI client library for JavaScript][openai_pkg_readme].

--- a/sdk/operationalinsights/arm-operationalinsights/README.md
+++ b/sdk/operationalinsights/arm-operationalinsights/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `OperationalInsightsManagementClient` is the primary interface for developers using the Azure OperationalInsightsManagement client library. Explore the methods on this client object to understand the different features of the Azure OperationalInsightsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/operationsmanagement/arm-operations/README.md
+++ b/sdk/operationsmanagement/arm-operations/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `OperationsManagementClient` is the primary interface for developers using the Azure OperationsManagement client library. Explore the methods on this client object to understand the different features of the Azure OperationsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/oracledatabase/arm-oracledatabase/README.md
+++ b/sdk/oracledatabase/arm-oracledatabase/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `OracleDatabaseManagementClient` is the primary interface for developers using the Azure OracleDatabaseManagement client library. Explore the methods on this client object to understand the different features of the Azure OracleDatabaseManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/orbital/arm-orbital/README.md
+++ b/sdk/orbital/arm-orbital/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureOrbital` is the primary interface for developers using the AzureOrbital client library. Explore the methods on this client object to understand the different features of the AzureOrbital service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/README.md
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PaloAltoNetworksCloudngfw` is the primary interface for developers using the Azure PaloAltoNetworksCloudngfw client library. Explore the methods on this client object to understand the different features of the Azure PaloAltoNetworksCloudngfw service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/peering/arm-peering/README.md
+++ b/sdk/peering/arm-peering/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PeeringManagementClient` is the primary interface for developers using the Azure PeeringManagement client library. Explore the methods on this client object to understand the different features of the Azure PeeringManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/pineconevectordb/arm-pineconevectordb/README.md
+++ b/sdk/pineconevectordb/arm-pineconevectordb/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `VectorDbClient` is the primary interface for developers using the Azure VectorDb client library. Explore the methods on this client object to understand the different features of the Azure VectorDb service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/planetarycomputer/arm-planetarycomputer/README.md
+++ b/sdk/planetarycomputer/arm-planetarycomputer/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SpatioClient` is the primary interface for developers using the Azure Spatio client library. Explore the methods on this client object to understand the different features of the Azure Spatio service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/playwright/arm-playwright/README.md
+++ b/sdk/playwright/arm-playwright/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PlaywrightManagementClient` is the primary interface for developers using the Azure PlaywrightManagement client library. Explore the methods on this client object to understand the different features of the Azure PlaywrightManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/README.md
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PolicyClient` is the primary interface for developers using the Azure Policy client library. Explore the methods on this client object to understand the different features of the Azure Policy service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/policy/arm-policy/README.md
+++ b/sdk/policy/arm-policy/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PolicyClient` is the primary interface for developers using the Azure Policy client library. Explore the methods on this client object to understand the different features of the Azure Policy service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/policyinsights/arm-policyinsights/README.md
+++ b/sdk/policyinsights/arm-policyinsights/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PolicyInsightsClient` is the primary interface for developers using the Azure PolicyInsights client library. Explore the methods on this client object to understand the different features of the Azure PolicyInsights service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/portal/arm-portal/README.md
+++ b/sdk/portal/arm-portal/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `Portal` is the primary interface for developers using the Azure Portal client library. Explore the methods on this client object to understand the different features of the Azure Portal service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/portalservices/arm-portalservicescopilot/README.md
+++ b/sdk/portalservices/arm-portalservicescopilot/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PortalServicesClient` is the primary interface for developers using the Azure PortalServices client library. Explore the methods on this client object to understand the different features of the Azure PortalServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/postgresql/arm-postgresql-flexible/README.md
+++ b/sdk/postgresql/arm-postgresql-flexible/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PostgreSQLManagementFlexibleServerClient` is the primary interface for developers using the Azure PostgreSQLManagement client library. Explore the methods on this client object to understand the different features of the Azure PostgreSQLManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/postgresql/arm-postgresql/README.md
+++ b/sdk/postgresql/arm-postgresql/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PostgreSQLManagementClient` is the primary interface for developers using the Azure PostgreSQLManagement client library. Explore the methods on this client object to understand the different features of the Azure PostgreSQLManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/postgresql/postgresql-auth/README.md
+++ b/sdk/postgresql/postgresql-auth/README.md
@@ -87,6 +87,10 @@ configureEntraAuthentication(sequelize, credential);
 await sequelize.authenticate();
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/postgresqlhsc/arm-postgresqlhsc/README.md
+++ b/sdk/postgresqlhsc/arm-postgresqlhsc/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DBforPostgreSQLClient` is the primary interface for developers using the Azure DBforPostgreSQL client library. Explore the methods on this client object to understand the different features of the Azure DBforPostgreSQL service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/powerbidedicated/arm-powerbidedicated/README.md
+++ b/sdk/powerbidedicated/arm-powerbidedicated/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PowerBIDedicated` is the primary interface for developers using the Azure PowerBIDedicated client library. Explore the methods on this client object to understand the different features of the Azure PowerBIDedicated service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/powerbiembedded/arm-powerbiembedded/README.md
+++ b/sdk/powerbiembedded/arm-powerbiembedded/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PowerBIEmbeddedManagementClient` is the primary interface for developers using the Azure Power BI Embedded Management client library. Explore the methods on this client object to understand the different features of the Azure Power BI Embedded Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/previewalertrule/arm-previewalertrule/README.md
+++ b/sdk/previewalertrule/arm-previewalertrule/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PreviewAlertRuleManagementClient` is the primary interface for developers using the Azure PreviewAlertRuleManagement client library. Explore the methods on this client object to understand the different features of the Azure PreviewAlertRuleManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/privatedns/arm-privatedns/README.md
+++ b/sdk/privatedns/arm-privatedns/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PrivateDnsManagementClient` is the primary interface for developers using the Azure PrivateDnsManagement client library. Explore the methods on this client object to understand the different features of the Azure PrivateDnsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/README.md
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ProgrammableConnectivityClient` is the primary interface for developers using the Azure ProgrammableConnectivity client library. Explore the methods on this client object to understand the different features of the Azure ProgrammableConnectivity service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/prometheusrulegroups/arm-prometheusrulegroups/README.md
+++ b/sdk/prometheusrulegroups/arm-prometheusrulegroups/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PrometheusRuleGroupsManagementClient` is the primary interface for developers using the Azure PrometheusRuleGroupsManagement client library. Explore the methods on this client object to understand the different features of the Azure PrometheusRuleGroupsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/providerhub/arm-providerhub/README.md
+++ b/sdk/providerhub/arm-providerhub/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ProviderHubClient` is the primary interface for developers using the Azure ProviderHub client library. Explore the methods on this client object to understand the different features of the Azure ProviderHub service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purestorageblock/arm-purestorageblock/README.md
+++ b/sdk/purestorageblock/arm-purestorageblock/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BlockClient` is the primary interface for developers using the Azure Block client library. Explore the methods on this client object to understand the different features of the Azure Block service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purview/arm-purview/README.md
+++ b/sdk/purview/arm-purview/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `PurviewManagementClient` is the primary interface for developers using the Azure PurviewManagement client library. Explore the methods on this client object to understand the different features of the Azure PurviewManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purview/purview-administration-rest/README.md
+++ b/sdk/purview/purview-administration-rest/README.md
@@ -135,6 +135,10 @@ for await (const policy of policies) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purview/purview-datamap-rest/README.md
+++ b/sdk/purview/purview-datamap-rest/README.md
@@ -108,6 +108,10 @@ for (const entityDef of result.body?.termTemplateDefs) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purview/purview-scanning-rest/README.md
+++ b/sdk/purview/purview-scanning-rest/README.md
@@ -99,6 +99,10 @@ for await (const dataSource of pagedDataSources) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purview/purview-sharing-rest/README.md
+++ b/sdk/purview/purview-sharing-rest/README.md
@@ -115,6 +115,10 @@ for await (const sharedInvitationOutput of pageData) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/purview/purview-workflow-rest/README.md
+++ b/sdk/purview/purview-workflow-rest/README.md
@@ -111,6 +111,10 @@ if (isUnexpected(result)) {
 console.log(`Task approved with Task ID: ${taskId}`);
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/quantum/arm-quantum/README.md
+++ b/sdk/quantum/arm-quantum/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureQuantumManagementClient` is the primary interface for developers using the Azure Quantum Management client library. Explore the methods on this client object to understand the different features of the Azure Quantum Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/quota/arm-quota/README.md
+++ b/sdk/quota/arm-quota/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureQuotaExtensionAPI` is the primary interface for developers using the AzureQuotaExtensionAPI client library. Explore the methods on this client object to understand the different features of the AzureQuotaExtensionAPI service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/recoveryservices/arm-recoveryservices/README.md
+++ b/sdk/recoveryservices/arm-recoveryservices/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `RecoveryServicesClient` is the primary interface for developers using the Azure RecoveryServices client library. Explore the methods on this client object to understand the different features of the Azure RecoveryServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `RecoveryServicesBackupClient` is the primary interface for developers using the Azure Recovery Services Backup client library. Explore the methods on this client object to understand the different features of the Azure Recovery Services Backup service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/README.md
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DataReplicationClient` is the primary interface for developers using the Azure DataReplication client library. Explore the methods on this client object to understand the different features of the Azure DataReplication service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SiteRecoveryManagementClient` is the primary interface for developers using the Azure SiteRecoveryManagement client library. Explore the methods on this client object to understand the different features of the Azure SiteRecoveryManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/redhatopenshift/arm-redhatopenshift/README.md
+++ b/sdk/redhatopenshift/arm-redhatopenshift/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureRedHatOpenShiftClient` is the primary interface for developers using the AzureRedHatOpenShift client library. Explore the methods on this client object to understand the different features of the AzureRedHatOpenShift service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/redis/arm-rediscache/README.md
+++ b/sdk/redis/arm-rediscache/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `RedisManagementClient` is the primary interface for developers using the Azure RedisManagement client library. Explore the methods on this client object to understand the different features of the Azure RedisManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/redisenterprise/arm-redisenterprisecache/README.md
+++ b/sdk/redisenterprise/arm-redisenterprisecache/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `RedisEnterpriseManagementClient` is the primary interface for developers using the Azure RedisEnterpriseManagement client library. Explore the methods on this client object to understand the different features of the Azure RedisEnterpriseManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/relationships/arm-relationships/README.md
+++ b/sdk/relationships/arm-relationships/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `RelationshipsClient` is the primary interface for developers using the Azure Relationships client library. Explore the methods on this client object to understand the different features of the Azure Relationships service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/relay/arm-relay/README.md
+++ b/sdk/relay/arm-relay/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `RelayAPI` is the primary interface for developers using the Azure RelayApi client library. Explore the methods on this client object to understand the different features of the Azure RelayApi service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/reservations/arm-reservations/README.md
+++ b/sdk/reservations/arm-reservations/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureReservationAPI` is the primary interface for developers using the AzureReservationApi client library. Explore the methods on this client object to understand the different features of the AzureReservationApi service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resourceconnector/arm-resourceconnector/README.md
+++ b/sdk/resourceconnector/arm-resourceconnector/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ResourceConnectorManagementClient` is the primary interface for developers using the Azure ResourceConnectorManagement client library. Explore the methods on this client object to understand the different features of the Azure ResourceConnectorManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resourcegraph/arm-resourcegraph/README.md
+++ b/sdk/resourcegraph/arm-resourcegraph/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ResourceGraphClient` is the primary interface for developers using the Azure ResourceGraph client library. Explore the methods on this client object to understand the different features of the Azure ResourceGraph service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resourcehealth/arm-resourcehealth/README.md
+++ b/sdk/resourcehealth/arm-resourcehealth/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftResourceHealth` is the primary interface for developers using the Azure MicrosoftResourceHealth client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftResourceHealth service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resourcemover/arm-resourcemover/README.md
+++ b/sdk/resourcemover/arm-resourcemover/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ResourceMoverServiceAPI` is the primary interface for developers using the Azure Resource Mover client library. Explore the methods on this client object to understand the different features of the Azure Resource Mover service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/README.md
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SubscriptionClient` is the primary interface for developers using the Azure Subscription client library. Explore the methods on this client object to understand the different features of the Azure Subscription service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/README.md
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ResourceManagementClient` is the primary interface for developers using the Azure ResourceManagement client library. Explore the methods on this client object to understand the different features of the Azure ResourceManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resources/arm-resources/README.md
+++ b/sdk/resources/arm-resources/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ResourceManagementClient` is the primary interface for developers using the Azure ResourceManagement client library. Explore the methods on this client object to understand the different features of the Azure ResourceManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resources/arm-resourcesbicep/README.md
+++ b/sdk/resources/arm-resourcesbicep/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `BicepClient` is the primary interface for developers using the Azure Bicep client library. Explore the methods on this client object to understand the different features of the Azure Bicep service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resources/arm-resourcesdeployments/README.md
+++ b/sdk/resources/arm-resourcesdeployments/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DeploymentsClient` is the primary interface for developers using the Azure Deployments client library. Explore the methods on this client object to understand the different features of the Azure Deployments service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/README.md
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `DeploymentStacksClient` is the primary interface for developers using the Azure DeploymentStacks client library. Explore the methods on this client object to understand the different features of the Azure DeploymentStacks service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/schemaregistry/schema-registry-avro/README.md
+++ b/sdk/schemaregistry/schema-registry-avro/README.md
@@ -120,6 +120,10 @@ console.log("Deserialized object:");
 console.log(JSON.stringify(deserializedObject));
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 The Avro serializer communicates with the [Schema Registry][schema_registry] service as needed to register or query schemas and those service calls could throw a [RestError][resterror]. Furthermore, errors of type `Error` will be thrown when serialization or deserialization fails. The `cause` property will contain the underlying error that was thrown from the Avro implementation library.

--- a/sdk/schemaregistry/schema-registry-json/README.md
+++ b/sdk/schemaregistry/schema-registry-json/README.md
@@ -106,6 +106,10 @@ validation callback function as one of the options to the deserialize method whe
 To see how the validation might be implemented, please checkout the [`schemaRegistryJsonWithValidation`](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/schemaregistry/schema-registry-json/samples-dev/schemaRegistryJsonWithValidation.ts)
 sample.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 The Json serializer communicates with the [Schema Registry][schema_registry] service as needed to register or query schemas and those service calls could throw a [RestError][resterror]. Furthermore, errors of type `Error` will be thrown when serialization or deserialization fails. The `cause` property will contain the underlying error that was thrown from the JSON parser.

--- a/sdk/schemaregistry/schema-registry/README.md
+++ b/sdk/schemaregistry/schema-registry/README.md
@@ -133,6 +133,10 @@ if (foundSchema) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/scvmm/arm-scvmm/README.md
+++ b/sdk/scvmm/arm-scvmm/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ScVmm` is the primary interface for developers using the Azure ScVmm client library. Explore the methods on this client object to understand the different features of the Azure ScVmm service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/search/arm-search/README.md
+++ b/sdk/search/arm-search/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SearchManagementClient` is the primary interface for developers using the Azure SearchManagement client library. Explore the methods on this client object to understand the different features of the Azure SearchManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -466,6 +466,10 @@ console.log(searchResults.facets);
 
 When retrieving results, a `facets` property will be available that will indicate the number of results that fall into each facet bucket. This can be used to drive refinement (e.g. issuing a follow-up search that filters on the `Rating` being greater than or equal to 3 and less than 4.)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/security/arm-security/README.md
+++ b/sdk/security/arm-security/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SecurityCenter` is the primary interface for developers using the Azure SecurityCenter client library. Explore the methods on this client object to understand the different features of the Azure SecurityCenter service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/securitydevops/arm-securitydevops/README.md
+++ b/sdk/securitydevops/arm-securitydevops/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftSecurityDevOps` is the primary interface for developers using the Azure MicrosoftSecurityDevOps client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftSecurityDevOps service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/securityinsight/arm-securityinsight/README.md
+++ b/sdk/securityinsight/arm-securityinsight/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SecurityInsights` is the primary interface for developers using the Azure SecurityInsights client library. Explore the methods on this client object to understand the different features of the Azure SecurityInsights service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/selfhelp/arm-selfhelp/README.md
+++ b/sdk/selfhelp/arm-selfhelp/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `HelpRP` is the primary interface for developers using the Azure HelpRP client library. Explore the methods on this client object to understand the different features of the Azure HelpRP service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/serialconsole/arm-serialconsole/README.md
+++ b/sdk/serialconsole/arm-serialconsole/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftSerialConsoleClient` is the primary interface for developers using the Azure MicrosoftSerialConsole client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftSerialConsole service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/service-map/arm-servicemap/README.md
+++ b/sdk/service-map/arm-servicemap/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceMap` is the primary interface for developers using the Azure ServiceMap client library. Explore the methods on this client object to understand the different features of the Azure ServiceMap service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicebus/arm-servicebus/README.md
+++ b/sdk/servicebus/arm-servicebus/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceBusManagementClient` is the primary interface for developers using the Azure ServiceBusManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceBusManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -513,6 +513,10 @@ await serviceBusAdministrationClient.deleteQueue(queueName);
 
 - Sample for reference - [administrationClient.ts](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/servicebus/service-bus/samples/v7/typescript/src/advanced/administrationClient.ts)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Here's some initial steps to start diagnosing issues. For more information please refer to the [Service Bus Troubleshooting Guide](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/servicebus/service-bus/TROUBLESHOOTING.md).

--- a/sdk/servicefabric/arm-servicefabric-rest/README.md
+++ b/sdk/servicefabric/arm-servicefabric-rest/README.md
@@ -80,6 +80,10 @@ for await (const cluster of clusters) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicefabric/arm-servicefabric/README.md
+++ b/sdk/servicefabric/arm-servicefabric/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceFabricManagementClient` is the primary interface for developers using the Azure ServiceFabricManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceFabricManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/README.md
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceFabricManagedClustersManagementClient` is the primary interface for developers using the Azure ServiceFabricManagedClustersManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceFabricManagedClustersManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceFabricMeshManagementClient` is the primary interface for developers using the Azure ServiceFabricMeshManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceFabricMeshManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicegroups/arm-servicegroups/README.md
+++ b/sdk/servicegroups/arm-servicegroups/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceGroupsManagementClient` is the primary interface for developers using the Azure ServiceGroupsManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceGroupsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicelinker/arm-servicelinker/README.md
+++ b/sdk/servicelinker/arm-servicelinker/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceLinkerManagementClient` is the primary interface for developers using the Azure ServiceLinkerManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceLinkerManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/servicenetworking/arm-servicenetworking/README.md
+++ b/sdk/servicenetworking/arm-servicenetworking/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `ServiceNetworkingManagementClient` is the primary interface for developers using the Azure ServiceNetworkingManagement client library. Explore the methods on this client object to understand the different features of the Azure ServiceNetworkingManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/signalr/arm-signalr/README.md
+++ b/sdk/signalr/arm-signalr/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SignalRManagementClient` is the primary interface for developers using the Azure SignalRManagement client library. Explore the methods on this client object to understand the different features of the Azure SignalRManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/sitemanager/arm-sitemanager/README.md
+++ b/sdk/sitemanager/arm-sitemanager/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `EdgeClient` is the primary interface for developers using the Azure Edge client library. Explore the methods on this client object to understand the different features of the Azure Edge service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/sphere/arm-sphere/README.md
+++ b/sdk/sphere/arm-sphere/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureSphereManagementClient` is the primary interface for developers using the AzureSphereManagement client library. Explore the methods on this client object to understand the different features of the AzureSphereManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/springappdiscovery/arm-springappdiscovery/README.md
+++ b/sdk/springappdiscovery/arm-springappdiscovery/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SpringAppDiscoveryManagementClient` is the primary interface for developers using the Azure SpringAppDiscoveryManagement client library. Explore the methods on this client object to understand the different features of the Azure SpringAppDiscoveryManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/sql/arm-sql/README.md
+++ b/sdk/sql/arm-sql/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SqlManagementClient` is the primary interface for developers using the Azure SqlManagement client library. Explore the methods on this client object to understand the different features of the Azure SqlManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SqlVirtualMachineManagementClient` is the primary interface for developers using the Azure SqlVirtualMachineManagement client library. Explore the methods on this client object to understand the different features of the Azure SqlVirtualMachineManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/standbypool/arm-standbypool/README.md
+++ b/sdk/standbypool/arm-standbypool/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StandbyPoolManagementClient` is the primary interface for developers using the Azure StandbyPoolManagement client library. Explore the methods on this client object to understand the different features of the Azure StandbyPoolManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/README.md
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageManagementClient` is the primary interface for developers using the Azure StorageManagement client library. Explore the methods on this client object to understand the different features of the Azure StorageManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storage/arm-storage/README.md
+++ b/sdk/storage/arm-storage/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageManagementClient` is the primary interface for developers using the Azure StorageManagement client library. Explore the methods on this client object to understand the different features of the Azure StorageManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storage/storage-blob-changefeed/README.md
+++ b/sdk/storage/storage-blob-changefeed/README.md
@@ -195,6 +195,10 @@ for await (const page of changeFeedClient.listChanges({ start, end }).byPage()) 
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -449,6 +449,10 @@ if (blobBody) {
 
 A complete example of simple scenarios is at [samples/v12/typescript/src/sharedKeyAuth.ts](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-blob/samples/v12/typescript/src/sharedKeyAuth.ts).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/storage/storage-common/README.md
+++ b/sdk/storage/storage-common/README.md
@@ -14,6 +14,10 @@
 
 - For internal use only.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 - For internal use only.

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -484,6 +484,10 @@ if (downloadResponse.contentAsBlob) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -433,6 +433,10 @@ if (downloadFileResponse.blobBody) {
 
 A complete example of simple `ShareServiceClient` scenarios is at [samples/v12/typescript/src/shareSerivceClient.ts](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-file-share/samples/v12/typescript/src/shareServiceClient.ts).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/storage/storage-internal-avro/README.md
+++ b/sdk/storage/storage-internal-avro/README.md
@@ -10,6 +10,10 @@
 ## Examples
 - For internal use only.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 - For internal use only.
 

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -385,6 +385,10 @@ console.log(
 
 A complete example of simple `QueueServiceClient` scenarios is at [samples/v12/typescript/src/queueClient.ts](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/storage/storage-queue/samples/v12/typescript/src/queueClient.ts).
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/storageactions/arm-storageactions/README.md
+++ b/sdk/storageactions/arm-storageactions/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageActionsManagementClient` is the primary interface for developers using the Azure StorageActionsManagement client library. Explore the methods on this client object to understand the different features of the Azure StorageActionsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storagecache/arm-storagecache/README.md
+++ b/sdk/storagecache/arm-storagecache/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageCacheManagementClient` is the primary interface for developers using the Azure StorageCacheManagement client library. Explore the methods on this client object to understand the different features of the Azure StorageCacheManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storagediscovery/arm-storagediscovery/README.md
+++ b/sdk/storagediscovery/arm-storagediscovery/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageDiscoveryClient` is the primary interface for developers using the Azure StorageDiscovery client library. Explore the methods on this client object to understand the different features of the Azure StorageDiscovery service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storageimportexport/arm-storageimportexport/README.md
+++ b/sdk/storageimportexport/arm-storageimportexport/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageImportExport` is the primary interface for developers using the Azure StorageImportExport client library. Explore the methods on this client object to understand the different features of the Azure StorageImportExport service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storagemover/arm-storagemover/README.md
+++ b/sdk/storagemover/arm-storagemover/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorageMoverClient` is the primary interface for developers using the Azure StorageMover client library. Explore the methods on this client object to understand the different features of the Azure StorageMover service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storagesync/arm-storagesync/README.md
+++ b/sdk/storagesync/arm-storagesync/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftStorageSync` is the primary interface for developers using the Azure MicrosoftStorageSync client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftStorageSync service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storsimple1200series/arm-storsimple1200series/README.md
+++ b/sdk/storsimple1200series/arm-storsimple1200series/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorSimpleManagementClient` is the primary interface for developers using the Azure StorSimpleManagement client library. Explore the methods on this client object to understand the different features of the Azure StorSimpleManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/storsimple8000series/arm-storsimple8000series/README.md
+++ b/sdk/storsimple8000series/arm-storsimple8000series/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StorSimple8000SeriesManagementClient` is the primary interface for developers using the Azure StorSimple8000SeriesManagement client library. Explore the methods on this client object to understand the different features of the Azure StorSimple8000SeriesManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/streamanalytics/arm-streamanalytics/README.md
+++ b/sdk/streamanalytics/arm-streamanalytics/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `StreamAnalyticsManagementClient` is the primary interface for developers using the Azure Stream Analytics Management client library. Explore the methods on this client object to understand the different features of the Azure Stream Analytics Management service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/README.md
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SubscriptionClient` is the primary interface for developers using the Azure Subscription client library. Explore the methods on this client object to understand the different features of the Azure Subscription service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/subscription/arm-subscriptions/README.md
+++ b/sdk/subscription/arm-subscriptions/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SubscriptionClient` is the primary interface for developers using the Azure Subscription client library. Explore the methods on this client object to understand the different features of the Azure Subscription service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/support/arm-support/README.md
+++ b/sdk/support/arm-support/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftSupport` is the primary interface for developers using the Azure MicrosoftSupport client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftSupport service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/synapse/arm-synapse/README.md
+++ b/sdk/synapse/arm-synapse/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `SynapseManagementClient` is the primary interface for developers using the Azure SynapseManagement client library. Explore the methods on this client object to understand the different features of the Azure SynapseManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/synapse/synapse-access-control-rest/README.md
+++ b/sdk/synapse/synapse-access-control-rest/README.md
@@ -44,6 +44,10 @@ for await (const assignment of assignments) {
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/synapse/synapse-access-control/README.md
+++ b/sdk/synapse/synapse-access-control/README.md
@@ -40,6 +40,10 @@ for await (const roleDefinition of roleDefinitions) {
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/synapse/synapse-artifacts/README.md
+++ b/sdk/synapse/synapse-artifacts/README.md
@@ -40,6 +40,10 @@ for await (const pipeline of pipelinesByWorkspace) {
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/synapse/synapse-managed-private-endpoints/README.md
+++ b/sdk/synapse/synapse-managed-private-endpoints/README.md
@@ -40,6 +40,10 @@ for await (const privateEndpoint of privateEndpoints) {
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/synapse/synapse-monitoring/README.md
+++ b/sdk/synapse/synapse-monitoring/README.md
@@ -43,6 +43,10 @@ if (sparkJobList.sparkJobs) {
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/synapse/synapse-spark/README.md
+++ b/sdk/synapse/synapse-spark/README.md
@@ -45,6 +45,10 @@ if (output.sessions) {
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:

--- a/sdk/tables/data-tables/README.md
+++ b/sdk/tables/data-tables/README.md
@@ -396,6 +396,10 @@ const client = new TableClient(
 );
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### General

--- a/sdk/template/template-dpg/README.md
+++ b/sdk/template/template-dpg/README.md
@@ -75,6 +75,10 @@ Create a section for each top-level service concept you want to explain.
 
 Create several code examples for how someone would use your library to accomplish a common task with the service.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/template/template/README.md
+++ b/sdk/template/template/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WidgetAnalyticsClient` is the primary interface for developers using the Azure WidgetAnalytics client library. Explore the methods on this client object to understand the different features of the Azure WidgetAnalytics service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/templatespecs/arm-templatespecs/README.md
+++ b/sdk/templatespecs/arm-templatespecs/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `TemplateSpecsClient` is the primary interface for developers using the Azure TemplateSpecs client library. Explore the methods on this client object to understand the different features of the Azure TemplateSpecs service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/README.md
+++ b/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/README.md
@@ -81,6 +81,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `TenantActivityLogAlertsManagementClient` is the primary interface for developers using the Azure TenantActivityLogAlertsManagement client library. Explore the methods on this client object to understand the different features of the Azure TenantActivityLogAlertsManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/terraform/arm-terraform/README.md
+++ b/sdk/terraform/arm-terraform/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `AzureTerraformClient` is the primary interface for developers using the AzureTerraformResourceProvider client library. Explore the methods on this client object to understand the different features of the AzureTerraformResourceProvider service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/test-utils/perf/README.md
+++ b/sdk/test-utils/perf/README.md
@@ -112,6 +112,10 @@ If you would like to run all the tests at once in sequence, use the following co
 
 > `pnpm test:node`
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 TODO

--- a/sdk/test-utils/recorder/README.md
+++ b/sdk/test-utils/recorder/README.md
@@ -413,6 +413,10 @@ Since new resources are likely to get accumulated because some tests would crash
 
 `@azure-tools/test-recorder` does support running tests in the browser. If you use vitest, as long as your vitest configuration is correct, your tests should work both on NodeJS and in the browsers!
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### 🤖 The test recording agent

--- a/sdk/test-utils/test-credential/README.md
+++ b/sdk/test-utils/test-credential/README.md
@@ -38,6 +38,10 @@ In record/live modes
 
 Try out this package in your application and provide feedback!
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Log an issue at https://github.com/Azure/azure-sdk-for-js/issues

--- a/sdk/test-utils/test-utils-vitest/README.md
+++ b/sdk/test-utils/test-utils-vitest/README.md
@@ -104,6 +104,10 @@ matrix(
 
 `matrix` takes a jagged 2D array and a function. It then runs this function with every possible combination of elements of each of the arrays. The example above will therefore generate 6 different test suites based on the values passed.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 Besides the usual debugging of your code and tests, if you ever encounter a problem, please follow

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -498,6 +498,10 @@ for await (const page of resultPages) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/README.md
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `TimeSeriesInsightsClient` is the primary interface for developers using the Azure TimeSeriesInsights client library. Explore the methods on this client object to understand the different features of the Azure TimeSeriesInsights service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/trafficmanager/arm-trafficmanager/README.md
+++ b/sdk/trafficmanager/arm-trafficmanager/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `TrafficManagerManagementClient` is the primary interface for developers using the Azure TrafficManagerManagement client library. Explore the methods on this client object to understand the different features of the Azure TrafficManagerManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/transcription/ai-speech-transcription/README.md
+++ b/sdk/transcription/ai-speech-transcription/README.md
@@ -398,6 +398,10 @@ for (const phrase of result.phrases) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Common issues

--- a/sdk/translation/ai-translation-document-rest/README.md
+++ b/sdk/translation/ai-translation-document-rest/README.md
@@ -391,6 +391,10 @@ for (const fileFormatType of response.body.value) {
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 When you interact with the Translator Service using the DocumentTranslator client library, errors returned by the Translator service correspond to the same HTTP status codes returned for REST API requests.

--- a/sdk/translation/ai-translation-text-rest/README.md
+++ b/sdk/translation/ai-translation-text-rest/README.md
@@ -241,6 +241,10 @@ Please refer to the service documentation for a conceptual discussion of [transl
 
 
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 When you interact with the Translator Service using the TextTranslator client library, errors returned by the Translator service correspond to the same HTTP status codes returned for REST API requests.

--- a/sdk/trustedsigning/arm-trustedsigning/README.md
+++ b/sdk/trustedsigning/arm-trustedsigning/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `CodeSigningClient` is the primary interface for developers using the Azure CodeSigningManagement client library. Explore the methods on this client object to understand the different features of the Azure CodeSigningManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/vision/ai-vision-image-analysis-rest/README.md
+++ b/sdk/vision/ai-vision-image-analysis-rest/README.md
@@ -300,6 +300,10 @@ if (imageAnalysisResult.readResult && imageAnalysisResult.readResult.blocks.leng
 }
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/visualstudio/arm-visualstudio/README.md
+++ b/sdk/visualstudio/arm-visualstudio/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `VisualStudioResourceProviderClient` is the primary interface for developers using the Azure Visual Studio Resource Provider client library. Explore the methods on this client object to understand the different features of the Azure Visual Studio Resource Provider service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/README.md
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `VMwareCloudSimple` is the primary interface for developers using the Azure VMwareCloudSimple client library. Explore the methods on this client object to understand the different features of the Azure VMwareCloudSimple service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/voicelive/ai-voicelive/README.md
+++ b/sdk/voicelive/ai-voicelive/README.md
@@ -416,6 +416,10 @@ const subscription = session.subscribe({
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Common errors and exceptions

--- a/sdk/voiceservices/arm-voiceservices/README.md
+++ b/sdk/voiceservices/arm-voiceservices/README.md
@@ -80,6 +80,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `MicrosoftVoiceServices` is the primary interface for developers using the Azure MicrosoftVoiceServices client library. Explore the methods on this client object to understand the different features of the Azure MicrosoftVoiceServices service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/web-pubsub/arm-webpubsub/README.md
+++ b/sdk/web-pubsub/arm-webpubsub/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WebPubSubManagementClient` is the primary interface for developers using the Azure WebPubSubManagement client library. Explore the methods on this client object to understand the different features of the Azure WebPubSubManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/README.md
@@ -32,6 +32,10 @@ const client = new WebPubSubClient("client-access-url", {
 });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Enable logs

--- a/sdk/web-pubsub/web-pubsub-client/README.md
+++ b/sdk/web-pubsub/web-pubsub-client/README.md
@@ -325,6 +325,10 @@ To use this client library in the browser, first, you need to use a bundler. For
 
 ---
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Enable logs

--- a/sdk/web-pubsub/web-pubsub-express/README.md
+++ b/sdk/web-pubsub/web-pubsub-express/README.md
@@ -344,6 +344,10 @@ app.listen(3000, () =>
 );
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Enable logs

--- a/sdk/web-pubsub/web-pubsub/README.md
+++ b/sdk/web-pubsub/web-pubsub/README.md
@@ -260,6 +260,10 @@ function onResponse(rawResponse) {
 await serviceClient.sendToAll({ message: "Hello world!" }, { onResponse });
 ```
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Enable logs

--- a/sdk/workloadorchestration/arm-workloadorchestration/README.md
+++ b/sdk/workloadorchestration/arm-workloadorchestration/README.md
@@ -86,6 +86,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WorkloadOrchestrationManagementClient` is the primary interface for developers using the Azure WorkloadOrchestrationManagement client library. Explore the methods on this client object to understand the different features of the Azure WorkloadOrchestrationManagement service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/workloads/arm-workloads/README.md
+++ b/sdk/workloads/arm-workloads/README.md
@@ -82,6 +82,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WorkloadsClient` is the primary interface for developers using the Azure Workloads client library. Explore the methods on this client object to understand the different features of the Azure Workloads service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging

--- a/sdk/workloads/arm-workloadssapvirtualinstance/README.md
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/README.md
@@ -83,6 +83,10 @@ To use this client library in the browser, first you need to use a bundler. For 
 
 `WorkloadsClient` is the primary interface for developers using the Azure Workloads client library. Explore the methods on this client object to understand the different features of the Azure Workloads service that you can access.
 
+## Use with AI tools
+
+AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
+
 ## Troubleshooting
 
 ### Logging


### PR DESCRIPTION
## Summary

- Adds a new `## Use with AI tools` section directly above `## Troubleshooting` in every `sdk/<group>/<lib>/README.md` (425 files).
- The section points readers to [aka.ms/azsdk/js/ai](https://aka.ms/azsdk/js/ai) for AI coding tool integrations (VS Code, GitHub Copilot, etc.).
- Sample / nested READMEs (e.g. under `sdk/eventhub/event-hubs/samples*/`) were intentionally excluded.

Inserted content (identical in every file):

```markdown
## Use with AI tools

AI coding tools such as VS Code and GitHub Copilot can help you write and debug code that uses this library. See [Using the Azure SDK for Javascript with AI tools](https://aka.ms/azsdk/js/ai) for available integrations.
```

## Test plan

- [ ] Spot-check rendering on a sample of READMEs (data-plane, mgmt-plane, core, identity)
- [ ] Confirm the section appears as a sibling of `Troubleshooting` (not nested inside `Examples`)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)