### PR TITLE
Bump versions for published packages with unreleased source changes

### DIFF
--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/CHANGELOG.md
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
+## 1.0.0-beta.6 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+### Other Changes
+
+## 1.0.0-beta.5 (2025-08-21)
 
 ### Other Changes
 

--- a/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
+++ b/sdk/apimanagement/api-management-custom-widgets-scaffolder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/api-management-custom-widgets-scaffolder",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "sdk-type": "client",

--- a/sdk/entra/functions-authentication-events/CHANGELOG.md
+++ b/sdk/entra/functions-authentication-events/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
+## 1.0.0-beta.4 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+## 1.0.0-beta.3 (2025-08-21)
 
 ## 1.0.0-beta.2 (2022-11-03)
 

--- a/sdk/entra/functions-authentication-events/package.json
+++ b/sdk/entra/functions-authentication-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/functions-authentication-events",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Typescript Trigger SDK for Azure AD Authentication event custom extensions. Lets you focus on your business logic.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/maps/maps-common/CHANGELOG.md
+++ b/sdk/maps/maps-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
+## 1.0.0-beta.4 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+## 1.0.0-beta.3 (2025-08-21)
 
 ## 1.0.0-beta.2 (2022-11-08)
 

--- a/sdk/maps/maps-common/package.json
+++ b/sdk/maps/maps-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/maps-common",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "An internal shared package for Azure Maps TypeScript SDK",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/CHANGELOG.md
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
     
