### PR TITLE
[Skills] Directory-based package skill discovery (drop registry table)

### DIFF
--- a/.github/skills/create-package-skill/SKILL.md
+++ b/.github/skills/create-package-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-package-skill
-description: 'Interactive wizard that walks service teams through creating a package-specific skill for their Azure SDK package. Scans the package, detects customization patterns, scaffolds a SKILL.md with references, validates with vally lint, and registers in find-package-skill. WHEN: create package skill; add service skill; bootstrap skill for package; new package skill; skill for my SDK package; write skill for search; write skill for cosmos.'
+description: 'Interactive wizard that walks service teams through creating a package-specific skill for their Azure SDK package. Scans the package, detects customization patterns, scaffolds a SKILL.md with references, and validates with vally lint. The skill is placed inside the package''s .github/skills/ directory so find-package-skill discovers it automatically. WHEN: create package skill; add service skill; bootstrap skill for package; new package skill; skill for my SDK package; write skill for search; write skill for cosmos.'
 ---
 
 # Create Package Skill Wizard
@@ -33,7 +33,7 @@ Run each phase in order. **Progressive loading:** Read only the current phase fi
 | **Phase 1** | 📝 Scaffold SKILL.md — generate skill with common pitfalls, architecture, workflow | [phases/01-scaffold-skill.md](phases/01-scaffold-skill.md) |
 | **Phase 2** | 📚 Generate References — create architecture.md and customization.md | [phases/02-generate-references.md](phases/02-generate-references.md) |
 | **Phase 3** | ✅ Validate — run vally lint | [phases/03-validate.md](phases/03-validate.md) |
-| **Phase 4** | 📋 Register — add to find-package-skill table | [phases/04-register.md](phases/04-register.md) |
+| **Phase 4** | 📋 Finalize — confirm discoverable location, summarize | [phases/04-finalize.md](phases/04-finalize.md) |
 
 ## Guardrails
 

--- a/.github/skills/create-package-skill/phases/03-validate.md
+++ b/.github/skills/create-package-skill/phases/03-validate.md
@@ -34,7 +34,7 @@ If over budget, split content into additional reference files.
 ## Step 3 — DECIDE
 
 Present validation results. If all pass:
-Question: "Validation passed. Proceed to register the skill?"
+Question: "Validation passed. Proceed to finalize the skill?"
 
 If failures exist, present them and ask:
 Question: "These issues need fixing. Fix now, or skip validation?"
@@ -42,5 +42,5 @@ Question: "These issues need fixing. Fix now, or skip validation?"
 📍 **Phase 3 complete** | Validation: pass/fail | Next: Phase 4
 
 ---
-## → Next: Phase 4 — Register
-Read [04-register.md](04-register.md) and begin immediately.
+## → Next: Phase 4 — Finalize
+Read [04-finalize.md](04-finalize.md) and begin immediately.

--- a/.github/skills/create-package-skill/phases/04-finalize.md
+++ b/.github/skills/create-package-skill/phases/04-finalize.md
@@ -1,14 +1,20 @@
-# Phase 4: Register 📋
+# Phase 4: Finalize 📋
 
-> 📍 **Phase 4 — Register** | Add the skill to the find-package-skill discovery table.
+> 📍 **Phase 4 — Finalize** | Confirm the skill is in its discoverable location and summarize.
 
-## Step 1 — Update find-package-skill
+## Step 1 — Confirm discoverable location
 
-Add a row to `.github/skills/find-package-skill/SKILL.md` in the **Package Skills** table:
+Package skills are discovered automatically by `find-package-skill`, which looks
+for a `.github/skills/` directory **inside the package directory**. There is no
+central registry to update — placement *is* registration.
 
-```markdown
-| `@azure/<package-name>` or `@azure-rest/<package-name>` | `sdk/<service>/<package>/.github/skills/<skill-name>/SKILL.md` |
+Verify the skill lives at:
+
 ```
