### PR TITLE
[Identity] Update MI test for SFI requirement

### DIFF
--- a/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
+++ b/sdk/identity/identity/integration/AzureKubernetes/Dockerfile
@@ -11,9 +11,11 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install --no-package-lock
+RUN npm install
 
 RUN npm run build
+
+RUN npm prune --omit=dev
 
 FROM ${BASE_IMAGE}
 WORKDIR /app
@@ -24,7 +26,6 @@ RUN tdnf install -y wget && tdnf clean all
 # Copy only the built app and necessary files
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./
-
-RUN npm install --only=production
+COPY --from=builder /app/node_modules ./node_modules
 
 CMD ["node", "dist/index.js"]

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -86,7 +86,13 @@ Write-Host "##[group]Deploying Identity Docker image to ACR"
 az acr login -n $DeploymentOutputs['IDENTITY_ACR_NAME']
 $loginServer = $DeploymentOutputs['IDENTITY_ACR_LOGIN_SERVER']
 $image = "$loginServer/identity-aks-test-image"
-docker build --no-cache -t $image "$workingFolder/AzureKubernetes"
+
+$kubernetesContext = "$workingFolder/AzureKubernetes"
+$kubernetesNpmrc = "$kubernetesContext/.npmrc"
+$sourceNpmrc = $env:NPM_CONFIG_USERCONFIG
+Write-Host "Copying authenticated .npmrc from $sourceNpmrc to $kubernetesNpmrc"
+Copy-Item -Path $sourceNpmrc -Destination $kubernetesNpmrc -Force
+docker build --no-cache -t $image $kubernetesContext
 docker push $image
 
 Write-Host "Deployed image to ACR"

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -90,10 +90,24 @@ $image = "$loginServer/identity-aks-test-image"
 $kubernetesContext = "$workingFolder/AzureKubernetes"
 $kubernetesNpmrc = "$kubernetesContext/.npmrc"
 $sourceNpmrc = $env:NPM_CONFIG_USERCONFIG
+
+if ([string]::IsNullOrEmpty($sourceNpmrc) -or -not (Test-Path -LiteralPath $sourceNpmrc)) {
+  throw "NPM_CONFIG_USERCONFIG is not set or points to a missing file: '$sourceNpmrc'"
+}
+
 Write-Host "Copying authenticated .npmrc from $sourceNpmrc to $kubernetesNpmrc"
-Copy-Item -Path $sourceNpmrc -Destination $kubernetesNpmrc -Force
-docker build --no-cache -t $image $kubernetesContext
-docker push $image
+try {
+  Copy-Item -Path $sourceNpmrc -Destination $kubernetesNpmrc -Force -ErrorAction Stop
+
+  docker build --no-cache -t $image $kubernetesContext
+  if ($LASTEXITCODE -ne 0) { throw "docker build failed with exit code $LASTEXITCODE" }
+
+  docker push $image
+  if ($LASTEXITCODE -ne 0) { throw "docker push failed with exit code $LASTEXITCODE" }
+}
+finally {
+  Remove-Item -LiteralPath $kubernetesNpmrc -Force -ErrorAction SilentlyContinue
+}
 
 Write-Host "Deployed image to ACR"
 Write-Host "##[endgroup]"


### PR DESCRIPTION
Ensure the MI test use the correct .npmrc that points to internal CFS to meet the network isolation requirement for SFI. Remove `npm install` step at runtime by pruning and just copying the node modules over

Pipeline passed [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6430021&view=logs&s=cb5ce6fe-dbe8-5b4a-ce11-aad725ccaf92&j=30daf185-540e-5cf8-e6b7-45fcd9eb71be)