### PR TITLE
[identity] Place workerd export before browser in warp.config.yml

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -124,13 +124,13 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
-      },
       "workerd": {
         "types": "./dist/workerd/index.d.ts",
         "default": "./dist/workerd/index.js"
+      },
+      "browser": {
+        "types": "./dist/browser/index.d.ts",
+        "default": "./dist/browser/index.js"
       },
       "import": {
         "types": "./dist/esm/index.d.ts",

--- a/sdk/identity/identity/warp.config.yml
+++ b/sdk/identity/identity/warp.config.yml
@@ -3,11 +3,11 @@
 extends: ../../../warp.base.config.yml
 
 targets:
-  - name: browser
-    tsconfig: "./config/tsconfig.src.browser.json"
-
   - name: workerd
     tsconfig: "./config/tsconfig.src.workerd.json"
+
+  - name: browser
+    tsconfig: "./config/tsconfig.src.browser.json"
 
   - name: esm
     condition: import


### PR DESCRIPTION
### Packages impacted by this PR

@azure/identity

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

When the `warp` build was introduced, the order of the conditional exports in `package.json` regressed: `browser` ended up listed before `workerd`. Conditional export order is significant because resolvers pick the first matching condition, so `workerd` runtimes could incorrectly resolve the `browser` entry. The export order is generated from the `targets` order in `warp.config.yml`, where `browser` was declared first.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The export order is driven by the `targets` list in `warp.config.yml`. Reordering the targets so `workerd` comes before `browser` and regenerating `package.json` restores the original, correct ordering at the source of truth rather than hand-editing generated output.

### Are there test cases added in this PR? _(If not, why?)_

No. This is a build-configuration ordering fix with no runtime logic change; it is verified by the regenerated `package.json` exports.

### Provide a list of related PRs _(if any)_

N/A

### Checklists
- [x] Added impacted package name to the issue description.
- [ ] Does this PR need any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here.)_
- [ ] Added a changelog (if necessary).