### PR TITLE
fix(ts-http-runtime): make proxyPolicy a no-op when proxy is unsupported

### DIFF
--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Other Changes
 
+- `proxyPolicy` no longer throws on platforms where proxies are not supported (such as browsers and React Native). Instead, it returns a no-op policy that forwards requests unchanged, and `getDefaultProxySettings` returns `undefined`.
 - Removed the internal `randomUUID` polyfill for Node.js and browsers, relying on `globalThis.crypto.randomUUID()` which is available on those platforms. React Native keeps a `Math.random()` based fallback since its JS engines do not provide `crypto.randomUUID()`.
 
 ## 0.3.6 (2026-06-04)

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-browser.api.diff.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-browser.api.diff.md
@@ -25,7 +25,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
 -// @public @deprecated
 -export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | undefined;
-+// @public (undocumented)
++// @public
 +export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined;
  
  // @public

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-browser.api.diff.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-browser.api.diff.md
@@ -18,14 +18,12 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export function defaultRetryPolicy(options?: DefaultRetryPolicyOptions): PipelinePolicy;
-@@ -44,10 +44,10 @@
- 
+@@ -45,9 +45,9 @@
  // @public
  export const formDataPolicyName = "formDataPolicy";
  
--// @public @deprecated
+ // @public @deprecated
 -export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | undefined;
-+// @public
 +export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined;
  
  // @public

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-react-native.api.diff.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-react-native.api.diff.md
@@ -25,7 +25,7 @@ For the complete API surface, see the corresponding -node.api.md file.
  
 -// @public @deprecated
 -export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | undefined;
-+// @public (undocumented)
++// @public
 +export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined;
  
  // @public

--- a/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-react-native.api.diff.md
+++ b/sdk/core/ts-http-runtime/review/ts-http-runtime-internal-policies-react-native.api.diff.md
@@ -18,14 +18,12 @@ For the complete API surface, see the corresponding -node.api.md file.
  
  // @public
  export function defaultRetryPolicy(options?: DefaultRetryPolicyOptions): PipelinePolicy;
-@@ -44,10 +44,10 @@
- 
+@@ -45,9 +45,9 @@
  // @public
  export const formDataPolicyName = "formDataPolicy";
  
--// @public @deprecated
+ // @public @deprecated
 -export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | undefined;
-+// @public
 +export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined;
  
  // @public

--- a/sdk/core/ts-http-runtime/src/policies/proxyPolicy.common.ts
+++ b/sdk/core/ts-http-runtime/src/policies/proxyPolicy.common.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { PipelineRequest, PipelineResponse, ProxySettings, SendRequest } from "../interfaces.js";
+import type {
+  PipelineRequest,
+  PipelineResponse,
+  ProxySettings,
+  SendRequest,
+} from "../interfaces.js";
 import type { PipelinePolicy } from "../pipeline.js";
 
 export const proxyPolicyName = "proxyPolicy";
