### PR TITLE
Optimize fix-test-failures token usage with DataOps pattern

### DIFF
--- a/.github/workflows/fix-test-failures-collect.sh
+++ b/.github/workflows/fix-test-failures-collect.sh
@@ -37,6 +37,7 @@
 #   known-failures.md    raw body of the tracking issue (for the agent)
 set -uo pipefail
 
+: "${GH_TOKEN:?GH_TOKEN is required (every \`gh api\` call needs an authenticated token)}"
 : "${REPO:?REPO is required}"
 : "${OUTDIR:?OUTDIR is required}"
 PACKAGE="${PACKAGE:-}"
@@ -50,6 +51,20 @@ api() { gh api -H "Accept: application/vnd.github+json" "$@"; }
 
 # Lower-case helper for case-insensitive substring scoping.
 lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# Preflight: fail loudly instead of silently emitting empty JSON. The files
+# written below are the agent's authoritative source of truth, so a missing
+# tool or an invalid/expired token must NOT be mistaken for "CI is green".
+# (Many `gh api` calls below redirect errors to /dev/null for per-item
+# resilience, which is exactly why this up-front check matters.)
+for _bin in gh jq; do
+  command -v "$_bin" >/dev/null 2>&1 \
+    || { echo "ERROR: required tool '$_bin' is not on PATH." >&2; exit 1; }
+done
+if [ "$(api "/repos/$REPO" --jq '.full_name' 2>/dev/null || true)" != "$REPO" ]; then
+  echo "ERROR: GitHub API preflight failed for '$REPO'. Is GH_TOKEN set, valid, and authorized?" >&2
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Step 1: find the most recent commit on main that has check runs, and pull
@@ -90,7 +105,7 @@ else
         | select(.name | test(" - tests-weekly| - tests| - perf") | not)
         | select(.name | startswith("js - "))
         | { id, name, html_url,
-            details_url: (.details_url // .external_id // null),
+            details_url: (.details_url // null),
             output_title:   (.output.title   // null),
             output_summary: (.output.summary // null) } ]' \
     "$raw_runs" > "$OUTDIR/.failing_ci.json"

--- a/.github/workflows/fix-test-failures-collect.sh
+++ b/.github/workflows/fix-test-failures-collect.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# Data collection for the "Analyze CI Test Failures" (fix-test-failures)
+# agentic workflow.
+#
+# This implements the gh-aw "DataOps" pattern: all GitHub API gathering
+# runs in a deterministic, authenticated shell step (GH_TOKEN -> 5000
+# req/hr, outside the agent sandbox) and writes compact JSON to $OUTDIR.
+# The agent then only reads those JSON files — it makes no API calls
+# itself. Before this change the agent paginated the check-runs API,
+# fetched annotations one-by-one, and polled the rate limit across ~40
+# model turns; the growing context tripped the AWF effective-token hard
+# rail (25M) and failed the run. Moving the work here removes that cost
+# entirely.
+#
+# Kept as a standalone script (rather than inlined in the workflow YAML)
+# so it has shell tooling support: shellcheck, editor highlighting, LSP,
+# clean diffs, and local runnability. The workflow's `run:` step is a
+# one-line `bash` invocation of this file.
+#
+# DataOps pattern: https://github.com/github/gh-aw/blob/main/docs/src/content/docs/patterns/data-ops.md
+# Invoked from: .github/workflows/fix-test-failures.md
+#
+# Required env:
+#   GH_TOKEN   authenticated token for `gh api`
+#   REPO       owner/name of the repository to inspect
+#   OUTDIR     directory to write *.json into (e.g. /tmp/gh-aw/agent)
+# Optional env:
+#   PACKAGE       package/service to scope to (from workflow_dispatch input)
+#   TRACKING_ISSUE  known-failures tracking issue number (default 37864)
+#   MAX_COMMITS   how many recent commits to scan for check runs (default 5)
+#
+# Outputs (under $OUTDIR):
+#   meta.json            commit inspected + counts + scope
+#   failures.json        array of failing CI check runs with annotations
+#   known-failures.json  parsed #37864 island entries with linked-issue state
+#   known-failures.md    raw body of the tracking issue (for the agent)
+set -uo pipefail
+
+: "${REPO:?REPO is required}"
+: "${OUTDIR:?OUTDIR is required}"
+PACKAGE="${PACKAGE:-}"
+TRACKING_ISSUE="${TRACKING_ISSUE:-37864}"
+MAX_COMMITS="${MAX_COMMITS:-5}"
+ISLAND_ID="fix-test-failures"
+
+mkdir -p "$OUTDIR"
+
+api() { gh api -H "Accept: application/vnd.github+json" "$@"; }
+
+# Lower-case helper for case-insensitive substring scoping.
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# ---------------------------------------------------------------------------
+# Step 1: find the most recent commit on main that has check runs, and pull
+# every failing CI check run for it. CI check-run names look like
+# "js - <service> (Build UnitTest ...)". Live-test and perf pipelines
+# (names containing " - tests", " - tests-weekly", " - perf") are excluded.
+# ---------------------------------------------------------------------------
+commit=""
+checked_commits=0
+total_check_runs=0
+raw_runs="$OUTDIR/.check_runs.json"
+: > "$raw_runs"
+
+mapfile -t recent_shas < <(api "/repos/$REPO/commits?sha=main&per_page=$MAX_COMMITS" \
+  --jq '.[].sha' 2>/dev/null)
+
+for sha in "${recent_shas[@]}"; do
+  checked_commits=$((checked_commits + 1))
+  runs=$(api --paginate "/repos/$REPO/commits/$sha/check-runs?per_page=100" \
+    --jq '.check_runs[]' 2>/dev/null | jq -s '.')
+  count=$(printf '%s' "$runs" | jq 'length' 2>/dev/null || echo 0)
+  if [ "${count:-0}" -gt 0 ]; then
+    commit="$sha"
+    total_check_runs="$count"
+    printf '%s' "$runs" > "$raw_runs"
+    break
+  fi
+done
+
+if [ -z "$commit" ]; then
+  echo "No check runs found on the last $MAX_COMMITS commit(s) of main."
+  echo '[]' > "$OUTDIR/failures.json"
+else
+  echo "Inspecting commit $commit ($total_check_runs check runs)."
+  # Failing CI check runs only (exclude live-test / perf pipelines).
+  jq '[ .[]
+        | select(.conclusion == "failure")
+        | select(.name | test(" - tests-weekly| - tests| - perf") | not)
+        | select(.name | startswith("js - "))
+        | { id, name, html_url,
+            details_url: (.details_url // .external_id // null),
+            output_title:   (.output.title   // null),
+            output_summary: (.output.summary // null) } ]' \
+    "$raw_runs" > "$OUTDIR/.failing_ci.json"
+
+  # Optional scoping to a single package/service from the dispatch input.
+  if [ -n "$PACKAGE" ]; then
+    needle="$(lc "$PACKAGE")"; needle="${needle##*/}"
+    jq --arg n "$needle" \
+      '[ .[] | select((.name | ascii_downcase) | contains($n)) ]' \
+      "$OUTDIR/.failing_ci.json" > "$OUTDIR/.failing_ci.scoped.json"
+    mv "$OUTDIR/.failing_ci.scoped.json" "$OUTDIR/.failing_ci.json"
+  fi
+
+  fail_count=$(jq 'length' "$OUTDIR/.failing_ci.json")
+  echo "Found $fail_count failing CI check run(s)."
+
+  # For each failing check run, fetch annotations (capped) + the full
+  # output.text, then assemble one compact record. All API work happens
+  # here so the agent never paginates or polls a rate limit.
+  echo '[]' > "$OUTDIR/failures.json"
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    base=$(jq --argjson id "$id" '.[] | select(.id == $id)' "$OUTDIR/.failing_ci.json")
+    annotations=$(api "/repos/$REPO/check-runs/$id/annotations" 2>/dev/null \
+      | jq '[ .[] | { path, start_line, end_line, annotation_level,
+                       title, message: (.message | .[0:1200]) } ] | .[0:25]' \
+      2>/dev/null)
+    [ -z "$annotations" ] && annotations='[]'
+    output_text=$(api "/repos/$REPO/check-runs/$id" \
+      --jq '.output.text // ""' 2>/dev/null | head -c 4000)
+    record=$(jq -n --argjson base "$base" --argjson ann "$annotations" \
+      --arg text "$output_text" \
+      '$base + { annotations: $ann, output_text: $text }')
+    jq --argjson rec "$record" '. + [ $rec ]' \
+      "$OUTDIR/failures.json" > "$OUTDIR/.failures.tmp" \
+      && mv "$OUTDIR/.failures.tmp" "$OUTDIR/failures.json"
+  done < <(jq -r '.[].id' "$OUTDIR/.failing_ci.json")
+fi
+
+failing_ci_count=$(jq 'length' "$OUTDIR/failures.json")
+
+# ---------------------------------------------------------------------------
+# Step 2: pull the known-failures tracking issue (#37864), parse the island,
+# and resolve each linked issue's open/closed state — so the agent can drop
+# closed entries without making any API calls.
+# ---------------------------------------------------------------------------
+body=$(api "/repos/$REPO/issues/$TRACKING_ISSUE" --jq '.body // ""' 2>/dev/null)
+printf '%s' "$body" > "$OUTDIR/known-failures.md"
+# GitHub issue bodies use CRLF; normalize so marker/entry parsing is clean.
+body=$(printf '%s' "$body" | tr -d '\r')
+
+start_marker="<!-- gh-aw-island-start:$ISLAND_ID -->"
+end_marker="<!-- gh-aw-island-end:$ISLAND_ID -->"
+island_present=false
+if printf '%s' "$body" | grep -qF "$start_marker"; then
+  island_present=true
+fi
+
+# Extract issue numbers referenced on island lines ("- #NNN — ...").
+island_lines=$(printf '%s\n' "$body" \
+  | awk -v s="$start_marker" -v e="$end_marker" \
+      'index($0,s){f=1;next} index($0,e){f=0} f' \
+  | grep -E '^- #[0-9]+' || true)
+
+echo '[]' > "$OUTDIR/known-failures.json"
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  num=$(printf '%s' "$line" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+  [ -z "$num" ] && continue
+  state=$(api "/repos/$REPO/issues/$num" --jq '.state // "unknown"' 2>/dev/null)
+  [ -z "$state" ] && state="unknown"
+  entry=$(jq -n --argjson n "$num" --arg s "$state" --arg raw "$line" \
+    '{issue_number:$n, state:$s, raw_line:$raw}')
+  jq --argjson e "$entry" '. + [ $e ]' \
+    "$OUTDIR/known-failures.json" > "$OUTDIR/.known.tmp" \
+    && mv "$OUTDIR/.known.tmp" "$OUTDIR/known-failures.json"
+done < <(printf '%s\n' "$island_lines")
+
+known_count=$(jq 'length' "$OUTDIR/known-failures.json")
+open_known=$(jq '[ .[] | select(.state == "open") ] | length' "$OUTDIR/known-failures.json")
+
+# ---------------------------------------------------------------------------
+# meta.json: everything the agent needs to orient itself in one small file.
+# ---------------------------------------------------------------------------
+jq -n \
+  --arg commit "$commit" \
+  --arg repo "$REPO" \
+  --arg package "$PACKAGE" \
+  --argjson tracking "$TRACKING_ISSUE" \
+  --argjson checked "$checked_commits" \
+  --argjson total "$total_check_runs" \
+  --argjson failing "$failing_ci_count" \
+  --argjson known "$known_count" \
+  --argjson open_known "$open_known" \
+  --argjson island_present "$island_present" \
+  '{
+     repository: $repo,
+     commit: (if $commit == "" then null else $commit end),
+     commit_url: (if $commit == "" then null else "https://github.com/\($repo)/commit/\($commit)" end),
+     package_scope: (if $package == "" then null else $package end),
+     tracking_issue: $tracking,
+     island_present: $island_present,
+     commits_scanned: $checked,
+     total_check_runs: $total,
+     failing_ci_check_runs: $failing,
+     known_failure_entries: $known,
+     open_known_failures: $open_known
+   }' > "$OUTDIR/meta.json"
+
+# Clean up scratch files; leave only the agent-facing JSON/MD.
+rm -f "$raw_runs" "$OUTDIR/.failing_ci.json" "$OUTDIR/.failures.tmp" "$OUTDIR/.known.tmp"
+
+echo "DataOps complete -> $OUTDIR"
+echo "  commit=$commit failing_ci=$failing_ci_count known=$known_count open_known=$open_known"

--- a/.github/workflows/fix-test-failures.lock.yml
+++ b/.github/workflows/fix-test-failures.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"94dffa5517cd8b5f45663e63a8706cf02df7f8caaf26d21abaf0042bab1ade8c","body_hash":"9f8e344c571df0a7a474e0f87055f2fe7780380093a016f33fd71f3949cf692c","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"34454fd3b2cefec3143d807f3cdcec800fdfafbda498812fc028f924bc9d8be7","body_hash":"501bad6dd9d7fb211a16d8fdb0137eb67563a6d0d450a41d3d18ba239a2eb07c","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -190,20 +190,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
+          cat << 'GH_AW_PROMPT_0a80b6f44f6c096d_EOF'
           <system>
-          GH_AW_PROMPT_0d7a149179f3000d_EOF
+          GH_AW_PROMPT_0a80b6f44f6c096d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
+          cat << 'GH_AW_PROMPT_0a80b6f44f6c096d_EOF'
           <safe-output-tools>
           Tools: create_issue, update_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_0d7a149179f3000d_EOF
+          GH_AW_PROMPT_0a80b6f44f6c096d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
+          cat << 'GH_AW_PROMPT_0a80b6f44f6c096d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -232,12 +232,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0d7a149179f3000d_EOF
+          GH_AW_PROMPT_0a80b6f44f6c096d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
+          cat << 'GH_AW_PROMPT_0a80b6f44f6c096d_EOF'
           </system>
           {{#runtime-import .github/workflows/fix-test-failures.md}}
-          GH_AW_PROMPT_0d7a149179f3000d_EOF
+          GH_AW_PROMPT_0a80b6f44f6c096d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -460,9 +460,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e495876a1d07d5e8_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bd0cd67d2b7e3221_EOF'
           {"create_issue":{"labels":["test-reliability"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"37864"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e495876a1d07d5e8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_bd0cd67d2b7e3221_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -725,7 +725,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c6e9c5b1fab67f2b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_0606f42025d836cd_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -766,7 +766,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c6e9c5b1fab67f2b_EOF
+          GH_AW_MCP_CONFIG_0606f42025d836cd_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/fix-test-failures.lock.yml
+++ b/.github/workflows/fix-test-failures.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"9c6f74cd5e531d366460a795ac1350d4191d6ba9b7116dcd42f667b4d653113c","body_hash":"706a74fcb4635e9f11161c110b4e02e2f5ab827e014722e25a5d86d46a4cb516","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"94dffa5517cd8b5f45663e63a8706cf02df7f8caaf26d21abaf0042bab1ade8c","body_hash":"9f8e344c571df0a7a474e0f87055f2fe7780380093a016f33fd71f3949cf692c","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -190,20 +190,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_6c1c20f569d23a20_EOF'
+          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
           <system>
-          GH_AW_PROMPT_6c1c20f569d23a20_EOF
+          GH_AW_PROMPT_0d7a149179f3000d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1c20f569d23a20_EOF'
+          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
           <safe-output-tools>
           Tools: create_issue, update_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_6c1c20f569d23a20_EOF
+          GH_AW_PROMPT_0d7a149179f3000d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1c20f569d23a20_EOF'
+          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -232,12 +232,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6c1c20f569d23a20_EOF
+          GH_AW_PROMPT_0d7a149179f3000d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6c1c20f569d23a20_EOF'
+          cat << 'GH_AW_PROMPT_0d7a149179f3000d_EOF'
           </system>
           {{#runtime-import .github/workflows/fix-test-failures.md}}
-          GH_AW_PROMPT_6c1c20f569d23a20_EOF
+          GH_AW_PROMPT_0d7a149179f3000d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -381,6 +381,15 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTDIR: /tmp/gh-aw/agent
+          PACKAGE: ${{ github.event.inputs.package || '' }}
+          REPO: ${{ github.repository }}
+          TRACKING_ISSUE: "37864"
+        name: Collect CI failure data
+        run: bash .github/workflows/fix-test-failures-collect.sh
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -451,9 +460,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3d48704ef442c75e_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e495876a1d07d5e8_EOF'
           {"create_issue":{"labels":["test-reliability"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"37864"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3d48704ef442c75e_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e495876a1d07d5e8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -716,7 +725,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_902f3bd45f546c56_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c6e9c5b1fab67f2b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -757,7 +766,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_902f3bd45f546c56_EOF
+          GH_AW_MCP_CONFIG_c6e9c5b1fab67f2b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/fix-test-failures.md
+++ b/.github/workflows/fix-test-failures.md
@@ -22,6 +22,14 @@ permissions:
 # Collection logic lives in a committed sibling script so it gets shellcheck,
 # highlighting, and clean diffs; in production the agent job sparse-checks-out
 # `.github` before this step, so the script is on disk.
+#
+# KNOWN LIMITATION: `gh aw trial` CANNOT exercise this script. In trial mode
+# the agent job checks out the `--logical-repo` (the simulated target), not
+# this branch, so the unmerged script is absent and the step fails with "No
+# such file". This is a trial limitation, not a production bug. To validate
+# pre-merge, run the script standalone (it is shellcheck-clean and takes
+# GH_TOKEN/REPO/OUTDIR env). Once merged to the default branch, the normal
+# scheduled / workflow_dispatch run exercises it for real.
 steps:
   - name: Collect CI failure data
     env:
@@ -66,9 +74,11 @@ annotations, or poll the rate limit yourself — read these files instead:
 - `/tmp/gh-aw/agent/failures.json` — array of failing **CI** check runs already
   filtered to the CI (playback) pipeline. Live-test (`- tests`,
   `- tests-weekly`) and `- perf` pipelines are already excluded. Each element
-  has: `name`, `html_url`, `details_url` (Azure DevOps build), `output_title`,
-  `output_summary`, `output_text`, and a capped `annotations` array
-  (`path`, `start_line`, `end_line`, `annotation_level`, `title`, `message`).
+  has: `name`, `html_url`, `details_url` (Azure DevOps build link; may be
+  `null`), `output_title`, `output_summary`, `output_text` (capped to ~4000
+  chars), and a capped `annotations` array (at most 25 entries, each with
+  `path`, `start_line`, `end_line`, `annotation_level`, `title`, and a
+  `message` truncated to ~1200 chars).
 - `/tmp/gh-aw/agent/known-failures.json` — the parsed tracking-island entries
   from issue #37864, each with its linked-issue `state` (`open`/`closed`)
   already resolved, plus the original `raw_line`.

--- a/.github/workflows/fix-test-failures.md
+++ b/.github/workflows/fix-test-failures.md
@@ -14,9 +14,24 @@ permissions:
   checks: read
   issues: read
   pull-requests: read
+# DataOps: all GitHub API gathering runs in this deterministic, authenticated
+# shell step (GH_TOKEN, zero AI tokens) and writes compact JSON to
+# /tmp/gh-aw/agent/. The agent only reads those files — it makes no API calls.
+# This replaces ~40 model turns of check-run pagination + annotation fetching
+# + rate-limit polling that previously tripped the effective-token hard rail.
+# Collection logic lives in a committed sibling script so it gets shellcheck,
+# highlighting, and clean diffs; in production the agent job sparse-checks-out
+# `.github` before this step, so the script is on disk.
+steps:
+  - name: Collect CI failure data
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PACKAGE: ${{ github.event.inputs.package || '' }}
+      TRACKING_ISSUE: "37864"
+      OUTDIR: /tmp/gh-aw/agent
+    run: bash .github/workflows/fix-test-failures-collect.sh
 tools:
-  github:
-    toolsets: [default]
   bash: true
 safe-outputs:
   create-issue:
@@ -40,6 +55,31 @@ Detect unit test failures on the `main` branch and open a GitHub issue containin
 a root cause analysis and, when possible, the exact code fix needed to resolve each
 failure.
 
+## Pre-computed Data (read these first)
+
+**All GitHub API gathering has already been done for you** by a deterministic
+shell step. Do **not** call the GitHub API, paginate check runs, fetch
+annotations, or poll the rate limit yourself — read these files instead:
+
+- `/tmp/gh-aw/agent/meta.json` — the commit inspected, counts, the package
+  scope (if any), and the tracking-issue number. Orient yourself here first.
+- `/tmp/gh-aw/agent/failures.json` — array of failing **CI** check runs already
+  filtered to the CI (playback) pipeline. Live-test (`- tests`,
+  `- tests-weekly`) and `- perf` pipelines are already excluded. Each element
+  has: `name`, `html_url`, `details_url` (Azure DevOps build), `output_title`,
+  `output_summary`, `output_text`, and a capped `annotations` array
+  (`path`, `start_line`, `end_line`, `annotation_level`, `title`, `message`).
+- `/tmp/gh-aw/agent/known-failures.json` — the parsed tracking-island entries
+  from issue #37864, each with its linked-issue `state` (`open`/`closed`)
+  already resolved, plus the original `raw_line`.
+- `/tmp/gh-aw/agent/known-failures.md` — the raw body of #37864 (reference
+  only; you normally only need `known-failures.json`).
+
+Read these files with `cat`/`jq`. Keep your own shell exploration minimal —
+every extra turn re-sends the whole context and is expensive. When you have
+emitted the issue (Step 5) and the tracking update (Step 6), **stop**; do not
+make further shell calls.
+
 ## Important Constraints
 
 - `snippets.spec.ts` files under `sdk/**/*/test/` are documentation snippet sources,
@@ -58,8 +98,19 @@ already tracked. Before filing a new issue, check the **known failures tracking
 issue** (https://github.com/Azure/azure-sdk-for-js/issues/37864) for pre-existing
 failures.
 
-The tracking list lives inside an **island** in the body of #37864, delimited by
-the markers:
+The tracking list for these known failures has already been fetched and parsed
+into `/tmp/gh-aw/agent/known-failures.json`. Each element is one island entry:
+
+```json
+{ "issue_number": 12345, "state": "open", "raw_line": "- #12345 — `web-pubsub` — `TypeError: ...` — 2026-06-18" }
+```
+
+The linked-issue `state` is already resolved for you — you do **not** need to
+call the GitHub API to check whether a tracked issue is still open.
+
+The raw island in #37864 is delimited by these markers (managed by the
+`update-issue` safe output, `operation: replace-island`); content **outside**
+the island is human-authored and must be preserved exactly:
 
 ```
 <!-- gh-aw-island-start:fix-test-failures -->
@@ -67,117 +118,101 @@ the markers:
 <!-- gh-aw-island-end:fix-test-failures -->
 ```
 
-These markers are managed by the `update-issue` safe output (`operation:
-replace-island`). Content **outside** the island is human-authored and must be
-preserved exactly. If the markers are not present yet (first run), treat the
-tracked list as empty — the framework will create the island on the first update.
-
-Each entry on the tracked list is a single line in this format:
+Each entry on the tracked list follows this format:
 
 ```
 - #<issue-number> — `<service or package>` — `<error pattern>` — <YYYY-MM-DD>
 ```
 
-1. Fetch the body of issue #37864 using the GitHub API. Locate the island content
-   between the markers shown above and parse the entries (one per line starting
-   with `- #`).
-2. For each parsed entry, fetch the linked issue with the GitHub API and inspect
-   its `state`:
-   - If `state == "open"` → keep the entry; it represents an active known
-     failure.
-   - If `state == "closed"` → **drop** the entry from the list (do not consider
-     it a known failure anymore). If the same failure recurs in this run it will
-     be filed as a brand-new issue in Step 5 and re-added to the list in Step 6.
-3. For each failing check run identified later in "Step 1 — Identify Failing
-   Packages", check whether the **service directory** (from the check-run name,
-   e.g. `attestation` in `js - attestation (Build UnitTest ...)`) or the **npm
-   package name** (from annotations/file paths) **and** the **error pattern**
-   match an entry that was *kept* in step 2.
-4. If a failure matches a kept entry:
+1. Read `known-failures.json`. Partition the entries by `state`:
+   - `state == "open"` → **keep** the entry; it is an active known failure.
+   - `state == "closed"` (or `unknown`) → **drop** it (do not carry it
+     forward). If the same failure recurs in this run it will be filed as a
+     brand-new issue in Step 5 and re-added in Step 6.
+2. For each failing check run in `/tmp/gh-aw/agent/failures.json`, check whether
+   the **service directory** (from the check-run name, e.g. `attestation` in
+   `js - attestation (Build UnitTest ...)`) or the **npm package name** (from
+   annotations/file paths) **and** the **error pattern** match a *kept* entry.
+3. If a failure matches a kept entry:
    - **Exclude** it from the new GitHub issue entirely.
    - Do **not** attempt to reproduce or root-cause it — it is already tracked.
-5. If **all** detected failures match kept entries, **do not** create a new CI
-   failure issue. Still proceed to Step 6 so that any entries dropped in step 2
+4. If **all** detected failures match kept entries, **do not** create a new CI
+   failure issue. Still proceed to Step 6 so that any entries dropped in step 1
    are removed from the tracked list.
-6. If some failures are new and some are known, create the issue for **new
+5. If some failures are new and some are known, create the issue for **new
    failures only**. Add a brief note in the "Additional Notes" section listing
    which known failures were excluded and linking to their tracking issues.
 
 ## Step 1 — Identify Failing Packages
 
-1. Use the GitHub API to list the most recent **check runs** on the `main` branch
-   (look at the HEAD commit of `main`). If there are no check runs on the HEAD
-   commit, check a few recent commits — CI may not run on every push.
-2. Filter for check runs whose `conclusion` is `failure`. CI runs are reported by
-   the **Azure Pipelines** GitHub App; the check-run **name** includes the service
-   directory and job type.
-3. **Only consider CI (playback) pipeline failures.** Each service has two separate
-   Azure DevOps pipelines that both report check runs against the same commit:
-   - **CI pipeline** (from `ci.yml`) — triggered on pushes to `main`; runs tests
-     in **playback** mode. Check-run name pattern: `js - <service>` with job
-     suffixes like `(Build ...)`, `(Build UnitTest ...)`, `(Build Analyze)`.
-     Example: `js - attestation (Build UnitTest ubuntu_22x_node)`.
-   - **Live-test pipeline** (from `tests.yml`) — triggered on a schedule or
-     manually; runs tests in **live** mode against real Azure services. Check-run
-     name pattern: `js - <service> - tests` with job suffixes like
-     `(Public ...)`. Example: `js - attestation - tests (Public macoslatest_24x_node)`.
+Read `/tmp/gh-aw/agent/meta.json` and `/tmp/gh-aw/agent/failures.json`. The
+collection step has already done all the API work and filtering:
 
-   **Ignore all check runs whose name contains `- tests`, `- tests-weekly`, or
-   `- perf`.** These are live-test and performance pipeline results, not CI
-   regressions. This workflow should only analyze CI pipeline failures.
-4. If a specific `package` input was provided, scope investigation to that package only.
-5. Collect the list of affected **service directories** or **package names** from the
-   check-run names (the pattern is `js - <service> (...)`).
-6. For each failing check run, **record the links needed to reach the failing build
-   logs** so they can be embedded in the issue later:
+1. `failures.json` already contains **only** failing **CI (playback) pipeline**
+   check runs. The collection step kept entries whose `conclusion` is `failure`
+   and whose name starts with `js - `, and excluded live-test
+   (`- tests`, `- tests-weekly`) and `- perf` pipelines. You do not need to
+   re-filter; just read the array.
+   - For context: CI check-run names look like `js - <service> (Build ...)`,
+     `(Build UnitTest ...)`, or `(Build Analyze)` — e.g.
+     `js - attestation (Build UnitTest ubuntu_22x_node)`.
+2. If `meta.json.package_scope` is set, the failures are already scoped to that
+   package/service.
+3. Derive the affected **service directories** / **package names** from each
+   `name` (the pattern is `js - <service> (...)`).
+4. Each failure record already carries the links to embed in the issue:
    - `html_url` — the GitHub check-run page for the failure.
-   - `details_url` (or `target_url`, depending on the API field available) — the Azure DevOps build that produced the
-     failure. This is the most useful link for inspecting the full failure logs.
-     It typically follows the pattern
-     `https://dev.azure.com/azure-sdk/public/_build/results?buildId=<ID>&view=results`.
-   Keep these URLs associated with their service/package so each failure section in
-   the issue can link directly to its build logs.
+   - `details_url` — the Azure DevOps build that produced the failure (the most
+     useful link for full logs; pattern
+     `https://dev.azure.com/azure-sdk/public/_build/results?buildId=<ID>&view=results`).
+   Keep these URLs associated with their service/package.
 
-If there are no test failures on `main`, **stop immediately** — do **not** create a
-GitHub issue. Simply report that CI is green and exit.
+If `failures.json` is an empty array (no CI failures on `main`), **stop
+immediately** — do **not** create a GitHub issue. Report that CI is green
+and exit.
 
 ## Step 2 — Gather Failure Details
 
-For each failing check run identified in Step 1:
+Each element of `/tmp/gh-aw/agent/failures.json` already contains the failure
+detail you need — no API calls required:
 
-1. Retrieve the check-run **annotations** via the GitHub API
-   (`GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations`).
-   Annotations contain error messages, failing test names, and stack traces.
-2. Read the check-run `output.text` field for a summary of test results
-   (e.g. pass/fail counts).
+1. `annotations` — a capped array of `{ path, start_line, end_line,
+   annotation_level, title, message }`. These contain the error messages,
+   failing test names, and stack traces.
+2. `output_title` / `output_summary` / `output_text` — the check-run output
+   summary (e.g. pass/fail counts).
 3. From the annotations, identify the failing test file(s) and test case name(s).
 4. Note the error type — for example: `TypeError`, `AssertionError`, compilation
    error, missing export, API mismatch, etc.
 
 ## Step 3 — Reproduce Locally
 
-For each failing package:
+## Step 3 — Reproduce Locally (best-effort, time-boxed)
 
-1. Install dependencies:
-   ```bash
-   pnpm install
-   ```
-2. Build the package and all its dependencies:
-   ```bash
-   pnpm turbo build --filter=<package-name>... --token 1
-   ```
-3. Run the failing tests:
-   ```bash
-   cd <package-directory> && pnpm run test
-   ```
-4. Confirm the failure reproduces locally. If it does not reproduce, note this —
-   still include it in the issue but mark it as non-reproducible locally.
+Local reproduction is **optional and best-effort**. `pnpm install` +
+`turbo build` for a package is slow and frequently not feasible in this
+sandbox; do **not** spiral into many shell turns trying to make it work, and do
+**not** explore unrelated packages "just in case". Each extra turn re-sends the
+whole context and is expensive.
+
+For each failing package, you may attempt **one** quick reproduction:
+
+1. Install dependencies (only if not already present): `pnpm install`
+2. Build the package and its dependencies:
+   `pnpm turbo build --filter=<package-name>... --token 1`
+3. Run the failing tests: `cd <package-directory> && pnpm run test`
+
+If the build/test does not complete quickly, or dependencies are not installed,
+**stop trying** and mark the failure as non-reproducible locally — still include
+it in the issue. The annotations in `failures.json` are usually enough to
+root-cause without a local run.
 
 ## Step 4 — Root Cause Analysis
 
 For each failure (reproduced or not):
 
-1. Read the failing test file and the source file(s) it exercises.
+1. Read the failing test file and the source file(s) it exercises — read only
+   the files the annotations point at; do not browse broadly.
 2. Determine the root cause — common causes include:
    - Source code change that broke an existing API contract.
    - Test expectations that are stale after a legitimate source change.
@@ -254,9 +289,9 @@ Update the tracking island inside issue #37864 with a single `update_issue`
 call so the list stays bounded and reflects only currently-open known failures.
 
 1. Build the new tracking list:
-   - Start from the entries **kept** in step 2 of "Known Pre-existing Failures"
+   - Start from the entries **kept** in step 1 of "Known Pre-existing Failures"
      (entries whose tracked issue is still `open`). Closed entries dropped in
-     step 2 are **not** carried forward.
+     step 1 are **not** carried forward.
    - For each issue this run created in Step 5, append one new entry using the
      line format from "Known Pre-existing Failures":
 
@@ -278,7 +313,7 @@ call so the list stays bounded and reflects only currently-open known failures.
    If the new list is empty (all previously-tracked issues closed and no new
    issues created this run), pass an empty `body` so the island is cleared.
 
-   Skip the call entirely **only** if step 2 dropped zero closed entries **and**
+   Skip the call entirely **only** if step 1 dropped zero closed entries **and**
    Step 5 created zero new issues — i.e. the list has not changed at all.
 
 3. Always call `update_issue` at most **once per run** on #37864 (the


### PR DESCRIPTION
## Problem

Workflow run [27823288415](https://github.com/Azure/azure-sdk-for-js/actions/runs/27823288415) of **Analyze CI Test Failures** (`fix-test-failures`) failed by tripping the AWF **effective-token hard rail**:

`429 Maximum effective tokens exceeded (25,378,579 / 25,000,000)`

The agent gathered all data agentically — ~40 model turns paginating the check-runs API (hitting GitHub rate limits and `sleep`-ing), fetching annotations one-by-one, then dozens of exploratory `cat`/`ls`/`grep` calls. Per-turn input context grew monotonically (34K -> 90K tokens/request) and compounded past the limit. Notably the issue **was created successfully** before the rail tripped; the run is still marked failed because the next inference was refused.

## Fix (gh-aw token-optimization guide: DataOps = the single biggest win)

Mirrors the existing `agent-observability` DataOps workflow in this repo:

- **New committed script `fix-test-failures-collect.sh`** does all GitHub API work in a deterministic, authenticated shell step (`GH_TOKEN`, zero AI tokens): resolves the HEAD commit, collects failing **CI** check runs (already filtered to exclude live-test/perf pipelines) with capped annotations + output text, and parses the #37864 known-failures island with each linked issue's open/closed state already resolved. Writes compact JSON to `/tmp/gh-aw/agent/`.
- **Top-level `steps:`** invokes the script before the agent runs.
- **Dropped the explicit `github` toolset** — reads now come from JSON, writes remain `safe-outputs`.
- **Rewrote prompt Steps 1-2 and Known-Failures** to read the pre-computed JSON instead of calling APIs; capped local exploration and instructed the agent to stop once the issue + tracking update are emitted (no post-completion rate-limit polling).

## Validation

- `gh aw compile fix-test-failures --strict` -> 0 errors, 0 warnings
- `bash -n` clean on the collect script
- Ran the collect script against the live repo: correctly resolved HEAD commit (286 check runs, 0 failing CI), detected the #37864 island, produced well-formed `meta.json` / `failures.json` / `known-failures.json`

## Diagnosed with

`gh aw audit` per https://raw.githubusercontent.com/github/gh-aw/main/debug.md, following https://github.com/github/gh-aw/blob/main/.github/aw/token-optimization.md