### PR TITLE
[App Configuration] - Fix apiKeyHeader bug

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.12.1 (Unreleased)
+
+### Bugs Fixed
+
+- Fixed a regression introduced in 1.12.0 where creating an `AppConfigurationClient` from a connection string caused every request to fail with `TypeError [ERR_INVALID_HTTP_TOKEN]: Header name must be a valid HTTP token ["Connection String"]`. [#39025](https://github.com/Azure/azure-sdk-for-js/issues/39025)
+
 ## 1.12.0 (2026-06-18)
 
 ### Features Added

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "sdk-type": "client",
   "keywords": [
     "node",

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -209,7 +209,7 @@ export class AppConfigurationClient {
     this._syncTokens = appConfigOptions.syncTokens || new SyncTokens();
     this.client = new GeneratedAppConfigurationClient(
       appConfigEndpoint,
-      // When a connection string is used, appConfigCredential is undefined here. We pass undefined to avoid @azure-rest/core-client's keyCredentialAuthenticationPolicy setting the apiKeyHeader on the request。
+      // When a connection string is used, appConfigCredential is undefined here. We pass undefined to avoid @azure-rest/core-client's keyCredentialAuthenticationPolicy setting the apiKeyHeader on the request.
       // Connection strings are authenticated by HMAC (appConfigKeyCredentialPolicy) and the secret should never leave the client.
       // The `as TokenCredential` cast bridges a gap between the generated client and the core SDK: the generated constructor types `credential` as required (KeyCredential | TokenCredential),
       // but @azure-rest/core-client's addCredentialPipelinePolicy no-ops when no credential is passed, so handing it undefined is safe at runtime.

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -49,7 +49,7 @@ import { audienceErrorHandlingPolicy } from "./internal/audienceErrorHandlingPol
 import { SyncTokens, syncTokenPolicy } from "./internal/syncTokenPolicy.js";
 import { queryParamPolicy } from "./internal/queryParamPolicy.js";
 import { emptyBodyPolicy } from "./internal/emptyBodyPolicy.js";
-import type { KeyCredential, TokenCredential } from "@azure/core-auth";
+import type { TokenCredential } from "@azure/core-auth";
 import { isTokenCredential } from "@azure/core-auth";
 import type {
   SendConfigurationSettingsOptions,
@@ -155,7 +155,7 @@ export class AppConfigurationClient {
     options?: AppConfigurationClientOptions,
   ) {
     let appConfigOptions: InternalAppConfigurationClientOptions = {};
-    let appConfigCredential: TokenCredential | KeyCredential;
+    let appConfigCredential: TokenCredential | undefined = undefined;
     let appConfigEndpoint: string;
     let authPolicy: PipelinePolicy | undefined;
     let authPolicyName: string;
@@ -176,7 +176,6 @@ export class AppConfigurationClient {
         appConfigEndpoint = regexMatch[1];
         authPolicy = appConfigKeyCredentialPolicy(regexMatch[2], regexMatch[3]);
         authPolicyName = authPolicy.name;
-        appConfigCredential = { key: regexMatch[2] };
       } else {
         throw new Error(
           `Invalid connection string. Valid connection strings should match the regex '${ConnectionStringRegex.source}'.` +
@@ -210,7 +209,11 @@ export class AppConfigurationClient {
     this._syncTokens = appConfigOptions.syncTokens || new SyncTokens();
     this.client = new GeneratedAppConfigurationClient(
       appConfigEndpoint,
-      appConfigCredential,
+      // When a connection string is used, appConfigCredential is undefined here. We pass undefined to avoid @azure-rest/core-client's keyCredentialAuthenticationPolicy setting the apiKeyHeader on the request。
+      // Connection strings are authenticated by HMAC (appConfigKeyCredentialPolicy) and the secret should never leave the client.
+      // The `as TokenCredential` cast bridges a gap between the generated client and the core SDK: the generated constructor types `credential` as required (KeyCredential | TokenCredential),
+      // but @azure-rest/core-client's addCredentialPipelinePolicy no-ops when no credential is passed, so handing it undefined is safe at runtime.
+      appConfigCredential as TokenCredential,
       generatedClientOptions,
     );
     this.client.pipeline.addPolicy(

--- a/sdk/appconfiguration/app-configuration/src/internal/constants.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/constants.ts
@@ -4,7 +4,7 @@
 /**
  * @internal
  */
-export const packageVersion = "1.12.0";
+export const packageVersion = "1.12.1";
 
 /**
  * @internal

--- a/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
@@ -3,6 +3,8 @@
 
 import { AppConfigurationClient } from "../../src/index.js";
 import { describe, it, assert } from "vitest";
+import type { HttpClient, PipelineRequest, PipelineResponse } from "@azure/core-rest-pipeline";
+import { createHttpHeaders } from "@azure/core-rest-pipeline";
 
 describe("AppConfigurationClient constructor error cases", () => {
   it("invalid connection string gives a decent error message", () => {
@@ -17,5 +19,45 @@ describe("AppConfigurationClient constructor error cases", () => {
       () => new AppConfigurationClient(undefined as any),
       /Invalid connection string\. Valid connection strings should match the regex 'Endpoint=\(\.\*\);Id=\(\.\*\);Secret=\(\.\*\)'/,
     );
+  });
+});
+
+describe("AppConfigurationClient connection string requests", () => {
+  const fakeConnectionString =
+    "Endpoint=https://contoso.azconfig.io;Id=fake-id;Secret=ABCD";
+
+  it("does not set an invalid 'Connection String' request header", async () => {
+    let capturedRequest: PipelineRequest | undefined;
+    const mockHttpClient: HttpClient = {
+      sendRequest: async (request: PipelineRequest): Promise<PipelineResponse> => {
+        capturedRequest = request;
+        return { request, status: 200, headers: createHttpHeaders(), bodyAsText: "{}" };
+      },
+    };
+
+    const client = new AppConfigurationClient(fakeConnectionString, {
+      httpClient: mockHttpClient,
+    });
+
+    // The response is mocked, so deserialization may fail; we only care that the request was built
+    // and handed to the HTTP client without an invalid header. Swallow any post-send error.
+    await client.getConfigurationSetting({ key: "key" }).catch(() => {
+      /* expected: the mocked response is not a real configuration setting */
+    });
+
+    assert.isDefined(capturedRequest, "the request should reach the HTTP client");
+    const request = capturedRequest!;
+
+    for (const name of Object.keys(request.headers.toJSON())) {
+      assert.notMatch(name, /\s/, `request header name "${name}" must be a valid HTTP token`);
+    }
+    assert.isUndefined(
+      request.headers.get("Connection String"),
+      "the invalid 'Connection String' header must not be set",
+    );
+
+    const authorization = request.headers.get("Authorization");
+    assert.isDefined(authorization, "HMAC Authorization header should be set");
+    assert.match(authorization!, /^HMAC-SHA256 /, "connection-string auth should use HMAC signing");
   });
 });

--- a/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/public/auth.spec.ts
@@ -23,8 +23,7 @@ describe("AppConfigurationClient constructor error cases", () => {
 });
 
 describe("AppConfigurationClient connection string requests", () => {
-  const fakeConnectionString =
-    "Endpoint=https://contoso.azconfig.io;Id=fake-id;Secret=ABCD";
+  const fakeConnectionString = "Endpoint=https://contoso.azconfig.io;Id=fake-id;Secret=ABCD";
 
   it("does not set an invalid 'Connection String' request header", async () => {
     let capturedRequest: PipelineRequest | undefined;


### PR DESCRIPTION
### Packages impacted by this PR
@azure/app-configuration

### Issues associated with this PR
#39020 

### Describe the problem that is addressed by this PR
The bug was introduced in PR #38154 

The generated [`appConfigurationContext`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/appconfiguration/app-configuration/src/generated/api/appConfigurationContext.ts) has default apiKeyHeader "Connection String" based the [spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/appconfiguration/data-plane/AppConfiguration/main.tsp#L15). It was discussed in this [comment](https://github.com/Azure/azure-sdk-for-js/pull/38154/changes#r3279847231).

The problem is that

Code path: [`appConfigurationContext`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/appconfiguration/app-configuration/src/generated/api/appConfigurationContext.ts#L44) calls [`getClient`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/src/getClient.ts#L61) where [`createDefaultPipeline`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/src/clientHelpers.ts#L33-L75) will be called. And if credential is undefined, credential pipeline policy will be [skipped](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/src/clientHelpers.ts#L39-L41). But if the credential is not empty and it is a `KeyCredential`, it will add [`keyCredentialAuthenticationPolicy`](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client-rest/src/keyCredentialAuthenticationPolicy.ts#L24) which will set api key name header. This is actually an unintended breaking change. The default generated api key header name is "Connection String". And it has a white space which is invalid for request header. This broke the usage of connection string in 1.12.0.

But App Configuration uses HMAC, the secret value should not leave client, thanks to the header name problem, we don't leak the secret in the request header.

### Are there test cases added in this PR? _(If not, why?)_
Yes

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
