### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1769,7 +1769,7 @@ sdk/postgresqlhsc/arm-postgresqlhsc/ @qiaozha @MaryGao @JialinHuang803
 /.github/prompts/security-review-guidelines.md     @Azure/azure-sdk-for-js-core
 /.github/prompts/test-recording.prompt.md          @Azure/azure-sdk-for-js-core
 /.github/prompts/test-review-guidelines.md         @Azure/azure-sdk-for-js-core
-/.github/skills/                         @Azure/azsdk-cli
+/.github/skills/                         @Azure/azsdk-cli @Azure/azure-sdk-for-js-core
 
 /.github/CODEOWNERS                      @xirzec @jeremymeng @qiaozha @MaryGao @JialinHuang803 @Azure/azure-sdk-eng
 /.github/copilot-instructions.md         @praveenkuttappan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1769,6 +1769,7 @@ sdk/postgresqlhsc/arm-postgresqlhsc/ @qiaozha @MaryGao @JialinHuang803
 /.github/prompts/security-review-guidelines.md     @Azure/azure-sdk-for-js-core
 /.github/prompts/test-recording.prompt.md          @Azure/azure-sdk-for-js-core
 /.github/prompts/test-review-guidelines.md         @Azure/azure-sdk-for-js-core
+/.github/skills/                         @Azure/azsdk-cli
 
 /.github/CODEOWNERS                      @xirzec @jeremymeng @qiaozha @MaryGao @JialinHuang803 @Azure/azure-sdk-eng
 /.github/copilot-instructions.md         @praveenkuttappan


### PR DESCRIPTION
Assigns ownership of skill definitions under `.github/skills/` to the `@azure/azsdk-cli` team so changes to those skills route to the right reviewers.

The new entry is grouped with the other `.github/` ownership rules in the existing "Eng Sys and CODEOWNERS" section.