### PR TITLE
[monitor-opentelemetry-exporter] Throttle startup replay of persisted telemetry

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bugs Fixed
 
-- Throttle startup replay of persisted telemetry to avoid a fleet-wide thundering herd against the ingestion endpoint. After an outage, replay now begins after a randomized startup delay (de-synchronizing replicas that restart together) and spaces out each persisted file with a jittered inter-batch delay, instead of draining the entire on-disk backlog back-to-back.
+- Throttle startup replay of persisted telemetry with a randomized startup delay and jittered inter-batch spacing to avoid a fleet-wide thundering herd against the ingestion endpoint.
 - Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk.
 - Clamp the server-controlled `Retry-After` header to a maximum of 24 hours, preventing a malformed value from overflowing `setTimeout` or stalling offline retries.
 - Refuse to follow server-issued 307/308 redirects whose `Location` header points outside the configured ingestion host or the known Azure Monitor / Application Insights ingestion domain suffixes. Previously a single attacker-controlled redirect could permanently re-point the exporter at a foreign host, causing every subsequent telemetry call (and the AAD bearer token attached by the auth policy) to be sent to the attacker.

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bugs Fixed
 
+- Throttle startup replay of persisted telemetry to avoid a fleet-wide thundering herd against the ingestion endpoint. After an outage, replay now begins after a randomized startup delay (de-synchronizing replicas that restart together) and spaces out each persisted file with a jittered inter-batch delay, instead of draining the entire on-disk backlog back-to-back.
 - Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk.
 - Refuse to follow server-issued 307/308 redirects whose `Location` header points outside the configured ingestion host or the known Azure Monitor / Application Insights ingestion domain suffixes. Previously a single attacker-controlled redirect could permanently re-point the exporter at a foreign host, causing every subsequent telemetry call (and the AAD bearer token attached by the auth policy) to be sent to the attacker.
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -30,6 +30,15 @@ import type { CustomerSDKStatsMetrics } from "../../export/statsbeat/customerSDK
 
 const DEFAULT_BATCH_SEND_RETRY_INTERVAL_MS = 60_000;
 
