### PR TITLE
Migrate tslib version specifiers to pnpm catalog

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -63,7 +63,7 @@
     "strip-json-comments": "^5.0.1",
     "tar": "^7.4.3",
     "ts-morph": "^27.0.0",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "typescript": "~6.0.2",
     "unzipper": "~0.12.3",
     "yaml": "^2.3.4"

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -85,7 +85,7 @@
     "@typescript-eslint/typescript-estree": "~8.60.0",
     "eslint-config-prettier": "^10.0.1",
     "glob": "^13.0.0",
-    "tslib": "^2.6.2",
+    "tslib": "catalog:",
     "typescript": "~6.0.2",
     "typescript-eslint": "~8.60.0"
   },

--- a/common/tools/vite-plugin-browser-test-map/package.json
+++ b/common/tools/vite-plugin-browser-test-map/package.json
@@ -44,7 +44,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/common/tools/warp/package.json
+++ b/common/tools/warp/package.json
@@ -43,7 +43,7 @@
     "eslint": "catalog:",
     "prettier": "catalog:",
     "rimraf": "catalog:",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "typescript-eslint": "~8.60.0",
     "vitest": "catalog:testing"
   },

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -31,7 +31,7 @@
     "@hapi/boom": "^10.0.1",
     "dotenv": "^16.5.0",
     "fastify": "^5.3.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         specifier: ^27.0.0
         version: 27.0.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       typescript:
         specifier: ~6.0.2
@@ -289,7 +289,7 @@ importers:
         specifier: ^13.0.0
         version: 13.0.6
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
       typescript:
         specifier: ~6.0.2
@@ -344,7 +344,7 @@ importers:
   common/tools/vite-plugin-browser-test-map:
     dependencies:
       tslib:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@eslint/js':
@@ -400,7 +400,7 @@ importers:
         specifier: 'catalog:'
         version: 6.1.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       typescript-eslint:
         specifier: ~8.60.0
@@ -430,7 +430,7 @@ importers:
         specifier: ^5.3.2
         version: 5.8.5
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@eslint/js':
@@ -485,7 +485,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -564,7 +564,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -637,7 +637,7 @@ importers:
         specifier: ^1.0.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -722,7 +722,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -795,7 +795,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -898,7 +898,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1025,7 +1025,7 @@ importers:
         specifier: ^6.16.0
         version: 6.37.0(ws@8.20.0)(zod@4.4.3)
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-rest/ai-inference':
@@ -1128,7 +1128,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1201,7 +1201,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1274,7 +1274,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1350,7 +1350,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1411,7 +1411,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1469,7 +1469,7 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
       yargs-parser:
         specifier: ^22.0.0
@@ -1536,7 +1536,7 @@ importers:
         specifier: ^4.0.1
         version: 4.1.0
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -1597,7 +1597,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1667,7 +1667,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1749,7 +1749,7 @@ importers:
         specifier: ^1.0.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1831,7 +1831,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -1886,7 +1886,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -1965,7 +1965,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2038,7 +2038,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2117,7 +2117,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2196,7 +2196,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2272,7 +2272,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2339,7 +2339,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2421,7 +2421,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2497,7 +2497,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2564,7 +2564,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2643,7 +2643,7 @@ importers:
         specifier: ^11.0.0
         version: 11.1.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2731,7 +2731,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2801,7 +2801,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2865,7 +2865,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -2935,7 +2935,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3008,7 +3008,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3084,7 +3084,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3145,7 +3145,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3215,7 +3215,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3294,7 +3294,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3370,7 +3370,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3443,7 +3443,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3528,7 +3528,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3622,7 +3622,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3722,7 +3722,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3801,7 +3801,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3877,7 +3877,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -3944,7 +3944,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4020,7 +4020,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4093,7 +4093,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4163,7 +4163,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4230,7 +4230,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4312,7 +4312,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4388,7 +4388,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/core-tracing
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-rest/core-client':
@@ -4479,7 +4479,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-rest/core-client':
@@ -4570,7 +4570,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -4622,7 +4622,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4695,7 +4695,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4765,7 +4765,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4838,7 +4838,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -4923,7 +4923,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.7.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5017,7 +5017,7 @@ importers:
         specifier: ^3.0.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5120,7 +5120,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.4
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5208,7 +5208,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -5293,7 +5293,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5384,7 +5384,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5466,7 +5466,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5563,7 +5563,7 @@ importers:
         specifier: ^5.0.1
         version: 5.0.4
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5660,7 +5660,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5751,7 +5751,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5839,7 +5839,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -5933,7 +5933,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6024,7 +6024,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6115,7 +6115,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6209,7 +6209,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6291,7 +6291,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6367,7 +6367,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6437,7 +6437,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6516,7 +6516,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6595,7 +6595,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6674,7 +6674,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6753,7 +6753,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6832,7 +6832,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6911,7 +6911,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -6981,7 +6981,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7057,7 +7057,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7136,7 +7136,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7212,7 +7212,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7276,7 +7276,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7346,7 +7346,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7419,7 +7419,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7498,7 +7498,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7580,7 +7580,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7647,7 +7647,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -7699,7 +7699,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7775,7 +7775,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7857,7 +7857,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -7936,7 +7936,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -8009,7 +8009,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -8100,7 +8100,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -8164,7 +8164,7 @@ importers:
   sdk/core/abort-controller:
     dependencies:
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -8240,7 +8240,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
       util:
         specifier: ^0.12.5
@@ -8313,7 +8313,7 @@ importers:
         specifier: ^1.13.0
         version: link:../core-util
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -8380,7 +8380,7 @@ importers:
         specifier: ^1.3.0
         version: link:../logger
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/core-xml':
@@ -8447,7 +8447,7 @@ importers:
         specifier: ^0.3.0
         version: link:../ts-http-runtime
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -8560,7 +8560,7 @@ importers:
         specifier: ^1.3.0
         version: link:../logger
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -8615,7 +8615,7 @@ importers:
   sdk/core/core-paging:
     dependencies:
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -8682,7 +8682,7 @@ importers:
         specifier: ^0.3.4
         version: link:../ts-http-runtime
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/vite-plugin-browser-test-map':
@@ -8746,7 +8746,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       undici:
         specifier: ^8.0.2
@@ -8789,7 +8789,7 @@ importers:
   sdk/core/core-sse:
     dependencies:
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-rest/core-client':
@@ -8868,7 +8868,7 @@ importers:
   sdk/core/core-tracing:
     dependencies:
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/core-auth':
@@ -8926,7 +8926,7 @@ importers:
         specifier: ^0.3.0
         version: link:../ts-http-runtime
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/vite-plugin-browser-test-map':
@@ -8981,7 +8981,7 @@ importers:
         specifier: ^5.5.9
         version: 5.7.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -9036,7 +9036,7 @@ importers:
         specifier: ^0.3.0
         version: link:../ts-http-runtime
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -9094,7 +9094,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.6
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/vite-plugin-browser-test-map':
@@ -9170,7 +9170,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9258,7 +9258,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -9346,7 +9346,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9416,7 +9416,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9486,7 +9486,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9556,7 +9556,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9635,7 +9635,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9708,7 +9708,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9787,7 +9787,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9863,7 +9863,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -9930,7 +9930,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10000,7 +10000,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10067,7 +10067,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10137,7 +10137,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10216,7 +10216,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10292,7 +10292,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10359,7 +10359,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10435,7 +10435,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10511,7 +10511,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10584,7 +10584,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10663,7 +10663,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10733,7 +10733,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10803,7 +10803,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10873,7 +10873,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -10946,7 +10946,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11019,7 +11019,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11098,7 +11098,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11174,7 +11174,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11247,7 +11247,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11332,7 +11332,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11408,7 +11408,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11475,7 +11475,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11542,7 +11542,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11621,7 +11621,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11703,7 +11703,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11776,7 +11776,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11855,7 +11855,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -11931,7 +11931,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12001,7 +12001,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12074,7 +12074,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12159,7 +12159,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12241,7 +12241,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12317,7 +12317,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12387,7 +12387,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12466,7 +12466,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12536,7 +12536,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12618,7 +12618,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12697,7 +12697,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12770,7 +12770,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12843,7 +12843,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12919,7 +12919,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -12998,7 +12998,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13071,7 +13071,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -13150,7 +13150,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13226,7 +13226,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13314,7 +13314,7 @@ importers:
         specifier: ^6.0.0
         version: 6.0.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13384,7 +13384,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -13430,7 +13430,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -13497,7 +13497,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13570,7 +13570,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13652,7 +13652,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       util:
         specifier: ^0.12.5
@@ -13779,7 +13779,7 @@ importers:
         specifier: ^2.30.1
         version: 2.30.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -13825,7 +13825,7 @@ importers:
         specifier: ^12.26.0
         version: 12.31.0
       tslib:
-        specifier: ^2.6.3
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -13928,7 +13928,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14019,7 +14019,7 @@ importers:
         specifier: ^3.0.2
         version: 3.0.5
       tslib:
-        specifier: ^2.6.3
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -14083,7 +14083,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14156,7 +14156,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14232,7 +14232,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14305,7 +14305,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14375,7 +14375,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14445,7 +14445,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14521,7 +14521,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14609,7 +14609,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -14658,7 +14658,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14728,7 +14728,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14795,7 +14795,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14874,7 +14874,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -14953,7 +14953,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15032,7 +15032,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15111,7 +15111,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15187,7 +15187,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15260,7 +15260,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15339,7 +15339,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15421,7 +15421,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15497,7 +15497,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15570,7 +15570,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15646,7 +15646,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15716,7 +15716,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15789,7 +15789,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -15871,7 +15871,7 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       tslib:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -15953,7 +15953,7 @@ importers:
         specifier: ^5.1.0
         version: 5.2.0
       tslib:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -16029,7 +16029,7 @@ importers:
         specifier: ^7.6.0
         version: 7.9.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -16099,7 +16099,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -16139,7 +16139,7 @@ importers:
         specifier: ^5.1.0
         version: 5.2.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -16218,7 +16218,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16297,7 +16297,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16373,7 +16373,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16443,7 +16443,7 @@ importers:
         specifier: ^2.0.0
         version: 2.7.1(@opentelemetry/api@1.9.1)
       tslib:
