### PR TITLE
Bump @azure/arm-monitorworkspaces to 1.0.0 for GA release

### DIFF
--- a/sdk/monitor/arm-monitorworkspaces/CHANGELOG.md
+++ b/sdk/monitor/arm-monitorworkspaces/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.0.0 (2026-06-10)
+## 1.0.0 (2026-06-12)
 
 ### Features Added
 
-Initial GA release of the @azure/arm-monitorworkspaces package
+- Initial GA release of the @azure/arm-monitorworkspaces package
 
 ## 1.0.0-beta.1 (2026-05-20)
 

--- a/sdk/monitor/arm-monitorworkspaces/CHANGELOG.md
+++ b/sdk/monitor/arm-monitorworkspaces/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
-    
+
+## 1.0.0 (2026-06-10)
+
+### Features Added
+
+Initial GA release of the @azure/arm-monitorworkspaces package
+
 ## 1.0.0-beta.1 (2026-05-20)
 
 ### Features Added

--- a/sdk/monitor/arm-monitorworkspaces/package.json
+++ b/sdk/monitor/arm-monitorworkspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-monitorworkspaces",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0",
   "description": "A generated SDK for MonitorClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/monitor/arm-monitorworkspaces/src/api/monitorContext.ts
+++ b/sdk/monitor/arm-monitorworkspaces/src/api/monitorContext.ts
@@ -32,7 +32,7 @@ export function createMonitor(
   const endpointUrl =
     options.endpoint ?? getArmEndpoint(options.cloudSetting) ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-monitorworkspaces/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-monitorworkspaces/1.0.0`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;


### PR DESCRIPTION
This PR bumps @azure/arm-monitorworkspaces from 1.0.0-beta.1 to 1.0.0 for GA release.

Changes:
- Updated version in package.json
- Updated userAgent version string
- Updated CHANGELOG.md with GA entry

Release plan: https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=2207
## Release Plan Details
- Release Plan: https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=34968
- Work Item Link: https://dev.azure.com/azure-sdk/fe81d705-3c06-41e5-bf7c-5ebea18efe89/_workitems/edit/34968
- Spec Pull Request: 
- Spec API version: 