### PR TITLE
Update confidential ledger changelog release date

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.2-beta.6 (Unreleased)
+## 1.1.2-beta.6 (2026-06-05)
 
 ### Bugs Fixed
 
@@ -14,12 +14,6 @@
 ### Other Changes
 
 - Hardened redirect handling in the Confidential Ledger client. Credentials and request bodies are now only forwarded on HTTPS redirects whose target hostname matches the configured ledger endpoint or one of its subdomains, with the same port. Redirects to any other target are refused.
-
-## 1.1.2-beta.5 (Unreleased)
-
-### Features Added
-
-- This pre-release was not published; its contents are included in 1.1.2-beta.6.
 
 ## 1.1.2-beta.4 (2026-02-18)
 


### PR DESCRIPTION
### Packages impacted by this PR

`@azure-rest/confidential-ledger`

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The release pipeline verifies the package changelog with `-ForRelease:$true`. The current changelog still had unreleased entries for beta.6 and the skipped beta.5 placeholder, causing verification to fail.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The release entry needs a real date. This PR dates `1.1.2-beta.6` and removes the skipped beta.5 placeholder instead of assigning a fake date to an unpublished version.

### Are there test cases added in this PR? _(If not, why?)_

No code changes. Verified with:

```powershell
pwsh -File eng/common/scripts/Verify-ChangeLog.ps1 -PackageName '@azure-rest/confidential-ledger' -ServiceDirectory 'confidentialledger' -ForRelease:$true
```

### Provide a list of related PRs _(if any)_

- #38569
- #38671

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists

- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator? **N/A — changelog-only.**
- [x] Added a changelog (if necessary)