+## 1.0.0-beta.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.0.0-beta.1 (2025-04-21)
 
 ### Features Added

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/package.json
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/arm-programmableconnectivity",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A generated SDK for ProgrammableConnectivityClient.",
   "engines": {
     "node": ">=20.0.0"

--- a/sdk/programmableconnectivity/arm-programmableconnectivity/src/api/programmableConnectivityContext.ts
+++ b/sdk/programmableconnectivity/arm-programmableconnectivity/src/api/programmableConnectivityContext.ts
@@ -30,7 +30,7 @@ export function createProgrammableConnectivity(
 ): ProgrammableConnectivityContext {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? "https://management.azure.com";
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-arm-programmableconnectivity/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-arm-programmableconnectivity/1.0.0-beta.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/schemaregistry/schema-registry/CHANGELOG.md
+++ b/sdk/schemaregistry/schema-registry/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
+## 1.4.0-beta.2 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+## 1.4.0-beta.1 (2025-08-21)
 
 ## 1.3.0 (2024-09-10)
 

--- a/sdk/schemaregistry/schema-registry/package.json
+++ b/sdk/schemaregistry/schema-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/schema-registry",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "Schema Registry Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/schemaregistry/schema-registry/src/constants.ts
+++ b/sdk/schemaregistry/schema-registry/src/constants.ts
@@ -9,4 +9,4 @@ export const DEFAULT_SCOPE = "https://eventhubs.azure.net/.default";
 /**
  * @internal
  */
-export const SDK_VERSION = "1.4.0-beta.1";
+export const SDK_VERSION = "1.4.0-beta.2";

--- a/sdk/synapse/synapse-access-control/CHANGELOG.md
+++ b/sdk/synapse/synapse-access-control/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
+## 1.0.0-beta.6 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+## 1.0.0-beta.5 (2025-08-21)
 
 ### Features Added
 

--- a/sdk/synapse/synapse-access-control/package.json
+++ b/sdk/synapse/synapse-access-control/package.json
@@ -9,7 +9,7 @@
     "directory": "sdk/synapse/synapse-access-control"
   },
   "sdk-type": "client",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "dependencies": {
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
@@ -21,7 +21,7 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/accessControlClientContext.ts",
+        "path": "src/accessControlClient.ts",
         "prefix": "packageDetails"
       },
       {

--- a/sdk/synapse/synapse-access-control/src/accessControlClient.ts
+++ b/sdk/synapse/synapse-access-control/src/accessControlClient.ts
@@ -46,7 +46,7 @@ export class AccessControlClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-synapse-access-control/1.0.0-beta.5`;
+    const packageDetails = `azsdk-js-synapse-access-control/1.0.0-beta.6`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/synapse/synapse-access-control/swagger/README.md
+++ b/sdk/synapse/synapse-access-control/swagger/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 package-name: "@azure/synapse-access-control"
-package-version: "1.0.0-beta.5"
+package-version: "1.0.0-beta.6"
 add-credentials: true
 license-header: MICROSOFT_MIT_NO_VERSION
 security-scopes: https://dev.azuresynapse.net/.default

--- a/sdk/synapse/synapse-managed-private-endpoints/CHANGELOG.md
+++ b/sdk/synapse/synapse-managed-private-endpoints/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Release History
 
-## 1.0.0-beta.6 (Unreleased)
+## 1.0.0-beta.7 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+## 1.0.0-beta.6 (2025-08-21)
 
 - Updated `@azure/core-tracing` to `1.0.0` GA.
 

--- a/sdk/synapse/synapse-managed-private-endpoints/package.json
+++ b/sdk/synapse/synapse-managed-private-endpoints/package.json
@@ -3,7 +3,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ManagedPrivateEndpointsClient.",
   "sdk-type": "client",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/synapse/synapse-managed-private-endpoints/README.md",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/managedPrivateEndpointsClientContext.ts",
+        "path": "src/managedPrivateEndpointsClient.ts",
         "prefix": "packageDetails"
       },
       {

--- a/sdk/synapse/synapse-managed-private-endpoints/src/managedPrivateEndpointsClient.ts
+++ b/sdk/synapse/synapse-managed-private-endpoints/src/managedPrivateEndpointsClient.ts
@@ -46,7 +46,7 @@ export class ManagedPrivateEndpointsClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-synapse-managed-private-endpoints/1.0.0-beta.6`;
+    const packageDetails = `azsdk-js-synapse-managed-private-endpoints/1.0.0-beta.7`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/synapse/synapse-managed-private-endpoints/swagger/README.md
+++ b/sdk/synapse/synapse-managed-private-endpoints/swagger/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 package-name: "@azure/synapse-managed-private-endpoints"
-package-version: "1.0.0-beta.6"
+package-version: "1.0.0-beta.7"
 title: ManagedPrivateEndpointsClient
 add-credentials: true
 license-header: MICROSOFT_MIT_NO_VERSION

--- a/sdk/synapse/synapse-monitoring/CHANGELOG.md
+++ b/sdk/synapse/synapse-monitoring/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Release History
 
-## 1.0.0-beta.4 (Unreleased)
+## 1.0.0-beta.5 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+## 1.0.0-beta.4 (2025-08-21)
 
 - Updated `@azure/core-tracing` to `1.0.0` GA.
 

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -51,6 +51,22 @@
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   },
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/monitoringClient.ts",
+        "prefix": "packageDetails"
+      },
+      {
+        "path": "src/tracing.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
+    ]
+  },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },

