### PR TITLE
Update test-resources-post.ps1

### DIFF
--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -90,9 +90,12 @@ $image = "$loginServer/identity-aks-test-image"
 $kubernetesContext = "$workingFolder/AzureKubernetes"
 $kubernetesNpmrc = "$kubernetesContext/.npmrc"
 $sourceNpmrc = $env:NPM_CONFIG_USERCONFIG
+if ([string]::IsNullOrEmpty($sourceNpmrc)) {
+  $sourceNpmrc = Join-Path $HOME '.npmrc'
+}
 
-if ([string]::IsNullOrEmpty($sourceNpmrc) -or -not (Test-Path -LiteralPath $sourceNpmrc)) {
-  throw "NPM_CONFIG_USERCONFIG is not set or points to a missing file: '$sourceNpmrc'"
+if (-not (Test-Path -LiteralPath $sourceNpmrc)) {
+  throw "No authenticated npmrc found. Checked NPM_CONFIG_USERCONFIG and fallback path: '$sourceNpmrc'"
 }
 
 Write-Host "Copying authenticated .npmrc from $sourceNpmrc to $kubernetesNpmrc"


### PR DESCRIPTION
This pull request updates the logic for locating the authenticated `.npmrc` file in the `sdk/identity/test-resources-post.ps1` script. The main improvement is to provide a fallback to the user's home directory if the `NPM_CONFIG_USERCONFIG` environment variable is not set, making the script more robust in different environments.

**Environment variable handling:**

* Added a fallback to use `$HOME/.npmrc` if `NPM_CONFIG_USERCONFIG` is not set, improving reliability when the environment variable is missing.
* Updated error handling to throw an error only if no `.npmrc` file is found at either location, with a clearer error message.