### PR TITLE
Remove AuthToken so that prepare-pipelines.yml can run

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -7,4 +7,3 @@ extends:
   template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
   parameters:
     Repository: Azure/azure-sdk-for-js
-    AuthToken: ''


### PR DESCRIPTION
This pull request makes a small change to the `eng/pipelines/prepare-pipelines.yml` file by removing the `AuthToken` parameter from the pipeline configuration. This helps clean up unused or unnecessary parameters.