### PR TITLE
[engsys] Add ccr-r4c sample helper scripts

### DIFF
--- a/eng/scripts/ccr-r4c-missing-copyright.ts
+++ b/eng/scripts/ccr-r4c-missing-copyright.ts
@@ -1,0 +1,5 @@
+export function farewell(name: string): string {
+  return `Goodbye, ${name}!`;
+}
+
+console.log(farewell("world"));

--- a/eng/scripts/ccr-r4c-with-copyright.ts
+++ b/eng/scripts/ccr-r4c-with-copyright.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+console.log(greet("world"));


### PR DESCRIPTION
Adds two small helper scripts demonstrating different copyright-header conventions. Companion to PR #38862 (R4) and #38863 (R4b) in our CCR-extensibility experiment series — testing whether a skill with a clearly-legitimate rule (copyright check, framed as serious) gets loaded and applied where the more arbitrary line-start rule did not. Branch will be retained for write-up reference.