### PR TITLE
Make PublishDocs depend on Publish to DevOps feed

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -124,6 +124,10 @@ stages:
                             - ci-configs/packages-latest.json
                             - ci-configs/packages-preview.json
                           NpmConfigUserConfig: $(Agent.TempDirectory)/doc-ms/.npmrc
+                          ${{ if eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-js')}}:
+                            PackageSourceOverride: '$(PublicDevOpsRegistry)'
+                          ${{ else }}:
+                            PackageSourceOverride: '$(PrivateDevOpsRegistry)'
 
               - ${{ if ne(artifact.skipPublishDocGithubIo, 'true') }}:
                   - job: PublishDocsGitHubIO
@@ -134,7 +138,7 @@ stages:
                         ne(variables['Skip.PublishDocs'], 'true'),
                         ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-js-pr')
                       )
-                    dependsOn: PublishPackage_${{ replace(artifact.name, '-', '_') }}
+                    dependsOn: PublishPackage_${{ replace(artifact.name, '-', '_') }}_To_DevFeed
                     pool:
                       name: $(LINUXPOOL)
                       image: $(LINUXVMIMAGE)
@@ -156,7 +160,7 @@ stages:
                   - job: UpdatePackageVersion
                     displayName: Update Package Version
                     condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-                    dependsOn: PublishPackage_${{ replace(artifact.name, '-', '_') }}
+                    dependsOn: PublishPackage_${{ replace(artifact.name, '-', '_') }}_To_DevFeed
                     pool:
                       name: $(LINUXPOOL)
                       image: $(LINUXVMIMAGE)

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -90,7 +90,7 @@ stages:
                         ne(variables['Skip.PublishDocs'], 'true'),
                         ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-js-pr')
                       )
-                    dependsOn: PublishPackage_${{ replace(artifact.name, '-', '_') }}
+                    dependsOn: PublishPackage_${{ replace(artifact.name, '-', '_') }}_To_DevFeed
                     pool:
                       name: $(LINUXPOOL)
                       image: $(LINUXVMIMAGE)

--- a/eng/scripts/docs/Docs-Onboarding.ps1
+++ b/eng/scripts/docs/Docs-Onboarding.ps1
@@ -95,36 +95,70 @@ function Get-DocsMsPackageName($packageName, $packageVersion) {
 
 # Defined in common.ps1 as:
 # $ValidateDocsMsPackagesFn = "Validate-${Language}-DocMsPackages"
-function Validate-javascript-DocMsPackages ($PackageInfo, $PackageInfos, $DocRepoLocation, $DocValidationImageId) {
+function Validate-javascript-DocMsPackages (
+  $PackageInfo,
+  $PackageInfos,
+  $DocRepoLocation,
+  $DocValidationImageId,
+  $PackageSourceOverride
+) {
   if (!$PackageInfos) {
     $PackageInfos = @($PackageInfo)
   }
 
-  $allSucceeded = $true
-  $failedPackages = @()
-
-  foreach ($packageInfo in $PackageInfos) {
-    $outputLocation = New-Item `
-      -ItemType Directory `
-      -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()))
-
-    Write-Host "type2docfx `"$($packageInfo.Name)@$($packageInfo.Version)`" $outputLocation"
-    $output = & type2docfx "$($packageInfo.Name)@$($packageInfo.Version)" $outputLocation 2>&1 | Tee-Object -Variable output | Out-Host
-    if ($LASTEXITCODE) {
-      $allSucceeded = $false
-      $failedPackages += $packageInfo.Name
-      Write-Host "Package $($packageInfo.Name)@$($packageInfo.Version) failed validation"
-      $output | Write-Host
-    }
+  $resolvedRegistry = if (![string]::IsNullOrWhiteSpace($PackageSourceOverride)) {
+    $PackageSourceOverride
+  }
+  else {
+    "https://registry.npmjs.org/"
   }
 
-  # Show failed packages at the end of the run
-  if ($failedPackages.Count -gt 0) {
-    Write-Host "Failed package: $($failedPackages.Count)"
-    foreach ($failedPackage in $failedPackages) {
-      Write-Host "Failed package: $failedPackage"
+  $previousRegistry = $env:npm_config_registry
+  $previousUserConfig = $env:npm_config_userconfig
+  $env:npm_config_registry = $resolvedRegistry
+
+  try {
+    $allSucceeded = $true
+    $failedPackages = @()
+
+    foreach ($packageInfo in $PackageInfos) {
+      $outputLocation = New-Item `
+        -ItemType Directory `
+        -Path (Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()))
+
+      Write-Host "type2docfx `"$($packageInfo.Name)@$($packageInfo.Version)`" $outputLocation"
+      $output = & type2docfx "$($packageInfo.Name)@$($packageInfo.Version)" $outputLocation 2>&1 | Tee-Object -Variable output | Out-Host
+      if ($LASTEXITCODE) {
+        $allSucceeded = $false
+        $failedPackages += $packageInfo.Name
+        Write-Host "Package $($packageInfo.Name)@$($packageInfo.Version) failed validation"
+        $output | Write-Host
+      }
+    }
+
+    # Show failed packages at the end of the run
+    if ($failedPackages.Count -gt 0) {
+      Write-Host "Failed package: $($failedPackages.Count)"
+      foreach ($failedPackage in $failedPackages) {
+        Write-Host "Failed package: $failedPackage"
+      }
+    }
+
+    return $allSucceeded
+  }
+  finally {
+    if ($null -eq $previousRegistry) {
+      Remove-Item Env:npm_config_registry -ErrorAction SilentlyContinue
+    }
+    else {
+      $env:npm_config_registry = $previousRegistry
+    }
+
+    if ($null -eq $previousUserConfig) {
+      Remove-Item Env:npm_config_userconfig -ErrorAction SilentlyContinue
+    }
+    else {
+      $env:npm_config_userconfig = $previousUserConfig
     }
   }
-
-  return $allSucceeded
 }


### PR DESCRIPTION
This pull request makes a targeted update to the release pipeline for JavaScript packages. The main change is to the dependency configuration for the documentation publishing stage, ensuring it now depends on the correct package publishing step.

**Pipeline dependency update:**

* In `archetype-js-release.yml`, the `dependsOn` property for the documentation publishing stage was updated to depend on `PublishPackage_${{ replace(artifact.name, '-', '_') }}_To_DevFeed` instead of the previous `PublishPackage_${{ replace(artifact.name, '-', '_') }}`. This ensures that documentation is published only after the package has been published to the development feed.