+// Startup replay throttling. After a Breeze outage, every process restarting at once
+// (autoscale, rolling deploy) would otherwise drain its full on-disk backlog the moment
+// connectivity returns, creating a fleet-wide thundering herd against shared ingestion
+// stamps. A randomized startup offset de-synchronizes replay across replicas, and an
+// inter-batch delay (with jitter) spaces out the files each process drains.
+const STARTUP_REPLAY_MAX_DELAY_MS = 60_000;
+const REPLAY_BATCH_BASE_DELAY_MS = 200;
+const REPLAY_BATCH_JITTER_MS = 200;
+
 /**
  * Base sender class
  * @internal
@@ -39,6 +48,7 @@ export abstract class BaseSender {
   private numConsecutiveRedirects: number;
   private retryTimer: NodeJS.Timeout | null;
   private retryTimerDeadlineMs: number = 0;
+  private startupReplayTimer: NodeJS.Timeout | null = null;
   private networkStatsbeatMetrics: NetworkStatsbeatMetrics | undefined;
   private customerSDKStatsMetrics: CustomerSDKStatsMetrics | undefined;
   private longIntervalStatsbeatMetrics;
@@ -111,9 +121,10 @@ export abstract class BaseSender {
     this.retryTimer = null;
     this.isStatsbeatSender = options.isStatsbeatSender || false;
 
-    // Send all persisted files from previous sessions immediately on startup
+    // Replay persisted files from previous sessions on startup. Schedule after a randomized
+    // delay so a fleet restarting together doesn't stampede Breeze the moment connectivity returns.
     if (!this.disableOfflineStorage) {
-      this.sendAllPersistedFiles();
+      this.scheduleStartupReplay();
     }
   }
 
@@ -414,7 +425,18 @@ export abstract class BaseSender {
       await this.persister.cleanExpiredFiles();
 
       let envelopes = (await this.persister.shift()) as Envelope[] | null;
+      let isFirstBatch = true;
       while (envelopes) {
+        // Space out batches (with jitter) so a single process doesn't fire its whole
+        // backlog at Breeze back-to-back. No delay before the first batch.
+        if (!isFirstBatch) {
+          const batchDelay = this.getReplayBatchDelayMs();
+          if (batchDelay > 0) {
+            await new Promise((resolve) => setTimeout(resolve, batchDelay));
+          }
+        }
+        isFirstBatch = false;
+
         const result = await this.exportEnvelopes(envelopes);
         if (result.code === ExportResultCode.FAILED) {
           // Stop processing — remaining files stay on disk for later retry
@@ -426,6 +448,31 @@ export abstract class BaseSender {
     } catch (err: any) {
       diag.warn(`Failed to read persisted files during startup`, err);
     }
+  }
+
+  /**
+   * Schedule startup replay of persisted files behind a randomized delay. The random
+   * offset breaks fleet-wide synchronization so co-located replicas don't all replay
+   * their backlog at the same instant after a shared outage or coordinated restart.
+   */
+  private scheduleStartupReplay(): void {
+    const delay = this.getStartupReplayDelayMs();
+    this.startupReplayTimer = setTimeout(() => {
+      this.startupReplayTimer = null;
+      this.sendAllPersistedFiles();
+    }, delay);
+    // Don't keep the event loop alive solely for startup replay
+    this.startupReplayTimer.unref();
+  }
+
+  // Randomized 0..max startup offset so fleet restarts don't replay in lockstep
+  protected getStartupReplayDelayMs(): number {
+    return Math.floor(Math.random() * STARTUP_REPLAY_MAX_DELAY_MS);
+  }
+
+  // Base spacing plus random jitter applied between persisted files during replay
+  protected getReplayBatchDelayMs(): number {
+    return REPLAY_BATCH_BASE_DELAY_MS + Math.floor(Math.random() * REPLAY_BATCH_JITTER_MS);
   }
 
   /**

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -1786,7 +1786,7 @@ describe("BaseSender", () => {
       vi.useRealTimers();
     });
 
-    it("does not replay synchronously and survives a clean process exit (timer unref'd)", () => {
+    it("schedules startup replay on an unref'd timer so it never keeps the process alive", () => {
       vi.useFakeTimers();
       const sendAllSpy = vi.spyOn(BaseSender.prototype as any, "sendAllPersistedFiles");
 
@@ -1799,7 +1799,11 @@ describe("BaseSender", () => {
 
       // Constructor must not drain the backlog inline
       expect(sendAllSpy).not.toHaveBeenCalled();
-      expect(throttledSender).toBeDefined();
+
+      // The pending replay timer must be unref'd so it can't hold the event loop open
+      const replayTimer = (throttledSender as any).startupReplayTimer as NodeJS.Timeout;
+      expect(replayTimer).not.toBeNull();
+      expect(replayTimer.hasRef()).toBe(false);
 
       sendAllSpy.mockRestore();
       vi.useRealTimers();

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -221,6 +221,16 @@ class TestBaseSender extends BaseSender {
     return (this as any).sendAllPersistedFiles();
   }
 
+  // Neutralize startup replay throttling so existing timing-sensitive tests stay
+  // deterministic and fast. Dedicated tests below exercise the real delay logic.
+  protected getStartupReplayDelayMs(): number {
+    return 0;
+  }
+
+  protected getReplayBatchDelayMs(): number {
+    return 0;
+  }
+
   public async callSendFirstPersistedFile(): Promise<void> {
     return (this as any).sendFirstPersistedFile();
   }
@@ -1352,7 +1362,8 @@ describe("BaseSender", () => {
       expect(callOrder).toEqual(["cleanExpiredFiles", "shift"]);
     });
 
-    it("should be called automatically from constructor when offline storage is enabled", async () => {
+    it("should be scheduled (not called synchronously) from constructor when offline storage is enabled", async () => {
+      vi.useFakeTimers();
       const sendAllSpy = vi.spyOn(BaseSender.prototype as any, "sendAllPersistedFiles");
 
       const newSender = new TestBaseSender({
@@ -1362,12 +1373,16 @@ describe("BaseSender", () => {
         exporterOptions: {},
       });
 
-      expect(sendAllSpy).toHaveBeenCalledTimes(1);
+      // Replay is deferred behind a randomized startup delay, not run synchronously
+      expect(sendAllSpy).not.toHaveBeenCalled();
       expect(newSender).toBeDefined();
 
-      // Flush async work
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Once the scheduled timer fires, replay runs exactly once
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sendAllSpy).toHaveBeenCalledTimes(1);
+
       sendAllSpy.mockRestore();
+      vi.useRealTimers();
     });
 
     it("should handle multiple files where middle send fails", async () => {
@@ -1653,6 +1668,141 @@ describe("BaseSender", () => {
       // Only file2's retriable envelope was re-persisted
       expect(mockPersist.push).toHaveBeenCalledTimes(1);
       expect(mockPersist.push).toHaveBeenCalledWith([file2[1]]);
+    });
+  });
+
+  describe("Startup replay throttling (thundering herd mitigation)", () => {
+    it("computes a randomized startup replay delay within [0, max)", () => {
+      const proto = BaseSender.prototype as any;
+      const randomSpy = vi.spyOn(Math, "random");
+
+      randomSpy.mockReturnValue(0);
+      expect(proto.getStartupReplayDelayMs.call({})).toBe(0);
+
+      randomSpy.mockReturnValue(0.999999);
+      const nearMax = proto.getStartupReplayDelayMs.call({});
+      expect(nearMax).toBeGreaterThan(0);
+      expect(nearMax).toBeLessThan(60_000);
+
+      randomSpy.mockRestore();
+    });
+
+    it("computes an inter-batch replay delay of base plus jitter", () => {
+      const proto = BaseSender.prototype as any;
+      const randomSpy = vi.spyOn(Math, "random");
+
+      // No jitter → base spacing only
+      randomSpy.mockReturnValue(0);
+      expect(proto.getReplayBatchDelayMs.call({})).toBe(200);
+
+      // Max jitter → strictly below base + jitter ceiling
+      randomSpy.mockReturnValue(0.999999);
+      const withJitter = proto.getReplayBatchDelayMs.call({});
+      expect(withJitter).toBeGreaterThan(200);
+      expect(withJitter).toBeLessThan(400);
+
+      randomSpy.mockRestore();
+    });
+
+    it("applies an inter-batch delay before every file except the first", async () => {
+      const file1 = [{ name: "f1", time: new Date() }];
+      const file2 = [{ name: "f2", time: new Date() }];
+      const file3 = [{ name: "f3", time: new Date() }];
+
+      sender.sendMock.mockResolvedValue({ result: "success", statusCode: 200 });
+      mockPersist.shift
+        .mockResolvedValueOnce(file1)
+        .mockResolvedValueOnce(file2)
+        .mockResolvedValueOnce(file3)
+        .mockResolvedValueOnce(null);
+
+      const delaySpy = vi.spyOn(sender as any, "getReplayBatchDelayMs");
+
+      await sender.callSendAllPersistedFiles();
+
+      // 3 files → delay computed before files 2 and 3, never before file 1
+      expect(delaySpy).toHaveBeenCalledTimes(2);
+      expect(sender.sendMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not apply an inter-batch delay for a single persisted file", async () => {
+      const file1 = [{ name: "single", time: new Date() }];
+
+      sender.sendMock.mockResolvedValue({ result: "success", statusCode: 200 });
+      mockPersist.shift.mockResolvedValueOnce(file1).mockResolvedValueOnce(null);
+
+      const delaySpy = vi.spyOn(sender as any, "getReplayBatchDelayMs");
+
+      await sender.callSendAllPersistedFiles();
+
+      expect(delaySpy).not.toHaveBeenCalled();
+      expect(sender.sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not apply an inter-batch delay when replay stops on the first failure", async () => {
+      const file1 = [{ name: "f1", time: new Date() }];
+      const file2 = [{ name: "f2", time: new Date() }];
+
+      // Non-retriable failure on the first file → loop breaks before any second batch
+      sender.sendMock.mockResolvedValue({ result: "", statusCode: 400 });
+      mockPersist.shift.mockResolvedValueOnce(file1).mockResolvedValueOnce(file2);
+
+      const delaySpy = vi.spyOn(sender as any, "getReplayBatchDelayMs");
+
+      await sender.callSendAllPersistedFiles();
+
+      expect(delaySpy).not.toHaveBeenCalled();
+      expect(sender.sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("waits for the inter-batch delay to elapse before sending the next file", async () => {
+      vi.useFakeTimers();
+      const file1 = [{ name: "f1", time: new Date() }];
+      const file2 = [{ name: "f2", time: new Date() }];
+
+      sender.sendMock.mockResolvedValue({ result: "success", statusCode: 200 });
+      mockPersist.shift
+        .mockResolvedValueOnce(file1)
+        .mockResolvedValueOnce(file2)
+        .mockResolvedValueOnce(null);
+
+      vi.spyOn(sender as any, "getReplayBatchDelayMs").mockReturnValue(5000);
+
+      const replayPromise = sender.callSendAllPersistedFiles();
+
+      // Drain microtasks: first file sent, second file shifted but gated behind the delay
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sender.sendMock).toHaveBeenCalledTimes(1);
+
+      // Before the delay elapses, the second file must not be sent
+      await vi.advanceTimersByTimeAsync(4999);
+      expect(sender.sendMock).toHaveBeenCalledTimes(1);
+
+      // Once the delay elapses, the second file is sent
+      await vi.advanceTimersByTimeAsync(1);
+      await replayPromise;
+      expect(sender.sendMock).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("does not replay synchronously and survives a clean process exit (timer unref'd)", () => {
+      vi.useFakeTimers();
+      const sendAllSpy = vi.spyOn(BaseSender.prototype as any, "sendAllPersistedFiles");
+
+      const throttledSender = new TestBaseSender({
+        endpointUrl: "https://example.com",
+        instrumentationKey: "test-key",
+        trackStatsbeat: true,
+        exporterOptions: {},
+      });
+
+      // Constructor must not drain the backlog inline
+      expect(sendAllSpy).not.toHaveBeenCalled();
+      expect(throttledSender).toBeDefined();
+
+      sendAllSpy.mockRestore();
+      vi.useRealTimers();
     });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/httpSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/httpSender.spec.ts
@@ -3,6 +3,7 @@
 
 import type { AccessToken, TokenCredential } from "@azure/core-auth";
 import { HttpSender } from "../../src/platform/nodejs/httpSender.js";
+import { BaseSender } from "../../src/platform/nodejs/baseSender.js";
 import { DEFAULT_BREEZE_ENDPOINT } from "../../src/Declarations/Constants.js";
 import {
   successfulBreezeResponse,
@@ -14,7 +15,7 @@ import nock from "nock";
 import type { PipelinePolicy, Pipeline } from "@azure/core-rest-pipeline";
 import { createEmptyPipeline } from "@azure/core-rest-pipeline";
 import { ExportResultCode } from "@opentelemetry/core";
-import { describe, it, assert, afterAll } from "vitest";
+import { describe, it, assert, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { delay } from "@azure/core-util";
 import { AzureMonitorTraceExporter } from "../../src/export/trace.js";
 
@@ -42,6 +43,18 @@ class TestTokenCredential implements TokenCredential {
 describe("HttpSender", () => {
   const scope = nock(DEFAULT_BREEZE_ENDPOINT).persist().post("/v2.1/track");
   nock.disableNetConnect();
+
+  // These senders all share an on-disk persister (same instrumentation key). The
+  // randomized startup-replay timer would otherwise fire mid-suite and drain that
+  // shared persister, stealing envelopes these tests assert on. Startup replay is
+  // covered explicitly in baseSender.spec.ts, so disable it here for determinism.
+  beforeEach(() => {
+    vi.spyOn(BaseSender.prototype as any, "scheduleStartupReplay").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   afterAll(() => {
     nock.cleanAll();


### PR DESCRIPTION
## Summary

Throttles startup replay of persisted telemetry in the Azure Monitor OpenTelemetry exporter to avoid a fleet-wide thundering herd against the ingestion endpoint.

On startup, `BaseSender` (`src/platform/nodejs/baseSender.ts`) drained **every** persisted telemetry file from disk in a tight loop (`sendAllPersistedFiles`) with no jitter, no inter-batch delay, and no randomized startup offset. After a Breeze ingestion brownout, every customer process that restarts together — autoscale (HPA) scale-out or a rolling deploy — simultaneously dumps its full on-disk backlog (up to 50 MB per ikey, potentially hundreds of small batch files) at Breeze the instant connectivity returns. Across hundreds/thousands of replicas this is a coordinated, self-reinforcing traffic spike: throttle responses cause more persistence, which causes bigger replays on the next restart.

This addresses Resilience Hunt bug **AB#37977258**.

## Fix

- **Randomized startup offset.** Replay is no longer kicked off synchronously from the constructor. It is scheduled behind a random `0–60s` delay (`scheduleStartupReplay` → `getStartupReplayDelayMs`) so co-located replicas don't all replay in lockstep after a shared outage or coordinated restart. The timer is `unref()`'d, matching the existing retry timer, so it never keeps the process alive.
- **Jittered inter-batch spacing.** Within `sendAllPersistedFiles`, each persisted file after the first now waits `base (200ms) + random jitter (0–200ms)` (`getReplayBatchDelayMs`) before the next batch, instead of firing the whole backlog back-to-back. No delay is applied before the first batch or when replay stops on a failure.

Both knobs are factored into `protected` methods so tests can deterministically override them, and so they're easy to tune later.

### What this does **not** change

The live export path is untouched — this only governs the offline/persisted-file drain. The break-on-`FAILED` semantics and re-persist behavior of the replay loop are preserved exactly.

> Note: this is complementary to #39130 (clamping the server-controlled `Retry-After` header). That PR bounds the per-retry-timer delay on the `sendFirstPersistedFile` path; this PR de-synchronizes and spaces out the `sendAllPersistedFiles` startup drain. No code overlap beyond a CHANGELOG bullet.

## Tests

Added a `Startup replay throttling (thundering herd mitigation)` suite plus an updated constructor test in `test/internal/baseSender.spec.ts` covering:

- the startup delay is randomized within `[0, 60_000)`,
- the inter-batch delay is `base + jitter` and stays within `[200, 400)`,
- an inter-batch delay is applied before every file **except** the first,
- no inter-batch delay for a single file, or when replay stops on the first failure,
- the next file is not sent until the inter-batch delay has actually elapsed (fake timers),
- the constructor **schedules** replay rather than running it synchronously, and the scheduled timer fires exactly once.

All 65 tests in `baseSender.spec.ts` pass; `tsc` and ESLint are clean on the changed files.
