### PR TITLE
[monitor-opentelemetry] Fix Live Metrics CPU-saturating deactivate/reactivate loop (#38854)

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a CPU-saturating deactivate/reactivate loop in Live Metrics that occurred when live-endpoint posts failed while subscribed.
+
 ### Other Changes
 
 ## 1.18.1 (2026-05-29)

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
@@ -162,6 +162,6 @@ export class MetricHandler {
   public async shutdown(): Promise<void> {
     this._standardMetrics?.shutdown();
     await this._liveMetrics?.shutdown();
-    this._performanceCounters?.shutdown();
+    await this._performanceCounters?.shutdown();
   }
 }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/handler.ts
@@ -159,10 +159,9 @@ export class MetricHandler {
   /**
    * Shutdown handler
    */
-  // eslint-disable-next-line @typescript-eslint/require-await
   public async shutdown(): Promise<void> {
     this._standardMetrics?.shutdown();
-    this._liveMetrics?.shutdown();
+    await this._liveMetrics?.shutdown();
     this._performanceCounters?.shutdown();
   }
 }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -204,7 +204,20 @@ export class LiveMetrics {
   }
 
   public async shutdown(): Promise<void> {
-    await this.meterProvider?.shutdown();
+    // Force collecting=false before tearing down so the shutdown's final
+    // force-flush export, if it fails, cannot trigger the deactivate/
+    // reactivate fallback in quickPulseDone(). Delegate to deactivateMetrics()
+    // so the re-entrancy guard and meterProvider clearing apply here too.
+    this.isCollectingData = false;
+    if (this.isDeactivating) {
+      return;
+    }
+    this.isDeactivating = true;
+    try {
+      await this.deactivateMetrics();
+    } finally {
+      this.isDeactivating = false;
+    }
   }
 
   private async goQuickpulse(): Promise<void> {
@@ -232,7 +245,6 @@ export class LiveMetrics {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   private async quickPulseDone(response: QuickpulseResponse | undefined): Promise<void> {
     if (!response) {
       if (!this.isCollectingData) {
@@ -252,6 +264,14 @@ export class LiveMetrics {
           this.postInterval = FALLBACK_INTERVAL;
           try {
             await this.deactivateMetrics();
+          } catch (error) {
+            // The exporter invokes postCallback without awaiting it, so a
+            // rejection here would surface as an unhandled rejection. Swallow
+            // and log so the failure path stays contained.
+            Logger.getInstance().warn(
+              "Failed to deactivate Live Metrics during failure fallback",
+              error,
+            );
           } finally {
             this.isDeactivating = false;
           }

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -100,6 +100,7 @@ export class LiveMetrics {
   private pingSender: QuickpulseSender;
   private isCollectingData: boolean;
   private isDeactivating: boolean = false;
+  private deactivatingPromise: Promise<void> | undefined;
   private lastSuccessTime: number = Date.now();
   private handle: NodeJS.Timer;
   // Monitoring data point with common properties
@@ -207,17 +208,11 @@ export class LiveMetrics {
     // Force collecting=false before tearing down so the shutdown's final
     // force-flush export, if it fails, cannot trigger the deactivate/
     // reactivate fallback in quickPulseDone(). Delegate to deactivateMetrics()
-    // so the re-entrancy guard and meterProvider clearing apply here too.
+    // which manages the in-flight deactivation promise so callers (including
+    // a concurrent failure-fallback in quickPulseDone) all observe the same
+    // completion and shutdown waits for any in-flight deactivation to finish.
     this.isCollectingData = false;
-    if (this.isDeactivating) {
-      return;
-    }
-    this.isDeactivating = true;
-    try {
-      await this.deactivateMetrics();
-    } finally {
-      this.isDeactivating = false;
-    }
+    await this.deactivateMetrics();
   }
 
   private async goQuickpulse(): Promise<void> {
@@ -254,13 +249,13 @@ export class LiveMetrics {
       } else {
         if (Date.now() - this.lastSuccessTime >= MAX_POST_WAIT_TIME) {
           // Re-entrancy guard: MeterProvider.shutdown() triggers a final
-          // force-flush export which, on failure, re-invokes this callback.
-          // Without this guard we would recursively call deactivateMetrics()
-          // from inside the shutdown's export, saturating the CPU.
+          // force-flush export which, on failure, re-invokes this callback
+          // synchronously from inside the shutdown's export call. If a
+          // deactivation is already in flight, bail out — awaiting the
+          // in-flight promise here would deadlock the exporter's callback.
           if (this.isDeactivating) {
             return;
           }
-          this.isDeactivating = true;
           this.postInterval = FALLBACK_INTERVAL;
           try {
             await this.deactivateMetrics();
@@ -272,13 +267,17 @@ export class LiveMetrics {
               "Failed to deactivate Live Metrics during failure fallback",
               error,
             );
-          } finally {
-            this.isDeactivating = false;
           }
           // Reset the success-time baseline so the FALLBACK_INTERVAL backoff
           // can take effect before we consider deactivating again.
           this.lastSuccessTime = Date.now();
-          this.activateMetrics({ collectionInterval: this.postInterval });
+          // Re-check after the await: shutdown() may have run concurrently and
+          // flipped isCollectingData to false. Don't restart collection in
+          // that case — doing so would re-create the meterProvider after
+          // shutdown has begun.
+          if (this.isCollectingData) {
+            this.activateMetrics({ collectionInterval: this.postInterval });
+          }
         }
       }
     } else {
@@ -294,14 +293,7 @@ export class LiveMetrics {
       // If collecting was stoped
       if (!this.isCollectingData && this.meterProvider) {
         this.etag = "";
-        if (!this.isDeactivating) {
-          this.isDeactivating = true;
-          try {
-            await this.deactivateMetrics();
-          } finally {
-            this.isDeactivating = false;
-          }
-        }
+        await this.deactivateMetrics();
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.handle = setTimeout(this.goQuickpulse.bind(this), this.pingInterval);
         this.handle.unref();
@@ -431,19 +423,36 @@ export class LiveMetrics {
    * Deactivate metric collection
    */
   public async deactivateMetrics(): Promise<void> {
-    this.documents = [];
-    this.validDocumentFilterConjuctionGroupInfos.clear();
-    this.errorTracker.clearRunTimeErrors();
-    this.errorTracker.clearValidationTimeErrors();
-    this.validDerivedMetrics.clear();
-    this.derivedMetricProjection.clearProjectionMaps();
-    this.seenMetricIds.clear();
-    // Capture and clear the reference before awaiting shutdown so any
-    // re-entrant calls triggered by the shutdown's final force-flush export
-    // observe meterProvider as undefined and exit early.
-    const provider = this.meterProvider;
-    this.meterProvider = undefined;
-    await provider?.shutdown();
+    // Coalesce concurrent deactivations: callers (shutdown(), the
+    // failure-fallback in quickPulseDone(), and the "unsubscribed" branch in
+    // goQuickpulse()) can all race. Return the in-flight promise so every
+    // caller awaits the same completion and the underlying meterProvider
+    // shutdown only runs once.
+    if (this.deactivatingPromise) {
+      return this.deactivatingPromise;
+    }
+    this.isDeactivating = true;
+    this.deactivatingPromise = (async () => {
+      try {
+        this.documents = [];
+        this.validDocumentFilterConjuctionGroupInfos.clear();
+        this.errorTracker.clearRunTimeErrors();
+        this.errorTracker.clearValidationTimeErrors();
+        this.validDerivedMetrics.clear();
+        this.derivedMetricProjection.clearProjectionMaps();
+        this.seenMetricIds.clear();
+        // Capture and clear the reference before awaiting shutdown so any
+        // re-entrant calls triggered by the shutdown's final force-flush
+        // export observe meterProvider as undefined and exit early.
+        const provider = this.meterProvider;
+        this.meterProvider = undefined;
+        await provider?.shutdown();
+      } finally {
+        this.isDeactivating = false;
+        this.deactivatingPromise = undefined;
+      }
+    })();
+    return this.deactivatingPromise;
   }
 
   /**

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -99,6 +99,7 @@ export class LiveMetrics {
   private quickpulseExporter: QuickpulseMetricExporter;
   private pingSender: QuickpulseSender;
   private isCollectingData: boolean;
+  private isDeactivating: boolean = false;
   private lastSuccessTime: number = Date.now();
   private handle: NodeJS.Timer;
   // Monitoring data point with common properties
@@ -202,8 +203,8 @@ export class LiveMetrics {
     this.lastHrTime = process.hrtime.bigint();
   }
 
-  public shutdown(): void {
-    this.meterProvider?.shutdown();
+  public async shutdown(): Promise<void> {
+    await this.meterProvider?.shutdown();
   }
 
   private async goQuickpulse(): Promise<void> {
@@ -240,8 +241,23 @@ export class LiveMetrics {
         }
       } else {
         if (Date.now() - this.lastSuccessTime >= MAX_POST_WAIT_TIME) {
+          // Re-entrancy guard: MeterProvider.shutdown() triggers a final
+          // force-flush export which, on failure, re-invokes this callback.
+          // Without this guard we would recursively call deactivateMetrics()
+          // from inside the shutdown's export, saturating the CPU.
+          if (this.isDeactivating) {
+            return;
+          }
+          this.isDeactivating = true;
           this.postInterval = FALLBACK_INTERVAL;
-          this.deactivateMetrics();
+          try {
+            await this.deactivateMetrics();
+          } finally {
+            this.isDeactivating = false;
+          }
+          // Reset the success-time baseline so the FALLBACK_INTERVAL backoff
+          // can take effect before we consider deactivating again.
+          this.lastSuccessTime = Date.now();
           this.activateMetrics({ collectionInterval: this.postInterval });
         }
       }
@@ -258,7 +274,14 @@ export class LiveMetrics {
       // If collecting was stoped
       if (!this.isCollectingData && this.meterProvider) {
         this.etag = "";
-        this.deactivateMetrics();
+        if (!this.isDeactivating) {
+          this.isDeactivating = true;
+          try {
+            await this.deactivateMetrics();
+          } finally {
+            this.isDeactivating = false;
+          }
+        }
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         this.handle = setTimeout(this.goQuickpulse.bind(this), this.pingInterval);
         this.handle.unref();
@@ -387,7 +410,7 @@ export class LiveMetrics {
   /**
    * Deactivate metric collection
    */
-  public deactivateMetrics(): void {
+  public async deactivateMetrics(): Promise<void> {
     this.documents = [];
     this.validDocumentFilterConjuctionGroupInfos.clear();
     this.errorTracker.clearRunTimeErrors();
@@ -395,8 +418,12 @@ export class LiveMetrics {
     this.validDerivedMetrics.clear();
     this.derivedMetricProjection.clearProjectionMaps();
     this.seenMetricIds.clear();
-    this.meterProvider?.shutdown();
+    // Capture and clear the reference before awaiting shutdown so any
+    // re-entrant calls triggered by the shutdown's final force-flush export
+    // observe meterProvider as undefined and exit early.
+    const provider = this.meterProvider;
     this.meterProvider = undefined;
+    await provider?.shutdown();
   }
 
   /**

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetrics.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/metrics/liveMetrics.test.ts
@@ -574,7 +574,7 @@ describe("#LiveMetrics", () => {
   });
 
   it("should not collect when disabled", async () => {
-    autoCollect.deactivateMetrics();
+    await autoCollect.deactivateMetrics();
     await new Promise((resolve) => setTimeout(resolve, 120));
     expect(exportStub).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
# [monitor-opentelemetry] Fix Live Metrics CPU-saturating deactivate/reactivate loop

## Packages impacted by this PR

- `@azure/monitor-opentelemetry`

## Issues associated with this PR

- Fixes #38854

## Describe the problem that is addressed by this PR

When Live Metrics (QuickPulse) was in the **collecting/subscribed** state and posts to the live endpoint started **failing**, `LiveMetrics` entered a re-entrant deactivate/reactivate loop that quickly saturated CPU. The hottest leaf was `os.cpus()`, invoked thousands of times per second instead of once per collection interval. The loop could only be exited by restarting the process.

## Root cause

In `src/metrics/quickpulse/liveMetrics.ts`:

1. `quickPulseDone()` — on a failed post while `isCollectingData` is `true` and `Date.now() - lastSuccessTime >= MAX_POST_WAIT_TIME` — ran `deactivateMetrics()` then `activateMetrics(...)`.
2. `deactivateMetrics()` called `this.meterProvider?.shutdown()` **without `await`**.
3. `MeterProvider.shutdown()`'s final force-flush runs a metric **collect** (executing the observable gauges, including `getProcessorTimeNormalized` → `os.cpus()`) and then calls the exporter's `export()`.
4. The QuickPulse exporter's `export()` invokes `postCallback = quickPulseDone()` again with the failed result.
5. `isCollectingData` was still `true` and `lastSuccessTime` was still stale, so step 1 fired again → **re-entrant loop**.

## Describe the changes made by this PR

- Added an `isDeactivating` re-entrancy guard so the shutdown-triggered failure callback exits early when a deactivate is already in flight.
- Made `deactivateMetrics()` `async` and `await`s `meterProvider.shutdown()`. The reference is cleared **before** awaiting, so any synchronous re-entry observes `meterProvider` as `undefined` and exits early.
- Reset `lastSuccessTime` after a fallback so the `FALLBACK_INTERVAL` backoff actually takes effect before the next potential deactivate.
- Updated the second `deactivateMetrics` call site (success / unsubscribed branch) and `LiveMetrics.shutdown()` / `MetricHandler.shutdown()` to `await` the new promise.
- Updated the affected unit test caller (`liveMetrics.test.ts`).
- Added a CHANGELOG entry under 1.18.2.

## API surface

No public API change. `LiveMetrics` is internal and not re-exported from the package index. `MetricHandler.shutdown` was already `async Promise<void>`.

## Verification

- `pnpm turbo build --filter=@azure/monitor-opentelemetry` — succeeds (API extractor included, no change to the public `.api.md`).
- `npx vitest run test/internal/unit/metrics/liveMetrics.test.ts` — 6/6 pass.
- Reporter's repro script (forces post failure while subscribed), executed against the patched build with the real Live endpoint connection string:
  - **Before fix (per issue):** ~2000+ deactivate/reactivate laps/sec, ~100% CPU/core, thousands of `os.cpus()` calls/sec.
  - **After fix:** 2 total laps over 20s, ~0% CPU, 2 total `os.cpus()` calls.
- End-to-end via the public `useAzureMonitor({ enableLiveMetrics: true })` API for 30s against the real Live endpoint: 0% steady-state CPU, no regression in normal ping behavior.

## Are there test cases added in this PR?

The repro script used to validate the fix is in the issue (#38854) and was run against the patched build, but is not committed as a unit test because it requires harnessing internal fields and 16+ seconds of wall time. The existing `liveMetrics.test.ts` suite continues to pass.

## Provide a list of related PRs

N/A
