### PR TITLE
Preserve token type in auth flow

### DIFF
--- a/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-rest-pipeline/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -141,7 +141,10 @@ async function defaultAuthorizeRequest(options: AuthorizeRequestOptions): Promis
   const accessToken = await getAccessToken(scopes, getTokenOptions);
 
   if (accessToken) {
-    options.request.headers.set("Authorization", `Bearer ${accessToken.token}`);
+    options.request.headers.set(
+      "Authorization",
+      `${accessToken.tokenType ?? "Bearer"} ${accessToken.token}`,
+    );
   }
 }
 

--- a/sdk/core/core-rest-pipeline/test/internal/bearerTokenAuthenticationPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/internal/bearerTokenAuthenticationPolicy.spec.ts
@@ -169,6 +169,33 @@ describe("BearerTokenAuthenticationPolicy", function () {
     assert.strictEqual(request.headers.get("Authorization"), `Bearer ${mockToken}`);
   });
 
+  it("correctly adds an Authentication header with a PoP token", async function () {
+    const mockToken = "pop-token";
+    const tokenScopes = ["scope1", "scope2"];
+    const fakeGetToken = vi.fn().mockResolvedValue({
+      token: mockToken,
+      expiresOnTimestamp: new Date().getTime(),
+      tokenType: "pop",
+    });
+    const mockCredential: TokenCredential = {
+      getToken: fakeGetToken,
+    };
+
+    const request = defaultRequest();
+    const successResponse: PipelineResponse = {
+      headers: createHttpHeaders(),
+      request,
+      status: 200,
+    };
+    const next = vi.fn<SendRequest>();
+    next.mockResolvedValue(successResponse);
+
+    const bearerTokenAuthPolicy = createBearerTokenPolicy(tokenScopes, mockCredential);
+    await bearerTokenAuthPolicy.sendRequest(request, next);
+
+    assert.strictEqual(request.headers.get("Authorization"), `pop ${mockToken}`);
+  });
+
   it("refreshes the token on initial request", async () => {
     const expiresOn = Date.now() + 1000 * 60; // One minute later.
     const credential = new MockRefreshAzureCredential(expiresOn);

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -111,7 +111,7 @@ export class IdentityClient extends ServiceClient implements INetworkModule {
           token: parsedBody.access_token,
           expiresOnTimestamp: parseExpirationTimestamp(parsedBody),
           refreshAfterTimestamp: parseRefreshTimestamp(parsedBody),
-          tokenType: "Bearer",
+          tokenType: parsedBody.token_type ?? "Bearer",
         } as AccessToken,
         refreshToken: parsedBody.refresh_token,
       };

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/index.ts
@@ -286,7 +286,7 @@ export class ManagedIdentityCredential implements TokenCredential {
           expiresOnTimestamp: token.expiresOn.getTime(),
           token: token.accessToken,
           refreshAfterTimestamp: token.refreshOn?.getTime(),
-          tokenType: "Bearer",
+          tokenType: token.tokenType?.toLowerCase() === "pop" ? "pop" : "Bearer",
         } as AccessToken;
       } catch (err: any) {
         logger.getToken.error(formatError(scopes, err));

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential/utils.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential/utils.ts
@@ -45,6 +45,7 @@ export function mapScopesToResource(scopes: string | string[]): string | undefin
 export interface TokenResponseParsedBody {
   access_token?: string;
   refresh_token?: string;
+  token_type?: "Bearer" | "pop";
   expires_in: number;
   expires_on?: number | string;
   refresh_on?: number | string;

--- a/sdk/identity/identity/src/msal/types.ts
+++ b/sdk/identity/identity/src/msal/types.ts
@@ -13,6 +13,7 @@ export type AppType = "public" | "confidential" | "publicFirst" | "confidentialF
 export interface MsalToken {
   accessToken?: string;
   expiresOn: Date | null;
+  tokenType?: string;
 }
 
 /**

--- a/sdk/identity/identity/test/internal/node/identityClient.spec.ts
+++ b/sdk/identity/identity/test/internal/node/identityClient.spec.ts
@@ -12,7 +12,7 @@ import { isExpectedError } from "../../authTestUtils.js";
 import { isNodeLike } from "@azure/core-util";
 import { describe, it, assert, beforeEach, afterEach, vi, expect } from "vitest";
 import type { HttpClient } from "@azure/core-rest-pipeline";
-import { createDefaultHttpClient, createHttpHeaders } from "@azure/core-rest-pipeline";
+import { createDefaultHttpClient, createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
 
 describe("IdentityClient", function () {
   let testContext: IdentityTestContextInterface;
@@ -216,5 +216,27 @@ describe("IdentityClient", function () {
       return client.refreshAccessToken("tenant", "client", "scopes", "token", undefined);
     }, response);
     isExpectedError("unknown_error")(error);
+  });
+
+  it("preserves token_type from token endpoint responses", async () => {
+    const mockHttpClient: HttpClient = createDefaultHttpClient();
+    vi.spyOn(mockHttpClient, "sendRequest").mockImplementation(async (request) => ({
+      request,
+      status: 200,
+      headers: createHttpHeaders(),
+      bodyAsText: JSON.stringify({
+        access_token: "token",
+        expires_in: 3600,
+        token_type: "pop",
+      }),
+    }));
+    const client = new IdentityClient({
+      authorityHost: "https://authority",
+      httpClient: mockHttpClient,
+    });
+
+    const tokenResponse = await client.sendTokenRequest(createPipelineRequest({ url: "https://token" }));
+
+    assert.equal(tokenResponse?.accessToken.tokenType, "pop");
   });
 });

--- a/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
+++ b/sdk/identity/identity/test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts
@@ -185,6 +185,16 @@ describe("ManagedIdentityCredential (MSAL)", function () {
         );
       });
 
+      it("preserves PoP token type from MSAL", async function () {
+        acquireTokenStub.mockResolvedValue({
+          ...validAuthenticationResult,
+          tokenType: "pop",
+        } as AuthenticationResult);
+        const credential = new ManagedIdentityCredential();
+        const token = await credential.getToken("scope");
+        assert.strictEqual(token.tokenType, "pop");
+      });
+
       describe("when using tokenExchangeMsi", function () {
         it("gets a token using the tokenExchangeMsi implementation", async function () {
           const validToken = {


### PR DESCRIPTION
Updates core-rest-pipeline to honor AccessToken.tokenType on initial authorization and identity to preserve token_type from token endpoint responses, including MSAL managed identity token results. This is a Core/Identity prerequisite for PoP/MSI token binding flows while preserving Bearer as the default.\n\nValidation:\n- pnpm exec vitest run test/internal/bearerTokenAuthenticationPolicy.spec.ts --config vitest.config.ts --coverage.enabled=false\n- pnpm exec vitest run test/internal/node/identityClient.spec.ts test/internal/node/managedIdentityCredential/msalMsiProvider.spec.ts --config vitest.config.ts --coverage.enabled=false