### PR TITLE
[monitor-opentelemetry-exporter] Clamp server-controlled Retry-After header

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 
 - Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk.
+- Clamp the server-controlled `Retry-After` header to a maximum of 24 hours, preventing a malformed value from overflowing `setTimeout` or stalling offline retries.
 - Refuse to follow server-issued 307/308 redirects whose `Location` header points outside the configured ingestion host or the known Azure Monitor / Application Insights ingestion domain suffixes. Previously a single attacker-controlled redirect could permanently re-point the exporter at a foreign host, causing every subsequent telemetry call (and the AAD bearer token attached by the auth policy) to be sent to the attacker.
 
 ### Other Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/breezeUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/breezeUtils.ts
@@ -22,8 +22,26 @@ export interface BreezeResponse {
 }
 
 /**
+ * Upper bound for a parsed Retry-After delay, in milliseconds (24 hours).
+ *
+ * The Retry-After value is server-controlled. Without a cap, a malformed or hostile
+ * header can break the exporter two ways:
+ *  - A value above Node's `setTimeout` ceiling (2^31-1 ms, ~24.85 days) is silently
+ *    clamped to 1 ms and emits `TimeoutOverflowWarning`, firing the retry almost
+ *    immediately and defeating backoff.
+ *  - A value just under that ceiling parks the offline-retry timer for weeks.
+ *
+ * Clamping to 24h keeps every delay well under the `setTimeout` ceiling while still
+ * honoring any realistic server-issued backoff.
+ * @internal
+ */
+export const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Parse a Retry-After header value into milliseconds.
  * Supports both delay-seconds (integer) and HTTP-date formats.
+ * The result is clamped to {@link MAX_RETRY_AFTER_MS} so a server-controlled value
+ * can never overflow `setTimeout` or stall retries for an unbounded period.
  * Returns undefined if the header is missing or unparseable.
  * @internal
  */
@@ -35,13 +53,13 @@ export function parseRetryAfterHeader(retryAfter: string | undefined): number | 
   const trimmed = retryAfter.trim();
   if (/^\d+$/.test(trimmed)) {
     const delaySec = Number(trimmed);
-    return delaySec > 0 ? delaySec * 1000 : undefined;
+    return delaySec > 0 ? Math.min(delaySec * 1000, MAX_RETRY_AFTER_MS) : undefined;
   }
   // Try HTTP-date
   const date = Date.parse(retryAfter);
   if (!isNaN(date)) {
     const delayMs = date - Date.now();
-    return delayMs > 0 ? delayMs : undefined;
+    return delayMs > 0 ? Math.min(delayMs, MAX_RETRY_AFTER_MS) : undefined;
   }
   return undefined;
 }

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/breezeUtils.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/breezeUtils.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { parseRetryAfterHeader } from "../../src/utils/breezeUtils.js";
+import { MAX_RETRY_AFTER_MS, parseRetryAfterHeader } from "../../src/utils/breezeUtils.js";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 describe("breezeUtils", () => {
@@ -54,6 +54,41 @@ describe("breezeUtils", () => {
 
     it("should return undefined for non-parseable string", () => {
       expect(parseRetryAfterHeader("not-a-number-or-date")).toBeUndefined();
+    });
+
+    // Node's setTimeout silently clamps any delay above 2^31-1 ms (~24.85 days) to 1 ms
+    // and emits a TimeoutOverflowWarning. A server-controlled Retry-After must never be
+    // able to reach that ceiling, so parseRetryAfterHeader caps the result.
+    const NODE_SET_TIMEOUT_MAX_MS = 2 ** 31 - 1;
+
+    it("should clamp a delay-seconds value above the cap to MAX_RETRY_AFTER_MS", () => {
+      // 9999999999 s -> 9999999999000 ms, far above Node's setTimeout ceiling
+      expect(parseRetryAfterHeader("9999999999")).toBe(MAX_RETRY_AFTER_MS);
+    });
+
+    it("should clamp the max-safe-int seconds value (~24.8 day stall) to MAX_RETRY_AFTER_MS", () => {
+      // 2147483 s -> ~24.8 days, just under Node's ceiling; without a cap this parks retries for weeks
+      expect(parseRetryAfterHeader("2147483")).toBe(MAX_RETRY_AFTER_MS);
+    });
+
+    it("should keep a clamped result safely below Node's setTimeout ceiling", () => {
+      const result = parseRetryAfterHeader("9999999999");
+      expect(result!).toBeLessThan(NODE_SET_TIMEOUT_MAX_MS);
+    });
+
+    it("should not clamp a delay-seconds value below the cap", () => {
+      // 23 hours, just under the 24h cap
+      expect(parseRetryAfterHeader("82800")).toBe(82_800_000);
+    });
+
+    it("should return exactly the cap for a delay-seconds value at the boundary", () => {
+      // 86400 s === 24h === MAX_RETRY_AFTER_MS
+      expect(parseRetryAfterHeader("86400")).toBe(MAX_RETRY_AFTER_MS);
+    });
+
+    it("should clamp a far-future HTTP-date to MAX_RETRY_AFTER_MS", () => {
+      const farFutureDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();
+      expect(parseRetryAfterHeader(farFutureDate)).toBe(MAX_RETRY_AFTER_MS);
     });
   });
 });


### PR DESCRIPTION
## Summary

Clamps the server-controlled `Retry-After` header to a 24-hour maximum in the Azure Monitor OpenTelemetry exporter.

`parseRetryAfterHeader` (`src/utils/breezeUtils.ts`) returned the parsed delay with no upper bound, and `scheduleRetryTimer` (`src/platform/nodejs/baseSender.ts`) feeds it straight into `setTimeout`. A malformed or hostile `Retry-After` (e.g. from a misbehaving Breeze stamp, buggy proxy, or on-path device) could therefore:

- **Overflow the timer.** `Retry-After: 9999999999` → 9,999,999,999,000 ms, far above Node's `setTimeout` ceiling (2^31-1 ms). Node silently clamps it to **1 ms** and emits `TimeoutOverflowWarning` — the retry fires almost immediately, the opposite of backoff, plus log spam.
- **Stall retries for weeks.** `Retry-After: 2147483` → ~24.8 days, just under the ceiling, parking the offline-retry timer with no recovery short of a restart.

Note this timer only drives the offline/persisted-file retry drain (`sendFirstPersistedFile`); the live export path is unaffected, so this is defensive hardening rather than a full outage.

## Fix

Clamp the parsed value (both the delay-seconds and HTTP-date branches) to `MAX_RETRY_AFTER_MS` (24h). This keeps every delay well under the `setTimeout` ceiling while still honoring any realistic server-issued backoff.

## Tests

Added unit tests in `test/internal/breezeUtils.spec.ts` covering:

- the overflow value (`9999999999`) clamps to the cap,
- the ~24.8-day max-safe-int value (`2147483`) clamps to the cap,
- the clamped result stays below Node's `setTimeout` ceiling,
- a sub-cap value (23h) is not clamped,
- the boundary value (`86400`) returns exactly the cap,
- a far-future HTTP-date clamps to the cap.

All 16 tests in the file pass; lint is clean (0 errors).