+sdk/<service>/<package>/.github/skills/<skill-name>/SKILL.md
+```
+
+If it's there, it will be discovered for that package. No further wiring needed.
 
 ## Step 2 — Summary
 
@@ -21,7 +27,7 @@ Print a summary of everything created:
 | SKILL.md | `sdk/<service>/<package-name>/.github/skills/<skill-name>/SKILL.md` | Created |
 | architecture.md | `...references/architecture.md` | Created/Skipped |
 | customization.md | `...references/customization.md` | Created/Skipped |
-| find-package-skill | `.github/skills/find-package-skill/SKILL.md` | Updated |
+| find-package-skill | discovers automatically via package `.github/skills/` | No action |
 | vally lint | 3/3 checks | Passed |
 
 **Next steps for the service team:**
@@ -36,6 +42,6 @@ Print a summary of everything created:
 
 ## Step 3 — CONFIRM
 
-Question: "Register the skill in find-package-skill now (recommended), or skip?"
+Question: "The skill is in place and will be discovered automatically. Anything else to adjust?"
 
-📍 **Phase 4 complete** | Skill registered | Wizard done 🎉
+📍 **Phase 4 complete** | Skill in place and discoverable | Wizard done 🎉

--- a/.github/skills/find-package-skill/SKILL.md
+++ b/.github/skills/find-package-skill/SKILL.md
@@ -1,25 +1,31 @@
 ---
 name: find-package-skill
-description: '**UTILITY SKILL** — Must be consulted before making any changes to packages under sdk/. Provides package-specific domain knowledge that prevents common mistakes. WHEN: "add feature to package", "fix bug in package", "modify package code", "regenerate from typespec", "change client library".'
+description: '**UTILITY SKILL** — Must be consulted before making any changes to packages under sdk/. Discovers and loads package-specific domain knowledge that prevents common mistakes. WHEN: "add feature to package", "fix bug in package", "modify package code", "regenerate from typespec", "change client library".'
 ---
 
 # Find Package Skill
 
-Before modifying any SDK package in this monorepo, check this registry to see
-if a package-specific skill exists. Package skills contain tribal knowledge
-(architecture, data flows, type mappings, pitfalls) that prevents common mistakes.
+Some SDK packages in this monorepo have **package-specific skills** — tribal
+knowledge (architecture, data flows, type mappings, pitfalls) that prevents
+common mistakes. Before modifying any SDK package, check whether a skill exists
+for it using the steps below.
 
-Always check this registry before modifying any SDK package — even if you think
-you already know the package well.
+## How to Discover Package Skills
 
-## How to Use
+1. **Determine the package directory.** If you already know the file path you're
+   modifying, extract the package directory from it (e.g., a file at
+   `sdk/search/search-documents/src/searchClient.ts` belongs to the package at
+   `sdk/search/search-documents/`). If you only have a package name, search for a
+   matching directory under `sdk/` (package directories are named after the
+   unscoped package name, e.g. `@azure/search-documents` →
+   `sdk/search/search-documents/`).
 
-1. Find the package you're modifying in the table below.
-2. Read the SKILL.md at the listed path using the Read tool. Then read all files under the `references/` directory next to it for additional context.
-3. If the package isn't listed, no package-specific skill exists yet — proceed normally.
+2. **Check for a `.github/skills/` directory** inside the package directory. For
+   example, check whether `sdk/search/search-documents/.github/skills/` exists.
 
-## Package Skills
+3. **If it exists**, read every `SKILL.md` found under that directory. If a
+   `references/` subdirectory exists next to a `SKILL.md`, read all files in it
+   too for additional context.
 
-| Package                   | Path                                                                   |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `@azure/search-documents` | `sdk/search/search-documents/.github/skills/search-documents/SKILL.md` |
+4. **If no `.github/skills/` directory exists** for the package, no
+   package-specific skill has been created yet — proceed normally.


### PR DESCRIPTION
## What this does

Switches package-specific skill discovery from a **hand-maintained registry table** to **directory-based discovery**, mirroring the approach used in [`azure-sdk-for-net`](https://github.com/Azure/azure-sdk-for-net/blob/main/.github/skills/find-package-skill/SKILL.md).

### Before
`find-package-skill/SKILL.md` contained a static `Package Skills` table mapping each package name to its `SKILL.md` path. Every new package skill required adding a row to this central table (the `create-package-skill` wizard had a dedicated "Register" phase for exactly this).

### After
`find-package-skill` now instructs the agent to:
1. Resolve the package directory from the file/package being modified.
2. Check for a `.github/skills/` directory **inside** that package directory.
3. Read every `SKILL.md` (+ adjacent `references/`) found there.

Placement *is* registration — no central table to maintain.

## Changes
- `find-package-skill/SKILL.md` — replace the registry table with directory-based discovery instructions.
- `create-package-skill` — Phase 4 "Register" → "Finalize" (rename `04-register.md` → `04-finalize.md`); it no longer edits a table, it just confirms the skill sits in the discoverable location. Updated the wizard `SKILL.md` description and the Phase 3 → 4 handoff wording.

## How this was tested

Validated against the `consult-package-skill` eval in the [agent-evals framework](https://github.com/Azure/azure-sdk-for-js/pull/38890) (separate PR). That eval drives a real agent with the prompt "add a small feature to `@azure/search-documents` — orient yourself first" and grades whether it reads the right skill files.

| Approach | Runs | Result |
| --- | --- | --- |
| Registry table (baseline) | 1 | ✅ 3/3 graders, 100% |
| Directory-based (this PR) | 3 | ✅ pass@3 100%, pass^3 100% |

Trajectory inspection confirmed that in every run the agent invoked `find-package-skill`, globbed `sdk/search/search-documents/.github/skills/**`, and read the package's `SKILL.md` — with **no registry present**. `vally lint` passes for all 8 skills.

## Notes
- Eval-framework changes live in #38890; this PR is **skill-only** and branches off `main`.
