### PR TITLE
Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs Fixed
 
+- Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk.
 - Refuse to follow server-issued 307/308 redirects whose `Location` header points outside the configured ingestion host or the known Azure Monitor / Application Insights ingestion domain suffixes. Previously a single attacker-controlled redirect could permanently re-point the exporter at a foreign host, causing every subsequent telemetry call (and the AAD bearer token attached by the auth policy) to be sent to the attacker.
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -106,7 +106,7 @@ export abstract class BaseSender {
     this.persister = new FileSystemPersist(
       options.instrumentationKey,
       options.exporterOptions,
-      this.customerSDKStatsMetrics,
+      () => this.customerSDKStatsMetrics,
     );
     this.retryTimer = null;
     this.isStatsbeatSender = options.isStatsbeatSender || false;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/persist/fileSystemPersist.ts
@@ -35,7 +35,7 @@ export class FileSystemPersist implements PersistentStorage {
   constructor(
     instrumentationKey: string,
     private _options?: AzureMonitorExporterOptions,
-    private _customerSDKStatsMetrics?: CustomerSDKStatsMetrics,
+    private _customerSDKStatsMetricsProvider?: () => CustomerSDKStatsMetrics | undefined,
   ) {
     this._instrumentationKey = instrumentationKey;
     if (this._options?.disableOfflineStorage) {
@@ -154,7 +154,10 @@ export class FileSystemPersist implements PersistentStorage {
     } catch (error: any) {
       // Check if error is due to permission/readonly issues
       if (error?.code === "EACCES" || error?.code === "EPERM") {
-        this._customerSDKStatsMetrics?.countDroppedItems(envelopes, DropCode.CLIENT_READONLY);
+        this._customerSDKStatsMetricsProvider?.()?.countDroppedItems(
+          envelopes,
+          DropCode.CLIENT_READONLY,
+        );
         diag.warn(
           `Permission denied while checking/creating directory: ${this._tempDirectory}`,
           error?.message,
@@ -169,7 +172,7 @@ export class FileSystemPersist implements PersistentStorage {
       const size = await getShallowDirectorySize(this._tempDirectory);
       if (size > this.maxBytesOnDisk) {
         // If the directory size exceeds the max limit, we send customer SDK Stats and warn the user
-        this._customerSDKStatsMetrics?.countDroppedItems(
+        this._customerSDKStatsMetricsProvider?.()?.countDroppedItems(
           envelopes,
           DropCode.CLIENT_PERSISTENCE_CAPACITY,
         );
@@ -201,7 +204,7 @@ export class FileSystemPersist implements PersistentStorage {
       }
     } catch (writeError: any) {
       // If the envelopes cannot be written to disk, we send customer SDK Stats and warn the user
-      this._customerSDKStatsMetrics?.countDroppedItems(
+      this._customerSDKStatsMetricsProvider?.()?.countDroppedItems(
         envelopes,
         DropCode.CLIENT_EXCEPTION,
         writeError?.message,

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/fileSystemPersist.spec.ts
@@ -424,7 +424,7 @@ describe("FileSystemPersist", () => {
     });
 
     it("should have CLIENT_READONLY logic implemented", () => {
-      const persister = new FileSystemPersist(instrumentationKey, {}, mockCustomerSDKStats);
+      const persister = new FileSystemPersist(instrumentationKey, {}, () => mockCustomerSDKStats);
       expect(persister).toBeDefined();
       expect(DropCode.CLIENT_READONLY).toBeDefined();
 
@@ -448,7 +448,7 @@ describe("FileSystemPersist", () => {
         .spyOn(helpersMod, "confirmDirExists")
         .mockRejectedValue(error);
 
-      const persister = new FileSystemPersist(instrumentationKey, {}, mockCustomerSDKStats);
+      const persister = new FileSystemPersist(instrumentationKey, {}, () => mockCustomerSDKStats);
 
       const result = await persister.push([envelope]);
 


### PR DESCRIPTION
### Packages impacted by this PR
`@azure/monitor-opentelemetry-exporter`

### Issues associated with this PR
None

### Describe the problem that is addressed by this PR
Customer SDK Stats were not counting telemetry that gets dropped while saving to disk. In the BaseSender class, the customerSDKStatsMetrics field is initialized through an asynchronous dynamic import (import().then()), which resolves on a later microtask. But the FileSystemPersist object is constructed synchronously right after, so it captured the still-undefined value by value. Even after the import resolved and customerSDKStatsMetrics was assigned, the persister's reference never updated.

As a result, the three drop paths in FileSystemPersist (CLIENT_READONLY, CLIENT_PERSISTENCE_CAPACITY, and STORAGE_EXCEPTION) silently did nothing, so dropped telemetry was undercounted in customer SDK Stats.

### Are there test cases added in this PR? _(If not, why?)
Existing [fileSystemPersist.spec.ts] tests were updated to the new provider signature and continue to cover the [CLIENT_READONLY] drop path.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [x] Added a changelog (if necessary)