-        specifier: ^2.7.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/core-rest-pipeline':
@@ -16519,7 +16519,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -16589,7 +16589,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16659,7 +16659,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16735,7 +16735,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16814,7 +16814,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16887,7 +16887,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -16966,7 +16966,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17042,7 +17042,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17124,7 +17124,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17215,7 +17215,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17291,7 +17291,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -17343,7 +17343,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -17419,7 +17419,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17489,7 +17489,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -17550,7 +17550,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17623,7 +17623,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -17672,7 +17672,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17745,7 +17745,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17818,7 +17818,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17897,7 +17897,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -17976,7 +17976,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18055,7 +18055,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18131,7 +18131,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18201,7 +18201,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18274,7 +18274,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18350,7 +18350,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18423,7 +18423,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18499,7 +18499,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18572,7 +18572,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18642,7 +18642,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18712,7 +18712,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18767,7 +18767,7 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -18837,7 +18837,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -18913,7 +18913,7 @@ importers:
         specifier: ^12.24.0
         version: 12.31.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -18977,7 +18977,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19038,7 +19038,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19108,7 +19108,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19172,7 +19172,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19239,7 +19239,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19309,7 +19309,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19370,7 +19370,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19437,7 +19437,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19498,7 +19498,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19565,7 +19565,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19641,7 +19641,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19714,7 +19714,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19793,7 +19793,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19872,7 +19872,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -19942,7 +19942,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20015,7 +20015,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20088,7 +20088,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -20155,7 +20155,7 @@ importers:
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20237,7 +20237,7 @@ importers:
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20325,7 +20325,7 @@ importers:
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20407,7 +20407,7 @@ importers:
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20495,7 +20495,7 @@ importers:
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20577,7 +20577,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20641,7 +20641,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20711,7 +20711,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20775,7 +20775,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20845,7 +20845,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20915,7 +20915,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -20988,7 +20988,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21067,7 +21067,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21143,7 +21143,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21219,7 +21219,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21286,7 +21286,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21365,7 +21365,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21450,7 +21450,7 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21529,7 +21529,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -21641,7 +21641,7 @@ importers:
         specifier: ^0.27.0
         version: 0.27.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -21738,7 +21738,7 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -21820,7 +21820,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -21875,7 +21875,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -21966,7 +21966,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22057,7 +22057,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22133,7 +22133,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22203,7 +22203,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22282,7 +22282,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22358,7 +22358,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22434,7 +22434,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22504,7 +22504,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22583,7 +22583,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22659,7 +22659,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22726,7 +22726,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22805,7 +22805,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22884,7 +22884,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -22972,7 +22972,7 @@ importers:
         specifier: ^1.1.2
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -23042,7 +23042,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23112,7 +23112,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23182,7 +23182,7 @@ importers:
         specifier: ^1.0.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.6.2
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23240,7 +23240,7 @@ importers:
   sdk/openai/openai:
     dependencies:
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23346,7 +23346,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23422,7 +23422,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23492,7 +23492,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23568,7 +23568,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23638,7 +23638,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23711,7 +23711,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23790,7 +23790,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23869,7 +23869,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -23948,7 +23948,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24021,7 +24021,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24091,7 +24091,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24161,7 +24161,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24225,7 +24225,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24292,7 +24292,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24368,7 +24368,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24438,7 +24438,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24511,7 +24511,7 @@ importers:
         specifier: '>=6.0.0'
         version: 6.37.8(pg@8.20.0)
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -24578,7 +24578,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24657,7 +24657,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24733,7 +24733,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24797,7 +24797,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24873,7 +24873,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -24946,7 +24946,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25019,7 +25019,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25098,7 +25098,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25177,7 +25177,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25256,7 +25256,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25326,7 +25326,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25399,7 +25399,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25481,7 +25481,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25560,7 +25560,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25636,7 +25636,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25718,7 +25718,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25791,7 +25791,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25864,7 +25864,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -25937,7 +25937,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26019,7 +26019,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26098,7 +26098,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26177,7 +26177,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26259,7 +26259,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26338,7 +26338,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26417,7 +26417,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26493,7 +26493,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26563,7 +26563,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26636,7 +26636,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26706,7 +26706,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26770,7 +26770,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26846,7 +26846,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26913,7 +26913,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -26989,7 +26989,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27059,7 +27059,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27126,7 +27126,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27205,7 +27205,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27284,7 +27284,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27360,7 +27360,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27433,7 +27433,7 @@ importers:
         specifier: ^11.1.0
         version: 11.3.6
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27533,7 +27533,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -27573,7 +27573,7 @@ importers:
         specifier: ^11.1.0
         version: 11.3.6
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27670,7 +27670,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27743,7 +27743,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27819,7 +27819,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -27898,7 +27898,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -27950,7 +27950,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28026,7 +28026,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28096,7 +28096,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28169,7 +28169,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28242,7 +28242,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28312,7 +28312,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28382,7 +28382,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28482,7 +28482,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       util:
         specifier: ^0.12.5
@@ -28597,7 +28597,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -28649,7 +28649,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28722,7 +28722,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28804,7 +28804,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28874,7 +28874,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -28947,7 +28947,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29023,7 +29023,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29096,7 +29096,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29172,7 +29172,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29245,7 +29245,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29321,7 +29321,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29391,7 +29391,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29464,7 +29464,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29540,7 +29540,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29613,7 +29613,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29692,7 +29692,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29768,7 +29768,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29859,7 +29859,7 @@ importers:
         specifier: ^3.0.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -29959,7 +29959,7 @@ importers:
         specifier: ^1.0.0
         version: link:../storage-internal-avro
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-recorder':
@@ -30032,7 +30032,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -30087,7 +30087,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -30175,7 +30175,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30248,7 +30248,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -30315,7 +30315,7 @@ importers:
         specifier: ^3.0.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30391,7 +30391,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -30431,7 +30431,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -30516,7 +30516,7 @@ importers:
         specifier: ^12.4.0
         version: link:../storage-common
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30598,7 +30598,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30677,7 +30677,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30756,7 +30756,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30826,7 +30826,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30899,7 +30899,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -30990,7 +30990,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31066,7 +31066,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31133,7 +31133,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31200,7 +31200,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31273,7 +31273,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31343,7 +31343,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31416,7 +31416,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31492,7 +31492,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31559,7 +31559,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/core-tracing
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31629,7 +31629,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31717,7 +31717,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/core-tracing
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31793,7 +31793,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/core-tracing
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31866,7 +31866,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/core-tracing
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -31936,7 +31936,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/core-tracing
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32021,7 +32021,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32094,7 +32094,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -32146,7 +32146,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32222,7 +32222,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32292,7 +32292,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -32335,7 +32335,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32399,7 +32399,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32478,7 +32478,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32554,7 +32554,7 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -32670,7 +32670,7 @@ importers:
         specifier: ^4.5.0
         version: 4.13.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -32734,7 +32734,7 @@ importers:
         specifier: ^1.9.0
         version: 1.9.1
       tslib:
-        specifier: ^2.6.3
+        specifier: 'catalog:'
         version: 2.8.1
       vitest:
         specifier: catalog:testing
@@ -32810,7 +32810,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32883,7 +32883,7 @@ importers:
         specifier: ^16.0.0
         version: 16.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure/dev-tool':
@@ -32932,7 +32932,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -32999,7 +32999,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33072,7 +33072,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33154,7 +33154,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33233,7 +33233,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33318,7 +33318,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33388,7 +33388,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33467,7 +33467,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33534,7 +33534,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33610,7 +33610,7 @@ importers:
         specifier: ^7.0.1
         version: 7.0.6
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       ws:
         specifier: ^8.18.3
@@ -33701,7 +33701,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33774,7 +33774,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33853,7 +33853,7 @@ importers:
         specifier: ^9.0.2
         version: 9.0.3
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -33938,7 +33938,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       ws:
         specifier: ^8.18.0
@@ -34014,7 +34014,7 @@ importers:
         specifier: ^7.4.0
         version: 7.6.1
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -34084,7 +34084,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-utils-vitest':
@@ -34169,7 +34169,7 @@ importers:
         specifier: ^1.2.0
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -34245,7 +34245,7 @@ importers:
         specifier: link:../../core/core-rest-pipeline
         version: link:../../core/core-rest-pipeline
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':
@@ -34318,7 +34318,7 @@ importers:
         specifier: ^1.1.4
         version: link:../../core/logger
       tslib:
-        specifier: ^2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@azure-tools/test-credential':

--- a/sdk/advisor/arm-advisor/package.json
+++ b/sdk/advisor/arm-advisor/package.json
@@ -272,7 +272,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/agricultureplatform/arm-agricultureplatform/package.json
+++ b/sdk/agricultureplatform/arm-agricultureplatform/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/agrifood/agrifood-farming-rest/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/package.json
@@ -79,7 +79,7 @@
     "@azure/core-auth": "^1.3.0",
     "@azure/core-lro": "^3.1.0",
     "@azure/logger": "^1.0.0",
-    "tslib": "^2.2.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/agrifood/arm-agrifood/package.json
+++ b/sdk/agrifood/arm-agrifood/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/ai/ai-agents/package.json
+++ b/sdk/ai/ai-agents/package.json
@@ -56,7 +56,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.9.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/ai/ai-inference-rest/package.json
+++ b/sdk/ai/ai-inference-rest/package.json
@@ -75,7 +75,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -59,7 +59,7 @@
     "@azure/logger": "^1.1.4",
     "@azure/storage-blob": "^12.26.0",
     "openai": "^6.16.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-rest/ai-inference": "^1.0.0-beta.6",

