### PR TITLE
[mgmt] fix arm-appservice build

### DIFF
--- a/sdk/appservice/arm-appservice/review/arm-appservice-node.api.md
+++ b/sdk/appservice/arm-appservice/review/arm-appservice-node.api.md
@@ -10379,7 +10379,7 @@ export interface WorkflowVersionsOperations {
 
 // Warnings were encountered during analysis:
 //
-// src/models/models.ts:26082:3 - (ae-forgotten-export) The symbol "NodeReadableStream" needs to be exported by the entry point index.d.ts
+// src/models/models.ts:26039:3 - (ae-forgotten-export) The symbol "NodeReadableStream" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 


### PR DESCRIPTION
It's review/arm-appservice-node.api.md has trivial line number change after
source files were re-formatted by prettier v3.9.1 and caused build failures in
CI.  This PR applies the updated api-extractor output.