### PR TITLE
Log signal and spawn error in ci-runner spawnWithLog for better CI failure diagnostics

### DIFF
--- a/eng/tools/ci-runner/src/spawn.js
+++ b/eng/tools/ci-runner/src/spawn.js
@@ -19,9 +19,29 @@ function isWindows() {
 function spawnWithLog(cmd, cwd, ...args) {
   console.log(`Executing: "${cmd} ${args.join(" ")}" in ${cwd}\n\n`);
   const proc = spawnSync(cmd, args, { cwd, stdio: "inherit", shell: isWindows() });
-  console.log(`\n\n${cmd} exited with code ${proc.status} `);
 
-  return proc.status ?? 1;
+  if (proc.error) {
+    console.error(`\n\nFailed to spawn ${cmd}: ${proc.error.stack ?? proc.error.message}`);
+  }
+
+  if (proc.signal) {
+    console.error(`\n\n${cmd} was terminated by signal ${proc.signal}`);
+    if (proc.signal === "SIGKILL") {
+      console.error(
+        `SIGKILL is likely an out-of-memory kill. Check the agent's available memory or reduce parallelism (e.g. turbo --concurrency).`,
+      );
+    }
+  }
+
+  console.log(`\n\n${cmd} exited with code ${proc.status}, signal ${proc.signal ?? "none"} `);
+
+  if (typeof proc.status === "number") {
+    return proc.status;
+  }
+
+  // No numeric status means the process was killed by a signal or failed to
+  // spawn; never report success in that case.
+  return 1;
 }
 
 /**

--- a/eng/tools/ci-runner/test/spawn.spec.js
+++ b/eng/tools/ci-runner/test/spawn.spec.js
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// @ts-check
+
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
+import { spawnSync } from "node:child_process";
+import { spawnPnpm } from "../src/spawn.js";
+
+vi.mock("node:child_process", () => {
+  return {
+    spawnSync: vi.fn(),
+  };
+});
+
+describe("spawnWithLog (via spawnPnpm)", () => {
+  /** @type {import("vitest").MockInstance} */
+  let errorSpy;
+  /** @type {import("vitest").MockInstance} */
+  let logSpy;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(spawnSync).mockReset();
+  });
+
+  it("returns the numeric exit status when the process exits normally", () => {
+    vi.mocked(spawnSync).mockReturnValue(
+      /** @type {any} */ ({ status: 0, signal: null, error: undefined }),
+    );
+
+    const result = spawnPnpm("cwd", "build");
+
+    assert.strictEqual(result, 0);
+    assert.strictEqual(errorSpy.mock.calls.length, 0);
+    assert.ok(
+      logSpy.mock.calls.some((c) => String(c[0]).includes("exited with code 0, signal none")),
+    );
+  });
+
+  it("returns the numeric exit status for a non-zero exit", () => {
+    vi.mocked(spawnSync).mockReturnValue(
+      /** @type {any} */ ({ status: 1, signal: null, error: undefined }),
+    );
+
+    const result = spawnPnpm("cwd", "build");
+
+    assert.strictEqual(result, 1);
+  });
+
+  it("logs the spawn error and returns 1 when the process fails to spawn", () => {
+    const error = new Error("spawn pnpm ENOENT");
+    vi.mocked(spawnSync).mockReturnValue(
+      /** @type {any} */ ({ status: null, signal: null, error }),
+    );
+
+    const result = spawnPnpm("cwd", "build");
+
+    assert.strictEqual(result, 1);
+    assert.ok(
+      errorSpy.mock.calls.some((c) => String(c[0]).includes("Failed to spawn")),
+      "should log a failed-to-spawn message",
+    );
+  });
+
+  it("logs the terminating signal and returns 1 when killed by a signal", () => {
+    vi.mocked(spawnSync).mockReturnValue(
+      /** @type {any} */ ({ status: null, signal: "SIGTERM", error: undefined }),
+    );
+
+    const result = spawnPnpm("cwd", "build");
+
+    assert.strictEqual(result, 1);
+    assert.ok(
+      errorSpy.mock.calls.some((c) => String(c[0]).includes("terminated by signal SIGTERM")),
+      "should log the terminating signal",
+    );
+    assert.ok(
+      logSpy.mock.calls.some((c) => String(c[0]).includes("signal SIGTERM")),
+      "should include the signal in the exit log line",
+    );
+  });
+
+  it("adds an out-of-memory hint when killed by SIGKILL", () => {
+    vi.mocked(spawnSync).mockReturnValue(
+      /** @type {any} */ ({ status: null, signal: "SIGKILL", error: undefined }),
+    );
+
+    const result = spawnPnpm("cwd", "build");
+
+    assert.strictEqual(result, 1);
+    assert.ok(
+      errorSpy.mock.calls.some((c) => String(c[0]).includes("out-of-memory")),
+      "should hint at an out-of-memory kill for SIGKILL",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

In CI, the "Build libraries" step runs `node eng/tools/ci-runner/index.js build ...`, which goes through `spawnPnpm` → `spawnWithLog` in `eng/tools/ci-runner/src/spawn.js`. We've seen builds fail with only:

```
ELIFECYCLE  Command failed with exit code 1
pnpm.CMD exited with code 1
```

…and no indication of *why*. This came from investigating a build where the "Build libraries" step failed with only `ELIFECYCLE Command failed with exit code 1`.

The root cause for the missing context is that `spawnWithLog` silently dropped two diagnostic fields returned by `spawnSync`:

- `proc.signal` — set when the process is terminated by a signal (e.g. `SIGKILL` from the OOM killer), in which case `proc.status` is `null`.
- `proc.error` — set when the spawn itself fails (e.g. `ENOENT` / `EACCES`).

So a turbo/pnpm process killed by a signal or that failed to spawn looked identical to an ordinary non-zero exit.

## Change

Edited only `eng/tools/ci-runner/src/spawn.js`, in the `spawnWithLog` helper. After `spawnSync`:

1. If `proc.error` is set, log it to stderr: `Failed to spawn <cmd>: <error.stack ?? error.message>`.
2. If `proc.signal` is set, log to stderr that the process was terminated by that signal, with an extra hint for `SIGKILL` that it is likely an out-of-memory kill (suggesting checking agent memory / reducing `turbo --concurrency`).
3. The exit log line now also includes the signal: `<cmd> exited with code <status>, signal <signal ?? "none">`.
4. Return value is preserved: return `proc.status` when it's a number; otherwise return `1` (killed by signal or failed to spawn), keeping the previous `proc.status ?? 1` behavior of never reporting success for an abnormal exit.

The other helpers (`spawnPnpm`, `spawnPnpmRun`, `spawnPnpmWithOutput`, `spawnGitWithOutput`) are unchanged.

## Tests

Added `eng/tools/ci-runner/test/spawn.spec.js`, which exercises `spawnWithLog` through `spawnPnpm` by mocking `node:child_process.spawnSync` and asserting:

- numeric exit status (0 and non-zero) is returned and the exit line includes `signal none`;
- a spawn error logs `Failed to spawn …` and returns `1`;
- a terminating signal logs `terminated by signal …`, includes the signal in the exit line, and returns `1`;
- `SIGKILL` adds the out-of-memory hint.

## Validation

- `pnpm exec vitest run` — all 6 test files / 63 tests pass (including the 5 new tests).
- `pnpm run typecheck` (`tsc`) — clean.
- `pnpm run lint` (`eslint`) — clean.
- `node --check eng/tools/ci-runner/src/spawn.js` — no syntax errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>