### PR TITLE
decouple "next step to merge" from mgmt.-review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1738,6 +1738,8 @@ sdk/postgresqlhsc/arm-postgresqlhsc/ @qiaozha @MaryGao @JialinHuang803
 /.github/workflows/                      @Azure/azure-sdk-eng
 /.github/workflows/mgmt-review.md        @MaryGao @lirenhe @qiaozha @JialinHuang803
 /.github/workflows/mgmt-review.lock.yml  @MaryGao @lirenhe @qiaozha @JialinHuang803
+/.github/workflows/mgmt-guidance.md      @MaryGao @lirenhe @qiaozha @JialinHuang803
+/.github/workflows/mgmt-guidance.lock.yml @MaryGao @lirenhe @qiaozha @JialinHuang803
 /.github/workflows/archie.md             @maorleger @Azure/azure-sdk-for-js-core
 /.github/workflows/archie.lock.yml       @maorleger @Azure/azure-sdk-for-js-core
 /.github/workflows/agent-observability.md             @maorleger @Azure/azure-sdk-for-js-core

--- a/.github/workflows/mgmt-guidance.lock.yml
+++ b/.github/workflows/mgmt-guidance.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"ff5a378724506330181e56e38b0175a4e0412131c2243b2d8d5cbae899faead6","body_hash":"47c974b19e574b5f08cb0052030830bfb6380b1b6bdbe95cafe6cff1307485ab","compiler_version":"v0.77.5","agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"6741188bfa1caff92c8c058a2c0c294504b2dabfde898badd880bb3eb6086d56","body_hash":"4bea01f520d0d324cbb42b48d4998e17502bbc45c4d4e631a6a853c552aa8370","compiler_version":"v0.77.5","agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Review a pull request for management-plane SDKs
+# Post Next Steps to Merge once all CI checks complete on management-plane SDK PRs
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -31,8 +31,6 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-#   - actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -50,43 +48,63 @@
 #   - ghcr.io/github/github-mcp-server:v1.1.0
 #   - node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 
-name: "Management Release Assistant"
+name: "Management SDK Merge Guidance"
 on:
-  # permissions: # Permissions applied to pre-activation job
-    # pull-requests: write
-  pull_request_target:
-    forks:
-    - "*"
+  check_suite:
     types:
-    - labeled
+    - completed
+  # permissions: # Permissions applied to pre-activation job
+    # actions: read
+    # checks: read
+    # pull-requests: read
   # steps: # Steps injected into pre-activation job
-  # - id: swap_label
-    # if: github.event_name == 'pull_request_target' && github.event.label.name == 'mgmt-review-needed'
-    # name: Swap trigger label to in-progress
+  # - env:
+      # CHECK_SUITE_APP: ${{ github.event.check_suite.app.name }}
+      # HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+      # ITEM_NUMBER: ${{ github.event.inputs.item_number }}
+    # id: gate
+    # name: Gate — extract PR number and verify all CI checks are complete
     # uses: actions/github-script@v8
     # with:
       # script: |
-        # const pr = context.payload.pull_request.number;
-        # // Remove trigger label
-        # try {
-          # await github.rest.issues.removeLabel({
-            # ...context.repo,
-            # issue_number: pr,
-            # name: 'mgmt-review-needed'
-          # });
-        # } catch (e) {
-          # core.warning(`Could not remove trigger label: ${e.message}`);
+        # const appName  = process.env.CHECK_SUITE_APP || '';
+        # const headSha  = process.env.HEAD_SHA        || '';
+        # const inputPr  = process.env.ITEM_NUMBER     || '';
+        # 
+        # if (context.eventName === 'workflow_dispatch') {
+          # core.setOutput('pr_number', inputPr);
+          # core.setOutput('ready', 'true');
+          # return;
         # }
-        # // Add in-progress label
-        # try {
-          # await github.rest.issues.addLabels({
-            # ...context.repo,
-            # issue_number: pr,
-            # labels: ['mgmt-review-in-progress']
-          # });
-        # } catch (e) {
-          # core.warning(`Could not add in-progress label: ${e.message}`);
+        # 
+        # // check_suite completed = entire ADO pipeline finished (one event, not N)
+        # if (!appName.includes('Azure Pipelines')) {
+          # core.setOutput('ready', 'false');
+          # return;
         # }
+        # 
+        # const prNum = context.payload.check_suite?.pull_requests?.[0]?.number;
+        # if (!prNum) {
+          # core.info('No PR associated with this check suite — skipping.');
+          # core.setOutput('ready', 'false');
+          # return;
+        # }
+        # 
+        # const { data: pr } = await github.rest.pulls.get({
+          # owner: context.repo.owner,
+          # repo:  context.repo.repo,
+          # pull_number: prNum,
+        # });
+        # const labels = (pr.labels || []).map(l => l.name);
+        # if (!labels.includes('mgmt-review-added')) {
+          # core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — skipping until review completes.`);
+          # core.setOutput('ready', 'false');
+          # return;
+        # }
+        # 
+        # core.info(`check_suite completed on ${headSha} — activating for PR #${prNum}`);
+        # core.setOutput('pr_number', String(prNum));
+        # core.setOutput('ready', 'true');
   workflow_dispatch:
     inputs:
       aw_context:
@@ -95,7 +113,7 @@ on:
         required: false
         type: string
       item_number:
-        description: PR number to run the review on
+        description: PR number to generate merge guidance for
         required: true
         type: string
 
@@ -103,22 +121,20 @@ permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.item_number || github.run_id }}-${{ github.event.label.name || '' }}
+  group: gh-aw-mgmt-guidance-${{ needs.pre_activation.outputs.pr_number }}
 
-run-name: "Management Release Assistant"
+run-name: "Management SDK Merge Guidance"
 
 jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event.label.name == 'mgmt-review-needed' ||
-      github.event_name == 'workflow_dispatch')
+      needs.pre_activation.outputs.activated == 'true' && (needs.pre_activation.outputs.ready == 'true' && needs.pre_activation.outputs.pr_number != '')
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
@@ -129,8 +145,6 @@ jobs:
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -141,8 +155,8 @@ jobs:
           trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.pre_activation.outputs.setup-parent-span-id || needs.pre_activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-guidance.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -155,11 +169,11 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AGENT_VERSION: "1.0.55"
           GH_AW_INFO_CLI_VERSION: "v0.77.5"
