### PR TITLE
[storage-common] Strip Node require() from browser CRC64 build

### DIFF
--- a/sdk/storage/storage-common/CHANGELOG.md
+++ b/sdk/storage/storage-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 12.4.1 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed the browser and react-native builds of the CRC64 checksum calculator still containing Node.js `require('fs')`/`require('path')` calls, which broke esbuild-based bundlers. The post-build step now replaces the unreachable Node-only filesystem read block with a no-op in the browser and react-native copies of `crc64.js`. Issue [#38924](https://github.com/Azure/azure-sdk-for-js/issues/38924).
+
 ## 12.4.0 (2026-05-22)
 
 ### Features Added

--- a/sdk/storage/storage-common/copyJSFiles.cjs
+++ b/sdk/storage/storage-common/copyJSFiles.cjs
@@ -1,7 +1,7 @@
-const fs = require('fs');
+const fs = require("fs");
 
-const SRC_CRC64 = './src/crc64.js';
-const SRC_GLUE = './src/crc64_glue.js';
+const SRC_CRC64 = "./src/crc64.js";
+const SRC_GLUE = "./src/crc64_glue.js";
 
 // `dist/commonjs/package.json` is `{ "type": "commonjs" }`, so the same .js file
 // must use CommonJS syntax there. Strip the ESM-only polyfill block and rewrite
@@ -10,8 +10,21 @@ const SRC_GLUE = './src/crc64_glue.js';
 const ESM_COMPAT_BLOCK = /\/\/ ESM-COMPAT-START[\s\S]*?\/\/ ESM-COMPAT-END\r?\n?/;
 const ESM_EXPORT_BLOCK =
   /\/\/ ESM-EXPORT-START[^\n]*\r?\nexport default NativeCRC64;\r?\n\/\/ ESM-EXPORT-END/;
+// The Emscripten Node branch eagerly calls `require('fs')`/`require('path')` and wires
+// up filesystem-backed `read_`/`readBinary`/`readAsync`. Although this code is unreachable
+// in browsers (it is guarded by `ENVIRONMENT_IS_NODE`), bundlers such as esbuild statically
+// resolve the bare `require('fs')` calls and fail. Replace the block with a no-op for the
+// browser and react-native builds so no Node `require()` references remain.
+// See https://github.com/Azure/azure-sdk-for-js/issues/38924.
+const NODE_READ_BLOCK = /\/\/ NODE-READ-START[\s\S]*?\/\/ NODE-READ-END\r?\n?/;
+const NODE_READ_NOOP = `// Node-only filesystem reads omitted in browser/react-native builds.
+  read_ = readBinary = readAsync = () => {
+    throw new Error('NodeJS filesystem reads are not supported in this environment.');
+  };
 
-const esmSource = fs.readFileSync(SRC_CRC64, 'utf8');
+`;
+
+const esmSource = fs.readFileSync(SRC_CRC64, "utf8");
 
 if (!ESM_COMPAT_BLOCK.test(esmSource)) {
   throw new Error(
@@ -23,26 +36,30 @@ if (!ESM_EXPORT_BLOCK.test(esmSource)) {
     "copyJSFiles.cjs: expected ESM-EXPORT marker block in src/crc64.js was not found.",
   );
 }
+if (!NODE_READ_BLOCK.test(esmSource)) {
+  throw new Error(
+    "copyJSFiles.cjs: expected NODE-READ marker block in src/crc64.js was not found.",
+  );
+}
 
-fs.writeFileSync('./dist/esm/crc64.js', esmSource);
+fs.writeFileSync("./dist/esm/crc64.js", esmSource);
 
 const cjsSource = esmSource
-  .replace(
-    ESM_COMPAT_BLOCK,
-    "// ESM compatibility block omitted in CommonJS build.\n",
-  )
+  .replace(ESM_COMPAT_BLOCK, "// ESM compatibility block omitted in CommonJS build.\n")
   .replace(ESM_EXPORT_BLOCK, "module.exports = NativeCRC64;");
 
-fs.writeFileSync('./dist/commonjs/crc64.js', cjsSource);
+fs.writeFileSync("./dist/commonjs/crc64.js", cjsSource);
 
 const browserSource = esmSource
-      .replace(
-        ESM_COMPAT_BLOCK,
-        `// ESM compatibility block omitted in browsers build as it is NodeJS only.\n`);
+  .replace(
+    ESM_COMPAT_BLOCK,
+    `// ESM compatibility block omitted in browsers build as it is NodeJS only.\n`,
+  )
+  .replace(NODE_READ_BLOCK, NODE_READ_NOOP);
 
-fs.writeFileSync('./dist/browser/crc64.js', browserSource);
-fs.writeFileSync('./dist/react-native/crc64.js', browserSource);
+fs.writeFileSync("./dist/browser/crc64.js", browserSource);
+fs.writeFileSync("./dist/react-native/crc64.js", browserSource);
 
-for (const dir of ['browser', 'esm', 'commonjs', 'react-native']) {
+for (const dir of ["browser", "esm", "commonjs", "react-native"]) {
   fs.cpSync(SRC_GLUE, `./dist/${dir}/crc64_glue.js`);
 }

--- a/sdk/storage/storage-common/package.json
+++ b/sdk/storage/storage-common/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "sideEffects": false,
   "author": "Microsoft Corporation",
-  "version": "12.4.0",
+  "version": "12.4.1",
   "description": "Azure Storage Common Client Library for JavaScript",
   "license": "MIT",
   "repository": {

--- a/sdk/storage/storage-common/src/crc64.js
+++ b/sdk/storage/storage-common/src/crc64.js
@@ -133,6 +133,7 @@ function logExceptionOnExit(e) {
 
 if (ENVIRONMENT_IS_NODE) {
   if (typeof process == 'undefined' || !process.release || process.release.name !== 'node') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+// NODE-READ-START (this block is replaced with a no-op in dist/browser and dist/react-native by copyJSFiles.cjs)
   // `require()` is no-op in an ESM module, use `createRequire()` to construct
   // the require()` function.  This is only necessary for multi-environment
   // builds, `-sENVIRONMENT=node` emits a static import declaration instead.
@@ -177,6 +178,7 @@ readAsync = (filename, onload, onerror) => {
 };
 
 // end include: node_shell_read.js
+// NODE-READ-END
   if (process['argv'].length > 1) {
     thisProgram = process['argv'][1].replace(/\\/g, '/');
   }


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/storage-common`

### Issues associated with this PR

Fixes #38924

### Describe the problem that is addressed by this PR

The browser and react-native copies of `dist/.../crc64.js` still contained the Emscripten Node branch with `require('fs')` and `require('path')`. That code is unreachable at runtime because it is guarded by `ENVIRONMENT_IS_NODE`, but esbuild statically resolves the bare `require('fs')` calls during bundling and fails. This broke esbuild-based bundlers for consumers of `@azure/storage-common` 12.4.0 in the browser.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

This follows the existing `ESM-COMPAT` marker pattern already used in the same post-build step, so the approach is consistent and self-documenting.

- New `// NODE-READ-START` / `// NODE-READ-END` markers in `src/crc64.js` delimit the Node-only filesystem block (the `require('fs')`/`require('path')` lines plus the `read_`/`readBinary`/`readAsync` setup).
- `copyJSFiles.cjs` replaces that block with a no-op (a `read_ = readBinary = readAsync` that throws "not supported in this environment") for the browser and react-native builds, while the esm and commonjs builds keep the real Node implementation verbatim.
- A build-time guard fails loudly if the markers ever drift out of the source, matching the existing guards for the other marker blocks.

Alternatives considered: marking `fs`/`path` as bundler externals pushes the problem onto every downstream consumer, and rewriting the Emscripten output to dynamic `import()` is far more invasive. Neutralizing the dead branch at copy time is the smallest, most contained fix.

### Are there test cases added in this PR? _(If not, why?)_

No automated test added. The package has no browser test harness (`test:browser` is a no-op), and `crc64.js` is generated Emscripten output excluded from linting. Verified manually after `pnpm turbo build`: the browser and react-native `crc64.js` contain zero real `require()` calls (only comment text remains) and no `fs.readFileSync`, while the esm and commonjs builds retain the Node read functions. Lint passes with 0 errors.

### Provide a list of related PRs _(if any)_

Related prior fixes: #38069, #38501 (earlier ESM/CommonJS `require`/`export` fixes for the same generated file).

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)