### PR TITLE
[engsys] Add ccr-r4d sample helper scripts

### DIFF
--- a/eng/scripts/ccr-r4d-missing-copyright.ts
+++ b/eng/scripts/ccr-r4d-missing-copyright.ts
@@ -1,0 +1,5 @@
+export function farewell(name: string): string {
+  return `Goodbye, ${name}!`;
+}
+
+console.log(farewell("world"));

--- a/eng/scripts/ccr-r4d-with-copyright.ts
+++ b/eng/scripts/ccr-r4d-with-copyright.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+console.log(greet("world"));


### PR DESCRIPTION
Adds two small helper scripts demonstrating different copyright-header conventions. Companion to PRs #38862 (R4), #38863 (R4b), and #38865 (R4c) in our CCR-extensibility experiment series.

This round (R4d) strips every other CCR guidance surface — AGENTS.md and `.github/instructions/reviewer/*` are deleted on the base branch, and `.github/copilot-instructions.md` is pared down to a single sentence invoking the skill. The SKILL.md itself now mandates a literal 💕 / 🤑 emoji prefix on every comment so we can tell at a glance whether the skill drove the output.

Branch will be retained for write-up reference.