--- a/sdk/synapse/synapse-monitoring/package.json
+++ b/sdk/synapse/synapse-monitoring/package.json
@@ -9,7 +9,7 @@
     "directory": "sdk/synapse/synapse-monitoring"
   },
   "sdk-type": "client",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "dependencies": {
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",

--- a/sdk/synapse/synapse-monitoring/src/monitoringClient.ts
+++ b/sdk/synapse/synapse-monitoring/src/monitoringClient.ts
@@ -46,7 +46,7 @@ export class MonitoringClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-synapse-monitoring/1.0.0-beta.3`;
+    const packageDetails = `azsdk-js-synapse-monitoring/1.0.0-beta.5`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/synapse/synapse-monitoring/src/tracing.ts
+++ b/sdk/synapse/synapse-monitoring/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Azure.Synapse.Monitoring",
   packageName: "@azure/synapse-monitoring",
-  packageVersion: "1.0.0-beta.3",
+  packageVersion: "1.0.0-beta.5",
 });

--- a/sdk/synapse/synapse-monitoring/swagger/README.md
+++ b/sdk/synapse/synapse-monitoring/swagger/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 package-name: "@azure/synapse-monitoring"
-package-version: "1.0.0-beta.3"
+package-version: "1.0.0-beta.5"
 add-credentials: true
 license-header: MICROSOFT_MIT_NO_VERSION
 security-scopes: https://dev.azuresynapse.net/.default

--- a/sdk/synapse/synapse-spark/CHANGELOG.md
+++ b/sdk/synapse/synapse-spark/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Release History
 
-## 1.0.0-beta.6 (Unreleased)
+## 1.0.0-beta.7 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+## 1.0.0-beta.6 (2025-08-21)
 
 ### Features Added
 

--- a/sdk/synapse/synapse-spark/package.json
+++ b/sdk/synapse/synapse-spark/package.json
@@ -9,7 +9,7 @@
     "directory": "sdk/synapse/synapse-spark"
   },
   "sdk-type": "client",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "dependencies": {
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
@@ -55,7 +55,7 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/sparkClientContext.ts",
+        "path": "src/sparkClient.ts",
         "prefix": "packageDetails"
       },
       {

--- a/sdk/synapse/synapse-spark/src/sparkClient.ts
+++ b/sdk/synapse/synapse-spark/src/sparkClient.ts
@@ -54,7 +54,7 @@ export class SparkClient extends coreClient.ServiceClient {
       credential: credentials,
     };
 
-    const packageDetails = `azsdk-js-synapse-spark/1.0.0-beta.6`;
+    const packageDetails = `azsdk-js-synapse-spark/1.0.0-beta.7`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/synapse/synapse-spark/swagger/README.md
+++ b/sdk/synapse/synapse-spark/swagger/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 package-name: "@azure/synapse-spark"
-package-version: "1.0.0-beta.6"
+package-version: "1.0.0-beta.7"
 add-credentials: true
 license-header: MICROSOFT_MIT_NO_VERSION
 security-scopes: https://dev.azuresynapse.net/.default


### PR DESCRIPTION
## Summary

These packages had their current `package.json` version already published to npm, but their `src/` had been modified since the corresponding release tag. Per `eng/tools/ci-runner/index.js check-package-version`, they require a version increment. Bumped with `dev-tool package increment-version` (prerelease increment).

| Package | Old → New |
|---|---|
| `@azure/api-management-custom-widgets-scaffolder` | 1.0.0-beta.5 → beta.6 |
| `@azure/functions-authentication-events` | 1.0.0-beta.3 → beta.4 |
| `@azure/maps-common` | 1.0.0-beta.3 → beta.4 |
| `@azure/arm-programmableconnectivity` | 1.0.0-beta.1 → beta.2 |
| `@azure/schema-registry` | 1.4.0-beta.1 → beta.2 |
| `@azure/synapse-access-control` | 1.0.0-beta.5 → beta.6 |
| `@azure/synapse-managed-private-endpoints` | 1.0.0-beta.6 → beta.7 |
| `@azure/synapse-monitoring` | 1.0.0-beta.4 → beta.5 |
| `@azure/synapse-spark` | 1.0.0-beta.6 → beta.7 |

Each bump updates `package.json`, adds a new `## <version> (Unreleased)` CHANGELOG section (and dates the previously-published entry), and refreshes embedded version constants / swagger `package-version` where present.

## Extra fix

The three `synapse-*` packages initially failed `dev-tool package increment-version` with `ENOENT` because their `package.json` `//metadata.constantPaths` pointed at old `src/*ClientContext.ts` files that were merged into `src/*Client.ts`. Corrected those stale paths so the user-agent version constant updates correctly.