--- a/sdk/alertprocessingrules/arm-alertprocessingrules/package.json
+++ b/sdk/alertprocessingrules/arm-alertprocessingrules/package.json
@@ -108,7 +108,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/alertrulerecommendations/arm-alertrulerecommendations/package.json
+++ b/sdk/alertrulerecommendations/arm-alertrulerecommendations/package.json
@@ -108,7 +108,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/alertsmanagement/arm-alertsmanagement/package.json
+++ b/sdk/alertsmanagement/arm-alertsmanagement/package.json
@@ -122,7 +122,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/analysisservices/arm-analysisservices/package.json
+++ b/sdk/analysisservices/arm-analysisservices/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/apicenter/arm-apicenter/package.json
+++ b/sdk/apicenter/arm-apicenter/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
@@ -71,7 +71,7 @@
     "glob": "^13.0.0",
     "inquirer": "^13.0.1",
     "mustache": "^4.2.0",
-    "tslib": "^2.6.2",
+    "tslib": "catalog:",
     "yargs-parser": "^22.0.0"
   },
   "exports": {

--- a/sdk/apimanagement/api-management-custom-widgets-tools/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-tools/package.json
@@ -64,7 +64,7 @@
     "@azure/identity": "^4.0.1",
     "@azure/storage-blob": "^12.17.0",
     "mime": "^4.0.1",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/apimanagement/arm-apimanagement/package.json
+++ b/sdk/apimanagement/arm-apimanagement/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
+++ b/sdk/appcomplianceautomation/arm-appcomplianceautomation/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/appconfiguration/app-configuration-perf-tests/package.json
+++ b/sdk/appconfiguration/app-configuration-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/app-configuration": "1.8.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -79,7 +79,7 @@
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.6.1",
     "@azure/logger": "^1.0.0",
-    "tslib": "^2.2.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/appconfiguration/arm-appconfiguration/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/appcontainers/arm-appcontainers/package.json
+++ b/sdk/appcontainers/arm-appcontainers/package.json
@@ -764,7 +764,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/applicationinsights/arm-appinsights/package.json
+++ b/sdk/applicationinsights/arm-appinsights/package.json
@@ -286,7 +286,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/appnetwork/arm-appnetwork/package.json
+++ b/sdk/appnetwork/arm-appnetwork/package.json
@@ -170,7 +170,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
+++ b/sdk/appservice/arm-appservice-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/appservice/arm-appservice-rest/package.json
+++ b/sdk/appservice/arm-appservice-rest/package.json
@@ -69,7 +69,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.18.1",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/appservice/arm-appservice/package.json
+++ b/sdk/appservice/arm-appservice/package.json
@@ -423,7 +423,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/artifactsigning/arm-artifactsigning/package.json
+++ b/sdk/artifactsigning/arm-artifactsigning/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/astro/arm-astro/package.json
+++ b/sdk/astro/arm-astro/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/attestation/arm-attestation/package.json
+++ b/sdk/attestation/arm-attestation/package.json
@@ -160,7 +160,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/attestation/attestation/package.json
+++ b/sdk/attestation/attestation/package.json
@@ -74,7 +74,7 @@
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.1.4",
     "jsrsasign": "^11.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
+++ b/sdk/authorization/arm-authorization-profile-2020-09-01-hybrid/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/authorization/arm-authorization/package.json
+++ b/sdk/authorization/arm-authorization/package.json
@@ -246,7 +246,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/automanage/arm-automanage/package.json
+++ b/sdk/automanage/arm-automanage/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/automation/arm-automation/package.json
+++ b/sdk/automation/arm-automation/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/avs/arm-avs/package.json
+++ b/sdk/avs/arm-avs/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
+++ b/sdk/azureadexternalidentities/arm-azureadexternalidentities/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/azurestack/arm-azurestack/package.json
+++ b/sdk/azurestack/arm-azurestack/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/azurestackhci/arm-azurestackhci/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/package.json
@@ -450,7 +450,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/azurestackhcivm/arm-azurestackhcivm/package.json
+++ b/sdk/azurestackhcivm/arm-azurestackhcivm/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/package.json
+++ b/sdk/baremetalinfrastructure/arm-baremetalinfrastructure/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/batch/arm-batch/package.json
+++ b/sdk/batch/arm-batch/package.json
@@ -226,7 +226,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/batch/batch-rest/package.json
+++ b/sdk/batch/batch-rest/package.json
@@ -57,7 +57,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/batch/batch/package.json
+++ b/sdk/batch/batch/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/billing/arm-billing/package.json
+++ b/sdk/billing/arm-billing/package.json
@@ -526,7 +526,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/billingbenefits/arm-billingbenefits/package.json
+++ b/sdk/billingbenefits/arm-billingbenefits/package.json
@@ -345,7 +345,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/botservice/arm-botservice/package.json
+++ b/sdk/botservice/arm-botservice/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/carbonoptimization/arm-carbonoptimization/package.json
+++ b/sdk/carbonoptimization/arm-carbonoptimization/package.json
@@ -50,7 +50,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/cdn/arm-cdn/package.json
+++ b/sdk/cdn/arm-cdn/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/certificateregistration/arm-certificateregistration/package.json
+++ b/sdk/certificateregistration/arm-certificateregistration/package.json
@@ -53,7 +53,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/changes/arm-changes/package.json
+++ b/sdk/changes/arm-changes/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/chaos/arm-chaos/package.json
+++ b/sdk/chaos/arm-chaos/package.json
@@ -53,7 +53,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/cloudhealth/arm-cloudhealth/package.json
+++ b/sdk/cloudhealth/arm-cloudhealth/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/cognitivelanguage/ai-language-conversations/package.json
+++ b/sdk/cognitivelanguage/ai-language-conversations/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-tracing": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/cognitivelanguage/ai-language-text-perf-tests/package.json
+++ b/sdk/cognitivelanguage/ai-language-text-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/ai-language-text": "^1.1.0",
     "@azure/identity": "^4.5.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/cognitivelanguage/ai-language-text/package.json
+++ b/sdk/cognitivelanguage/ai-language-text/package.json
@@ -92,7 +92,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-rest/core-client": "^2.3.4",

--- a/sdk/cognitiveservices/arm-cognitiveservices/package.json
+++ b/sdk/cognitiveservices/arm-cognitiveservices/package.json
@@ -722,7 +722,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
+++ b/sdk/commerce/arm-commerce-profile-2020-09-01-hybrid/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/commerce/arm-commerce/package.json
+++ b/sdk/commerce/arm-commerce/package.json
@@ -126,7 +126,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.23.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/arm-communication/package.json
+++ b/sdk/communication/arm-communication/package.json
@@ -212,7 +212,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-alpha-ids/package.json
+++ b/sdk/communication/communication-alpha-ids/package.json
@@ -60,7 +60,7 @@
     "@azure/core-rest-pipeline": "^1.17.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.7.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -74,7 +74,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-chat/package.json
+++ b/sdk/communication/communication-chat/package.json
@@ -63,7 +63,7 @@
     "@azure/core-tracing": "^1.0.0",
     "@azure/logger": "^1.0.0",
     "eventemitter3": "^5.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-common/package.json
+++ b/sdk/communication/communication-common/package.json
@@ -61,7 +61,7 @@
     "@azure/core-util": "^1.11.0",
     "events": "^3.3.0",
     "jwt-decode": "^4.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/communication/communication-email/package.json
+++ b/sdk/communication/communication-email/package.json
@@ -50,7 +50,7 @@
     "@azure/core-rest-pipeline": "^1.18.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-identity/package.json
+++ b/sdk/communication/communication-identity/package.json
@@ -96,7 +96,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-job-router-rest/package.json
+++ b/sdk/communication/communication-job-router-rest/package.json
@@ -59,7 +59,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.18.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-messages-rest/package.json
+++ b/sdk/communication/communication-messages-rest/package.json
@@ -64,7 +64,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "eventemitter3": "^5.0.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-phone-numbers/package.json
+++ b/sdk/communication/communication-phone-numbers/package.json
@@ -63,7 +63,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-recipient-verification/package.json
+++ b/sdk/communication/communication-recipient-verification/package.json
@@ -61,7 +61,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-rooms/package.json
+++ b/sdk/communication/communication-rooms/package.json
@@ -16,7 +16,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/communication/communication-short-codes/package.json
+++ b/sdk/communication/communication-short-codes/package.json
@@ -61,7 +61,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -62,7 +62,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-tiering/package.json
+++ b/sdk/communication/communication-tiering/package.json
@@ -61,7 +61,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/communication/communication-toll-free-verification/package.json
+++ b/sdk/communication/communication-toll-free-verification/package.json
@@ -61,7 +61,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
+++ b/sdk/compute/arm-compute-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/compute/arm-compute-rest/package.json
+++ b/sdk/compute/arm-compute-rest/package.json
@@ -60,7 +60,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -170,7 +170,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/compute/arm-computerecommender/package.json
+++ b/sdk/compute/arm-computerecommender/package.json
@@ -50,7 +50,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/computebulkactions/arm-computebulkactions/package.json
+++ b/sdk/computebulkactions/arm-computebulkactions/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/computefleet/arm-computefleet/package.json
+++ b/sdk/computefleet/arm-computefleet/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/computelimit/arm-computelimit/package.json
+++ b/sdk/computelimit/arm-computelimit/package.json
@@ -50,7 +50,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "@azure/core-lro": "^3.1.0",
     "@azure/abort-controller": "^2.1.2"
   },

