### PR TITLE
regen-pipeline: pre-install powershell-yaml to avoid concurrent install race

### DIFF
--- a/eng/pipelines/scripts/sdk-regenerate.mjs
+++ b/eng/pipelines/scripts/sdk-regenerate.mjs
@@ -324,6 +324,10 @@ async function runShard() {
 
   installGlobalCliTools();
   preinstallReleaseTools();
+  // Pre-install powershell-yaml once before concurrent regen. TypeSpec-Project-Sync.ps1
+  // auto-installs it per package, so 4 concurrent first packages would race to register
+  // the same package source and corrupt it; pre-installing makes that step a no-op.
+  runShell(`pwsh -NoProfile -Command "Install-Module powershell-yaml -RequiredVersion 0.4.7 -Force -Scope CurrentUser"`, SDK_ROOT);
   const specRepoCloneDir = shallowCloneSpecRepoMain();
 
   const shardPackages = loadShardPackages(directoryListFile);

--- a/eng/pipelines/sdk-regenerate.yml
+++ b/eng/pipelines/sdk-regenerate.yml
@@ -24,7 +24,6 @@ trigger:
   branches: { include: [main] }
   paths:
     include:
-      - eng/emitter-package.json
       - eng/pipelines/sdk-regenerate.yml
       - eng/pipelines/scripts/sdk-regenerate.mjs
 
@@ -32,7 +31,6 @@ pr:
   branches: { include: [main] }
   paths:
     include:
-      - eng/emitter-package.json
       - eng/pipelines/sdk-regenerate.yml
       - eng/pipelines/scripts/sdk-regenerate.mjs
 


### PR DESCRIPTION
TypeSpec-Project-Sync.ps1 auto-installs powershell-yaml per package; with concurrency=4 the first packages race to register the same package source and corrupt it, failing the shard's first package. Install once before the concurrent regen so the per-package install is a no-op.


### Packages impacted by this PR


### Issues associated with this PR


### Describe the problem that is addressed by this PR


### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?


### Are there test cases added in this PR? _(If not, why?)_


### Provide a list of related PRs _(if any)_


### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

### Checklists
- [ ] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_
- [ ] Added a changelog (if necessary)
