### PR TITLE
[storage-common] Trim dead file/path I/O from embedded-wasm crc64.js

### DIFF
--- a/sdk/storage/storage-common/CHANGELOG.md
+++ b/sdk/storage/storage-common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 12.4.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- Fixed the ESM build of the CRC64 checksum calculator crashing (`TypeError [ERR_INVALID_ARG_VALUE]` from `import.meta.url`) when an ESM consumer is bundled to CommonJS with a Node-targeted bundler such as esbuild. Because the WebAssembly module is base64-embedded, none of the Emscripten-generated filesystem/URL machinery is reachable, so the `import.meta.url` polyfill, `node:*` imports, `require('fs')`/`require('path')` reads, and the shell/web read hooks have been removed from `crc64.js`. The ESM, browser, and react-native builds are now identical, and the CommonJS copy differs only by its export statement. Issue [#39057](https://github.com/Azure/azure-sdk-for-js/issues/39057).
+
+### Other Changes
+
 ## 12.4.1 (2026-06-22)
 
 ### Bugs Fixed

--- a/sdk/storage/storage-common/copyJSFiles.cjs
+++ b/sdk/storage/storage-common/copyJSFiles.cjs
@@ -3,62 +3,32 @@ const fs = require("fs");
 const SRC_CRC64 = "./src/crc64.js";
 const SRC_GLUE = "./src/crc64_glue.js";
 
-// `dist/commonjs/package.json` is `{ "type": "commonjs" }`, so the same .js file
-// must use CommonJS syntax there. Strip the ESM-only polyfill block and rewrite
-// the ESM `export default` to `module.exports`. The other targets (esm, browser,
-// react-native) sit under `{ "type": "module" }` and get the ESM source verbatim.
-const ESM_COMPAT_BLOCK = /\/\/ ESM-COMPAT-START[\s\S]*?\/\/ ESM-COMPAT-END\r?\n?/;
+// `src/crc64.js` is Emscripten output whose wasm is base64-embedded, so it no longer
+// performs any filesystem/URL I/O: the Node `require('fs')`/`require('path')` reads and
+// the ESM `import.meta.url` polyfill have been removed at the source. As a result the
+// esm, browser and react-native builds (all under `{ "type": "module" }`) are byte
+// identical and get the source verbatim. The only per-target difference is the module
+// system: `dist/commonjs/package.json` is `{ "type": "commonjs" }`, so the ESM
+// `export default` is rewritten to `module.exports` there.
 const ESM_EXPORT_BLOCK =
   /\/\/ ESM-EXPORT-START[^\n]*\r?\nexport default NativeCRC64;\r?\n\/\/ ESM-EXPORT-END/;
-// The Emscripten Node branch eagerly calls `require('fs')`/`require('path')` and wires
-// up filesystem-backed `read_`/`readBinary`/`readAsync`. Although this code is unreachable
-// in browsers (it is guarded by `ENVIRONMENT_IS_NODE`), bundlers such as esbuild statically
-// resolve the bare `require('fs')` calls and fail. Replace the block with a no-op for the
-// browser and react-native builds so no Node `require()` references remain.
-// See https://github.com/Azure/azure-sdk-for-js/issues/38924.
-const NODE_READ_BLOCK = /\/\/ NODE-READ-START[\s\S]*?\/\/ NODE-READ-END\r?\n?/;
-const NODE_READ_NOOP = `// Node-only filesystem reads omitted in browser/react-native builds.
-  read_ = readBinary = readAsync = () => {
-    throw new Error('NodeJS filesystem reads are not supported in this environment.');
-  };
-
-`;
 
 const esmSource = fs.readFileSync(SRC_CRC64, "utf8");
 
-if (!ESM_COMPAT_BLOCK.test(esmSource)) {
-  throw new Error(
-    "copyJSFiles.cjs: expected ESM-COMPAT marker block in src/crc64.js was not found.",
-  );
-}
 if (!ESM_EXPORT_BLOCK.test(esmSource)) {
   throw new Error(
     "copyJSFiles.cjs: expected ESM-EXPORT marker block in src/crc64.js was not found.",
   );
 }
-if (!NODE_READ_BLOCK.test(esmSource)) {
-  throw new Error(
-    "copyJSFiles.cjs: expected NODE-READ marker block in src/crc64.js was not found.",
-  );
+
+// esm, browser and react-native share the identical ESM source.
+for (const dir of ["esm", "browser", "react-native"]) {
+  fs.writeFileSync(`./dist/${dir}/crc64.js`, esmSource);
 }
 
-fs.writeFileSync("./dist/esm/crc64.js", esmSource);
-
-const cjsSource = esmSource
-  .replace(ESM_COMPAT_BLOCK, "// ESM compatibility block omitted in CommonJS build.\n")
-  .replace(ESM_EXPORT_BLOCK, "module.exports = NativeCRC64;");
+const cjsSource = esmSource.replace(ESM_EXPORT_BLOCK, "module.exports = NativeCRC64;");
 
 fs.writeFileSync("./dist/commonjs/crc64.js", cjsSource);
-
-const browserSource = esmSource
-  .replace(
-    ESM_COMPAT_BLOCK,
-    `// ESM compatibility block omitted in browsers build as it is NodeJS only.\n`,
-  )
-  .replace(NODE_READ_BLOCK, NODE_READ_NOOP);
-
-fs.writeFileSync("./dist/browser/crc64.js", browserSource);
-fs.writeFileSync("./dist/react-native/crc64.js", browserSource);
 
 for (const dir of ["browser", "esm", "commonjs", "react-native"]) {
   fs.cpSync(SRC_GLUE, `./dist/${dir}/crc64_glue.js`);

--- a/sdk/storage/storage-common/package.json
+++ b/sdk/storage/storage-common/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "sideEffects": false,
   "author": "Microsoft Corporation",
-  "version": "12.4.1",
+  "version": "12.4.2",
   "description": "Azure Storage Common Client Library for JavaScript",
   "license": "MIT",
   "repository": {

--- a/sdk/storage/storage-common/src/crc64.js
+++ b/sdk/storage/storage-common/src/crc64.js
@@ -1,33 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// ESM-COMPAT-START (this block is stripped from dist/commonjs by copyJSFiles.cjs)
-// In ESM under Node, `require`, `__filename`, and `__dirname` are not defined.
-// Synthesize them from `import.meta.url` so the Emscripten Node branch below works as-is.
-// Specifiers are held in variables to prevent web bundlers from statically resolving `node:*`.
-// The detection check below MUST stay byte-for-byte identical to the Emscripten-generated
-// `ENVIRONMENT_IS_NODE` check later in this file; otherwise the polyfill and the Node branch
-// can disagree and the ESM `ReferenceError: require is not defined` bug returns.
-import { createRequire } from "node:module";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-const __isNode__ =
-  typeof process === "object" &&
-  typeof process.versions === "object" &&
-  typeof process.versions.node === "string";
-let require;
-let __filename;
-let __dirname;
-if (__isNode__) {
-  require = createRequire(import.meta.url);
-  __filename = fileURLToPath(import.meta.url);
-  __dirname = dirname(__filename);
-}
-// ESM-COMPAT-END
-
 var NativeCRC64 = (() => {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
-  if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;
   return (
 function(NativeCRC64) {
   NativeCRC64 = NativeCRC64 || {};
@@ -133,52 +108,10 @@ function logExceptionOnExit(e) {
 
 if (ENVIRONMENT_IS_NODE) {
   if (typeof process == 'undefined' || !process.release || process.release.name !== 'node') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-// NODE-READ-START (this block is replaced with a no-op in dist/browser and dist/react-native by copyJSFiles.cjs)
-  // `require()` is no-op in an ESM module, use `createRequire()` to construct
-  // the require()` function.  This is only necessary for multi-environment
-  // builds, `-sENVIRONMENT=node` emits a static import declaration instead.
-  // TODO: Swap all `require()`'s with `import()`'s?
-  // These modules will usually be used on Node.js. Load them eagerly to avoid
-  // the complexity of lazy-loading.
-  var fs = require('fs');
-  var nodePath = require('path');
-
-  if (ENVIRONMENT_IS_WORKER) {
-    scriptDirectory = nodePath.dirname(scriptDirectory) + '/';
-  } else {
-    scriptDirectory = __dirname + '/';
-  }
-
-// include: node_shell_read.js
-
-
-read_ = (filename, binary) => {
-  // We need to re-wrap `file://` strings to URLs. Normalizing isn't
-  // necessary in that case, the path should already be absolute.
-  filename = isFileURI(filename) ? new URL(filename) : nodePath.normalize(filename);
-  return fs.readFileSync(filename, binary ? undefined : 'utf8');
-};
-
-readBinary = (filename) => {
-  var ret = read_(filename, true);
-  if (!ret.buffer) {
-    ret = new Uint8Array(ret);
-  }
-  assert(ret.buffer);
-  return ret;
-};
-
-readAsync = (filename, onload, onerror) => {
-  // See the comment in the `read_` function.
-  filename = isFileURI(filename) ? new URL(filename) : nodePath.normalize(filename);
-  fs.readFile(filename, function(err, data) {
-    if (err) onerror(err);
-    else onload(data.buffer);
-  });
-};
-
-// end include: node_shell_read.js
-// NODE-READ-END
+  // The wasm is base64-embedded (see `binaryInString`) and loaded via `getBinary()`,
+  // so the Node fs/path read hooks emitted by Emscripten are never exercised and
+  // have been removed. This keeps the file free of Node built-in imports so it can be
+  // consumed as-is by web bundlers and by ESM-to-CommonJS bundlers (see issue #39057).
   if (process['argv'].length > 1) {
     thisProgram = process['argv'][1].replace(/\\/g, '/');
   }
@@ -217,26 +150,6 @@ if (ENVIRONMENT_IS_SHELL) {
 
   if ((typeof process == 'object' && typeof require === 'function') || typeof window == 'object' || typeof importScripts == 'function') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
 
-  if (typeof read != 'undefined') {
-    read_ = function shell_read(f) {
-      return read(f);
-    };
-  }
-
-  readBinary = function readBinary(f) {
-    let data;
-    if (typeof readbuffer == 'function') {
-      return new Uint8Array(readbuffer(f));
-    }
-    data = read(f, 'binary');
-    assert(typeof data == 'object');
-    return data;
-  };
-
-  readAsync = function readAsync(f, onload, onerror) {
-    setTimeout(() => onload(readBinary(f)), 0);
-  };
-
   if (typeof scriptArgs != 'undefined') {
     arguments_ = scriptArgs;
   } else if (typeof arguments != 'undefined') {
@@ -263,72 +176,9 @@ if (ENVIRONMENT_IS_SHELL) {
 // Node.js workers are detected as a combination of ENVIRONMENT_IS_WORKER and
 // ENVIRONMENT_IS_NODE.
 if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
-  if (ENVIRONMENT_IS_WORKER) { // Check worker, not web, since window could be polyfilled
-    scriptDirectory = self.location.href;
-  } else if (typeof document != 'undefined' && document.currentScript) { // web
-    scriptDirectory = document.currentScript.src;
-  }
-  // When MODULARIZE, this JS may be executed later, after document.currentScript
-  // is gone, so we saved it, and we use it here instead of any other info.
-  if (_scriptDir) {
-    scriptDirectory = _scriptDir;
-  }
-  // blob urls look like blob:http://site.com/etc/etc and we cannot infer anything from them.
-  // otherwise, slice off the final part of the url to find the script directory.
-  // if scriptDirectory does not contain a slash, lastIndexOf will return -1,
-  // and scriptDirectory will correctly be replaced with an empty string.
-  // If scriptDirectory contains a query (starting with ?) or a fragment (starting with #),
-  // they are removed because they could contain a slash.
-  if (scriptDirectory.indexOf('blob:') !== 0) {
-    scriptDirectory = scriptDirectory.substr(0, scriptDirectory.replace(/[?#].*/, "").lastIndexOf('/')+1);
-  } else {
-    scriptDirectory = '';
-  }
-
   if (!(typeof window == 'object' || typeof importScripts == 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-
-  // Differentiate the Web Worker from the Node Worker case, as reading must
-  // be done differently.
-  {
-// include: web_or_worker_shell_read.js
-
-
-  read_ = (url) => {
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', url, false);
-      xhr.send(null);
-      return xhr.responseText;
-  }
-
-  if (ENVIRONMENT_IS_WORKER) {
-    readBinary = (url) => {
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', url, false);
-        xhr.responseType = 'arraybuffer';
-        xhr.send(null);
-        return new Uint8Array(/** @type{!ArrayBuffer} */(xhr.response));
-    };
-  }
-
-  readAsync = (url, onload, onerror) => {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
-    xhr.responseType = 'arraybuffer';
-    xhr.onload = () => {
-      if (xhr.status == 200 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
-        onload(xhr.response);
-        return;
-      }
-      onerror();
-    };
-    xhr.onerror = onerror;
-    xhr.send(null);
-  }
-
-// end include: web_or_worker_shell_read.js
-  }
-
-  setWindowTitle = (title) => document.title = title;
+  // The XHR-based read hooks emitted by Emscripten are unused because the wasm is
+  // base64-embedded; they have been removed so the file contains no DOM/XHR I/O.
 } else
 {
   throw new Error('environment detection error');


### PR DESCRIPTION
### Packages impacted by this PR

`@azure/storage-common`

### Issues associated with this PR

Fixes #39057

### Describe the problem that is addressed by this PR

`crc64.js` is Emscripten output whose WebAssembly module is base64-embedded (`binaryInString`), so `getBinary()` returns the bytes directly and never touches the filesystem or a URL. Despite that, the generated file still carried all of Emscripten's environment-detection and file/URL machinery. That dead code caused real consumer breakage:

- The ESM build synthesized `require`/`__filename`/`__dirname` from `import.meta.url`. When an ESM consumer was bundled to CommonJS with a Node-targeted bundler (esbuild `--platform=node --format=cjs`), `import.meta.url` became `undefined` and the module crashed at load with `TypeError [ERR_INVALID_ARG_VALUE]`.
- The Node branch eagerly called `require('fs')`/`require('path')`, which web bundlers statically choke on. The previous fix for this (#38924) worked around it with a post-build no-op transform rather than removing the unreachable code.

I verified empirically (load-time instrumentation) that the read hooks `read_`/`readBinary`/`readAsync` are called 0 times, confirming the entire I/O surface is unreachable for the embedded-wasm path.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Two options were considered:

1. Keep papering over the generated output with more post-build regex transforms (the current approach). This leaves the misleading dead code in place and grows the transform surface.
2. Remove the unreachable file/path I/O at the source so every build target is clean by construction. Chosen.

This PR removes the ESM-COMPAT block (`import.meta.url`, `node:*` imports, `createRequire`, `__filename`/`__dirname`), the Node `fs`/`path` read hooks, the shell read hooks, and the web/worker XHR read hooks. The harmless string helpers (`locateFile`/`scriptDirectory`/`isDataURI`/`isFileURI`) are kept because the wasm-instantiate error path references them and they do not break bundlers.

A useful side effect: with the I/O gone, the `esm`, `browser`, and `react-native` outputs are now byte-identical, so `copyJSFiles.cjs` collapses from three transforms (ESM-compat strip, Node-read no-op, CommonJS export rewrite) down to a single CommonJS `export default` -> `module.exports` rewrite. A single physical file is not possible because `export default` is static ESM-only syntax that cannot be conditionally emitted under `"type": "commonjs"`.

Note: `crc64.js` is generated code, so these edits are intentionally surgical and confined to removing provably-dead branches; the CRC computation path and the embedded wasm bytes are untouched.

### Are there test cases added in this PR? _(If not, why?)_

No automated tests are added. `storage-common` has no direct unit tests for `crc64.js` (it is exercised indirectly via the structured-message/CRC paths in `storage-blob`). The change was validated manually against the built `dist`:

- All four variants (`esm`, `commonjs`, `browser`, `react-native`) compute the correct CRC64 for bytes `[1..10]` => `254,76,247,68,98,30,20,6`.
- All four variants contain 0 occurrences of `import.meta`, `require(`, or `node:`.
- `esm` == `browser` == `react-native` are byte-identical.
- An ESM consumer of `dist/esm/crc64.js` bundled with esbuild to CommonJS (`--platform=node`) now builds and runs correctly (the original #39057 crash is gone).
- `pnpm lint` (0 errors), `pnpm test:node` (9/9 pass), and the full package build are green.

### Provide a list of related PRs _(if any)_

Related prior fixes: #38924, and earlier CRC64 module-system fixes referenced in the 12.4.0 changelog (#38069, #38501).

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)