--- a/sdk/computeschedule/arm-computeschedule/package.json
+++ b/sdk/computeschedule/arm-computeschedule/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/confidentialledger/arm-confidentialledger/package.json
+++ b/sdk/confidentialledger/arm-confidentialledger/package.json
@@ -134,7 +134,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -76,7 +76,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/confluent/arm-confluent/package.json
+++ b/sdk/confluent/arm-confluent/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/connectedcache/arm-connectedcache/package.json
+++ b/sdk/connectedcache/arm-connectedcache/package.json
@@ -51,7 +51,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/connectedvmware/arm-connectedvmware/package.json
+++ b/sdk/connectedvmware/arm-connectedvmware/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/consumption/arm-consumption/package.json
+++ b/sdk/consumption/arm-consumption/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/containerinstance/arm-containerinstance/package.json
+++ b/sdk/containerinstance/arm-containerinstance/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/containerregistry/arm-containerregistry/package.json
+++ b/sdk/containerregistry/arm-containerregistry/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/containerregistry/arm-containerregistrytasks/package.json
+++ b/sdk/containerregistry/arm-containerregistrytasks/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/containerregistry/container-registry-perf-tests/package.json
+++ b/sdk/containerregistry/container-registry-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/container-registry": "^1.1.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/containerregistry/container-registry/package.json
+++ b/sdk/containerregistry/container-registry/package.json
@@ -74,7 +74,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/containerservice/arm-containerservice-rest/package.json
+++ b/sdk/containerservice/arm-containerservice-rest/package.json
@@ -69,7 +69,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/containerservice/arm-containerservice/package.json
+++ b/sdk/containerservice/arm-containerservice/package.json
@@ -380,7 +380,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/containerservice/arm-containerservicefleet/package.json
+++ b/sdk/containerservice/arm-containerservicefleet/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/containerservice/arm-containerservicesafeguards/package.json
+++ b/sdk/containerservice/arm-containerservicesafeguards/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/contentsafety/ai-content-safety-rest/package.json
+++ b/sdk/contentsafety/ai-content-safety-rest/package.json
@@ -59,7 +59,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/contentunderstanding/ai-content-understanding/package.json
+++ b/sdk/contentunderstanding/ai-content-understanding/package.json
@@ -62,7 +62,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -78,7 +78,7 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -81,7 +81,7 @@
     "process": "^0.11.10",
     "rhea": "^3.0.0",
     "rhea-promise": "^3.0.0",