@@ -9,6 +14,7 @@ export const proxyPolicyName = "proxyPolicy";
 /**
  * Proxy settings are not supported outside of Node.js, so there are no
  * settings to retrieve in this environment.
+ * @deprecated - Internally this method is no longer necessary when setting proxy information.
  */
 export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined {
   return undefined;

--- a/sdk/core/ts-http-runtime/src/policies/proxyPolicy.common.ts
+++ b/sdk/core/ts-http-runtime/src/policies/proxyPolicy.common.ts
@@ -1,19 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { ProxySettings } from "../interfaces.js";
+import type { PipelineRequest, PipelineResponse, ProxySettings, SendRequest } from "../interfaces.js";
 import type { PipelinePolicy } from "../pipeline.js";
 
 export const proxyPolicyName = "proxyPolicy";
-const errorMessage = "proxyPolicy is not supported in browser environment";
 
+/**
+ * Proxy settings are not supported outside of Node.js, so there are no
+ * settings to retrieve in this environment.
+ */
 export function getDefaultProxySettings(_proxyUrl?: string): ProxySettings | undefined {
-  throw new Error(errorMessage);
+  return undefined;
 }
 
 /**
- * proxyPolicy is not supported in the browser and attempting
- * to use it will raise an error.
+ * proxyPolicy is not supported outside of Node.js. To avoid breaking pipelines
+ * that include it on unsupported platforms, this implementation returns a
+ * no-op policy that simply forwards the request to the next policy.
  */
 export function proxyPolicy(
   _proxySettings?: ProxySettings,
@@ -21,15 +25,20 @@ export function proxyPolicy(
     customNoProxyList?: string[];
   },
 ): PipelinePolicy {
-  throw new Error(errorMessage);
+  return {
+    name: proxyPolicyName,
+    sendRequest(request: PipelineRequest, next: SendRequest): Promise<PipelineResponse> {
+      // Proxy is not supported outside of Node.js, so do nothing.
+      return next(request);
+    },
+  };
 }
 
 /**
  * A function to reset the cached agents.
- * proxyPolicy is not supported in the browser and attempting
- * to use it will raise an error.
+ * proxyPolicy is not supported outside of Node.js, so this is a no-op.
  * @internal
  */
 export function resetCachedProxyAgents(): void {
-  throw new Error(errorMessage);
+  // Proxy is not supported outside of Node.js, so there is nothing to reset.
 }

--- a/sdk/core/ts-http-runtime/test/internal/browser/proxyPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/browser/proxyPolicy.spec.ts
@@ -5,9 +5,8 @@ import { describe, it, assert } from "vitest";
 import { proxyPolicy } from "../../../src/policies/internal.js";
 
 describe("proxyPolicy (browser)", function () {
-  it("Throws on creation", function () {
-    assert.throws(() => {
-      proxyPolicy();
-    }, /proxyPolicy is not supported in browser environment/);
+  it("returns a no-op policy", function () {
+    const policy = proxyPolicy();
+    assert.strictEqual(policy.name, "proxyPolicy");
   });
 });

--- a/sdk/core/ts-http-runtime/test/internal/react-native/proxyPolicy.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/react-native/proxyPolicy.spec.ts
@@ -5,9 +5,8 @@ import { describe, it, assert } from "vitest";
 import { proxyPolicy } from "../../../src/policies/internal.js";
 
 describe("proxyPolicy (react-native)", function () {
-  it("Throws on creation", function () {
-    assert.throws(() => {
-      proxyPolicy();
-    }, /proxyPolicy is not supported in browser environment/);
+  it("returns a no-op policy", function () {
+    const policy = proxyPolicy();
+    assert.strictEqual(policy.name, "proxyPolicy");
   });
 });


### PR DESCRIPTION
## Why

On non-Node.js platforms (browser, React Native), `ts-http-runtime`'s `proxyPolicy` threw an error on creation. Any pipeline that unconditionally added the proxy policy would break in those environments, even when the caller had no intention of using a proxy. Proxies are simply not supported on those platforms, so attempting to configure one should be harmless rather than fatal.

## What

The non-Node implementation in `proxyPolicy.common.ts` (used by browser and React Native via `proxyPolicy-web.mts`) no longer throws:

- `proxyPolicy` returns a no-op `PipelinePolicy` that forwards the request to the next policy unchanged.
- `getDefaultProxySettings` returns `undefined` instead of throwing.
- `resetCachedProxyAgents` is a no-op.

Each is commented to explain that proxies are unsupported outside Node.js. The Node implementation is untouched.

## Tests

Updated the browser and React Native `proxyPolicy` specs to assert the no-op policy is returned (with name `proxyPolicy`) instead of expecting a throw. `pnpm turbo build lint` passes and the browser spec passes. The build also regenerated the two API diff review files to reflect the now-documented `getDefaultProxySettings`.