### PR TITLE
Update swagger input-file to point to main-merged spec commit

### DIFF
--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -12,7 +12,7 @@ enable-xml: true
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/06810b88403df038b68f89283491ad26c57e0845/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-06-06/blob.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/15d7f54a5389d5906ffb4e56bb2f38fe5525c0d3/specification/storage/data-plane/Microsoft.BlobStorage/stable/2026-06-06/blob.json
 model-date-time-as-string: true
 optional-response-headers: true
 v3: true

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -12,7 +12,7 @@ enable-xml: true
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../src/generated
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/06810b88403df038b68f89283491ad26c57e0845/specification/storage/data-plane/Microsoft.FileStorage/stable/2026-06-06/file.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/15d7f54a5389d5906ffb4e56bb2f38fe5525c0d3/specification/storage/data-plane/Microsoft.FileStorage/stable/2026-06-06/file.json
 model-date-time-as-string: true
 optional-response-headers: true
 v3: true


### PR DESCRIPTION
### Packages impacted by this PR
- `@azure/storage-blob`
- `@azure/storage-file-share`

### Issues associated with this PR


### Describe the problem that is addressed by this PR
The storage release pipeline was failing at the "Verify REST API spec location"
step for `storage-blob` and `storage-file-share`. Both packages' swagger
`README.md` had their `input-file` pointing at commit
`06810b88403df038b68f89283491ad26c57e0845`, which exists only on the
`feature/storage/stg102base` branch of `Azure/azure-rest-api-specs`. The
release verification requires the spec commit to be reachable from the `main`
branch, so a feature-branch-only commit fails the check.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?
The spec changes from the feature branch were merged into `main` via commit
`15d7f54a5389d5906ffb4e56bb2f38fe5525c0d3` (STG 102), which contains the
`2026-06-06` `blob.json` and `file.json`. Repointing the `input-file` URLs to
this main-merged commit satisfies the verification step without altering the
spec content used for generation. This is the minimal, correct fix.

### Are there test cases added in this PR? _(If not, why?)_
No. This is a codegen-configuration change (swagger `input-file` source commit
only); it does not change SDK behavior, so no new tests are required.

### Provide a list of related PRs _(if any)_
- Azure/azure-rest-api-specs#41492 (Storage STG 102 — merged the specs to main)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_
N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
