### PR TITLE
Fix Push-Location leak in SetPackageVersion

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -411,14 +411,23 @@ function SetPackageVersion ($PackageName, $Version, $ReleaseDate, $ReplaceLatest
     $ReleaseDate = Get-Date -Format "yyyy-MM-dd"
   }
   Push-Location "$EngDir/tools/eng-package-utils"
-  Confirm-NodeInstallation
-  npm install
-  Push-Location "$EngDir/tools/versioning"
-  npm install
-  $artifactName = $PackageName.Replace("@", "").Replace("/", "-")
-  node ./set-version.js --artifact-name $artifactName --new-version $Version --release-date $ReleaseDate `
-    --replace-latest-entry-title $ReplaceLatestEntryTitle --repo-root $RepoRoot
-  Pop-Location
+  try {
+    Confirm-NodeInstallation
+    npm install
+    Push-Location "$EngDir/tools/versioning"
+    try {
+      npm install
+      $artifactName = $PackageName.Replace("@", "").Replace("/", "-")
+      node ./set-version.js --artifact-name $artifactName --new-version $Version --release-date $ReleaseDate `
+        --replace-latest-entry-title $ReplaceLatestEntryTitle --repo-root $RepoRoot
+    }
+    finally {
+      Pop-Location
+    }
+  }
+  finally {
+    Pop-Location
+  }
 }
 
 # PackageName: Pass full package name e.g. @azure/abort-controller


### PR DESCRIPTION
### Packages impacted by this PR

Engineering scripts (`eng/scripts/Language-Settings.ps1`). No shipping package affected.

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

Running `Prepare-Release.ps1` left the shell in `eng/tools/eng-package-utils` instead of returning to the original directory. The cause is in `SetPackageVersion`: it called `Push-Location` twice (into `eng-package-utils`, then `versioning`) but only called `Pop-Location` once. The push into `eng-package-utils` was never balanced, so the location stack was left one level deep after the script completed. Any error in `npm install` or `set-version.js` made it worse, since the lone `Pop-Location` would be skipped too.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The minimal fix would be to add a second `Pop-Location`, but that still leaks the location if a command between the pushes throws. Instead, each `Push-Location` is now paired with a `Pop-Location` inside a `finally` block. This guarantees the working directory is restored even when `npm install` or `node ./set-version.js` fails, which is the more robust option.

### Are there test cases added in this PR? _(If not, why?)_

No. This is a small fix to an interactive release-prep PowerShell script with no existing test harness. The change was validated by confirming the script parses with no syntax errors.

### Provide a list of related PRs _(if any)_

N/A

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)