### PR TITLE
Remove link verification from analyze job

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -40,15 +40,6 @@ steps:
     parameters:
       SourceDirectory: $(Build.SourcesDirectory)
 
-  - template: /eng/common/pipelines/templates/steps/verify-links.yml
-    parameters:
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        Directory: ""
-        Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        Directory: sdk/${{ parameters.ServiceDirectory }}
-      CheckLinkGuidance: $true
-
   - template: /eng/common/pipelines/templates/steps/verify-samples.yml
     parameters:
       ServiceDirectories: $(ChangedServicesCsv)


### PR DESCRIPTION
This pull request removes the step that verifies links in markdown files from the `analyze.yml` pipeline. The verification of sample files remains unchanged.

Pipeline simplification:

* Removed the `verify-links.yml` template step, which previously checked links in markdown files depending on the build reason (`PullRequest` or not), from the `eng/pipelines/templates/steps/analyze.yml` pipeline configuration.