### PR TITLE
[notification-hubs][samples] update to use re-exported `isRestError`

### DIFF
--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.fcmLegacy.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.fcmLegacy.ts
@@ -27,7 +27,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.fcmV1.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.fcmV1.ts
@@ -27,7 +27,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotification.ts
@@ -27,7 +27,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotificationBatch.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendDirectNotificationBatch.ts
@@ -27,7 +27,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendTagExpression.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendTagExpression.ts
@@ -27,7 +27,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples-dev/sendTagsList.ts
+++ b/sdk/notificationhubs/notification-hubs/samples-dev/sendTagsList.ts
@@ -28,7 +28,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/package.json
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@azure/notification-hubs": "latest",
     "dotenv": "latest",
-    "@azure/core-util": "^1.11.0",
-    "@azure/core-rest-pipeline": "^1.19.0"
+    "@azure/core-util": "^1.11.0"
   },
   "devDependencies": {
     "cross-env": "latest"

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotification.fcmLegacy.js
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotification.fcmLegacy.js
@@ -21,7 +21,7 @@ const {
   sendNotification,
 } = require("@azure/notification-hubs/api");
 const { delay } = require("@azure/core-util");
-const { isRestError } = require("@azure/core-rest-pipeline");
+const { isRestError } = require("@azure/notification-hubs");
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotification.fcmV1.js
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotification.fcmV1.js
@@ -21,7 +21,7 @@ const {
   sendNotification,
 } = require("@azure/notification-hubs/api");
 const { delay } = require("@azure/core-util");
-const { isRestError } = require("@azure/core-rest-pipeline");
+const { isRestError } = require("@azure/notification-hubs");
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotification.js
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotification.js
@@ -21,7 +21,7 @@ const {
   sendNotification,
 } = require("@azure/notification-hubs/api");
 const { delay } = require("@azure/core-util");
-const { isRestError } = require("@azure/core-rest-pipeline");
+const { isRestError } = require("@azure/notification-hubs");
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotificationBatch.js
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendDirectNotificationBatch.js
@@ -21,7 +21,7 @@ const {
   sendNotification,
 } = require("@azure/notification-hubs/api");
 const { delay } = require("@azure/core-util");
-const { isRestError } = require("@azure/core-rest-pipeline");
+const { isRestError } = require("@azure/notification-hubs");
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendTagExpression.js
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendTagExpression.js
@@ -21,7 +21,7 @@ const {
   sendNotification,
 } = require("@azure/notification-hubs/api");
 const { delay } = require("@azure/core-util");
-const { isRestError } = require("@azure/core-rest-pipeline");
+const { isRestError } = require("@azure/notification-hubs");
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendTagsList.js
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/javascript/sendTagsList.js
@@ -21,7 +21,7 @@ const {
   sendNotification,
 } = require("@azure/notification-hubs/api");
 const { delay } = require("@azure/core-util");
-const { isRestError } = require("@azure/core-rest-pipeline");
+const { isRestError } = require("@azure/notification-hubs");
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/package.json
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "@azure/notification-hubs": "latest",
     "dotenv": "latest",
-    "@azure/core-util": "^1.11.0",
-    "@azure/core-rest-pipeline": "^1.19.0"
+    "@azure/core-util": "^1.11.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotification.fcmLegacy.ts
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotification.fcmLegacy.ts
@@ -26,7 +26,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotification.fcmV1.ts
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotification.fcmV1.ts
@@ -26,7 +26,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotification.ts
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotification.ts
@@ -26,7 +26,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotificationBatch.ts
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendDirectNotificationBatch.ts
@@ -26,7 +26,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendTagExpression.ts
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendTagExpression.ts
@@ -26,7 +26,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";

--- a/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendTagsList.ts
+++ b/sdk/notificationhubs/notification-hubs/samples/v2/typescript/src/sendTagsList.ts
@@ -27,7 +27,7 @@ import {
   sendNotification,
 } from "@azure/notification-hubs/api";
 import { delay } from "@azure/core-util";
-import { isRestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/notification-hubs";
 
 // Define connection string and hub name
 const connectionString = process.env.NOTIFICATIONHUBS_CONNECTION_STRING || "<connection string>";


### PR DESCRIPTION
now that ths notification-hubs SDK re-exports `RestError` and `isRestError`