### PR TITLE
[monitor-query-logs] reduce the build targets to esm and commonjs

### DIFF
--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -5,7 +5,7 @@
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
-  "browser": "./dist/browser/index.js",
+  "browser": "./dist/esm/index.js",
   "//metadata": {
     "constantPaths": [
       {
@@ -110,14 +110,6 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
-      },
-      "react-native": {
-        "types": "./dist/react-native/index.d.ts",
-        "default": "./dist/react-native/index.js"
-      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -128,7 +120,7 @@
       }
     }
   },
-  "react-native": "./dist/react-native/index.js",
+  "react-native": "./dist/esm/index.js",
   "imports": {
     "#platform/*": {
       "react-native": "./src/*-react-native.mts",

--- a/sdk/monitor/monitor-query-logs/warp.config.yml
+++ b/sdk/monitor/monitor-query-logs/warp.config.yml
@@ -1,1 +1,10 @@
 extends: ../../../warp.base.config.yml
+
+targets:
+  - name: esm
+    condition: import
+    tsconfig: "../../../tsconfig.src.esm.json"
+  - name: commonjs
+    condition: require
+    tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs


### PR DESCRIPTION
This package doesn't have any browser or react-native platform specific code.  We can save build time and published package size by removing the browser and react-native build target. With commonjs and ESM we could still support browser and react-native:

After removing the browser and react-native conditions from exports["."], the resolution flow for a browser or React Native consumer becomes:

| Consumer | Resolver sends conditions like | Matches | Resolves to |
|---|---|---|---|
| Webpack 5 / Vite / Rollup / esbuild (browser target) | `["browser", "import", "module", "default"]` | `import` (browser missing) | `./dist/esm/index.js` |
| Metro with package exports enabled (RN ≥ 0.79) | `["react-native", "browser", "import", "default"]` | `import` (react-native + browser missing) | `./dist/esm/index.js` |
| Node ESM | `["node", "import", "default"]` | `import` | `./dist/esm/index.js` |
| Node CJS | `["node", "require", "default"]` | `require` | `./dist/commonjs/index.js` |