### PR TITLE
Fix duplicate dependency-upgrade issue filing in weekly automation

### DIFF
--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -21,7 +21,7 @@ Write-Host "Repo root: $RepoRoot"
 $EngCommonScriptsPath = Join-Path (Resolve-Path "${PSScriptRoot}/..") "common" "scripts"
 . (Join-Path $EngCommonScriptsPath common.ps1)
 
-$ghIssues = Get-GitHubIssues -RepoOwner $RepoOwner -RepoName $RepoName -Labels "dependency-upgrade-required" -AuthToken $AuthToken
+$ghIssues = Get-GitHubIssues -RepoOwner $RepoOwner -RepoName $RepoName -Labels $dependencyUpgradeLabel -AuthToken $AuthToken
 # Check and return if an issue already exists to upgrade the package
 function Get-GithubIssue($IssueTitle) {
   foreach ($issue in $ghIssues) {

--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -21,10 +21,6 @@ Write-Host "Repo root: $RepoRoot"
 $EngCommonScriptsPath = Join-Path (Resolve-Path "${PSScriptRoot}/..") "common" "scripts"
 . (Join-Path $EngCommonScriptsPath common.ps1)
 
-# Don't filter by creator: the pipeline identity changed from the `azure-sdk` user PAT
-# to the `azure-sdk-automation[bot]` GitHub App, and the GitHub REST `creator` filter is
-# an exact login match. Scoping by the `dependency-upgrade-required` label is sufficient
-# because it is only applied by this script.
 $ghIssues = Get-GitHubIssues -RepoOwner $RepoOwner -RepoName $RepoName -Labels "dependency-upgrade-required" -AuthToken $AuthToken
 # Check and return if an issue already exists to upgrade the package
 function Get-GithubIssue($IssueTitle) {

--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -21,7 +21,11 @@ Write-Host "Repo root: $RepoRoot"
 $EngCommonScriptsPath = Join-Path (Resolve-Path "${PSScriptRoot}/..") "common" "scripts"
 . (Join-Path $EngCommonScriptsPath common.ps1)
 
-$ghIssues = Get-GitHubIssues -RepoOwner $RepoOwner -RepoName $RepoName -CreatedBy "azure-sdk" -Labels "dependency-upgrade-required" -AuthToken $AuthToken
+# Don't filter by creator: the pipeline identity changed from the `azure-sdk` user PAT
+# to the `azure-sdk-automation[bot]` GitHub App, and the GitHub REST `creator` filter is
+# an exact login match. Scoping by the `dependency-upgrade-required` label is sufficient
+# because it is only applied by this script.
+$ghIssues = Get-GitHubIssues -RepoOwner $RepoOwner -RepoName $RepoName -Labels "dependency-upgrade-required" -AuthToken $AuthToken
 # Check and return if an issue already exists to upgrade the package
 function Get-GithubIssue($IssueTitle) {
   foreach ($issue in $ghIssues) {


### PR DESCRIPTION
The weekly external-dependency check (`eng/scripts/check-external-dependency.ps1`) has been creating duplicate issues for the same package on every run — e.g. three open issues for `concurrently`:

- #38759 (2026-06-01)
- #38771 (2026-06-01)
- #38860 (2026-06-08)

All have identical titles, so the script's title comparison (`$issue.title -eq $IssueTitle`) is not the culprit. The real bug is upstream: the pre-filtered issue list is empty.

## Root cause

```powershell
$ghIssues = Get-GitHubIssues ... -CreatedBy "azure-sdk" -Labels "dependency-upgrade-required" ...
```

GitHub's REST `creator` query parameter is an **exact login match**. The pipeline identity rolled over from the `azure-sdk` user PAT to the `azure-sdk-automation[bot]` GitHub App (last `azure-sdk`-authored issue was #38668 on 2026-05-26; everything since is `azure-sdk-automation[bot]`). The filter no longer matches the bot's own issues, so `$ghIssues` excludes every recent entry and `Get-GithubIssue` returns `$null` for every package — producing a fresh duplicate each run.

## Fix

Drop the `-CreatedBy` argument. The `dependency-upgrade-required` label is only applied by this script, so scoping by label alone is sufficient and is resilient to future identity changes.

## Follow-up

Closing duplicate issues #38771 and #38860 as duplicates of #38759.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>