### PR TITLE
feat(cosmos): add enablePreviewFeatures to CosmosClientOptions

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 ## 4.9.4 (Unreleased)
 
+### Features Added
+
+- Added `enablePreviewFeatures` to `CosmosClientOptions`, a dictionary for opting into preview features of the SDK.
+
 ### Bugs Fixed
 
 - [#38087](https://github.com/Azure/azure-sdk-for-js/issues/38087) Made `boundingBox` optional on the `SpatialIndex` type. Bounding boxes are only required for geometry spatial indexes, not geography ones.

--- a/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos-node.api.md
@@ -822,6 +822,7 @@ export interface CosmosClientOptions {
     defaultHeaders?: CosmosHeaders_2;
     // (undocumented)
     diagnosticLevel?: CosmosDbDiagnosticLevel;
+    enablePreviewFeatures?: Record<string, unknown>;
     endpoint?: string;
     httpClient?: HttpClient;
     key?: string;

--- a/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/CosmosClientOptions.ts
@@ -81,4 +81,12 @@ export interface CosmosClientOptions {
 
   /** An optional parameter that represents the connection string. Your database connection string can be found in the Azure Portal. */
   connectionString?: string;
+
+  /**
+   * A dictionary for opting into preview features of the SDK.
+   *
+   * Preview features are not generally available and may change in backward-incompatible
+   * ways before they become GA; they are not recommended for production use.
+   */
+  enablePreviewFeatures?: Record<string, unknown>;
 }


### PR DESCRIPTION
### Packages impacted by this PR
@Azure/cosmos


### Describe the problem that is addressed by this PR
Adds an optional enablePreviewFeatures dictionary to CosmosClientOptions for opting into SDK preview features. 