### PR TITLE
[ai-projects] Use agent_reference instead of deprecated agent property in tests

### DIFF
--- a/sdk/ai/ai-projects/assets.json
+++ b/sdk/ai/ai-projects/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/ai/ai-projects",
-  "Tag": "js/ai/ai-projects_99bbc79fc3"
+  "Tag": "js/ai/ai-projects_dab5f2123e"
 }

--- a/sdk/ai/ai-projects/assets.json
+++ b/sdk/ai/ai-projects/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/ai/ai-projects",
-  "Tag": "js/ai/ai-projects_dab5f2123e"
+  "Tag": "js/ai/ai-projects_3a6576c351"
 }

--- a/sdk/ai/ai-projects/assets.json
+++ b/sdk/ai/ai-projects/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "js",
   "TagPrefix": "js/ai/ai-projects",
-  "Tag": "js/ai/ai-projects_044bfba6b9"
+  "Tag": "js/ai/ai-projects_99bbc79fc3"
 }

--- a/sdk/ai/ai-projects/test/public/agents/agentToAgent.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/agentToAgent.spec.ts
@@ -50,7 +50,7 @@ describe("agents - agent-to-agent (A2A)", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/agents.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/agents.spec.ts
@@ -89,7 +89,7 @@ describe("agents - conversation flow", () => {
         conversation: conversation.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
     assert.isNotNull(franceResponse);
@@ -108,7 +108,7 @@ describe("agents - conversation flow", () => {
         conversation: conversation.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
     assert.isNotNull(capitalResponse);

--- a/sdk/ai/ai-projects/test/public/agents/aiSearch.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/aiSearch.spec.ts
@@ -109,7 +109,7 @@ describe("agents - ai search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -143,7 +143,7 @@ describe("agents - ai search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -208,7 +208,7 @@ describe("agents - ai search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/bingCustomSearch.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/bingCustomSearch.spec.ts
@@ -112,7 +112,7 @@ describe("agents - bing custom search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -147,7 +147,7 @@ describe("agents - bing custom search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -244,7 +244,7 @@ describe("agents - bing custom search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/bingGrounding.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/bingGrounding.spec.ts
@@ -108,7 +108,7 @@ describe("agents - bing grounding - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -142,7 +142,7 @@ describe("agents - bing grounding - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -237,7 +237,7 @@ describe("agents - bing grounding - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/fabric.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/fabric.spec.ts
@@ -55,7 +55,7 @@ describe("agents - fabric tool", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/fabricIQ.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/fabricIQ.spec.ts
@@ -50,7 +50,7 @@ describe("agents - fabric IQ tool", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/functionTool.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/functionTool.spec.ts
@@ -115,7 +115,7 @@ describe("agents - function tool - execution flow", () => {
         ],
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
     assert.isNotNull(response);
@@ -151,7 +151,7 @@ describe("agents - function tool - execution flow", () => {
         previous_response_id: response.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 
@@ -189,7 +189,7 @@ describe("agents - function tool - execution flow", () => {
         conversation: conversation.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
     assert.isNotNull(response);
@@ -225,7 +225,7 @@ describe("agents - function tool - execution flow", () => {
         input: inputList,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 

--- a/sdk/ai/ai-projects/test/public/agents/mcp.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/mcp.spec.ts
@@ -60,7 +60,7 @@ describe("agents - mcp tool", () => {
         input: "Please summarize the Azure REST API specifications Readme",
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 
@@ -90,7 +90,7 @@ describe("agents - mcp tool", () => {
         previous_response_id: response.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 
@@ -138,7 +138,7 @@ describe("agents - mcp tool", () => {
         input: "What is my username in Github profile?",
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 
@@ -168,7 +168,7 @@ describe("agents - mcp tool", () => {
         previous_response_id: response.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 

--- a/sdk/ai/ai-projects/test/public/agents/memorySearch.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/memorySearch.spec.ts
@@ -105,7 +105,7 @@ describe("agents - memory search tool", () => {
         conversation: conversation.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 

--- a/sdk/ai/ai-projects/test/public/agents/sharepoint.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/sharepoint.spec.ts
@@ -59,7 +59,7 @@ describe("agents - sharepoint tool", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
         },
       },
     );

--- a/sdk/ai/ai-projects/test/public/agents/structureOutput.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/structureOutput.spec.ts
@@ -116,7 +116,7 @@ describe("agents - structured output - execution flow", () => {
         ],
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
     assert.isNotNull(response);
@@ -172,7 +172,7 @@ describe("agents - structured output - execution flow", () => {
         conversation: conversation.id,
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
     assert.isNotNull(response);

--- a/sdk/ai/ai-projects/test/public/agents/webSearch.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/webSearch.spec.ts
@@ -101,7 +101,7 @@ describe("agents - web search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -135,7 +135,7 @@ describe("agents - web search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -200,7 +200,7 @@ describe("agents - web search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/agents/workflow.spec.ts
+++ b/sdk/ai/ai-projects/test/public/agents/workflow.spec.ts
@@ -155,7 +155,7 @@ trigger:
       },
       {
         body: {
-          agent: { name: workflow.name, type: "agent_reference" },
+          agent_reference: { name: workflow.name, type: "agent_reference" },
           metadata: { "x-ms-debug-mode-enabled": "1" },
         },
       },

--- a/sdk/ai/ai-projects/test/public/node/agents/computerUse.spec.ts
+++ b/sdk/ai/ai-projects/test/public/node/agents/computerUse.spec.ts
@@ -95,7 +95,7 @@ Be direct and efficient. When you reach the search results page, read and descri
         truncation: "auto",
       },
       {
-        body: { agent: { name: agent.name, type: "agent_reference" } },
+        body: { agent_reference: { name: agent.name, type: "agent_reference" } },
       },
     );
 
@@ -146,7 +146,7 @@ Be direct and efficient. When you reach the search results page, read and descri
           truncation: "auto",
         },
         {
-          body: { agent: { name: agent.name, type: "agent_reference" } },
+          body: { agent_reference: { name: agent.name, type: "agent_reference" } },
         },
       );
       console.log(`Follow-up response ID: ${response.id}`);

--- a/sdk/ai/ai-projects/test/public/node/agents/fileSearch.spec.ts
+++ b/sdk/ai/ai-projects/test/public/node/agents/fileSearch.spec.ts
@@ -140,7 +140,7 @@ describe("agents - file search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -198,7 +198,7 @@ describe("agents - file search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },
@@ -287,7 +287,7 @@ describe("agents - file search - execution flow", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
           tool_choice: "required",
         },
       },

--- a/sdk/ai/ai-projects/test/public/node/agents/imageGeneration.spec.ts
+++ b/sdk/ai/ai-projects/test/public/node/agents/imageGeneration.spec.ts
@@ -58,7 +58,7 @@ describe("agents - image generation tool", () => {
       },
       {
         body: {
-          agent: { name: agent.name, type: "agent_reference" },
+          agent_reference: { name: agent.name, type: "agent_reference" },
         },
         headers: { "x-ms-oai-image-generation-deployment": imageDeploymentName },
       },


### PR DESCRIPTION
## Summary
The Foundry service now rejects the `agent` property on `openAIClient.responses.create(...)` with a 400:

> `The 'agent' property is deprecated. Use 'agent_reference' instead.`

This renames the outer request-body key from `agent` to `agent_reference` across the ai-projects agent spec files, matching the already-migrated `samples-dev` usage. The inner discriminator `type: "agent_reference"` is unchanged.

## Changes
- Renamed `body: { agent: { ... } }` → `body: { agent_reference: { ... } }` in 17 spec files (36 call sites).
- Excluded `snippets.spec.ts` (documentation source) and `tracing/overwriteOpenAIClient.spec.ts` (mock-based; the SDK's tracing detection already handles both keys).

## Verification
`npm run test` (TEST_MODE=live): the `'agent' property is deprecated` 400 dropped from many occurrences to **0**. Tests that previously failed solely on this error now pass. Remaining failures are unrelated environment/connection issues (missing/invalid Foundry connections, 500s) out of scope here.

## Follow-up
Test recordings in `Azure/azure-sdk-assets` will need re-recording + asset-sync push, since the default recorder matcher matches on request body and the payload key changed.