### PR TITLE
fix: retry CBS token renewal after a failed renewal (#38467)

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Read `com.microsoft:max-message-batch-size` vendor property from the AMQP sender link to correctly limit batch size on Premium large-message entities, where `max-message-size` can be up to 100 MB but the batch limit is 1 MB.
 - Fixed `TimeoutNegativeWarning` on Node.js v24+ when timeout budget is exceeded during CBS authentication by clamping remaining-time computations to a minimum of 0. [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
+- Fixed CBS token renewal stopping permanently after a single failed renewal. A transient credential error (for example a failed AAD `getToken` during a workload-identity rotation) no longer leaves the link's token un-renewed; renewal now retries with a capped exponential backoff until it succeeds or the link closes. [#38467](https://github.com/Azure/azure-sdk-for-js/issues/38467)
 
 ### Other Changes
 

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -26,6 +26,19 @@ import type { ServiceBusLogger } from "../log.js";
 import { ServiceBusError } from "../serviceBusError.js";
 
 /**
+ * The base delay (in milliseconds) before retrying a failed CBS token renewal.
+ * The delay doubles on each consecutive failure, capped at
+ * {@link maxTokenRenewalRetryDelayInMs}.
+ * @internal
+ */
+const tokenRenewalRetryBaseDelayInMs = 3000;
+/**
+ * The maximum delay (in milliseconds) between CBS token renewal retries.
+ * @internal
+ */
+const maxTokenRenewalRetryDelayInMs = 60000;
+
+/**
  * @internal
  * Options passed to the constructor of LinkEntity
  */
@@ -139,6 +152,11 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
    * the Client Entity is due for token renewal.
    */
   private _tokenRenewalTimer?: NodeJS.Timeout;
+  /**
+   * The number of consecutive failed token renewal attempts. Drives the retry
+   * backoff and is reset to 0 after a successful renewal or when the link closes.
+   */
+  private _tokenRenewalRetryCount = 0;
   /**
    * Indicates token timeout
    */
@@ -345,6 +363,7 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
 
     clearTimeout(this._tokenRenewalTimer as NodeJS.Timeout);
     this._tokenRenewalTimer = undefined;
+    this._tokenRenewalRetryCount = 0;
 
     if (this._link) {
       try {
@@ -516,10 +535,73 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
   }
 
   /**
+   * Renews the CBS token once. On success the next renewal is scheduled at the
+   * full margin (via `_negotiateClaim`) and the retry backoff is reset. On
+   * failure the renewal is re-armed with an exponential, capped backoff so a
+   * transient credential error (for example a failed AAD getToken during
+   * workload-identity rotation) self-heals instead of permanently stopping
+   * renewal. This mirrors the proactive-renewal behavior of the Go and Java
+   * Service Bus SDKs.
+   */
+  private async _renewToken(): Promise<void> {
+    try {
+      await this._negotiateClaim({
+        setTokenRenewal: true,
+        abortSignal: undefined,
+        timeoutInMs: Constants.defaultOperationTimeoutInMs,
+      });
+      // A successful renewal reschedules the next renewal at the full margin
+      // (via `_negotiateClaim` -> `_ensureTokenRenewal`), so reset the backoff.
+      this._tokenRenewalRetryCount = 0;
+    } catch (err: any) {
+      this._logger.logError(
+        err,
+        "%s %s '%s' with address %s, an error occurred while renewing the token",
+        this.logPrefix,
+        this._type,
+        this.name,
+        this.address,
+      );
+      // Re-arm the renewal on failure so renewal keeps retrying instead of
+      // stopping after a single error. Back off exponentially, capped at
+      // `maxTokenRenewalRetryDelayInMs`. There is intentionally no maximum retry
+      // count: a transient credential failure can take a while to clear (for
+      // example a workload-identity rotation completing), and giving up would
+      // leave the token permanently un-renewed - the failure this retry loop
+      // exists to prevent (issue #38467).
+      // Retries are bounded by the link lifetime instead - `closeLinkImpl`
+      // clears the timer and resets the counter. The counter only drives the
+      // backoff, so its unbounded growth is harmless (`Math.min` caps the delay).
+      const retryDelayInMs = Math.min(
+        tokenRenewalRetryBaseDelayInMs * 2 ** this._tokenRenewalRetryCount,
+        maxTokenRenewalRetryDelayInMs,
+      );
+      this._tokenRenewalRetryCount++;
+      this._logger.verbose(
+        "%s %s '%s' with address %s, retrying token renewal in %d milliseconds (attempt %d).",
+        this.logPrefix,
+        this._type,
+        this.name,
+        this.address,
+        retryDelayInMs,
+        this._tokenRenewalRetryCount,
+      );
+      this._ensureTokenRenewal(retryDelayInMs);
+    }
+  }
+
+  /**
    * Ensures that the token is renewed within the predefined renewal margin.
    */
-  private _ensureTokenRenewal(): void {
-    if (!this._tokenTimeout) {
+  private _ensureTokenRenewal(nextRenewalTimeoutInMs?: number): void {
+    // A renewal that is still in flight when `close()` runs would otherwise
+    // schedule a fresh timer here, after `closeLinkImpl` already cleared one,
+    // leaving a self-refiring timer on a permanently closed link.
+    if (this._wasClosedPermanently) {
+      return;
+    }
+    const renewalTimeoutInMs = nextRenewalTimeoutInMs ?? this._tokenTimeout;
+    if (!renewalTimeoutInMs) {
       return;
     }
     // Clear the existing token renewal timer.
@@ -528,32 +610,17 @@ export abstract class LinkEntity<LinkT extends Receiver | AwaitableSender | Requ
     if (this._tokenRenewalTimer) {
       clearTimeout(this._tokenRenewalTimer);
     }
-    this._tokenRenewalTimer = setTimeout(async () => {
-      try {
-        await this._negotiateClaim({
-          setTokenRenewal: true,
-          abortSignal: undefined,
-          timeoutInMs: Constants.defaultOperationTimeoutInMs,
-        });
-      } catch (err: any) {
-        this._logger.logError(
-          err,
-          "%s %s '%s' with address %s, an error occurred while renewing the token",
-          this.logPrefix,
-          this._type,
-          this.name,
-          this.address,
-        );
-      }
-    }, this._tokenTimeout);
+    this._tokenRenewalTimer = setTimeout(() => {
+      void this._renewToken();
+    }, renewalTimeoutInMs);
     this._logger.verbose(
       "%s %s '%s' with address %s, has next token renewal in %d milliseconds @(%s).",
       this.logPrefix,
       this._type,
       this.name,
       this.address,
-      this._tokenTimeout,
-      new Date(Date.now() + this._tokenTimeout).toString(),
+      renewalTimeoutInMs,
+      new Date(Date.now() + renewalTimeoutInMs).toString(),
     );
   }
 }

--- a/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts
@@ -485,6 +485,140 @@ describe("LinkEntity unit tests", () => {
     }
   });
 
+  describe("token renewal (issue #38467)", () => {
+    it("retries a failed token renewal with backoff instead of stopping", async () => {
+      await linkEntity.initLink({});
+      // Drop the renewal timer armed by init so it cannot fire during the test.
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+
+      linkEntity["_negotiateClaim"] = async () => {
+        throw new Error("simulated token renewal failure");
+      };
+
+      // Drive a single renewal attempt. Before the fix the renewal chain stopped
+      // after a failure; now it must increment the retry counter and re-arm.
+      await linkEntity["_renewToken"]();
+      assert.equal(
+        linkEntity["_tokenRenewalRetryCount"],
+        1,
+        "the retry counter should increment after a failed renewal",
+      );
+      assert.exists(
+        linkEntity["_tokenRenewalTimer"],
+        "the renewal timer should be re-armed after a failed renewal (issue #38467)",
+      );
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+
+      // A second failure keeps backing off rather than stopping.
+      await linkEntity["_renewToken"]();
+      assert.equal(
+        linkEntity["_tokenRenewalRetryCount"],
+        2,
+        "the retry counter should keep incrementing across consecutive failures",
+      );
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+    });
+
+    it("resets the retry backoff after a successful renewal", async () => {
+      await linkEntity.initLink({});
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+
+      let shouldFail = true;
+      linkEntity["_negotiateClaim"] = async (props: any) => {
+        if (shouldFail) {
+          throw new Error("simulated token renewal failure");
+        }
+        // Mimic the real success path, which re-arms the renewal timer.
+        if (props?.setTokenRenewal) {
+          linkEntity["_ensureTokenRenewal"]();
+        }
+      };
+
+      // First renewal fails -> retry counter is now 1.
+      await linkEntity["_renewToken"]();
+      assert.equal(linkEntity["_tokenRenewalRetryCount"], 1);
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+
+      // A subsequent successful renewal resets the retry counter.
+      shouldFail = false;
+      await linkEntity["_renewToken"]();
+      assert.equal(
+        linkEntity["_tokenRenewalRetryCount"],
+        0,
+        "the retry counter should reset after a successful renewal",
+      );
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+    });
+
+    it("backs off exponentially and caps the retry delay", async () => {
+      await linkEntity.initLink({});
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+      linkEntity["_negotiateClaim"] = async () => {
+        throw new Error("simulated token renewal failure");
+      };
+
+      // Capture the delay the failed renewal re-arms with, then let the real
+      // implementation run so the backoff state advances.
+      const delays: number[] = [];
+      const ensureTokenRenewal = linkEntity["_ensureTokenRenewal"].bind(linkEntity);
+      linkEntity["_ensureTokenRenewal"] = (nextRenewalTimeoutInMs?: number): void => {
+        if (nextRenewalTimeoutInMs !== undefined) {
+          delays.push(nextRenewalTimeoutInMs);
+        }
+        ensureTokenRenewal(nextRenewalTimeoutInMs);
+      };
+
+      for (let i = 0; i < 7; i++) {
+        await linkEntity["_renewToken"]();
+      }
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+
+      // Base 3000 ms doubling each attempt, capped at 60000 ms.
+      assert.deepEqual(delays.slice(0, 6), [3000, 6000, 12000, 24000, 48000, 60000]);
+      assert.equal(delays[6], 60000, "the retry delay should stay capped at the maximum");
+    });
+
+    it("resets the retry counter when the link is permanently closed", async () => {
+      await linkEntity.initLink({});
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+      linkEntity["_negotiateClaim"] = async () => {
+        throw new Error("simulated token renewal failure");
+      };
+
+      await linkEntity["_renewToken"]();
+      assert.equal(linkEntity["_tokenRenewalRetryCount"], 1);
+
+      await linkEntity.close();
+      assert.equal(
+        linkEntity["_tokenRenewalRetryCount"],
+        0,
+        "closing the link should reset the retry counter",
+      );
+      assert.notExists(
+        linkEntity["_tokenRenewalTimer"],
+        "closing the link should clear the renewal timer",
+      );
+    });
+
+    it("does not re-arm renewal after the link is permanently closed", async () => {
+      await linkEntity.initLink({});
+      clearTimeout(linkEntity["_tokenRenewalTimer"] as NodeJS.Timeout);
+      linkEntity["_tokenRenewalTimer"] = undefined;
+      linkEntity["_negotiateClaim"] = async () => {
+        throw new Error("simulated token renewal failure");
+      };
+
+      // Mimic a renewal still in flight when close() set the permanent-close flag.
+      linkEntity["_wasClosedPermanently"] = true;
+      await linkEntity["_renewToken"]();
+
+      assert.notExists(
+        linkEntity["_tokenRenewalTimer"],
+        "a renewal completing after permanent close must not re-arm the timer (issue #38467)",
+      );
+    });
+  });
+
   function assertLinkEntityOpen(): void {
     assert.isTrue(linkEntity.isOpen(), "link should be open");
     assert.exists(linkEntity["_tokenRenewalTimer"], "the tokenrenewal timer should have been set");


### PR DESCRIPTION
Addresses #38467.

## Problem

`LinkEntity._ensureTokenRenewal` scheduled CBS token renewal with a one-shot
`setTimeout`. The renewal callback caught any error from `_negotiateClaim` (for
example a failed AAD `getToken` during a workload-identity rotation) and only
logged it; it never rescheduled. After a single failed renewal the renewal chain
stopped permanently, so the link's token was never refreshed again and the link
was eventually left running on a stale credential.

This is the proactive-renewal model JS shares with the Go and Java Service Bus
SDKs, where a renewal failure reschedules instead of stopping.

## Fix

Re-arm the renewal on failure with a capped exponential backoff so a transient
credential error self-heals instead of permanently stopping renewal.

- Extract the renewal into `_renewToken()`. On success it reschedules at the full
  margin (via `_negotiateClaim`) and resets the backoff; on failure it re-arms
  with `Math.min(3000 * 2 ** count, 60000)` ms backoff.
- Reset the retry counter on a successful renewal and on link close
  (`closeLinkImpl`).
- No maximum retry count: a transient failure can take a while to clear, and
  giving up would leave the token un-renewed. Retries are bounded by the link
  lifetime.
- Guard `_ensureTokenRenewal` with `_wasClosedPermanently` so a renewal
  completing concurrently with `close()` cannot arm a self-refiring timer on a
  permanently-closed link.

No public API surface change (all changed members are private or `@internal`).

## Testing

- 5 new `LinkEntity` unit tests: re-arm plus counter increment across consecutive
  failures, counter reset after a successful renewal, exponential backoff with the
  60000 ms cap, counter reset on link close, and no re-arm after permanent close.
  `LinkEntity` suite 25/25.
- Full `@azure/service-bus` unit suite: 379 passed, 6 skipped (baseline), 0 failed.
- prettier clean; eslint 0 errors; tsc build passes.
- Live validation against a real Standard namespace (identity auth): a wrapper
  credential fires renewal early, fails for a window, then recovers. The fixed
  build re-armed 4 times with backoff 3000/6000/12000/24000 ms, recovered,
  rescheduled at the full margin, and delivered messages before and after the
  failure window. Run as a contrast, the published 7.9.5 build made exactly one
  renewal attempt and then stopped (the current behavior).

## What changed

- `sdk/servicebus/service-bus/src/core/linkEntity.ts`
- `sdk/servicebus/service-bus/test/internal/unit/linkentity.unittest.spec.ts`
- `sdk/servicebus/service-bus/CHANGELOG.md`
