### PR TITLE
Use centralized install-pnpm template in dev-tool ci.yml

### DIFF
--- a/common/tools/dev-tool/ci.yml
+++ b/common/tools/dev-tool/ci.yml
@@ -32,11 +32,7 @@ jobs:
       demands: ImageOverride -equals $(LINUXVMIMAGE)
 
     steps:
-      - template: /eng/pipelines/templates/steps/common.yml
-
-      - script: |
-          npm install -g pnpm
-        displayName: "Install Pnpm"
+      - template: /eng/pipelines/templates/steps/install-pnpm.yml
 
       - script: |
           pnpm install


### PR DESCRIPTION
## Why

`common/tools/dev-tool/ci.yml` installed pnpm with a hardcoded `npm install -g pnpm` step instead of the centralized `install-pnpm.yml` template that every other pipeline uses. That meant it ignored the pinned `packageManager` version from the root `package.json`, risking version drift between this pipeline and the rest of the repo.

## What

Replaces the manual `common.yml` reference plus the `npm install -g pnpm` script with a single `- template: /eng/pipelines/templates/steps/install-pnpm.yml` step. The template already pulls in `common.yml` and installs the exact pinned pnpm version, so no behavior is lost and the dev-tool pipeline now stays consistent with the rest of CI.