-          GH_AW_INFO_WORKFLOW_NAME: "Management Release Assistant"
+          GH_AW_INFO_WORKFLOW_NAME: "Management SDK Merge Guidance"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","node","dev.azure.com"]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","dev.azure.com"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -203,7 +217,7 @@ jobs:
         id: check-lock-file
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_WORKFLOW_FILE: "mgmt-review.lock.yml"
+          GH_AW_WORKFLOW_FILE: "mgmt-guidance.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -221,17 +235,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,dev.azure.com,esm.sh,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -241,31 +244,28 @@ jobs:
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.item_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_WIKI_NOTE: ${{ '' }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_PR_NUMBER: ${{ needs.pre_activation.outputs.pr_number }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9ee0b9cb0269ee02_EOF'
+          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
           <system>
-          GH_AW_PROMPT_9ee0b9cb0269ee02_EOF
+          GH_AW_PROMPT_32014e1e0cee986d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
-          cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
-          cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9ee0b9cb0269ee02_EOF'
+          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
           <safe-output-tools>
-          Tools: create_pull_request_review_comment(max:10), submit_pull_request_review, add_labels, remove_labels, dispatch_workflow, missing_tool, missing_data, noop
+          Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_9ee0b9cb0269ee02_EOF
+          GH_AW_PROMPT_32014e1e0cee986d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9ee0b9cb0269ee02_EOF'
+          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -294,19 +294,19 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9ee0b9cb0269ee02_EOF
+          GH_AW_PROMPT_32014e1e0cee986d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9ee0b9cb0269ee02_EOF'
+          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
           </system>
-          {{#runtime-import .github/workflows/mgmt-review.md}}
-          GH_AW_PROMPT_9ee0b9cb0269ee02_EOF
+          {{#runtime-import .github/workflows/mgmt-guidance.md}}
+          GH_AW_PROMPT_32014e1e0cee986d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.item_number }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_PR_NUMBER: ${{ needs.pre_activation.outputs.pr_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -317,26 +317,17 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_ALLOWED_EXTENSIONS: ''
-          GH_AW_CACHE_DESCRIPTION: ''
-          GH_AW_CACHE_DIR: '/tmp/gh-aw/cache-memory/'
           GH_AW_EXPR_1A3A194A: ${{ github.event.discussion.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'discussion' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_463A214A: ${{ github.event.pull_request.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'pull_request' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_802A9F6A: ${{ github.event.issue.number || (fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_type == 'issue' && fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').item_number) }}
           GH_AW_EXPR_FF1D34CE: ${{ github.event.comment.id || fromJSON(github.event.inputs.aw_context || github.event.client_payload.aw_context || '{}').comment_id }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || inputs.item_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_MEMORY_BRANCH_NAME: 'memory/mgmt-review'
-          GH_AW_MEMORY_CONSTRAINTS: "\n\n**Constraints:**\n- **Max File Size**: 102400 bytes (0.10 MB) per file\n- **Max File Count**: 100 files per commit\n- **Max Patch Size**: 10240 bytes (10 KB) total per push (max: 1024 KB)\n"
-          GH_AW_MEMORY_DESCRIPTION: ''
-          GH_AW_MEMORY_DIR: '/tmp/gh-aw/repo-memory/default/'
-          GH_AW_MEMORY_TARGET_REPO: ' of the current repository'
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
-          GH_AW_WIKI_NOTE: ''
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_PR_NUMBER: ${{ needs.pre_activation.outputs.pr_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -348,26 +339,17 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
-                GH_AW_ALLOWED_EXTENSIONS: process.env.GH_AW_ALLOWED_EXTENSIONS,
-                GH_AW_CACHE_DESCRIPTION: process.env.GH_AW_CACHE_DESCRIPTION,
-                GH_AW_CACHE_DIR: process.env.GH_AW_CACHE_DIR,
                 GH_AW_EXPR_1A3A194A: process.env.GH_AW_EXPR_1A3A194A,
                 GH_AW_EXPR_463A214A: process.env.GH_AW_EXPR_463A214A,
                 GH_AW_EXPR_802A9F6A: process.env.GH_AW_EXPR_802A9F6A,
                 GH_AW_EXPR_FF1D34CE: process.env.GH_AW_EXPR_FF1D34CE,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
-                GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
                 GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_MEMORY_BRANCH_NAME: process.env.GH_AW_MEMORY_BRANCH_NAME,
-                GH_AW_MEMORY_CONSTRAINTS: process.env.GH_AW_MEMORY_CONSTRAINTS,
-                GH_AW_MEMORY_DESCRIPTION: process.env.GH_AW_MEMORY_DESCRIPTION,
-                GH_AW_MEMORY_DIR: process.env.GH_AW_MEMORY_DIR,
-                GH_AW_MEMORY_TARGET_REPO: process.env.GH_AW_MEMORY_TARGET_REPO,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED,
-                GH_AW_WIKI_NOTE: process.env.GH_AW_WIKI_NOTE
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_PR_NUMBER: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_PR_NUMBER
               }
             });
       - name: Validate prompt placeholders
@@ -412,7 +394,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: mgmtreview
+      GH_AW_WORKFLOW_ID_SANITIZED: mgmtguidance
     outputs:
       agentic_engine_timeout: ${{ steps.detect-agent-errors.outputs.agentic_engine_timeout || 'false' }}
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
@@ -438,8 +420,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-guidance.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -451,40 +433,31 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      # Cache memory file share configuration from frontmatter processed below
-      - name: Create cache-memory directory
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/create_cache_memory_dir.sh"
-      - name: Restore cache-memory file share data
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
-          path: /tmp/gh-aw/cache-memory
-          restore-keys: |
-            memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-
-      - name: Setup cache-memory git repository
+      - name: Configure Git credentials
         env:
-          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
-          GH_AW_MIN_INTEGRITY: none
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/setup_cache_memory_git.sh"
-      # Repo memory git-based storage configuration from frontmatter processed below
-      - name: Clone repo-memory branch (default)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          BRANCH_NAME: memory/mgmt-review
-          TARGET_REPO: ${{ github.repository }}
-          MEMORY_DIR: /tmp/gh-aw/repo-memory/default
-          CREATE_ORPHAN: true
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/clone_repo_memory_branch.sh"
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global am.keepcr true
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Checkout PR branch
         id: checkout-pr
-        continue-on-error: true
         if: |
           github.event.pull_request || github.event.issue.pull_request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -540,63 +513,22 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fd909d4e82e315cf_EOF'
-          {"add_labels":{"max":1,"target":"${{ github.event.pull_request.number || github.event.issue.number }}"},"create_pull_request_review_comment":{"max":10,"side":"RIGHT","target":"${{ github.event.pull_request.number || github.event.issue.number }}"},"create_report_incomplete_issue":{},"dispatch_workflow":{"max":1,"workflow_files":{"format-auto-fix":".yml"},"workflows":["format-auto-fix"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"remove_labels":{"max":1,"target":"${{ github.event.pull_request.number || github.event.issue.number }}"},"report_incomplete":{},"submit_pull_request_review":{"footer":"if-body","max":1,"target":"${{ github.event.pull_request.number || github.event.issue.number }}"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fd909d4e82e315cf_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8f93e48a2807c253_EOF'
+          {"add_comment":{"footer":false,"hide_older_comments":true,"max":1,"target":"${{ needs.pre_activation.outputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_8f93e48a2807c253_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_labels": " CONSTRAINTS: Maximum 1 label(s) can be added. Target: ${{ github.event.pull_request.number || github.event.issue.number }}.",
-                "create_pull_request_review_comment": " CONSTRAINTS: Maximum 10 review comment(s) can be created. Comments will be on the RIGHT side of the diff.",
-                "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Target: ${{ github.event.pull_request.number || github.event.issue.number }}.",
-                "submit_pull_request_review": " CONSTRAINTS: Maximum 1 review(s) can be submitted."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: ${{ needs.pre_activation.outputs.pr_number }}. Supports reply_to_id for discussion threading."
               },
               "repo_params": {},
-              "dynamic_tools": [
-                {
-                  "_workflow_name": "format-auto-fix",
-                  "description": "Dispatch the 'format-auto-fix' workflow with workflow_dispatch trigger. This workflow must support workflow_dispatch and be in .github/workflows/ directory in the same repository.",
-                  "inputSchema": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "pr_number": {
-                        "description": "PR number to run format fix on",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "pr_number"
-                    ],
-                    "type": "object"
-                  },
-                  "name": "format_auto_fix"
-                }
-              ]
+              "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "add_labels": {
-                "defaultMax": 5,
-                "fields": {
-                  "item_number": {
-                    "issueNumberOrTemporaryId": true
-                  },
-                  "labels": {
-                    "required": true,
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
-              "create_pull_request_review_comment": {
+              "add_comment": {
                 "defaultMax": 1,
                 "fields": {
                   "body": {
@@ -605,33 +537,18 @@ jobs:
                     "sanitize": true,
                     "maxLength": 65000
                   },
-                  "line": {
-                    "required": true,
-                    "positiveInteger": true
+                  "item_number": {
+                    "issueOrPRNumber": true
                   },
-                  "path": {
-                    "required": true,
-                    "type": "string"
-                  },
-                  "pull_request_number": {
-                    "optionalPositiveInteger": true
+                  "reply_to_id": {
+                    "type": "string",
+                    "maxLength": 256
                   },
                   "repo": {
                     "type": "string",
                     "maxLength": 256
-                  },
-                  "side": {
-                    "type": "string",
-                    "enum": [
-                      "LEFT",
-                      "RIGHT"
-                    ]
-                  },
-                  "start_line": {
-                    "optionalPositiveInteger": true
                   }
-                },
-                "customValidation": "startLineLessOrEqualLine"
+                }
               },
               "missing_data": {
                 "defaultMax": 20,
@@ -690,25 +607,6 @@ jobs:
                   }
                 }
               },
-              "remove_labels": {
-                "defaultMax": 5,
-                "fields": {
-                  "item_number": {
-                    "issueNumberOrTemporaryId": true
-                  },
-                  "labels": {
-                    "required": true,
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
               "report_incomplete": {
                 "defaultMax": 5,
                 "fields": {
@@ -722,24 +620,6 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 1024
-                  }
-                }
-              },
-              "submit_pull_request_review": {
-                "defaultMax": 1,
-                "fields": {
-                  "body": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  },
-                  "event": {
-                    "type": "string",
-                    "enum": [
-                      "APPROVE",
-                      "REQUEST_CHANGES",
-                      "COMMENT"
-                    ]
                   }
                 }
               }
@@ -829,7 +709,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a7a013715afab746_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_9e32c940fb21040c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -870,7 +750,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a7a013715afab746_EOF
+          GH_AW_MCP_CONFIG_9e32c940fb21040c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -895,7 +775,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 35
+        timeout-minutes: 10
         run: |
           set -o pipefail
           printf '%s' "$(date +%s%3N)" > /tmp/gh-aw/agent_cli_start_ms.txt
@@ -904,7 +784,7 @@ jobs:
           export GH_AW_NODE_BIN
           export COPILOT_API_KEY="$COPILOT_DUMMY_BYOK"
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
-          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.58/awf-config.schema.json","network":{"allowDomains":["api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.npms.io","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","bun.sh","cdn.jsdelivr.net","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","deb.nodesource.com","deno.land","dev.azure.com","esm.sh","get.pnpm.io","github.com","googleapis.deno.dev","googlechromelabs.github.io","host.docker.internal","json-schema.org","json.schemastore.org","jsr.io","keyserver.ubuntu.com","nodejs.org","npm.pkg.github.com","npmjs.com","npmjs.org","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","ppa.launchpad.net","raw.githubusercontent.com","registry.bower.io","registry.npmjs.com","registry.npmjs.org","registry.yarnpkg.com","repo.yarnpkg.com","s.symcb.com","s.symcd.com","security.ubuntu.com","skimdb.npmjs.com","storage.googleapis.com","telemetry.enterprise.githubcopilot.com","telemetry.vercel.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com","www.npmjs.com","www.npmjs.org","yarnpkg.com"]},"apiProxy":{"enabled":true,"enableTokenSteering":true,"maxRuns":500,"maxEffectiveTokens":25000000,"models":{"agent":["sonnet-6x","gpt-5.4","gpt-5.3","gemini-pro","any"],"antigravity":["copilot/antigravity*","google/antigravity*","gemini/antigravity*"],"any":["copilot/*","anthropic/*","openai/*","google/*","gemini/*"],"claude":["agent"],"codex":["agent"],"coding":["copilot/gpt-5*codex*","openai/gpt-5*codex*","gpt-5-codex"],"computer-use":["copilot/*computer-use*","google/*computer-use*","gemini/*computer-use*","openai/*computer-use*"],"copilot":["agent"],"deep-research":["copilot/deep-research*","copilot/o3-deep-research*","copilot/o4-mini-deep-research*","google/deep-research*","gemini/deep-research*","openai/o3-deep-research*","openai/o4-mini-deep-research*"],"gemini":["agent"],"gemini-3-flash":["copilot/gemini-3*flash*","google/gemini-3*flash*","gemini/gemini-3*flash*"],"gemini-3-pro":["copilot/gemini-3*pro*","google/gemini-3*pro*","gemini/gemini-3*pro*"],"gemini-3.1-flash":["copilot/gemini-3.1*flash*","google/gemini-3.1*flash*","gemini/gemini-3.1*flash*"],"gemini-3.1-pro":["copilot/gemini-3.1*pro*","google/gemini-3.1*pro*","gemini/gemini-3.1*pro*"],"gemini-3.5-flash":["copilot/gemini-3.5*flash*","google/gemini-3.5*flash*","gemini/gemini-3.5*flash*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*","gemini/gemini-*flash*"],"gemini-flash-lite":["copilot/gemini-*flash*lite*","google/gemini-*flash*lite*","gemini/gemini-*flash*lite*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*","gemini/gemini-*pro*"],"gemma":["copilot/gemma*","google/gemma*","gemini/gemma*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"gpt-5.2":["copilot/gpt-5.2*","openai/gpt-5.2*"],"gpt-5.3":["copilot/gpt-5.3*","openai/gpt-5.3*"],"gpt-5.4":["copilot/gpt-5.4*","openai/gpt-5.4*"],"gpt-5.5":["copilot/gpt-5.5*","openai/gpt-5.5*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash-lite"],"opus":["copilot/*opus*","anthropic/*opus*"],"opusplan":["opus?effort=high"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"robotics":["copilot/*robotics*","google/*robotics*","gemini/*robotics*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"],"sonnet-6x":["copilot/*sonnet-4-5-*","anthropic/*sonnet-4-5-*","copilot/*sonnet-4-6*","anthropic/*sonnet-4-6*"],"summarization":["haiku","gpt-5-mini","gemini-flash-lite","mini"],"vision":["copilot/gemini-*image*","gemini/gemini-*image*","copilot/gemini-*flash*","gemini/gemini-*flash*"]}},"container":{"imageTag":"0.25.58"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json"
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.58/awf-config.schema.json","network":{"allowDomains":["api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","dev.azure.com","github.com","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","ppa.launchpad.net","raw.githubusercontent.com","registry.npmjs.org","s.symcb.com","s.symcd.com","security.ubuntu.com","telemetry.enterprise.githubcopilot.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com"]},"apiProxy":{"enabled":true,"enableTokenSteering":true,"maxRuns":500,"maxEffectiveTokens":25000000,"models":{"agent":["sonnet-6x","gpt-5.4","gpt-5.3","gemini-pro","any"],"antigravity":["copilot/antigravity*","google/antigravity*","gemini/antigravity*"],"any":["copilot/*","anthropic/*","openai/*","google/*","gemini/*"],"claude":["agent"],"codex":["agent"],"coding":["copilot/gpt-5*codex*","openai/gpt-5*codex*","gpt-5-codex"],"computer-use":["copilot/*computer-use*","google/*computer-use*","gemini/*computer-use*","openai/*computer-use*"],"copilot":["agent"],"deep-research":["copilot/deep-research*","copilot/o3-deep-research*","copilot/o4-mini-deep-research*","google/deep-research*","gemini/deep-research*","openai/o3-deep-research*","openai/o4-mini-deep-research*"],"gemini":["agent"],"gemini-3-flash":["copilot/gemini-3*flash*","google/gemini-3*flash*","gemini/gemini-3*flash*"],"gemini-3-pro":["copilot/gemini-3*pro*","google/gemini-3*pro*","gemini/gemini-3*pro*"],"gemini-3.1-flash":["copilot/gemini-3.1*flash*","google/gemini-3.1*flash*","gemini/gemini-3.1*flash*"],"gemini-3.1-pro":["copilot/gemini-3.1*pro*","google/gemini-3.1*pro*","gemini/gemini-3.1*pro*"],"gemini-3.5-flash":["copilot/gemini-3.5*flash*","google/gemini-3.5*flash*","gemini/gemini-3.5*flash*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*","gemini/gemini-*flash*"],"gemini-flash-lite":["copilot/gemini-*flash*lite*","google/gemini-*flash*lite*","gemini/gemini-*flash*lite*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*","gemini/gemini-*pro*"],"gemma":["copilot/gemma*","google/gemma*","gemini/gemma*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"gpt-5.2":["copilot/gpt-5.2*","openai/gpt-5.2*"],"gpt-5.3":["copilot/gpt-5.3*","openai/gpt-5.3*"],"gpt-5.4":["copilot/gpt-5.4*","openai/gpt-5.4*"],"gpt-5.5":["copilot/gpt-5.5*","openai/gpt-5.5*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash-lite"],"opus":["copilot/*opus*","anthropic/*opus*"],"opusplan":["opus?effort=high"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"robotics":["copilot/*robotics*","google/*robotics*","gemini/*robotics*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"],"sonnet-6x":["copilot/*sonnet-4-5-*","anthropic/*sonnet-4-5-*","copilot/*sonnet-4-6*","anthropic/*sonnet-4-6*"],"summarization":["haiku","gpt-5-mini","gemini-flash-lite","mini"],"vision":["copilot/gemini-*image*","gemini/gemini-*image*","copilot/gemini-*flash*","gemini/gemini-*flash*"]}},"container":{"imageTag":"0.25.58"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json"
           GH_AW_MODEL_MULTIPLIERS_PATH="/tmp/gh-aw/model_multipliers.json" node "${RUNNER_TEMP}/gh-aw/actions/merge_awf_model_multipliers.cjs"
           cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS=""
@@ -922,7 +802,7 @@ jobs:
           fi
           # shellcheck disable=SC1003
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" ${GH_AW_TOOL_CACHE_MOUNT:+--mount "$GH_AW_TOOL_CACHE_MOUNT"} ${GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS} --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
-            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && GH_AW_TOOL_CACHE="${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}"; export PATH="$(find "$GH_AW_TOOL_CACHE" /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --add-dir /tmp/gh-aw/cache-memory/ --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && GH_AW_TOOL_CACHE="${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}"; export PATH="$(find "$GH_AW_TOOL_CACHE" /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -954,6 +834,19 @@ jobs:
         id: detect-agent-errors
         continue-on-error: true
         run: node "${RUNNER_TEMP}/gh-aw/actions/detect_agent_errors.cjs"
+      - name: Configure Git credentials
+        env:
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global am.keepcr true
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Copy Copilot session state files to logs
         if: always()
         continue-on-error: true
@@ -998,7 +891,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,dev.azure.com,esm.sh,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dev.azure.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
         with:
@@ -1069,39 +962,6 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
-      # Upload repo memory as artifacts for push job
-      - name: Sanitize repo-memory filenames (default)
-        if: always()
-        continue-on-error: true
-        env:
-          MEMORY_DIR: /tmp/gh-aw/repo-memory/default
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/sanitize_repo_memory_filenames.sh"
-      - name: Upload repo-memory artifact (default)
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: repo-memory-default
-          path: /tmp/gh-aw/repo-memory/default
-          retention-days: 1
-          if-no-files-found: ignore
-      - name: Commit cache-memory changes
-        if: always()
-        env:
-          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/commit_cache_memory_git.sh"
-      - name: Check cache-memory git integrity
-        if: always()
-        continue-on-error: true
-        env:
-          GH_AW_CACHE_DIR: /tmp/gh-aw/cache-memory
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/check_cache_memory_git_integrity.sh"
-      - name: Upload cache-memory data as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: cache-memory
-          include-hidden-files: true
-          path: /tmp/gh-aw/cache-memory
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
@@ -1133,20 +993,18 @@ jobs:
       - activation
       - agent
       - detection
-      - push_repo_memory
       - safe_outputs
-      - update_cache_memory
     if: >
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      actions: write
       contents: read
+      discussions: write
       issues: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-mgmt-review"
+      group: "gh-aw-conclusion-mgmt-guidance"
       cancel-in-progress: false
       queue: max
     outputs:
@@ -1164,8 +1022,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-guidance.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1189,8 +1047,8 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-review.md"
+          GH_AW_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-guidance.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -1206,8 +1064,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-review.md"
+          GH_AW_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-guidance.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -1224,8 +1082,8 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-review.md"
+          GH_AW_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-guidance.md"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1239,8 +1097,8 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-review.md"
+          GH_AW_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-guidance.md"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1254,11 +1112,11 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-review.md"
+          GH_AW_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-guidance.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "mgmt-review"
+          GH_AW_WORKFLOW_ID: "mgmt-guidance"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
@@ -1272,18 +1130,13 @@ jobs:
           GH_AW_ENGINE_API_HOSTS: "api.enterprise.githubcopilot.com,api.githubcopilot.com,api.business.githubcopilot.com,api.individual.githubcopilot.com"
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
-          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e ⚡ *Benchmarked by [{workflow_name}]({run_url})*\",\"runStarted\":\"⚡ [{workflow_name}]({run_url}) is profiling this PR for guidance and review...\",\"runSuccess\":\"⚡ [{workflow_name}]({run_url}) completed the management SDK PR review. ✅\",\"runFailure\":\"⚡ [{workflow_name}]({run_url}) {status}. ❌\"}"
-          GH_AW_PUSH_REPO_MEMORY_RESULT: ${{ needs.push_repo_memory.result }}
-          GH_AW_REPO_MEMORY_VALIDATION_FAILED_default: ${{ needs.push_repo_memory.outputs.validation_failed_default }}
-          GH_AW_REPO_MEMORY_VALIDATION_ERROR_default: ${{ needs.push_repo_memory.outputs.validation_error_default }}
-          GH_AW_REPO_MEMORY_PATCH_SIZE_EXCEEDED_default: ${{ needs.push_repo_memory.outputs.patch_size_exceeded_default }}
+          GH_AW_SAFE_OUTPUT_MESSAGES: "{\"runFailure\":\"⚡ [{workflow_name}]({run_url}) failed to post merge guidance. ❌\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "35"
+          GH_AW_TIMEOUT_MINUTES: "10"
           GH_AW_MAX_EFFECTIVE_TOKENS: "25000000"
-          GH_AW_CACHE_MEMORY_ENABLED: "true"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1315,8 +1168,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-guidance.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1387,8 +1240,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          WORKFLOW_NAME: "Management Release Assistant"
-          WORKFLOW_DESCRIPTION: "Review a pull request for management-plane SDKs"
+          WORKFLOW_NAME: "Management SDK Merge Guidance"
+          WORKFLOW_DESCRIPTION: "Post Next Steps to Merge once all CI checks complete on management-plane SDK PRs"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1509,17 +1362,20 @@ jobs:
             }
 
   pre_activation:
-    if: github.event.label.name == 'mgmt-review-needed' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
+      actions: read
+      checks: read
+      pull-requests: read
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      gate_result: ${{ steps.gate.outcome }}
       matched_command: ''
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      ready: ${{ steps.gate.outputs.ready }}
       setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
       setup-span-id: ${{ steps.setup.outputs.span-id }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-      swap_label_result: ${{ steps.swap_label.outcome }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -1528,8 +1384,8 @@ jobs:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-guidance.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1545,113 +1401,53 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
-      - name: Swap trigger label to in-progress
-        id: swap_label
-        if: github.event_name == 'pull_request_target' && github.event.label.name == 'mgmt-review-needed'
+      - name: Gate — extract PR number and verify all CI checks are complete
+        id: gate
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          CHECK_SUITE_APP: ${{ github.event.check_suite.app.name }}
+          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          ITEM_NUMBER: ${{ github.event.inputs.item_number }}
         with:
           script: |
-            const pr = context.payload.pull_request.number;
-            // Remove trigger label
-            try {
-              await github.rest.issues.removeLabel({
-                ...context.repo,
-                issue_number: pr,
-                name: 'mgmt-review-needed'
-              });
-            } catch (e) {
-              core.warning(`Could not remove trigger label: ${e.message}`);
-            }
-            // Add in-progress label
-            try {
-              await github.rest.issues.addLabels({
-                ...context.repo,
-                issue_number: pr,
-                labels: ['mgmt-review-in-progress']
-              });
-            } catch (e) {
-              core.warning(`Could not add in-progress label: ${e.message}`);
+            const appName  = process.env.CHECK_SUITE_APP || '';
+            const headSha  = process.env.HEAD_SHA        || '';
+            const inputPr  = process.env.ITEM_NUMBER     || '';
+
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('pr_number', inputPr);
+              core.setOutput('ready', 'true');
+              return;
             }
 
-  push_repo_memory:
-    needs:
-      - activation
-      - agent
-      - detection
-    if: >
-      always() && (!cancelled()) && (needs.detection.result == 'success' || needs.detection.result == 'skipped') &&
-      needs.agent.result == 'success'
-    runs-on: ubuntu-slim
-    permissions:
-      contents: write
-    concurrency:
-      group: "push-repo-memory-${{ github.repository }}|memory/mgmt-review"
-      cancel-in-progress: false
-    outputs:
-      patch_size_exceeded_default: ${{ steps.push_repo_memory_default.outputs.patch_size_exceeded }}
-      validation_error_default: ${{ steps.push_repo_memory_default.outputs.validation_error }}
-      validation_failed_default: ${{ steps.push_repo_memory_default.outputs.validation_failed }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
-          parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "1.0.55"
-          GH_AW_INFO_AWF_VERSION: "v0.25.58"
-          GH_AW_INFO_ENGINE_ID: "copilot"
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          sparse-checkout: .
-      - name: Configure Git credentials
-        env:
-          REPO_NAME: ${{ github.repository }}
-          SERVER_URL: ${{ github.server_url }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git config --global am.keepcr true
-          # Re-authenticate git with GitHub token
-          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
-          echo "Git configured with standard GitHub Actions identity"
-      - name: Download repo-memory artifact (default)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
-        with:
-          name: repo-memory-default
-          path: /tmp/gh-aw/repo-memory/default
-      - name: Push repo-memory changes (default)
-        id: push_repo_memory_default
-        if: always()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          ARTIFACT_DIR: /tmp/gh-aw/repo-memory/default
-          MEMORY_ID: default
-          TARGET_REPO: ${{ github.repository }}
-          BRANCH_NAME: memory/mgmt-review
-          MAX_FILE_SIZE: 102400
-          MAX_FILE_COUNT: 100
-          MAX_PATCH_SIZE: 10240
-          ALLOWED_EXTENSIONS: '[]'
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/push_repo_memory.cjs');
-            await main();
+            // check_suite completed = entire ADO pipeline finished (one event, not N)
+            if (!appName.includes('Azure Pipelines')) {
+              core.setOutput('ready', 'false');
+              return;
+            }
+
+            const prNum = context.payload.check_suite?.pull_requests?.[0]?.number;
+            if (!prNum) {
+              core.info('No PR associated with this check suite — skipping.');
+              core.setOutput('ready', 'false');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              pull_number: prNum,
+            });
+            const labels = (pr.labels || []).map(l => l.name);
+            if (!labels.includes('mgmt-review-added')) {
+              core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — skipping until review completes.`);
+              core.setOutput('ready', 'false');
+              return;
+            }
+
+            core.info(`check_suite completed on ${headSha} — activating for PR #${prNum}`);
+            core.setOutput('pr_number', String(prNum));
+            core.setOutput('ready', 'true');
 
   safe_outputs:
     needs:
@@ -1661,26 +1457,28 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      actions: write
       contents: read
+      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/mgmt-review"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/mgmt-guidance"
       GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
       GH_AW_ENGINE_VERSION: "1.0.55"
-      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"footer\":\"\\u003e ⚡ *Benchmarked by [{workflow_name}]({run_url})*\",\"runStarted\":\"⚡ [{workflow_name}]({run_url}) is profiling this PR for guidance and review...\",\"runSuccess\":\"⚡ [{workflow_name}]({run_url}) completed the management SDK PR review. ✅\",\"runFailure\":\"⚡ [{workflow_name}]({run_url}) {status}. ❌\"}"
-      GH_AW_WORKFLOW_ID: "mgmt-review"
-      GH_AW_WORKFLOW_NAME: "Management Release Assistant"
-      GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-review.md"
+      GH_AW_SAFE_OUTPUT_MESSAGES: "{\"runFailure\":\"⚡ [{workflow_name}]({run_url}) failed to post merge guidance. ❌\"}"
+      GH_AW_WORKFLOW_ID: "mgmt-guidance"
+      GH_AW_WORKFLOW_NAME: "Management SDK Merge Guidance"
+      GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/mgmt-guidance.md"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
+      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
+      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
@@ -1695,8 +1493,8 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Management SDK Merge Guidance"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-guidance.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AWF_VERSION: "v0.25.58"
           GH_AW_INFO_ENGINE_ID: "copilot"
@@ -1729,10 +1527,10 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,dev.azure.com,esm.sh,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dev.azure.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_labels\":{\"max\":1,\"target\":\"${{ github.event.pull_request.number || github.event.issue.number }}\"},\"create_pull_request_review_comment\":{\"max\":10,\"side\":\"RIGHT\",\"target\":\"${{ github.event.pull_request.number || github.event.issue.number }}\"},\"create_report_incomplete_issue\":{},\"dispatch_workflow\":{\"max\":1,\"workflow_files\":{\"format-auto-fix\":\".yml\"},\"workflows\":[\"format-auto-fix\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"max\":1,\"target\":\"${{ github.event.pull_request.number || github.event.issue.number }}\"},\"report_incomplete\":{},\"submit_pull_request_review\":{\"footer\":\"if-body\",\"max\":1,\"target\":\"${{ github.event.pull_request.number || github.event.issue.number }}\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"footer\":false,\"hide_older_comments\":true,\"max\":1,\"target\":\"${{ needs.pre_activation.outputs.pr_number }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1750,50 +1548,3 @@ jobs:
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
 
-  update_cache_memory:
-    needs:
-      - activation
-      - agent
-      - detection
-    if: always() && needs.detection.result == 'success' && needs.agent.result == 'success'
-    runs-on: ubuntu-slim
-    permissions: {}
-    env:
-      GH_AW_WORKFLOW_ID_SANITIZED: mgmtreview
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
-          parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Management Release Assistant"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/mgmt-review.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "1.0.55"
-          GH_AW_INFO_AWF_VERSION: "v0.25.58"
-          GH_AW_INFO_ENGINE_ID: "copilot"
-      - name: Download cache-memory artifact (default)
-        id: download_cache_default
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
-        with:
-          name: cache-memory
-          path: /tmp/gh-aw/cache-memory
-      - name: Check if cache-memory folder has content (default)
-        id: check_cache_default
-        shell: bash
-        run: |
-          if [ -d "/tmp/gh-aw/cache-memory" ] && [ "$(ls -A /tmp/gh-aw/cache-memory 2>/dev/null)" ]; then
-            echo "has_content=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_content=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Save cache-memory to cache (default)
-        if: steps.check_cache_default.outputs.has_content == 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: memory-none-nopolicy-${{ env.GH_AW_WORKFLOW_ID_SANITIZED }}-${{ github.run_id }}
-          path: /tmp/gh-aw/cache-memory

--- a/.github/workflows/mgmt-guidance.lock.yml
+++ b/.github/workflows/mgmt-guidance.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"6741188bfa1caff92c8c058a2c0c294504b2dabfde898badd880bb3eb6086d56","body_hash":"4bea01f520d0d324cbb42b48d4998e17502bbc45c4d4e631a6a853c552aa8370","compiler_version":"v0.77.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"21a944b6e646728cd9a5b1e02f2af0fda7576691c2b913611a003f190cc92333","body_hash":"4bea01f520d0d324cbb42b48d4998e17502bbc45c4d4e631a6a853c552aa8370","compiler_version":"v0.77.5","agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -63,7 +63,7 @@ on:
       # HEAD_SHA: ${{ github.event.check_suite.head_sha }}
       # ITEM_NUMBER: ${{ github.event.inputs.item_number }}
     # id: gate
-    # name: Gate — extract PR number and verify all CI checks are complete
+    # name: Gate — verify CI complete and PR has mgmt-review-added label
     # uses: actions/github-script@v8
     # with:
       # script: |
@@ -77,7 +77,8 @@ on:
           # return;
         # }
         # 
-        # // check_suite completed = entire ADO pipeline finished (one event, not N)
+        # // Only care about Azure Pipelines (ADO) check suites — filters out GitHub Actions
+        # // and other CI systems, and exits immediately for all non-mgmt PRs that lack ADO.
         # if (!appName.includes('Azure Pipelines')) {
           # core.setOutput('ready', 'false');
           # return;
@@ -90,6 +91,8 @@ on:
           # return;
         # }
         # 
+        # // Filter to mgmt PRs only: must have 'mgmt-review-added' label,
+        # // which is set exclusively by the mgmt-review agent after it completes.
         # const { data: pr } = await github.rest.pulls.get({
           # owner: context.repo.owner,
           # repo:  context.repo.repo,
@@ -97,12 +100,12 @@ on:
         # });
         # const labels = (pr.labels || []).map(l => l.name);
         # if (!labels.includes('mgmt-review-added')) {
-          # core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — skipping until review completes.`);
+          # core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — not a mgmt PR or review not yet complete.`);
           # core.setOutput('ready', 'false');
           # return;
         # }
         # 
-        # core.info(`check_suite completed on ${headSha} — activating for PR #${prNum}`);
+        # core.info(`ADO check suite completed on ${headSha} — activating for mgmt PR #${prNum}`);
         # core.setOutput('pr_number', String(prNum));
         # core.setOutput('ready', 'true');
   workflow_dispatch:
@@ -252,20 +255,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
+          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
           <system>
-          GH_AW_PROMPT_32014e1e0cee986d_EOF
+          GH_AW_PROMPT_136f94974bf605c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
+          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_32014e1e0cee986d_EOF
+          GH_AW_PROMPT_136f94974bf605c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
+          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -294,12 +297,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_32014e1e0cee986d_EOF
+          GH_AW_PROMPT_136f94974bf605c7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_32014e1e0cee986d_EOF'
+          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
           </system>
           {{#runtime-import .github/workflows/mgmt-guidance.md}}
-          GH_AW_PROMPT_32014e1e0cee986d_EOF
+          GH_AW_PROMPT_136f94974bf605c7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -513,9 +516,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8f93e48a2807c253_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4b3a06fc2e48ec61_EOF'
           {"add_comment":{"footer":false,"hide_older_comments":true,"max":1,"target":"${{ needs.pre_activation.outputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8f93e48a2807c253_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4b3a06fc2e48ec61_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -709,7 +712,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9e32c940fb21040c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_301955b55d1d1894_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -750,7 +753,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9e32c940fb21040c_EOF
+          GH_AW_MCP_CONFIG_301955b55d1d1894_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1401,7 +1404,7 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
-      - name: Gate — extract PR number and verify all CI checks are complete
+      - name: Gate — verify CI complete and PR has mgmt-review-added label
         id: gate
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
@@ -1420,7 +1423,8 @@ jobs:
               return;
             }
 
-            // check_suite completed = entire ADO pipeline finished (one event, not N)
+            // Only care about Azure Pipelines (ADO) check suites — filters out GitHub Actions
+            // and other CI systems, and exits immediately for all non-mgmt PRs that lack ADO.
             if (!appName.includes('Azure Pipelines')) {
               core.setOutput('ready', 'false');
               return;
@@ -1433,6 +1437,8 @@ jobs:
               return;
             }
 
+            // Filter to mgmt PRs only: must have 'mgmt-review-added' label,
+            // which is set exclusively by the mgmt-review agent after it completes.
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo:  context.repo.repo,
@@ -1440,12 +1446,12 @@ jobs:
             });
             const labels = (pr.labels || []).map(l => l.name);
             if (!labels.includes('mgmt-review-added')) {
-              core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — skipping until review completes.`);
+              core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — not a mgmt PR or review not yet complete.`);
               core.setOutput('ready', 'false');
               return;
             }
 
-            core.info(`check_suite completed on ${headSha} — activating for PR #${prNum}`);
+            core.info(`ADO check suite completed on ${headSha} — activating for mgmt PR #${prNum}`);
             core.setOutput('pr_number', String(prNum));
             core.setOutput('ready', 'true');
 

--- a/.github/workflows/mgmt-guidance.lock.yml
+++ b/.github/workflows/mgmt-guidance.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"21a944b6e646728cd9a5b1e02f2af0fda7576691c2b913611a003f190cc92333","body_hash":"4bea01f520d0d324cbb42b48d4998e17502bbc45c4d4e631a6a853c552aa8370","compiler_version":"v0.77.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"da9a5c953256973d5800d31963d8ebc5b9f3ca10796934f3ba50826f14487f4d","body_hash":"4bea01f520d0d324cbb42b48d4998e17502bbc45c4d4e631a6a853c552aa8370","compiler_version":"v0.77.5","agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -124,7 +124,7 @@ permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: gh-aw-mgmt-guidance-${{ needs.pre_activation.outputs.pr_number }}
+  group: gh-aw-mgmt-guidance-${{ github.event.check_suite.pull_requests[0].number || github.event.inputs.item_number || github.run_id }}
 
 run-name: "Management SDK Merge Guidance"
 
@@ -255,20 +255,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
+          cat << 'GH_AW_PROMPT_16aaf5c2de5741dd_EOF'
           <system>
-          GH_AW_PROMPT_136f94974bf605c7_EOF
+          GH_AW_PROMPT_16aaf5c2de5741dd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
+          cat << 'GH_AW_PROMPT_16aaf5c2de5741dd_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_136f94974bf605c7_EOF
+          GH_AW_PROMPT_16aaf5c2de5741dd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
+          cat << 'GH_AW_PROMPT_16aaf5c2de5741dd_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -297,12 +297,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_136f94974bf605c7_EOF
+          GH_AW_PROMPT_16aaf5c2de5741dd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_136f94974bf605c7_EOF'
+          cat << 'GH_AW_PROMPT_16aaf5c2de5741dd_EOF'
           </system>
           {{#runtime-import .github/workflows/mgmt-guidance.md}}
-          GH_AW_PROMPT_136f94974bf605c7_EOF
+          GH_AW_PROMPT_16aaf5c2de5741dd_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -516,9 +516,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4b3a06fc2e48ec61_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_440f7111ded418bf_EOF'
           {"add_comment":{"footer":false,"hide_older_comments":true,"max":1,"target":"${{ needs.pre_activation.outputs.pr_number }}"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4b3a06fc2e48ec61_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_440f7111ded418bf_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -712,7 +712,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_301955b55d1d1894_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ac433ed758872e91_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -753,7 +753,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_301955b55d1d1894_EOF
+          GH_AW_MCP_CONFIG_ac433ed758872e91_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/mgmt-guidance.md
+++ b/.github/workflows/mgmt-guidance.md
@@ -17,7 +17,7 @@ on:
   # env: vars in steps use the full GitHub Actions expression context —
   # gh-aw's expression allowlist only restricts frontmatter YAML field values.
   steps:
-    - name: Gate — extract PR number and verify all CI checks are complete
+    - name: Gate — verify CI complete and PR has mgmt-review-added label
       id: gate
       uses: actions/github-script@v8
       env:
@@ -36,7 +36,8 @@ on:
             return;
           }
 
-          // check_suite completed = entire ADO pipeline finished (one event, not N)
+          // Only care about Azure Pipelines (ADO) check suites — filters out GitHub Actions
+          // and other CI systems, and exits immediately for all non-mgmt PRs that lack ADO.
           if (!appName.includes('Azure Pipelines')) {
             core.setOutput('ready', 'false');
             return;
@@ -49,6 +50,8 @@ on:
             return;
           }
 
+          // Filter to mgmt PRs only: must have 'mgmt-review-added' label,
+          // which is set exclusively by the mgmt-review agent after it completes.
           const { data: pr } = await github.rest.pulls.get({
             owner: context.repo.owner,
             repo:  context.repo.repo,
@@ -56,12 +59,12 @@ on:
           });
           const labels = (pr.labels || []).map(l => l.name);
           if (!labels.includes('mgmt-review-added')) {
-            core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — skipping until review completes.`);
+            core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — not a mgmt PR or review not yet complete.`);
             core.setOutput('ready', 'false');
             return;
           }
 
-          core.info(`check_suite completed on ${headSha} — activating for PR #${prNum}`);
+          core.info(`ADO check suite completed on ${headSha} — activating for mgmt PR #${prNum}`);
           core.setOutput('pr_number', String(prNum));
           core.setOutput('ready', 'true');
 

--- a/.github/workflows/mgmt-guidance.md
+++ b/.github/workflows/mgmt-guidance.md
@@ -1,0 +1,172 @@
+---
+on:
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      item_number:
+        description: PR number to generate merge guidance for
+        required: true
+        type: string
+  # on.permissions: scopes for the pre-activation job that runs on.steps
+  permissions:
+    checks: read
+    pull-requests: read
+    actions: read
+  # on.steps: runs BEFORE agent activation; gates via `if:` below.
+  # env: vars in steps use the full GitHub Actions expression context —
+  # gh-aw's expression allowlist only restricts frontmatter YAML field values.
+  steps:
+    - name: Gate — extract PR number and verify all CI checks are complete
+      id: gate
+      uses: actions/github-script@v8
+      env:
+        CHECK_SUITE_APP: ${{ github.event.check_suite.app.name }}
+        HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+        ITEM_NUMBER: ${{ github.event.inputs.item_number }}
+      with:
+        script: |
+          const appName  = process.env.CHECK_SUITE_APP || '';
+          const headSha  = process.env.HEAD_SHA        || '';
+          const inputPr  = process.env.ITEM_NUMBER     || '';
+
+          if (context.eventName === 'workflow_dispatch') {
+            core.setOutput('pr_number', inputPr);
+            core.setOutput('ready', 'true');
+            return;
+          }
+
+          // check_suite completed = entire ADO pipeline finished (one event, not N)
+          if (!appName.includes('Azure Pipelines')) {
+            core.setOutput('ready', 'false');
+            return;
+          }
+
+          const prNum = context.payload.check_suite?.pull_requests?.[0]?.number;
+          if (!prNum) {
+            core.info('No PR associated with this check suite — skipping.');
+            core.setOutput('ready', 'false');
+            return;
+          }
+
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo:  context.repo.repo,
+            pull_number: prNum,
+          });
+          const labels = (pr.labels || []).map(l => l.name);
+          if (!labels.includes('mgmt-review-added')) {
+            core.info(`PR #${prNum} does not have 'mgmt-review-added' label (${labels.join(', ') || 'none'}) — skipping until review completes.`);
+            core.setOutput('ready', 'false');
+            return;
+          }
+
+          core.info(`check_suite completed on ${headSha} — activating for PR #${prNum}`);
+          core.setOutput('pr_number', String(prNum));
+          core.setOutput('ready', 'true');
+
+jobs:
+  pre-activation:
+    outputs:
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      ready: ${{ steps.gate.outputs.ready }}
+
+if: needs.pre_activation.outputs.ready == 'true' && needs.pre_activation.outputs.pr_number != ''
+
+concurrency:
+  group: "gh-aw-mgmt-guidance-${{ needs.pre_activation.outputs.pr_number }}"
+  cancel-in-progress: true
+
+description: "Post Next Steps to Merge once all CI checks complete on management-plane SDK PRs"
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+strict: false
+network:
+  allowed:
+    - defaults
+    - "dev.azure.com"
+tools:
+  github:
+    toolsets: [context, repos, pull_requests, actions]
+  bash: true
+safe-outputs:
+  add-comment:
+    max: 1
+    target: "${{ needs.pre_activation.outputs.pr_number }}"
+    hide-older-comments: true
+    footer: false
+  messages:
+    run-failure: "⚡ [{workflow_name}]({run_url}) failed to post merge guidance. ❌"
+timeout-minutes: 10
+
+---
+
+# Management SDK Merge Guidance
+
+You provide merge readiness guidance for Azure SDK for JS management-plane PRs.
+
+**PR to evaluate:** `${{ needs.pre_activation.outputs.pr_number }}`
+
+All CI checks have finished on this PR's head commit. Determine whether the PR is ready to merge or has blocking failures, then post a single comment.
+
+## Step 1. Confirm merge readiness
+
+Fetch the PR using the GitHub API. If `mergeable_state == "clean"` and no check has `conclusion: "failure"`, `"cancelled"`, or `"timed_out"`:
+
+Post this comment and stop:
+```markdown
+## PR is ready to merge
+```
+
+## Step 2. Diagnose blocking items
+
+Collect every blocker:
+
+1. **PR merge conflicts** — if `mergeable_state == "dirty"` → pnpm-lock or code conflict.
+2. **Failed CI checks** — every check run with `conclusion: "failure"`, `"cancelled"`, or `"timed_out"`.
+3. **Diagnose each failed ADO sub-check** (names like `js - pullrequest (Build Build)`, `js - pullrequest (UnitTest ubuntu_24x_node)`):
+   - Extract `buildId` from `target_url` (pattern: `https://dev.azure.com/azure-sdk/public/_build/results?buildId=<ID>&view=results`)
+   - Timeline: `curl -s "https://dev.azure.com/azure-sdk/public/_apis/build/builds/<buildId>/timeline?api-version=7.1"` — find `records` with `result: "failed"`
+   - Logs: `curl -s "<record.log.url>"` — search for specific error messages
+   - **CRITICAL**: Use only the real `target_url` from the API. Never fabricate or use placeholder URLs.
+
+#### CI Check → Category
+
+| Sub-check (text in parentheses) | What it validates | Fix |
+|---|---|---|
+| `Build Build` | TypeScript compilation | Fix compile errors |
+| `Build Analyze` | Format, ESLint, snippets, READMEs | `cd <pkg> && pnpm format` then push |
+| `UnitTest <env>` | Tests on node/browser environments | Fix tests or skip with maintainer approval |
+| `verify-links` | Markdown link validation | Add URL to `eng/ignore-links.txt` |
+| `checkenforcer` | Meta-check (waits for all others) | `/check-enforcer override` to unblock |
+
+#### Log Symptom → Root Cause
+
+| Symptom | Root cause | Action |
+|---|---|---|
+| `UnitTest FAILED` request url mismatch | Stale recordings | Re-record per [test guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md#run-tests-in-record-mode) or skip with maintainer approval |
+| `UnitTest FAILED` missing browser recordings | Missing browser recordings | Re-record browser recordings |
+| `Build FAILED` | Compile error | Fix compile errors |
+| `Check-format FAILED` | Unformatted code | `cd <pkg-dir> && pnpm format` then push |
+| `verify-links` broken URL | Broken markdown link | Add URL to `eng/ignore-links.txt` |
+| `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` | pnpm-lock conflict | Follow [conflict guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/resolve-pnpm-lock-merge-conflict.md) |
+
+Extra rules:
+- If the same UnitTest error appears across multiple environments, list it only once.
+- Include pnpm-lock guidance if `mergeable_state == "dirty"`.
+- Link to [CI troubleshooting](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Troubleshoot-ci-failure.md) for unrecognized failures.
+
+## Step 3. Post the result
+
+Post a single `add-comment`. Include marker `<!-- gh-aw-workflow-id: mgmt-guidance -->` in the body. Keep the comment concise (≤ 15 lines). Do NOT include passed checks.
+
+```markdown
+## Next Steps to Merge
+Only failed checks and required actions are listed below.
+
+- ❌ <failed check name>: <short reason>. Action: <specific fix>. Review [ADO logs](<real target_url>).
+- ❌ Check-format: code not formatted. Action: Run `cd <package-dir> && pnpm format`, then commit and push. Review [ADO logs](<target_url>).
+- 🔄 pnpm-lock conflict: merge conflict in pnpm-lock.yaml. Follow the [conflict guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/resolve-pnpm-lock-merge-conflict.md).
+```

--- a/.github/workflows/mgmt-guidance.md
+++ b/.github/workflows/mgmt-guidance.md
@@ -120,7 +120,8 @@ Fetch the PR using the GitHub API. If `mergeable_state == "clean"` and no check 
 
 Post this comment and stop:
 ```markdown
-## PR is ready to merge
+## Next Steps to Merge
+No further action is required from the service team. The SDK PR reviewer will handle the review and merge of this PR.
 ```
 
 ## Step 2. Diagnose blocking items

--- a/.github/workflows/mgmt-guidance.md
+++ b/.github/workflows/mgmt-guidance.md
@@ -77,7 +77,7 @@ jobs:
 if: needs.pre_activation.outputs.ready == 'true' && needs.pre_activation.outputs.pr_number != ''
 
 concurrency:
-  group: "gh-aw-mgmt-guidance-${{ needs.pre_activation.outputs.pr_number }}"
+  group: "gh-aw-mgmt-guidance-${{ github.event.check_suite.pull_requests[0].number || github.event.inputs.item_number || github.run_id }}"
   cancel-in-progress: true
 
 description: "Post Next Steps to Merge once all CI checks complete on management-plane SDK PRs"

--- a/.github/workflows/mgmt-review.md
+++ b/.github/workflows/mgmt-review.md
@@ -63,11 +63,6 @@ tools:
   cache-memory:
   repo-memory:
 safe-outputs:
-  add-comment:
-    max: 1
-    target: "${{ github.event.pull_request.number || github.event.issue.number }}"
-    hide-older-comments: true
-    footer: false
   create-pull-request-review-comment:
     max: 10
     side: "RIGHT"
@@ -95,9 +90,7 @@ timeout-minutes: 35
 
 # Management Release Assistant
 
-You are an SDK release assistant that helps 
-- 1) review the PR and provide review comments
-- 2) provide next-step guidance with merging status 
+You are an SDK release assistant that reviews management-plane SDK PRs and provides API surface and tooling review comments.
 
 ## Workflow to review the management PR
 Review Azure SDK for JS management library pull request #${{ github.event.pull_request.number }} against the official API review guidelines.
@@ -180,112 +173,6 @@ body confirming that the API surface looks good.
 
 Store a brief summary in `cache-memory` (PR number, package, outcome) so future runs can detect repeat patterns.
 
-
-## Workflow to provide next-step guidance
-
-### Step 1. Gather information
-
-- Fetch PR details, check statuses, changed files, and workflow runs using GitHub MCP tools.
-- **Distinguish between CI systems:**
-  - **Azure DevOps pipelines** (e.g., `js - PullRequest`): These are NOT GitHub Actions jobs. Do NOT call `get_job_logs` for them — it will return 404. Instead, extract the `target_url` or `details_url` from the check run API. The URL pattern is `https://dev.azure.com/azure-sdk/public/_build/results?buildId=<ID>&view=results`. Include it in the comment as a clickable link.
-    - **Fetching ADO logs**: ADO logs for the `azure-sdk/public` project are publicly accessible. Extract the `buildId` from the `target_url`, then use `curl` (via bash) to query the ADO REST API:
-      1. **Timeline** (lists all jobs/tasks and their results): `curl -s "https://dev.azure.com/azure-sdk/public/_apis/build/builds/<buildId>/timeline?api-version=7.1"` — look for `records` with `result: "failed"`. Each record has a `log.url` field.
-      2. **Logs** (actual log content for a failed task): `curl -s "<log.url>"` — returns plain-text log output. Search for error messages.
-      3. **If checks are still in progress**: If the timeline shows records with `result: null` or `state: "inProgress"` and no failed records are available yet, wait **5 minutes** and then re-query the timeline and logs before proceeding. Retry at most once; if checks are still running after the retry, mark them as "⏳ still running" in the comment.
-      Use these logs to diagnose failures with specifics rather than guessing from check names alone.
-    - **CRITICAL**: You MUST use the real `target_url` from the check run API response for ADO links. NEVER use placeholder URLs like `dev.azure.com/redacted` or fabricate URLs. If the `target_url` is unavailable, omit the link entirely rather than using a fake one.
-  - **GitHub Actions workflows** (e.g., `mgmt-review`, `pnpm-lock-conflict-resolver`): These ARE GitHub Actions jobs. Use the GitHub MCP Actions toolset (`get_job_logs`) to fetch their log content.
-- **Diagnosing ADO pipeline failures**: ADO pipelines report sub-checks with names like `js - pullrequest (Build Analyze)`, `js - pullrequest (Build Build)`, `js - pullrequest (UnitTest node22 linux)`, etc. The text in parentheses maps to the CI Check Name table below. When an ADO sub-check fails:
-  1. Identify which sub-check failed from its name (e.g., `Build Analyze` → Analyze, `Build Build` → Build).
-  2. Use the CI Check Name → Failure Mapping table to determine what it validates.
-  3. **Fetch ADO logs** for the failed sub-check using the ADO REST API (timeline → find failed record → fetch its `log.url`). Search the log output for error messages.
-  4. **Inspect the PR's changed files directly** to cross-reference with log errors — e.g., read the package's source files for compile errors, check if `pnpm run check-format` would fail, look for broken markdown links.
-  5. Match the diagnosis against the Log Symptom → Root Cause Mapping table to provide specific guidance.
-  6. Do NOT just say "check failed" with generic guesses. Provide the **specific** failure reason based on log output and code inspection.
-
-### Step 2. Identify gaps to merge
-
-- If the PR is ready to merge means there will be a button `Squash and merge` enabled, stop the analysis and comment `## PR is ready to merge`;
-- Otherwise, **build a complete list of ALL blocking items before proceeding to Step 3**. Do NOT start fixing anything until you have catalogued every failure. Classify each blocker using the CI check mapping and log symptom patterns below.
-- Check **all** of the following sources:
-  1. PR merge status (`mergeable_state`) — look for merge conflicts
-  2. All CI check runs — list every check with `conclusion: failure` or `state: error`
-  3. ADO pipeline results — check `state`/`conclusion` fields; for failures, fetch ADO logs via the REST API to get specific error details
-- For checks still `pending` or `in_progress`, note them as "⏳ still running" — do NOT skip them.
-- **Important**: Record each failure in a structured list before moving to Step 3. This list will be used for both auto-fix attempts and the final comment.
-
-#### CI Check Name → Failure Mapping
-
-These are the Azure DevOps and GitHub checks that run on SDK PRs. The check names are repo-specific and not discoverable from general knowledge.
-
-| Check Name Pattern | What It Validates | Key Script |
-|---|---|---|
-| `Build` | Compilation on src/samples/test codes | `pnpm turbo build --filter=<package-name>... --token 1` |
-| `Analyze` | Samples, READMEs, snippets compile, Format, ESlint | `pnpm run check-format`/`pnpm run update-snippets` etc |
-| `verify-links` | Markdown link validation | `eng/common/scripts/Verify-Links.ps1` |
-| `UnitTest ${environment}` | Run test cases on different environments including node and browser testings | `pnpm test` or `.skip` on test files to skip running|
-| `checkenforcer` | Meta-check: waits for all other checks to pass | `/check-enforcer override` to override if blocking |
-
-#### Log Symptom → Root Cause Mapping
-
-These are exact strings/patterns to search for in CI logs and PR status. They are specific to this repo's scripts and not inferable from general knowledge.
-
-| Log symptom | Root cause | Action | Auto Fix |
-|---|---|---|---|
-| `UnitTest FAILED` request url mismatch | Stale test recordings | You need to record new recordings per [test guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md#run-tests-in-record-mode). Or you could simply skip tests with maintainer approval. | No |
-| `UnitTest FAILED` missing browser recordings | Missing browser recordings | You need to record browser recordings per [test guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md#run-tests-in-record-mode). | No |
-| `Build FAILED` | Compilation failure | Fix compile errors | No |
-| `Check-format FAILED` | Code not formatted | Dispatch the `format-auto-fix` workflow to apply the formatting fix | dispatch-workflow |
-| `verify-links` broken URL | Broken markdown links | Add URL to `eng/ignore-links.txt` | No |
-| PR `Merging is blocking` pnpm-lock conflict | pnpm-lock.yaml conflict | Bot regenerates `pnpm-lock.yaml` and pushes the fix to the PR branch; if auto-fix fails, follow the [conflict guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/resolve-pnpm-lock-merge-conflict.md) | No |
-| `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` Broken lockfile | pnpm-lock.yaml conflict | Bot regenerates `pnpm-lock.yaml` and pushes the fix to the PR branch; if auto-fix fails, follow the [conflict guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/resolve-pnpm-lock-merge-conflict.md) | NO |
-
-Besides above cases also:
-- Only log one failure case if `UnitTest` failed with same errors across environments
-- Provide [test guidance](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md) for recording-related failures
-- Check [CI troubleshooting](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Troubleshoot-ci-failure.md) for other failures
-- Provide general guidance if merging conflict exists
-
-### Step 3. Auto-fix failures if possible
-
-- If `Check-format FAILED` is detected:
-  1. Dispatch the `format-auto-fix` workflow immediately via `dispatch-workflow`, passing the PR number as input `pr_number`. Use the actual PR number from context (pull_request event number or `item_number` input).
-- All other failures require manual fixes by the contributor.
-
-### Step 4. Post a comment
-
-The comment must report **every** blocking item from your Step 2 list — not just the ones you attempted to auto-fix. This is the most important step.
-
-- Do NOT include passed checks or extra sections.
-- Do NOT include any review comments.
-- Do NOT skip failures just because auto-fix was attempted but failed.
-
-Compose a single GitHub PR comment (not a review) with:
-- **Header**: `## Next Steps to Merge`
-- **Message**: `Only failed checks and required actions are listed below:`
-- Include **all** currently failing/blocking checks from your Step 2 list:
-  - Format auto-fix triggered: `- 🔧 <Check name>: code not formatted — auto-fix workflow dispatched, will apply \`pnpm format\` and push.`
-  - Not auto-fixed: `- ❌ <Check name>: <reason>. Action: <fix steps>. Review [ADO logs](<target_url from check API>).`
-  - pnpm-lock conflict (manual): `- 🔄 pnpm-lock conflict: <reason>. Follow the [conflict guide](...).`
-  - Still running: `- ⏳ <Check name>: still running.`
-  - **Note:** Always include the real ADO `target_url` link; never use placeholder URLs.
-- Keep concise (target <= 15 lines). If nothing blocks: `## PR is ready to merge`.
-
-Post via `add-comment` exactly once. Use `hide-older-comments: true` to avoid duplicates. Include marker `<!-- gh-aw-workflow-id: mgmt-review -->` in the body.
-
-### Required Output Template
-
-Use this exact shape and keep it short. The comment MUST include ALL blocking items from Step 2:
-
-```markdown
-## Next Steps to Merge
-Only failed checks and required actions are listed below.
-
-- ❌ <failed check name>: <short failure reason>. Action: <specific fix command or step>. Review [ADO logs](<real target_url from check API>).
-- 🔧 <format check name>: code not formatted — auto-fix workflow dispatched, will apply `pnpm format` and push.
-- 🔄 pnpm-lock conflict: merge conflict in pnpm-lock.yaml. Follow the [conflict guide](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/resolve-pnpm-lock-merge-conflict.md) to fix this issue.
-- ⏳ <pending check name>: still running.
-```
 
 ## Final Step — Update Labels
 


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/16048
This pull request removes support for the `add-comment` tool from the management-plane SDK review workflows, both in the workflow YAML and in the safe outputs configuration. This change affects how comments are posted during the review process, streamlining the available actions and focusing on review comments and labels instead. The PR also updates documentation and workflow descriptions for clarity.
test pipleline: https://github.com/skywing918/azure-sdk-for-js/pull/37