### PR TITLE
Add failing build log links to CI test failure report

### DIFF
--- a/.github/workflows/fix-test-failures.md
+++ b/.github/workflows/fix-test-failures.md
@@ -41,7 +41,8 @@ failure.
 - `snippets.spec.ts` files under `sdk/**/*/test/` are documentation snippet sources,
   **not** real tests — ignore failures in those files.
 - Do **not** follow `details_url` links on check runs — they point to Azure DevOps
-  which is not accessible from this environment.
+  which is not accessible from this environment. (You may still **include** these
+  links in the issue so a human can open them; you just must not fetch them yourself.)
 - Do **not** create pull requests or modify source files. The only mutable output
   of this workflow is a GitHub issue; when no new failures exist the workflow
   exits silently with no issue created.
@@ -94,6 +95,15 @@ failures.
 4. If a specific `package` input was provided, scope investigation to that package only.
 5. Collect the list of affected **service directories** or **package names** from the
    check-run names (the pattern is `js - <service> (...)`).
+6. For each failing check run, **record the links needed to reach the failing build
+   logs** so they can be embedded in the issue later:
+   - `html_url` — the GitHub check-run page for the failure.
+   - `details_url` (a.k.a. `target_url`) — the Azure DevOps build that produced the
+     failure. This is the most useful link for inspecting the full failure logs.
+     It typically follows the pattern
+     `https://dev.azure.com/azure-sdk/public/_build/results?buildId=<ID>&view=results`.
+   Keep these URLs associated with their service/package so each failure section in
+   the issue can link directly to its build logs.
 
 If there are no test failures on `main`, **stop immediately** — do **not** create a
 GitHub issue. Simply report that CI is green and exit.
@@ -164,6 +174,8 @@ date/commit of the CI run inspected.>
 ## Failures
 
 ### <Package Name 1>
+
+**Failing CI build:** [<check-run name>](<details_url / Azure DevOps build link>) ([check run](<html_url>))
 
 **Failing tests:**
 - `<test name 1>` in `<test-file-path>`

--- a/.github/workflows/fix-test-failures.md
+++ b/.github/workflows/fix-test-failures.md
@@ -98,7 +98,7 @@ failures.
 6. For each failing check run, **record the links needed to reach the failing build
    logs** so they can be embedded in the issue later:
    - `html_url` — the GitHub check-run page for the failure.
-   - `details_url` (a.k.a. `target_url`) — the Azure DevOps build that produced the
+   - `details_url` (or `target_url`, depending on the API field available) — the Azure DevOps build that produced the
      failure. This is the most useful link for inspecting the full failure logs.
      It typically follows the pattern
      `https://dev.azure.com/azure-sdk/public/_build/results?buildId=<ID>&view=results`.


### PR DESCRIPTION
### Packages impacted by this PR

None. This updates the `Analyze CI Test Failures` agentic workflow prompt (`.github/workflows/fix-test-failures.md`).

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

The report produced by the `Analyze CI Test Failures` workflow did not link to the failing public CI builds, so anyone reading the generated issue had no quick way to jump to the actual failure logs. They had to manually hunt down the corresponding build in Azure DevOps.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The fix is entirely in the workflow prompt, so no code/lock regeneration was needed (the `.lock.yml` imports the markdown body at runtime via `{{#runtime-import ...}}`). The prompt now:

- Clarifies the existing "do not follow `details_url`" constraint to note that the link may still be *included* in the issue (the agent just must not fetch it itself, since Azure DevOps is unreachable from the workflow environment).
- Adds a Step 1 instruction to record each failing check run's `html_url` (GitHub check-run page) and `details_url`/`target_url` (the Azure DevOps build, which has the full failure logs at the `dev.azure.com/azure-sdk/public/_build/results?buildId=...` URL), keyed to each service/package.
- Adds a `**Failing CI build:**` link line to each package section of the generated issue template.

This keeps the change minimal and consistent with how `mgmt-review.md` already surfaces Azure DevOps build links.

### Are there test cases added in this PR? _(If not, why?)_

No. This is a prompt/documentation change for an agentic workflow; there is no automated test harness for the generated issue content. `gh aw compile` was run (with the repo's pinned compiler v0.72.1) and passed with 0 errors and 0 warnings.

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)