### PR TITLE
Follow-up fixes for ts-package-json-approved-dependencies rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,6 @@
 /documentation/ @Azure/azure-sdk-js-dev
 /samples/       @Azure/azure-sdk-js-dev
 
-# Approved third-party runtime dependency allow-list
-/eng/approved-third-party-dependencies.yml @Azure/azure-sdk-js-dev
-
 ################
 # Architecture
 ################
@@ -1743,6 +1740,8 @@ sdk/resiliencemanagement/arm-resiliencemanagement/ @qiaozha @MaryGao @JialinHuan
 /eng/vitestconfigs/                      @Azure/azure-sdk-for-js-core
 /eng/common/                             @Azure/azure-sdk-eng
 /eng/ignore-links.txt                    @Azure/azure-sdk-eng @Azure/azure-sdk-js-dev
+# Approved third-party runtime dependency allow-list
+/eng/approved-third-party-dependencies.yml @Azure/azure-sdk-js-dev
 /.config/1espt/                          @benbp @mikeharder
 
 /.github/workflows/                      @Azure/azure-sdk-eng

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/approvedDependencies.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/approvedDependencies.ts
@@ -27,18 +27,22 @@ export const FIRST_PARTY_PREFIXES = [
 ] as const;
 
 /**
+ * The path segments, relative to the monorepo root, of the allow-list file.
+ * Single source of truth so the platform-specific and display paths below
+ * cannot drift apart if the location ever changes.
+ */
+const APPROVED_DEPENDENCIES_PATH_SEGMENTS = ["eng", "approved-third-party-dependencies.yml"];
+
+/**
  * The path, relative to the monorepo root, of the allow-list file.
  */
-export const APPROVED_DEPENDENCIES_RELATIVE_PATH = path.join(
-  "eng",
-  "approved-third-party-dependencies.yml",
-);
+export const APPROVED_DEPENDENCIES_RELATIVE_PATH = path.join(...APPROVED_DEPENDENCIES_PATH_SEGMENTS);
 
 /**
  * The allow-list path as displayed in user-facing messages, always using
  * forward slashes regardless of platform.
  */
-export const APPROVED_DEPENDENCIES_DISPLAY_PATH = "eng/approved-third-party-dependencies.yml";
+export const APPROVED_DEPENDENCIES_DISPLAY_PATH = APPROVED_DEPENDENCIES_PATH_SEGMENTS.join("/");
 
 /**
  * The parsed and normalized allow-list.


### PR DESCRIPTION
Addresses post-merge review feedback on #39105.

## Changes

**1. Fix CODEOWNERS ordering for the allow-list (maorleger, jeremymeng)**

The `eng/approved-third-party-dependencies.yml` entry was placed near the top of `.github/CODEOWNERS`, above the general `/eng/ @mikeharder @benbp` rule. Because CODEOWNERS resolves by **last-matching pattern**, the broad `/eng/` rule overrode the specific entry, so `@Azure/azure-sdk-js-dev` did not actually own the allow-list file. Moved the entry into the eng block (after `/eng/`) so it is the last match and takes effect.

**2. Derive allow-list paths from a single source of truth (maorleger)**

`APPROVED_DEPENDENCIES_RELATIVE_PATH` and `APPROVED_DEPENDENCIES_DISPLAY_PATH` independently spelled out the path segments, so renaming the file could update one and miss the other. Both now derive from a shared `APPROVED_DEPENDENCIES_PATH_SEGMENTS` array. Resulting values are byte-for-byte identical to before (relative path uses platform separators; display path forces `/`).

## Feedback intentionally not actioned

- mtime cache invalidation, `@scope/` vs `@scope/*`, and the `events` dependency were all resolved by discussion on the original PR.
- The `@file` first-party-scopes comment nit and the "throw on undefined root" suggestion were considered and left as-is.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>