### PR TITLE
[EventGrid] Set release date for eventgrid-systemevents 1.0.3

### DIFF
--- a/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.3 (Unreleased)
+## 1.0.3 (2026-06-25)
 
 ### Bugs Fixed
 


### PR DESCRIPTION
Sets the release date for `@azure/eventgrid-systemevents` **1.0.3** so the release pipeline's `Verify-ChangeLogEntry` check passes (it requires a `yyyy-MM-dd` date and rejects `(Unreleased)`).

### Change
- CHANGELOG.md: `## 1.0.3 (Unreleased)` -> `## 1.0.3 (2026-06-25)`