### PR TITLE
[monitor-opentelemetry] Add loggerConfigurator option for severity-based log filtering

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added a `loggerConfigurator` option to `AzureMonitorOpenTelemetryOptions` (and re-exported the upstream `createLoggerConfigurator` helper). This surfaces the OpenTelemetry logger configuration feature, allowing logs to be filtered by severity (verbosity) or disabled per logger scope at the logger level — before any processor or exporter runs — independently of trace-based sampling. Resolves [#33242](https://github.com/Azure/azure-sdk-for-js/issues/33242).
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -201,6 +201,11 @@ useAzureMonitor(options);
     <td></td>
   </tr>
   <tr>
+    <td><code>loggerConfigurator</code></td>
+    <td>Function that computes per-logger configuration (e.g. minimum severity, disabled state), keyed by instrumentation scope. Use <code>createLoggerConfigurator</code> to build one. Enables filtering logs by verbosity/severity independently of trace-based sampling, including logs emitted by libraries through the logger provider.</td>
+    <td></td>
+  </tr>
+  <tr>
     <td><code>spanProcessors</code></td>
     <td>Array of span processors to register to the global tracer provider. </td>
     <td></td>
@@ -496,6 +501,28 @@ You might use the following ways to filter out telemetry before it leaves your a
           }
         }
       }
+      ```
+
+1.  Filter logs by severity (verbosity). Use `loggerConfigurator` to drop logs below a minimum severity, or to disable a specific logger entirely. Unlike a custom `LogRecordProcessor`, this filtering happens at the logger level — before any processor or exporter runs — so it works for logs emitted by libraries through the OpenTelemetry logger provider and is independent of trace-based sampling.
+
+      ```ts snippet:ReadmeSampleFilterLogsBySeverity
+      import {
+        AzureMonitorOpenTelemetryOptions,
+        createLoggerConfigurator,
+        useAzureMonitor,
+      } from "@azure/monitor-opentelemetry";
+      import { SeverityNumber } from "@opentelemetry/api-logs";
+
+      const options: AzureMonitorOpenTelemetryOptions = {
+        // Drop logs below WARN severity, except for the noisy "express" logger which
+        // is disabled entirely. Filtering happens at the logger level, before any
+        // processor or exporter, so it is independent of trace-based sampling.
+        loggerConfigurator: createLoggerConfigurator([
+          { pattern: "express", config: { disabled: true } },
+          { pattern: "*", config: { minimumSeverity: SeverityNumber.WARN } },
+        ]),
+      };
+      useAzureMonitor(options);
       ```
 
 ## Custom telemetry

--- a/sdk/monitor/monitor-opentelemetry/review/monitor-opentelemetry-node.api.md
+++ b/sdk/monitor/monitor-opentelemetry/review/monitor-opentelemetry-node.api.md
@@ -5,7 +5,11 @@
 ```ts
 
 import type { AzureMonitorExporterOptions } from '@azure/monitor-opentelemetry-exporter';
