### PR TITLE
[storage-common] Bump @azure/core-rest-pipeline to ^1.24.0

### DIFF
--- a/sdk/storage/storage-common/package.json
+++ b/sdk/storage/storage-common/package.json
@@ -59,7 +59,7 @@
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-http-compat": "^2.2.0",
-    "@azure/core-rest-pipeline": "^1.19.1",
+    "@azure/core-rest-pipeline": "^1.24.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",


### PR DESCRIPTION
### Packages impacted by this PR
- `@azure/storage-common`

### Issues associated with this PR
N/A

### Describe the problem that is addressed by this PR
`@azure/storage-common` relies on the newly exported `NodeBuffer` type from `@azure/core-rest-pipeline`, which was introduced in v1.24.0. The declared minimum version (`^1.19.1`) was below that, so consumers installing storage-common without a matching transitive resolution could end up with an older core-rest-pipeline that does not export `NodeBuffer`. This raises the declared minimum to `^1.24.0` so the dependency contract matches what the code actually requires.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
Bump the minimum compatible range in `package.json` to `^1.24.0`. This is the standard semver-friendly way to express a new minimum requirement without forcing an exact version.

### Are there test cases added in this PR? _(If not, why?)_
No. This is a dependency version range adjustment only; no behavior change in source.

### Provide a list of related PRs _(if any)_
N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)