### PR TITLE
Remove dead links to deleted writing-performance-tests.md doc

### DIFF
--- a/.github/skills/sdk-workflow/SKILL.md
+++ b/.github/skills/sdk-workflow/SKILL.md
@@ -26,7 +26,6 @@ development tasks. Read the referenced docs — don't guess at commands.
 | Post-generation steps (changelog, samples, release prep) | `documentation/steps-after-generations.md` |
 | Bundling for browser | `documentation/Bundling.md` |
 | Resolving pnpm-lock.yaml merge conflicts | `documentation/resolve-pnpm-lock-merge-conflict.md` |
-| Writing and running perf tests | `documentation/writing-performance-tests.md` |
 | TypeSpec client generator CLI | `eng/common/tsp-client/README.md` |
 | Code review agents (archie, scribe, sentinel, tester, dash, dexter) | `documentation/reviewer-agents.md` |
 | Troubleshooting CI failures | `documentation/Troubleshoot-ci-failure.md` |

--- a/sdk/test-utils/perf/README.md
+++ b/sdk/test-utils/perf/README.md
@@ -6,8 +6,6 @@
 
 To start a new perf test project for the your SDK in the js repository, follow the steps in the [GettingStarted.md](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/test-utils/perf/GettingStarted.md).
 
-Link to the docs - [Writing-Performance-Tests](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/writing-performance-tests.md) (has the same contents as the GettingStarted docs)
-
 ## KeyConcepts
 
 - A **PerfTest** test is a test that will be executed repeatedly to show both the performance of the program, and how it behaves under stress.


### PR DESCRIPTION
Removes two dead links to the deleted `documentation/writing-performance-tests.md` file:

- `sdk/test-utils/perf/README.md`: removed the line referencing the deleted doc
- `.github/skills/sdk-workflow/SKILL.md`: removed the table row for "Writing and running perf tests"