+import { createLoggerConfigurator } from '@opentelemetry/sdk-logs';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { LoggerConfig } from '@opentelemetry/sdk-logs';
+import { LoggerConfigurator } from '@opentelemetry/sdk-logs';
+import { LoggerPattern } from '@opentelemetry/sdk-logs';
 import type { LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import type { MetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -22,6 +26,7 @@ export interface AzureMonitorOpenTelemetryOptions {
     enableStandardMetrics?: boolean;
     enableTraceBasedSamplingForLogs?: boolean;
     instrumentationOptions?: InstrumentationOptions;
+    loggerConfigurator?: LoggerConfigurator;
     logRecordProcessors?: LogRecordProcessor[];
     metricReaders?: MetricReader[];
     resource?: Resource;
@@ -36,6 +41,8 @@ export interface BrowserSdkLoaderOptions {
     connectionString?: string;
     enabled?: boolean;
 }
+
+export { createLoggerConfigurator }
 
 // @internal
 export function _getSdkInstance(): NodeSDK | undefined;
@@ -52,6 +59,12 @@ export interface InstrumentationOptions {
     redis4?: InstrumentationConfig;
     winston?: InstrumentationConfig;
 }
+
+export { LoggerConfig }
+
+export { LoggerConfigurator }
+
+export { LoggerPattern }
 
 // @public
 export function shutdownAzureMonitor(): Promise<void>;

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -25,6 +25,8 @@ import { BrowserSdkLoader } from "./browserSdkLoader/browserSdkLoader.js";
 import { setSdkPrefix } from "./metrics/quickpulse/utils.js";
 import type { SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import type { LogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { LoggerProvider } from "@opentelemetry/sdk-logs";
+import { detectResources } from "@opentelemetry/resources";
 import { getInstance } from "./utils/statsbeat.js";
 import { patchOpenTelemetryInstrumentationEnable } from "./utils/opentelemetryInstrumentationPatcher.js";
 import { ensureAzureSdkTracingBridge } from "./utils/azureSdkTracingBridge.js";
@@ -40,10 +42,13 @@ import { SEMRESATTRS_K8S_CLUSTER_NAME } from "@opentelemetry/semantic-convention
 const CLOUD_RESOURCE_ID_ATTRIBUTE = "cloud.resource_id";
 
 export type { AzureMonitorOpenTelemetryOptions, InstrumentationOptions, BrowserSdkLoaderOptions };
+export { createLoggerConfigurator } from "@opentelemetry/sdk-logs";
+export type { LoggerConfigurator, LoggerConfig, LoggerPattern } from "@opentelemetry/sdk-logs";
 
 process.env["AZURE_MONITOR_DISTRO_VERSION"] = AZURE_MONITOR_OPENTELEMETRY_VERSION;
 
 let sdk: NodeSDK;
+let loggerProvider: LoggerProvider | undefined;
 let browserSdkLoader: BrowserSdkLoader | undefined;
 
 /**
@@ -140,17 +145,34 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
 
   const views: ViewOptions[] = metricHandler.getViews().concat(customViews);
 
+  // Build the LoggerProvider in the distro rather than letting NodeSDK own it.
+  // NodeSDK does not forward upstream logger configuration (e.g. severity-based
+  // filtering via loggerConfigurator), so we construct the provider ourselves and
+  // register it globally before sdk.start(). NodeSDK is then given an empty
+  // logRecordProcessors array, so the (empty) provider it builds fails to register
+  // (setGlobalLoggerProvider is a no-op once a provider is set) and stays inert.
+  let logResource = config.resource;
+  if (resourceDetectorsList.length > 0) {
+    logResource = logResource.merge(detectResources({ detectors: resourceDetectorsList }));
+  }
+  loggerProvider = new LoggerProvider({
+    resource: logResource,
+    processors: [
+      logHandler.getAzureLogRecordProcessor(),
+      ...logRecordProcessors,
+      logHandler.getBatchLogRecordProcessor(),
+    ],
+    loggerConfigurator: config.loggerConfigurator,
+  });
+  logs.setGlobalLoggerProvider(loggerProvider);
+
   // Initialize OpenTelemetry SDK
   const sdkConfig: Partial<NodeSDKConfiguration> = {
     autoDetectResources: true,
     metricReaders: metricReaders,
     views,
     instrumentations: instrumentations,
-    logRecordProcessors: [
-      logHandler.getAzureLogRecordProcessor(),
-      ...logRecordProcessors,
-      logHandler.getBatchLogRecordProcessor(),
-    ],
+    logRecordProcessors: [],
     resource: config.resource,
     sampler: traceHandler.getSampler(),
     spanProcessors: [
@@ -176,7 +198,9 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
  */
 export function shutdownAzureMonitor(): Promise<void> {
   browserSdkLoader?.dispose();
-  return sdk?.shutdown();
+  const provider = loggerProvider;
+  loggerProvider = undefined;
+  return Promise.all([sdk?.shutdown(), provider?.shutdown()]).then(() => undefined);
 }
 
 /**

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -14,6 +14,7 @@ import type {
   InstrumentationOptions,
 } from "../types.js";
 import type { Sampler } from "@opentelemetry/sdk-trace-base";
+import type { LoggerConfigurator } from "@opentelemetry/sdk-logs";
 import type { AzureMonitorExporterOptions } from "@azure/monitor-opentelemetry-exporter";
 import { EnvConfig } from "./envConfig.js";
 import { JsonConfig } from "./jsonConfig.js";
@@ -51,6 +52,8 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
   public metricExportIntervalMillis: number;
   /** Custom OpenTelemetry sampler (env-only) */
   public sampler?: Sampler;
+  /** Computes per-logger configuration (e.g. minimum severity) for the logger provider */
+  public loggerConfigurator?: LoggerConfigurator;
 
   private _resource: Resource = emptyResource();
 
@@ -130,6 +133,7 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
         options.enablePerformanceCounters !== undefined
           ? options.enablePerformanceCounters
           : this.enablePerformanceCounters;
+      this.loggerConfigurator = options.loggerConfigurator ?? this.loggerConfigurator;
     }
     // JSON configuration will take precedence over options provided
     this._mergeJsonConfig();

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -3,7 +3,7 @@
 import type { AzureMonitorExporterOptions } from "@azure/monitor-opentelemetry-exporter";
 import type { InstrumentationConfig } from "@opentelemetry/instrumentation";
 import type { Resource } from "@opentelemetry/resources";
-import type { LogRecordProcessor } from "@opentelemetry/sdk-logs";
+import type { LoggerConfigurator, LogRecordProcessor } from "@opentelemetry/sdk-logs";
 import type { MetricReader, ViewOptions } from "@opentelemetry/sdk-metrics";
 import type { SpanProcessor } from "@opentelemetry/sdk-trace-base";
 
@@ -33,6 +33,13 @@ export interface AzureMonitorOpenTelemetryOptions {
   browserSdkLoaderOptions?: BrowserSdkLoaderOptions;
   /** An array of log record processors to register to the logger provider.*/
   logRecordProcessors?: LogRecordProcessor[];
+  /**
+   * A function that computes the configuration (e.g. minimum severity, disabled state) for each
+   * logger, keyed by its instrumentation scope. Use {@link createLoggerConfigurator} to build one
+   * from a list of patterns. This enables filtering logs by verbosity/severity, independently of
+   * trace-based sampling, including logs emitted by libraries through the OpenTelemetry logger provider.
+   */
+  loggerConfigurator?: LoggerConfigurator;
   /** An array of span processors to register to the tracer provider.*/
   spanProcessors?: SpanProcessor[];
   /** An array of metric readers to register to the meter provider.*/

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/loggerConfigurator.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/loggerConfigurator.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import type { LogRecordProcessor, SdkLogRecord } from "@opentelemetry/sdk-logs";
+import type { AzureMonitorOpenTelemetryOptions } from "../../../../src/index.js";
+import {
+  createLoggerConfigurator,
+  shutdownAzureMonitor,
+  useAzureMonitor,
+} from "../../../../src/index.js";
+import { afterEach, assert, beforeEach, describe, it } from "vitest";
+
+const GLOBAL_OPENTELEMETRY_API_KEY = Symbol.for("opentelemetry.js.api.1");
+
+class CapturingProcessor implements LogRecordProcessor {
+  public records: SdkLogRecord[] = [];
+  onEmit(record: SdkLogRecord): void {
+    this.records.push(record);
+  }
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("Library/loggerConfigurator", () => {
+  let savedOTelGlobal: unknown;
+
+  beforeEach(() => {
+    savedOTelGlobal = Reflect.get(globalThis, GLOBAL_OPENTELEMETRY_API_KEY);
+  });
+
+  afterEach(async () => {
+    await shutdownAzureMonitor();
+    if (savedOTelGlobal === undefined) {
+      Reflect.deleteProperty(globalThis, GLOBAL_OPENTELEMETRY_API_KEY);
+    } else {
+      Reflect.set(globalThis, GLOBAL_OPENTELEMETRY_API_KEY, savedOTelGlobal);
+    }
+  });
+
+  function emit(loggerName: string, severityNumber: SeverityNumber): void {
+    logs.getLogger(loggerName).emit({ body: "test", severityNumber });
+  }
+
+  it("filters out log records below the configured minimum severity", () => {
+    const capture = new CapturingProcessor();
+    const options: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      logRecordProcessors: [capture],
+      loggerConfigurator: createLoggerConfigurator([
+        { pattern: "*", config: { minimumSeverity: SeverityNumber.WARN } },
+      ]),
+    };
+    useAzureMonitor(options);
+
+    emit("test-logger", SeverityNumber.INFO);
+    emit("test-logger", SeverityNumber.WARN);
+    emit("test-logger", SeverityNumber.ERROR);
+
+    // INFO is dropped at the logger level; WARN and ERROR pass through.
+    assert.strictEqual(capture.records.length, 2);
+    assert.strictEqual(capture.records[0].severityNumber, SeverityNumber.WARN);
+    assert.strictEqual(capture.records[1].severityNumber, SeverityNumber.ERROR);
+  });
+
+  it("disables logging entirely for a matching logger scope", () => {
+    const capture = new CapturingProcessor();
+    const options: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      logRecordProcessors: [capture],
+      loggerConfigurator: createLoggerConfigurator([
+        { pattern: "noisy-logger", config: { disabled: true } },
+        { pattern: "*", config: {} },
+      ]),
+    };
+    useAzureMonitor(options);
+
+    emit("noisy-logger", SeverityNumber.ERROR);
+    emit("other-logger", SeverityNumber.ERROR);
+
+    // Only the non-disabled logger's record is captured.
+    assert.strictEqual(capture.records.length, 1);
+  });
+
+  it("emits all records when no loggerConfigurator is provided", () => {
+    const capture = new CapturingProcessor();
+    const options: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      logRecordProcessors: [capture],
+    };
+    useAzureMonitor(options);
+
+    emit("test-logger", SeverityNumber.DEBUG);
+    emit("test-logger", SeverityNumber.INFO);
+
+    assert.strictEqual(capture.records.length, 2);
+  });
+});

--- a/sdk/monitor/monitor-opentelemetry/test/snippets.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/snippets.spec.ts
@@ -3,7 +3,8 @@
 
 import { resourceFromAttributes, emptyResource } from "@opentelemetry/resources";
 import type { AzureMonitorOpenTelemetryOptions } from "../src";
-import { useAzureMonitor } from "../src";
+import { createLoggerConfigurator, useAzureMonitor } from "../src";
+import { SeverityNumber } from "@opentelemetry/api-logs";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import type { Context, Exception, ObservableResult, Span } from "@opentelemetry/api";
 import { metrics, SpanKind, trace, TraceFlags } from "@opentelemetry/api";
@@ -178,6 +179,19 @@ describe("snippets", () => {
       logRecordProcessors: [new LogRecordEnrichingProcessor()],
     };
     // @ts-preserve-whitespace
+    useAzureMonitor(options);
+  });
+
+  it("ReadmeSampleFilterLogsBySeverity", () => {
+    const options: AzureMonitorOpenTelemetryOptions = {
+      // Drop logs below WARN severity, except for the noisy "express" logger which
+      // is disabled entirely. Filtering happens at the logger level, before any
+      // processor or exporter, so it is independent of trace-based sampling.
+      loggerConfigurator: createLoggerConfigurator([
+        { pattern: "express", config: { disabled: true } },
+        { pattern: "*", config: { minimumSeverity: SeverityNumber.WARN } },
+      ]),
+    };
     useAzureMonitor(options);
   });
 


### PR DESCRIPTION
## Summary

Surfaces the upstream OpenTelemetry **LoggerConfig / Logger Configurator** feature in `@azure/monitor-opentelemetry` so logs can be filtered by **severity (verbosity)** — or disabled per logger scope — at the **logger level, before any processor or exporter runs**, and independently of trace-based sampling.

Resolves #33242.

## Motivation

The issue asked for a way to drop logs based on verbosity (and for logs emitted by libraries through the OTel logger provider), not only via trace sampling. Upstream shipped this capability (`createLoggerConfigurator`, `LoggerConfig.minimumSeverity`/`disabled`) in opentelemetry-js [#5991](https://github.com/open-telemetry/opentelemetry-js/pull/5991) / [#6371](https://github.com/open-telemetry/opentelemetry-js/pull/6371) (in the `0.218.0` deps already pinned here), but the distro never exposed it because `NodeSDK` owns LoggerProvider creation and does not forward `loggerConfigurator`.

## Changes

- **`src/types.ts`** — new `loggerConfigurator?: LoggerConfigurator` option on `AzureMonitorOpenTelemetryOptions`.
- **`src/index.ts`** — the distro now constructs the `LoggerProvider` itself (resource + Azure/user/batch processors + `loggerConfigurator`) and registers it globally **before** `sdk.start()`. `NodeSDK` is given `logRecordProcessors: []`, so the provider it builds fails to register (`setGlobalLoggerProvider` is a no-op once one is set) and stays inert. `shutdownAzureMonitor` also shuts down our provider. Re-exports `createLoggerConfigurator` and the related types.
- **`src/shared/config.ts`** — threads the option into `InternalConfig`.
- **Docs** — README "Filter logs by severity" example + options-table row (validated snippet), CHANGELOG entry, regenerated API report.
- **Tests** — `test/internal/unit/logs/loggerConfigurator.test.ts` covering minimum-severity filtering, per-scope `disabled`, and no-config passthrough.

## Usage

```ts
import { createLoggerConfigurator, useAzureMonitor } from "@azure/monitor-opentelemetry";
import { SeverityNumber } from "@opentelemetry/api-logs";

useAzureMonitor({
  loggerConfigurator: createLoggerConfigurator([
    { pattern: "express", config: { disabled: true } },
    { pattern: "*", config: { minimumSeverity: SeverityNumber.WARN } },
  ]),
});
```

## Validation

- `pnpm turbo build --filter=@azure/monitor-opentelemetry...` ✅ (API Extractor regenerated the report)
- Full unit suite: **224 passed / 5 todo**, including 3 new tests — no regressions
- ESLint 0 errors; Prettier clean; README snippets synced