-    "tslib": "^2.6.2",
+    "tslib": "catalog:",
     "util": "^0.12.5"
   },
   "devDependencies": {

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-util": "^1.13.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/core-client-rest/package.json
+++ b/sdk/core/core-client-rest/package.json
@@ -84,7 +84,7 @@
     "@azure/core-rest-pipeline": "^1.22.0",
     "@azure/core-tracing": "^1.3.0",
     "@typespec/ts-http-runtime": "^0.3.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/core-client/package.json
+++ b/sdk/core/core-client/package.json
@@ -78,7 +78,7 @@
     "@azure/core-tracing": "^1.3.0",
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.3.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/core-xml": "^1.5.0",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -90,7 +90,7 @@
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.3.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -78,7 +78,7 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/core-rest-pipeline-perf-tests/package.json
+++ b/sdk/core/core-rest-pipeline-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/core-auth": "^1.10.0",
     "@azure/core-rest-pipeline": "^1.22.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "undici": "^8.0.2"
   },
   "devDependencies": {

--- a/sdk/core/core-rest-pipeline/package.json
+++ b/sdk/core/core-rest-pipeline/package.json
@@ -96,7 +96,7 @@
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.3.0",
     "@typespec/ts-http-runtime": "^0.3.4",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/vite-plugin-browser-test-map": "workspace:^",

--- a/sdk/core/core-sse/package.json
+++ b/sdk/core/core-sse/package.json
@@ -110,7 +110,7 @@
     "vitest": "catalog:testing"
   },
   "dependencies": {
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "//metadata": {
     "sampleConfiguration": {

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -72,7 +72,7 @@
     "update-snippets": "dev-tool run update-snippets"
   },
   "dependencies": {
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/core-auth": "workspace:^",

--- a/sdk/core/core-util/package.json
+++ b/sdk/core/core-util/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.1.2",
     "@typespec/ts-http-runtime": "^0.3.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/vite-plugin-browser-test-map": "workspace:^",

--- a/sdk/core/core-xml/package.json
+++ b/sdk/core/core-xml/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^5.5.9",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@typespec/ts-http-runtime": "^0.3.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -227,7 +227,7 @@
   "dependencies": {
     "http-proxy-agent": "^7.0.0",
     "https-proxy-agent": "^7.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/vite-plugin-browser-test-map": "workspace:^",

--- a/sdk/cosmosdb/arm-cosmosdb/package.json
+++ b/sdk/cosmosdb/arm-cosmosdb/package.json
@@ -828,7 +828,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -80,7 +80,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "priorityqueuejs": "^2.0.0",
     "semaphore": "^1.1.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/package.json
+++ b/sdk/cosmosforpostgresql/arm-cosmosdbforpostgresql/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/cost-management/arm-costmanagement/package.json
+++ b/sdk/cost-management/arm-costmanagement/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/customer-insights/arm-customerinsights/package.json
+++ b/sdk/customer-insights/arm-customerinsights/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/dashboard/arm-dashboard/package.json
+++ b/sdk/dashboard/arm-dashboard/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/databasewatcher/arm-databasewatcher/package.json
+++ b/sdk/databasewatcher/arm-databasewatcher/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/databoundaries/arm-databoundaries/package.json
+++ b/sdk/databoundaries/arm-databoundaries/package.json
@@ -132,7 +132,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/databox/arm-databox/package.json
+++ b/sdk/databox/arm-databox/package.json
@@ -148,7 +148,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
+++ b/sdk/databoxedge/arm-databoxedge-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/databoxedge/arm-databoxedge/package.json
+++ b/sdk/databoxedge/arm-databoxedge/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/databricks/arm-databricks/package.json
+++ b/sdk/databricks/arm-databricks/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/datacatalog/arm-datacatalog/package.json
+++ b/sdk/datacatalog/arm-datacatalog/package.json
@@ -13,7 +13,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-lro": "^2.2.0",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/datadog/arm-datadog/package.json
+++ b/sdk/datadog/arm-datadog/package.json
@@ -260,7 +260,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/datafactory/arm-datafactory/package.json
+++ b/sdk/datafactory/arm-datafactory/package.json
@@ -432,7 +432,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/datalake-analytics/arm-datalake-analytics/package.json
+++ b/sdk/datalake-analytics/arm-datalake-analytics/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/datamigration/arm-datamigration/package.json
+++ b/sdk/datamigration/arm-datamigration/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/dataprotection/arm-dataprotection/package.json
+++ b/sdk/dataprotection/arm-dataprotection/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/defendereasm/arm-defendereasm/package.json
+++ b/sdk/defendereasm/arm-defendereasm/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.3",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/dell/arm-dell-storage/package.json
+++ b/sdk/dell/arm-dell-storage/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/dependencymap/arm-dependencymap/package.json
+++ b/sdk/dependencymap/arm-dependencymap/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/desktopvirtualization/arm-desktopvirtualization/package.json
+++ b/sdk/desktopvirtualization/arm-desktopvirtualization/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/devcenter/arm-devcenter/package.json
+++ b/sdk/devcenter/arm-devcenter/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/devcenter/developer-devcenter-rest/package.json
+++ b/sdk/devcenter/developer-devcenter-rest/package.json
@@ -51,7 +51,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/devhub/arm-devhub/package.json
+++ b/sdk/devhub/arm-devhub/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/package.json
@@ -13,7 +13,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/deviceregistry/arm-deviceregistry/package.json
+++ b/sdk/deviceregistry/arm-deviceregistry/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/deviceupdate/arm-deviceupdate/package.json
+++ b/sdk/deviceupdate/arm-deviceupdate/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/deviceupdate/iot-device-update-rest/package.json
+++ b/sdk/deviceupdate/iot-device-update-rest/package.json
@@ -82,7 +82,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
+++ b/sdk/devopsinfrastructure/arm-devopsinfrastructure/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/devspaces/arm-devspaces/package.json
+++ b/sdk/devspaces/arm-devspaces/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/devtestlabs/arm-devtestlabs/package.json
+++ b/sdk/devtestlabs/arm-devtestlabs/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/digitaltwins/arm-digitaltwins/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/digitaltwins/digital-twins-core/package.json
+++ b/sdk/digitaltwins/digital-twins-core/package.json
@@ -63,7 +63,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/disconnectedoperations/arm-disconnectedoperations/package.json
+++ b/sdk/disconnectedoperations/arm-disconnectedoperations/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/discovery/arm-discovery/package.json
+++ b/sdk/discovery/arm-discovery/package.json
@@ -296,7 +296,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
+++ b/sdk/dns/arm-dns-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/dns/arm-dns/package.json
+++ b/sdk/dns/arm-dns/package.json
@@ -162,7 +162,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/dnsresolver/arm-dnsresolver/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/documentintelligence/ai-document-intelligence-rest/package.json
+++ b/sdk/documentintelligence/ai-document-intelligence-rest/package.json
@@ -48,7 +48,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/documenttranslator/ai-document-translator-rest/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/package.json
@@ -84,7 +84,7 @@
     "@azure/core-lro": "^3.0.0",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/domainregistration/arm-domainregistration/package.json
+++ b/sdk/domainregistration/arm-domainregistration/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/domainservices/arm-domainservices/package.json
+++ b/sdk/domainservices/arm-domainservices/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/durabletask/arm-durabletask/package.json
+++ b/sdk/durabletask/arm-durabletask/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/dynatrace/arm-dynatrace/package.json
+++ b/sdk/dynatrace/arm-dynatrace/package.json
@@ -190,7 +190,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/easm/defender-easm-rest/package.json
+++ b/sdk/easm/defender-easm-rest/package.json
@@ -49,7 +49,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/edgeactions/arm-edgeactions/package.json
+++ b/sdk/edgeactions/arm-edgeactions/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/edgeorder/arm-edgeorder/package.json
+++ b/sdk/edgeorder/arm-edgeorder/package.json
@@ -176,7 +176,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/edgezones/arm-edgezones/package.json
+++ b/sdk/edgezones/arm-edgezones/package.json
@@ -49,7 +49,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/education/arm-education/package.json
+++ b/sdk/education/arm-education/package.json
@@ -188,7 +188,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/elastic/arm-elastic/package.json
+++ b/sdk/elastic/arm-elastic/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/elasticsans/arm-elasticsan/package.json
+++ b/sdk/elasticsans/arm-elasticsan/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/entra/functions-authentication-events/package.json
+++ b/sdk/entra/functions-authentication-events/package.json
@@ -55,7 +55,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/eventgrid/arm-eventgrid/package.json
+++ b/sdk/eventgrid/arm-eventgrid/package.json
@@ -534,7 +534,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/eventgrid/eventgrid-namespaces/package.json
+++ b/sdk/eventgrid/eventgrid-namespaces/package.json
@@ -72,7 +72,7 @@
     "@azure/eventgrid": "^5.8.0",
     "@azure/logger": "^1.1.4",
     "buffer": "^6.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/eventgrid/eventgrid-perf-tests/package.json
+++ b/sdk/eventgrid/eventgrid-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/eventgrid": "^5.11.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/eventgrid/eventgrid-systemevents/package.json
+++ b/sdk/eventgrid/eventgrid-systemevents/package.json
@@ -58,7 +58,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/eventgrid/eventgrid/package.json
+++ b/sdk/eventgrid/eventgrid/package.json
@@ -88,7 +88,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/eventhub/arm-eventhub-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/eventhub/arm-eventhub/package.json
+++ b/sdk/eventhub/arm-eventhub/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/eventhub/event-hubs-perf-tests/package.json
+++ b/sdk/eventhub/event-hubs-perf-tests/package.json
@@ -52,7 +52,7 @@
     "@azure/event-hubs": "^6.0.0-beta.1",
     "dotenv": "^16.0.0",
     "moment": "^2.30.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -94,7 +94,7 @@
     "is-buffer": "^2.0.5",
     "process": "^0.11.10",
     "rhea-promise": "^3.0.0",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "util": "^0.12.5"
   },
   "devDependencies": {

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -57,7 +57,7 @@
     "@azure/event-hubs": "^6.0.0",
     "@azure/logger": "^1.1.4",
     "@azure/storage-blob": "^12.26.0",
-    "tslib": "^2.6.3"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -56,7 +56,7 @@
     "@azure/data-tables": "^13.3.0",
     "@azure/event-hubs": "^6.0.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/eventhub/mock-hub/package.json
+++ b/sdk/eventhub/mock-hub/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@azure/abort-controller": "^2.1.2",
     "rhea": "^3.0.2",
-    "tslib": "^2.6.3"
+    "tslib": "catalog:"
   },
   "//sampleConfiguration": {
     "productName": "Internal Mock Hub",

--- a/sdk/extendedlocation/arm-extendedlocation/package.json
+++ b/sdk/extendedlocation/arm-extendedlocation/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/fabric/arm-fabric/package.json
+++ b/sdk/fabric/arm-fabric/package.json
@@ -51,7 +51,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/face/ai-vision-face-rest/package.json
+++ b/sdk/face/ai-vision-face-rest/package.json
@@ -51,7 +51,7 @@
     "@azure/core-lro": "^3.0.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/fileshares/arm-fileshares/package.json
+++ b/sdk/fileshares/arm-fileshares/package.json
@@ -183,7 +183,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/fluidrelay/arm-fluidrelay/package.json
+++ b/sdk/fluidrelay/arm-fluidrelay/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/formrecognizer/ai-form-recognizer-perf-tests/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/ai-form-recognizer": "^5.0.0",
     "@azure/identity": "^4.8.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -79,7 +79,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/frontdoor/arm-frontdoor/package.json
+++ b/sdk/frontdoor/arm-frontdoor/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/graphservices/arm-graphservices/package.json
+++ b/sdk/graphservices/arm-graphservices/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.3",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/guestconfiguration/arm-guestconfiguration/package.json
+++ b/sdk/guestconfiguration/arm-guestconfiguration/package.json
@@ -230,7 +230,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/hanaonazure/arm-hanaonazure/package.json
+++ b/sdk/hanaonazure/arm-hanaonazure/package.json
@@ -148,7 +148,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
+++ b/sdk/hardwaresecuritymodules/arm-hardwaresecuritymodules/package.json
@@ -54,7 +54,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/hdinsight/arm-hdinsight/package.json
+++ b/sdk/hdinsight/arm-hdinsight/package.json
@@ -250,7 +250,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/healthbot/arm-healthbot/package.json
+++ b/sdk/healthbot/arm-healthbot/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/healthcareapis/arm-healthcareapis/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
+++ b/sdk/healthdataaiservices/arm-healthdataaiservices/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/healthdataaiservices/health-deidentification-rest/package.json
+++ b/sdk/healthdataaiservices/health-deidentification-rest/package.json
@@ -53,7 +53,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/horizondb/arm-horizondb/package.json
+++ b/sdk/horizondb/arm-horizondb/package.json
@@ -208,7 +208,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/hybridcompute/arm-hybridcompute/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
+++ b/sdk/hybridconnectivity/arm-hybridconnectivity/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/hybridcontainerservice/arm-hybridcontainerservice/package.json
+++ b/sdk/hybridcontainerservice/arm-hybridcontainerservice/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/hybridnetwork/arm-hybridnetwork/package.json
+++ b/sdk/hybridnetwork/arm-hybridnetwork/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/identity/identity-broker/package.json
+++ b/sdk/identity/identity-broker/package.json
@@ -61,7 +61,7 @@
     "@azure/identity": "^4.7.0",
     "@azure/msal-node": "^5.1.0",
     "@azure/msal-node-extensions": "^5.1.0",
-    "tslib": "^2.2.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "workspace:^",

--- a/sdk/identity/identity-cache-persistence/package.json
+++ b/sdk/identity/identity-cache-persistence/package.json
@@ -64,7 +64,7 @@
     "@azure/msal-node": "^5.1.0",
     "@azure/msal-node-extensions": "^5.1.0",
     "keytar": "^7.6.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "workspace:^",

--- a/sdk/identity/identity-perf-tests/package.json
+++ b/sdk/identity/identity-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/identity/identity-vscode/package.json
+++ b/sdk/identity/identity-vscode/package.json
@@ -62,7 +62,7 @@
     "@azure/identity": "^4.11.0",
     "@azure/msal-node": "^5.1.0",
     "@azure/msal-node-extensions": "^5.1.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "workspace:^",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -95,7 +95,7 @@
     "@azure/msal-browser": "^5.5.0",
     "@azure/msal-node": "^5.1.0",
     "open": "^11.0.0",
-    "tslib": "^2.2.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "workspace:^",

--- a/sdk/imagebuilder/arm-imagebuilder/package.json
+++ b/sdk/imagebuilder/arm-imagebuilder/package.json
@@ -148,7 +148,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/impactreporting/arm-impactreporting/package.json
+++ b/sdk/impactreporting/arm-impactreporting/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/informatica/arm-informaticadatamanagement/package.json
+++ b/sdk/informatica/arm-informaticadatamanagement/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
+++ b/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/instrumentation": "^0.211.0",
     "@opentelemetry/sdk-trace-web": "^2.0.0",
-    "tslib": "^2.7.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/core-rest-pipeline": "workspace:^",

--- a/sdk/iot/iot-modelsrepository/package.json
+++ b/sdk/iot/iot-modelsrepository/package.json
@@ -57,7 +57,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "workspace:^",

--- a/sdk/iotcentral/arm-iotcentral/package.json
+++ b/sdk/iotcentral/arm-iotcentral/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
+++ b/sdk/iotfirmwaredefense/arm-iotfirmwaredefense/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
+++ b/sdk/iothub/arm-iothub-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/iothub/arm-iothub/package.json
+++ b/sdk/iothub/arm-iothub/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/iotoperations/arm-iotoperations/package.json
+++ b/sdk/iotoperations/arm-iotoperations/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
+++ b/sdk/keyvault/arm-keyvault-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/keyvault/arm-keyvault/package.json
+++ b/sdk/keyvault/arm-keyvault/package.json
@@ -254,7 +254,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -90,7 +90,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/keyvault-common": "^2.0.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/keyvault/keyvault-certificates-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-certificates-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/keyvault-certificates": "^4.9.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -84,7 +84,7 @@
     "@azure/core-util": "^1.12.0",
     "@azure/keyvault-common": "^2.1.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -57,7 +57,7 @@
     "@azure/core-tracing": "^1.0.0",
     "@azure/core-util": "^1.10.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.2.0"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/keyvault/keyvault-keys-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-keys-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/keyvault-keys": "^4.9.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -85,7 +85,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/keyvault-common": "^2.1.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/keyvault/keyvault-secrets-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-secrets-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/keyvault-secrets": "^4.9.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -96,7 +96,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/keyvault-common": "^2.1.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensions/package.json
@@ -128,7 +128,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-extensiontypes/package.json
@@ -112,7 +112,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-fluxconfigurations/package.json
@@ -128,7 +128,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration-privatelinkscopes/package.json
@@ -142,7 +142,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
+++ b/sdk/kubernetesconfiguration/arm-kubernetesconfiguration/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
+++ b/sdk/kubernetesruntime/arm-containerorchestratorruntime/package.json
@@ -51,7 +51,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/kusto/arm-kusto/package.json
+++ b/sdk/kusto/arm-kusto/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/labservices/arm-labservices/package.json
+++ b/sdk/labservices/arm-labservices/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/package.json
+++ b/sdk/lambdatesthyperexecute/arm-lambdatesthyperexecute/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/largeinstance/arm-largeinstance/package.json
+++ b/sdk/largeinstance/arm-largeinstance/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/liftrarize/arm-arizeaiobservabilityeval/package.json
+++ b/sdk/liftrarize/arm-arizeaiobservabilityeval/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/liftrqumulo/arm-qumulo/package.json
+++ b/sdk/liftrqumulo/arm-qumulo/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/liftrweightsandbiases/arm-weightsandbiases/package.json
+++ b/sdk/liftrweightsandbiases/arm-weightsandbiases/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/loadtesting/arm-loadtesting/package.json
+++ b/sdk/loadtesting/arm-loadtesting/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/loadtesting/create-playwright/package.json
+++ b/sdk/loadtesting/create-playwright/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "prompts": "^2.4.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/loadtesting/load-testing-rest/package.json
+++ b/sdk/loadtesting/load-testing-rest/package.json
@@ -65,7 +65,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/loadtesting/playwright/package.json
+++ b/sdk/loadtesting/playwright/package.json
@@ -77,7 +77,7 @@
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.1.4",
     "@azure/storage-blob": "^12.24.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
+++ b/sdk/locks/arm-locks-profile-2020-09-01-hybrid/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/logic/arm-logic/package.json
+++ b/sdk/logic/arm-logic/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/machinelearning/arm-commitmentplans/package.json
+++ b/sdk/machinelearning/arm-commitmentplans/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/machinelearning/arm-machinelearning/package.json
+++ b/sdk/machinelearning/arm-machinelearning/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/machinelearning/arm-webservices/package.json
+++ b/sdk/machinelearning/arm-webservices/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/machinelearning/arm-workspaces/package.json
+++ b/sdk/machinelearning/arm-workspaces/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/maintenance/arm-maintenance/package.json
+++ b/sdk/maintenance/arm-maintenance/package.json
@@ -272,7 +272,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/managednetworkfabric/arm-managednetworkfabric/package.json
+++ b/sdk/managednetworkfabric/arm-managednetworkfabric/package.json
@@ -450,7 +450,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/managedops/arm-managedops/package.json
+++ b/sdk/managedops/arm-managedops/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/managementgroups/arm-managementgroups/package.json
+++ b/sdk/managementgroups/arm-managementgroups/package.json
@@ -177,7 +177,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/managementpartner/arm-managementpartner/package.json
+++ b/sdk/managementpartner/arm-managementpartner/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/maps/arm-maps/package.json
+++ b/sdk/maps/arm-maps/package.json
@@ -198,7 +198,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/maps/maps-common/package.json
+++ b/sdk/maps/maps-common/package.json
@@ -59,7 +59,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-lro": "^2.2.0",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/maps/maps-geolocation-rest/package.json
+++ b/sdk/maps/maps-geolocation-rest/package.json
@@ -59,7 +59,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
     "@azure/maps-common": "1.0.0-beta.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/maps/maps-render-rest/package.json
+++ b/sdk/maps/maps-render-rest/package.json
@@ -59,7 +59,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
     "@azure/maps-common": "1.0.0-beta.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/maps/maps-route-rest/package.json
+++ b/sdk/maps/maps-route-rest/package.json
@@ -83,7 +83,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
     "@azure/maps-common": "1.0.0-beta.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/maps/maps-search-rest/package.json
+++ b/sdk/maps/maps-search-rest/package.json
@@ -60,7 +60,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
     "@azure/maps-common": "1.0.0-beta.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/maps/maps-timezone-rest/package.json
+++ b/sdk/maps/maps-timezone-rest/package.json
@@ -61,7 +61,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "@azure/maps-common": "1.0.0-beta.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/mariadb/arm-mariadb/package.json
+++ b/sdk/mariadb/arm-mariadb/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/marketplace/arm-marketplace/package.json
+++ b/sdk/marketplace/arm-marketplace/package.json
@@ -154,7 +154,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/marketplaceordering/arm-marketplaceordering/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/migrate/arm-migrate/package.json
+++ b/sdk/migrate/arm-migrate/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/migrate/arm-migrationassessment/package.json
+++ b/sdk/migrate/arm-migrationassessment/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/migrationdiscovery/arm-migrationdiscoverysap/package.json
+++ b/sdk/migrationdiscovery/arm-migrationdiscoverysap/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/mongocluster/arm-mongocluster/package.json
+++ b/sdk/mongocluster/arm-mongocluster/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/mongodbatlas/arm-mongodbatlas/package.json
+++ b/sdk/mongodbatlas/arm-mongodbatlas/package.json
@@ -54,7 +54,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
+++ b/sdk/monitor/arm-monitor-profile-2020-09-01-hybrid/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/monitor/arm-monitor/package.json
+++ b/sdk/monitor/arm-monitor/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/monitor/arm-monitorslis/package.json
+++ b/sdk/monitor/arm-monitorslis/package.json
@@ -112,7 +112,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/monitor/arm-monitorworkspaces/package.json
+++ b/sdk/monitor/arm-monitorworkspaces/package.json
@@ -152,7 +152,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/monitor/monitor-ingestion-perf-tests/package.json
+++ b/sdk/monitor/monitor-ingestion-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/monitor-ingestion": "^1.1.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/monitor/monitor-ingestion/package.json
+++ b/sdk/monitor/monitor-ingestion/package.json
@@ -79,7 +79,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "pako": "^2.1.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -97,7 +97,7 @@
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "@azure/core-util": "^1.11.0"
   },
   "sideEffects": false,

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/api-logs": "^0.200.0",
     "@opentelemetry/sdk-logs": "^0.200.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -109,7 +109,7 @@
     "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@opentelemetry/winston-transport": "^0.27.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "sideEffects": false,
   "keywords": [

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -67,7 +67,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -56,7 +56,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/msi/arm-msi/package.json
+++ b/sdk/msi/arm-msi/package.json
@@ -160,7 +160,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/mysql/arm-mysql-flexible/package.json
+++ b/sdk/mysql/arm-mysql-flexible/package.json
@@ -456,7 +456,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/mysql/arm-mysql/package.json
+++ b/sdk/mysql/arm-mysql/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/netapp/arm-netapp/package.json
+++ b/sdk/netapp/arm-netapp/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
+++ b/sdk/network/arm-network-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/network/arm-network-rest/package.json
+++ b/sdk/network/arm-network-rest/package.json
@@ -60,7 +60,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/network/arm-network/package.json
+++ b/sdk/network/arm-network/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/networkcloud/arm-networkcloud/package.json
+++ b/sdk/networkcloud/arm-networkcloud/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/networkfunction/arm-networkfunction/package.json
+++ b/sdk/networkfunction/arm-networkfunction/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/newrelicobservability/arm-newrelicobservability/package.json
+++ b/sdk/newrelicobservability/arm-newrelicobservability/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/nginx/arm-nginx/package.json
+++ b/sdk/nginx/arm-nginx/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/notificationhubs/arm-notificationhubs/package.json
+++ b/sdk/notificationhubs/arm-notificationhubs/package.json
@@ -162,7 +162,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/notificationhubs/notification-hubs/package.json
+++ b/sdk/notificationhubs/notification-hubs/package.json
@@ -95,7 +95,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/core-xml": "^1.4.4",
     "@azure/logger": "^1.1.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/oep/arm-oep/package.json
+++ b/sdk/oep/arm-oep/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/onlineexperimentation/arm-onlineexperimentation/package.json
+++ b/sdk/onlineexperimentation/arm-onlineexperimentation/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
+++ b/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
@@ -50,7 +50,7 @@
     "@azure/core-auth": "^1.6.0",
     "@azure/core-rest-pipeline": "^1.5.0",
     "@azure/logger": "^1.0.0",
-    "tslib": "^2.6.2"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/openai/openai/package.json
+++ b/sdk/openai/openai/package.json
@@ -125,7 +125,7 @@
     "zod": "^3.24.2"
   },
   "dependencies": {
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "//sampleConfiguration": {
     "productName": "Azure OpenAI",

--- a/sdk/operationalinsights/arm-operationalinsights/package.json
+++ b/sdk/operationalinsights/arm-operationalinsights/package.json
@@ -428,7 +428,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/operationsmanagement/arm-operations/package.json
+++ b/sdk/operationsmanagement/arm-operations/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/oracledatabase/arm-oracledatabase/package.json
+++ b/sdk/oracledatabase/arm-oracledatabase/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/orbital/arm-orbital/package.json
+++ b/sdk/orbital/arm-orbital/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
+++ b/sdk/paloaltonetworksngfw/arm-paloaltonetworksngfw/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/peering/arm-peering/package.json
+++ b/sdk/peering/arm-peering/package.json
@@ -332,7 +332,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/pineconevectordb/arm-pineconevectordb/package.json
+++ b/sdk/pineconevectordb/arm-pineconevectordb/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/planetarycomputer/arm-planetarycomputer/package.json
+++ b/sdk/planetarycomputer/arm-planetarycomputer/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/playwright/arm-playwright/package.json
+++ b/sdk/playwright/arm-playwright/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
+++ b/sdk/policy/arm-policy-profile-2020-09-01-hybrid/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -50,7 +50,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/policyinsights/arm-policyinsights/package.json
+++ b/sdk/policyinsights/arm-policyinsights/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/portal/arm-portal/package.json
+++ b/sdk/portal/arm-portal/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/portalservices/arm-portalservicescopilot/package.json
+++ b/sdk/portalservices/arm-portalservicescopilot/package.json
@@ -50,7 +50,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/postgresql/arm-postgresql-flexible/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/postgresql/arm-postgresql/package.json
+++ b/sdk/postgresql/arm-postgresql/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/postgresql/postgresql-auth/package.json
+++ b/sdk/postgresql/postgresql-auth/package.json
@@ -52,7 +52,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-util": "^1.13.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "peerDependencies": {
     "pg": ">=8.0.0",

--- a/sdk/postgresqlhsc/arm-postgresqlhsc/package.json
+++ b/sdk/postgresqlhsc/arm-postgresqlhsc/package.json
@@ -218,7 +218,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/powerbidedicated/arm-powerbidedicated/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/package.json
@@ -148,7 +148,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/powerbiembedded/arm-powerbiembedded/package.json
+++ b/sdk/powerbiembedded/arm-powerbiembedded/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/previewalertrule/arm-previewalertrule/package.json
+++ b/sdk/previewalertrule/arm-previewalertrule/package.json
@@ -98,7 +98,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/privatedns/arm-privatedns/package.json
+++ b/sdk/privatedns/arm-privatedns/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/package.json
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/prometheusrulegroups/arm-prometheusrulegroups/package.json
+++ b/sdk/prometheusrulegroups/arm-prometheusrulegroups/package.json
@@ -108,7 +108,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/providerhub/arm-providerhub/package.json
+++ b/sdk/providerhub/arm-providerhub/package.json
@@ -250,7 +250,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purestorageblock/arm-purestorageblock/package.json
+++ b/sdk/purestorageblock/arm-purestorageblock/package.json
@@ -54,7 +54,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purview/arm-purview/package.json
+++ b/sdk/purview/arm-purview/package.json
@@ -232,7 +232,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purview/purview-administration-rest/package.json
+++ b/sdk/purview/purview-administration-rest/package.json
@@ -78,7 +78,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purview/purview-datamap-rest/package.json
+++ b/sdk/purview/purview-datamap-rest/package.json
@@ -58,7 +58,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purview/purview-scanning-rest/package.json
+++ b/sdk/purview/purview-scanning-rest/package.json
@@ -80,7 +80,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purview/purview-sharing-rest/package.json
+++ b/sdk/purview/purview-sharing-rest/package.json
@@ -60,7 +60,7 @@
     "@azure/core-lro": "^3.0.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/purview/purview-workflow-rest/package.json
+++ b/sdk/purview/purview-workflow-rest/package.json
@@ -58,7 +58,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/quantum/arm-quantum/package.json
+++ b/sdk/quantum/arm-quantum/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/quota/arm-quota/package.json
+++ b/sdk/quota/arm-quota/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/recoveryservices/arm-recoveryservices/package.json
+++ b/sdk/recoveryservices/arm-recoveryservices/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
+++ b/sdk/recoveryservicesdatareplication/arm-recoveryservicesdatareplication/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
+++ b/sdk/recoveryservicessiterecovery/arm-recoveryservices-siterecovery/package.json
@@ -530,7 +530,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/redhatopenshift/arm-redhatopenshift/package.json
+++ b/sdk/redhatopenshift/arm-redhatopenshift/package.json
@@ -176,7 +176,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/redis/arm-rediscache/package.json
+++ b/sdk/redis/arm-rediscache/package.json
@@ -247,7 +247,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/arm-network": "^36.0.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/redisenterprise/arm-redisenterprisecache/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/package.json
@@ -232,7 +232,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/relationships/arm-relationships/package.json
+++ b/sdk/relationships/arm-relationships/package.json
@@ -138,7 +138,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/relay/arm-relay/package.json
+++ b/sdk/relay/arm-relay/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/reservations/arm-reservations/package.json
+++ b/sdk/reservations/arm-reservations/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/resourceconnector/arm-resourceconnector/package.json
+++ b/sdk/resourceconnector/arm-resourceconnector/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/resourcegraph/arm-resourcegraph/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/resourcehealth/arm-resourcehealth/package.json
+++ b/sdk/resourcehealth/arm-resourcehealth/package.json
@@ -244,7 +244,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/resourcemover/arm-resourcemover/package.json
+++ b/sdk/resourcemover/arm-resourcemover/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
+++ b/sdk/resources-subscriptions/arm-resources-subscriptions/package.json
@@ -146,7 +146,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
+++ b/sdk/resources/arm-resources-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/resources/arm-resourcesbicep/package.json
+++ b/sdk/resources/arm-resourcesbicep/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/resources/arm-resourcesdeployments/package.json
+++ b/sdk/resources/arm-resourcesdeployments/package.json
@@ -134,7 +134,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/package.json
+++ b/sdk/resourcesdeploymentstacks/arm-resourcesdeploymentstacks/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/schemaregistry/schema-registry-avro-perf-tests/package.json
+++ b/sdk/schemaregistry/schema-registry-avro-perf-tests/package.json
@@ -52,7 +52,7 @@
     "@azure/schema-registry": "1.3.0",
     "@azure/schema-registry-avro": "^1.1.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -65,7 +65,7 @@
     "@azure/schema-registry": "^1.2.0",
     "avsc": "^5.5.1",
     "lru-cache": "^11.1.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/schemaregistry/schema-registry-json/package.json
+++ b/sdk/schemaregistry/schema-registry-json/package.json
@@ -63,7 +63,7 @@
     "@azure/logger": "^1.1.4",
     "@azure/schema-registry": "^1.3.0",
     "lru-cache": "^11.1.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -74,7 +74,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/scvmm/arm-scvmm/package.json
+++ b/sdk/scvmm/arm-scvmm/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/search/arm-search/package.json
+++ b/sdk/search/arm-search/package.json
@@ -240,7 +240,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/search/search-documents-perf-tests/package.json
+++ b/sdk/search/search-documents-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/search-documents": "12.1.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -76,7 +76,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/security/arm-security/package.json
+++ b/sdk/security/arm-security/package.json
@@ -558,7 +558,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/securitydevops/arm-securitydevops/package.json
+++ b/sdk/securitydevops/arm-securitydevops/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/securityinsight/arm-securityinsight/package.json
+++ b/sdk/securityinsight/arm-securityinsight/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/selfhelp/arm-selfhelp/package.json
+++ b/sdk/selfhelp/arm-selfhelp/package.json
@@ -232,7 +232,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/serialconsole/arm-serialconsole/package.json
+++ b/sdk/serialconsole/arm-serialconsole/package.json
@@ -119,7 +119,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/service-map/arm-servicemap/package.json
+++ b/sdk/service-map/arm-servicemap/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/servicebus/arm-servicebus/package.json
+++ b/sdk/servicebus/arm-servicebus/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/servicebus/service-bus-perf-tests/package.json
+++ b/sdk/servicebus/service-bus-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/service-bus": "^7.9.5",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -97,7 +97,7 @@
     "long": "^5.3.1",
     "process": "^0.11.10",
     "rhea-promise": "^3.0.3",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "util": "^0.12.5"
   },
   "devDependencies": {

--- a/sdk/servicefabric/arm-servicefabric-rest/package.json
+++ b/sdk/servicefabric/arm-servicefabric-rest/package.json
@@ -70,7 +70,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/servicefabric/arm-servicefabric/package.json
+++ b/sdk/servicefabric/arm-servicefabric/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
+++ b/sdk/servicefabricmanagedclusters/arm-servicefabricmanagedclusters/package.json
@@ -52,7 +52,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/servicegroups/arm-servicegroups/package.json
+++ b/sdk/servicegroups/arm-servicegroups/package.json
@@ -114,7 +114,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/servicelinker/arm-servicelinker/package.json
+++ b/sdk/servicelinker/arm-servicelinker/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/servicenetworking/arm-servicenetworking/package.json
+++ b/sdk/servicenetworking/arm-servicenetworking/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/signalr/arm-signalr/package.json
+++ b/sdk/signalr/arm-signalr/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/sitemanager/arm-sitemanager/package.json
+++ b/sdk/sitemanager/arm-sitemanager/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/sphere/arm-sphere/package.json
+++ b/sdk/sphere/arm-sphere/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/springappdiscovery/arm-springappdiscovery/package.json
+++ b/sdk/springappdiscovery/arm-springappdiscovery/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/sql/arm-sql/package.json
+++ b/sdk/sql/arm-sql/package.json
@@ -2168,7 +2168,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
+++ b/sdk/sqlvirtualmachine/arm-sqlvirtualmachine/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.3",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/standbypool/arm-standbypool/package.json
+++ b/sdk/standbypool/arm-standbypool/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
+++ b/sdk/storage/arm-storage-profile-2020-09-01-hybrid/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/storage/arm-storage/package.json
+++ b/sdk/storage/arm-storage/package.json
@@ -484,7 +484,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -76,7 +76,7 @@
     "@azure/logger": "^1.1.4",
     "@azure/storage-blob": "^12.26.0",
     "@azure/storage-internal-avro": "^1.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "workspace:^",

--- a/sdk/storage/storage-blob-perf-tests/package.json
+++ b/sdk/storage/storage-blob-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/storage-blob": "^12.27.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -110,7 +110,7 @@
     "@azure/logger": "^1.1.4",
     "@azure/storage-common": "^12.4.0",
     "events": "^3.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storage/storage-common/package.json
+++ b/sdk/storage/storage-common/package.json
@@ -64,7 +64,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/storage/storage-file-datalake-perf-tests/package.json
+++ b/sdk/storage/storage-file-datalake-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/storage-file-datalake": "^12.26.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -99,7 +99,7 @@
     "@azure/storage-blob": "^12.32.0",
     "@azure/storage-common": "^12.4.0",
     "events": "^3.3.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storage/storage-file-share-perf-tests/package.json
+++ b/sdk/storage/storage-file-share-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/storage-file-share": "^12.27.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -105,7 +105,7 @@
     "@azure/logger": "^1.1.4",
     "@azure/storage-common": "^12.4.0",
     "events": "^3.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storage/storage-internal-avro/package.json
+++ b/sdk/storage/storage-internal-avro/package.json
@@ -52,7 +52,7 @@
     "@azure/abort-controller": "^2.1.2",
     "@azure/core-paging": "^1.6.2",
     "buffer": "^6.0.3",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -103,7 +103,7 @@
     "@azure/core-xml": "^1.4.3",
     "@azure/logger": "^1.1.4",
     "@azure/storage-common": "^12.4.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storageactions/arm-storageactions/package.json
+++ b/sdk/storageactions/arm-storageactions/package.json
@@ -54,7 +54,7 @@
     "@azure/core-rest-pipeline": "^1.18.2",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storagecache/arm-storagecache/package.json
+++ b/sdk/storagecache/arm-storagecache/package.json
@@ -14,7 +14,7 @@
     "@azure/core-client": "^1.9.3",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.1",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/storagediscovery/arm-storagediscovery/package.json
+++ b/sdk/storagediscovery/arm-storagediscovery/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storageimportexport/arm-storageimportexport/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/storagemover/arm-storagemover/package.json
+++ b/sdk/storagemover/arm-storagemover/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storagesync/arm-storagesync/package.json
+++ b/sdk/storagesync/arm-storagesync/package.json
@@ -246,7 +246,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/storsimple1200series/arm-storsimple1200series/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/storsimple8000series/arm-storsimple8000series/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/streamanalytics/arm-streamanalytics/package.json
+++ b/sdk/streamanalytics/arm-streamanalytics/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.5.4",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
+++ b/sdk/subscription/arm-subscriptions-profile-2020-09-01-hybrid/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/subscription/arm-subscriptions/package.json
+++ b/sdk/subscription/arm-subscriptions/package.json
@@ -194,7 +194,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/support/arm-support/package.json
+++ b/sdk/support/arm-support/package.json
@@ -344,7 +344,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/synapse/arm-synapse/package.json
+++ b/sdk/synapse/arm-synapse/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/synapse/synapse-access-control-rest/package.json
+++ b/sdk/synapse/synapse-access-control-rest/package.json
@@ -14,7 +14,7 @@
     "@azure-rest/core-client": "^2.3.1",
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -16,7 +16,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "//metadata": {
     "constantPaths": [

--- a/sdk/synapse/synapse-artifacts/package.json
+++ b/sdk/synapse/synapse-artifacts/package.json
@@ -18,7 +18,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "browser": "./dist/browser/index.js",
   "keywords": [

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -16,7 +16,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -15,7 +15,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -15,7 +15,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-tracing": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/tables/data-tables-perf-tests/package.json
+++ b/sdk/tables/data-tables-perf-tests/package.json
@@ -50,7 +50,7 @@
     "@azure-tools/test-perf": "^1.0.0",
     "@azure/data-tables": "^13.3.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/tables/data-tables/package.json
+++ b/sdk/tables/data-tables/package.json
@@ -58,7 +58,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/core-xml": "^1.4.4",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/template/template-dpg/package.json
+++ b/sdk/template/template-dpg/package.json
@@ -133,7 +133,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "browser": "./dist/browser/index.js",
   "react-native": "./dist/react-native/index.js",

--- a/sdk/template/template-perf-tests/package.json
+++ b/sdk/template/template-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/identity": "^4.8.0",
     "@azure/template": "workspace:^",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -61,7 +61,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/templatespecs/arm-templatespecs/package.json
+++ b/sdk/templatespecs/arm-templatespecs/package.json
@@ -12,7 +12,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/package.json
+++ b/sdk/tenantactivitylogalerts/arm-tenantactivitylogalerts/package.json
@@ -112,7 +112,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/terraform/arm-terraform/package.json
+++ b/sdk/terraform/arm-terraform/package.json
@@ -51,7 +51,7 @@
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/test-utils/perf/package.json
+++ b/sdk/test-utils/perf/package.json
@@ -58,7 +58,7 @@
     "@azure/core-util": "^1.3.2",
     "@types/minimist": "^1.2.2",
     "minimist": "^1.2.8",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/test-utils/test-credential/package.json
+++ b/sdk/test-utils/test-credential/package.json
@@ -52,7 +52,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-util": "^1.11.0",
     "@azure/identity": "^4.5.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/test-utils/test-utils-vitest/package.json
+++ b/sdk/test-utils/test-utils-vitest/package.json
@@ -50,7 +50,7 @@
     "@azure/core-rest-pipeline": "^1.16.3",
     "@azure/core-tracing": "^1.1.2",
     "@opentelemetry/api": "^1.9.0",
-    "tslib": "^2.6.3",
+    "tslib": "catalog:",
     "vitest": "catalog:testing"
   },
   "devDependencies": {

--- a/sdk/textanalytics/ai-text-analytics-perf-tests/package.json
+++ b/sdk/textanalytics/ai-text-analytics-perf-tests/package.json
@@ -51,7 +51,7 @@
     "@azure/ai-text-analytics": "^5.1.0",
     "@azure/identity": "^4.8.0",
     "dotenv": "^16.0.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -89,7 +89,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
+++ b/sdk/timeseriesinsights/arm-timeseriesinsights/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/trafficmanager/arm-trafficmanager/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/package.json
@@ -168,7 +168,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/transcription/ai-speech-transcription/package.json
+++ b/sdk/transcription/ai-speech-transcription/package.json
@@ -50,7 +50,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/translation/ai-translation-document-rest/package.json
+++ b/sdk/translation/ai-translation-document-rest/package.json
@@ -64,7 +64,7 @@
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/translation/ai-translation-text-rest/package.json
+++ b/sdk/translation/ai-translation-text-rest/package.json
@@ -75,7 +75,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/trustedsigning/arm-trustedsigning/package.json
+++ b/sdk/trustedsigning/arm-trustedsigning/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/vision/ai-vision-image-analysis-rest/package.json
+++ b/sdk/vision/ai-vision-image-analysis-rest/package.json
@@ -59,7 +59,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-rest-pipeline": "^1.19.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/visualstudio/arm-visualstudio/package.json
+++ b/sdk/visualstudio/arm-visualstudio/package.json
@@ -13,7 +13,7 @@
     "@azure/core-client": "^1.9.2",
     "@azure/core-lro": "^2.2.0",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
+++ b/sdk/vmwarecloudsimple/arm-vmwarecloudsimple/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.2.0",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/voicelive/ai-voicelive/package.json
+++ b/sdk/voicelive/ai-voicelive/package.json
@@ -49,7 +49,7 @@
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
     "https-proxy-agent": "^7.0.1",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/sdk/voiceservices/arm-voiceservices/package.json
+++ b/sdk/voiceservices/arm-voiceservices/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/web-pubsub/arm-webpubsub/package.json
+++ b/sdk/web-pubsub/arm-webpubsub/package.json
@@ -260,7 +260,7 @@
     "@azure/core-lro": "^3.1.0",
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
+++ b/sdk/web-pubsub/web-pubsub-client-protobuf/package.json
@@ -59,7 +59,7 @@
     "@azure/web-pubsub-client": "1.0.0-beta.2",
     "long": "^5.3.1",
     "protobufjs": "^7.4.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/web-pubsub/web-pubsub-client/package.json
+++ b/sdk/web-pubsub/web-pubsub-client/package.json
@@ -54,7 +54,7 @@
     "@azure/logger": "^1.1.4",
     "buffer": "^6.0.0",
     "events": "^3.3.0",
-    "tslib": "^2.8.1",
+    "tslib": "catalog:",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/sdk/web-pubsub/web-pubsub-express/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/package.json
@@ -45,7 +45,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-utils-vitest": "workspace:^",

--- a/sdk/web-pubsub/web-pubsub/package.json
+++ b/sdk/web-pubsub/web-pubsub/package.json
@@ -63,7 +63,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "jsonwebtoken": "^9.0.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/workloadorchestration/arm-workloadorchestration/package.json
+++ b/sdk/workloadorchestration/arm-workloadorchestration/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.20.0",
     "@azure/core-util": "^1.12.0",
     "@azure/logger": "^1.2.0",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",

--- a/sdk/workloads/arm-workloads/package.json
+++ b/sdk/workloads/arm-workloads/package.json
@@ -14,7 +14,7 @@
     "@azure/core-lro": "^2.7.2",
     "@azure/core-paging": "^1.6.2",
     "@azure/core-rest-pipeline": "^1.18.2",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "keywords": [
     "node",

--- a/sdk/workloads/arm-workloadssapvirtualinstance/package.json
+++ b/sdk/workloads/arm-workloadssapvirtualinstance/package.json
@@ -52,7 +52,7 @@
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.1.4",
-    "tslib": "^2.8.1"
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",


### PR DESCRIPTION
### Packages impacted by this PR

All workspace packages that depend on `tslib` (456 `package.json` files across `sdk/**`, `common/tools/**`, and `eng/containers/turborepo-remote-cache`).

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

`tslib` was pinned independently across workspace packages at a mix of `^1.10.0`, `^2.2.0`, `^2.6.2`, `^2.6.3`, `^2.7.0`, and `^2.8.1`. A `tslib: ^2.8.1` entry already exists in `pnpm-workspace.yaml` under `catalog:`, so the per-package specifiers were redundant and a source of drift whenever a new package landed with whatever version its template happened to ship.

This PR routes every workspace package through the catalog by replacing the explicit specifier with `"tslib": "catalog:"`, so the version lives in exactly one place.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The catalog protocol is the pattern this repo already adopted for other shared dev dependencies (`typescript`, `eslint`, `prettier`, `tsx`, etc.). Extending it to `tslib` is the lowest-friction option and matches existing convention. The alternative (continuing to pin per package and policing versions via lint) was rejected because it does not prevent drift.

### Are there test cases added in this PR? _(If not, why?)_

No code changes; this is a dependency-spec refactor. Validated locally with `pnpm install --lockfile-only` - the only `pnpm-lock.yaml` delta is `specifier:` lines changing from the previous version range to `'catalog:'`. No resolution drift.

Three `package.json` files under paths explicitly excluded from the pnpm workspace (`sdk/identity/identity/integration/**`, `sdk/identity/identity/test/manual/**`) were intentionally left alone since they are not workspace members and cannot reference the catalog.

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)