### PR TITLE
Increment versions for packages missed by PR #39007

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.12.2 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.12.1 (2026-06-22)
 
 ### Bugs Fixed

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "sdk-type": "client",
   "keywords": [
     "node",

--- a/sdk/appconfiguration/app-configuration/src/internal/constants.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/constants.ts
@@ -4,7 +4,7 @@
 /**
  * @internal
  */
-export const packageVersion = "1.12.1";
+export const packageVersion = "1.12.2";
 
 /**
  * @internal

--- a/sdk/communication/communication-sms/CHANGELOG.md
+++ b/sdk/communication/communication-sms/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.2.0-beta.5 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.2.0-beta.4 (2025-06-16)
 
 ### Features Added

--- a/sdk/communication/communication-sms/package.json
+++ b/sdk/communication/communication-sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/communication-sms",
-  "version": "1.2.0-beta.4",
+  "version": "1.2.0-beta.5",
   "description": "SDK for Azure Communication SMS service which facilitates the sending of SMS messages.",
   "sdk-type": "client",
   "main": "./dist/commonjs/index.js",

--- a/sdk/communication/communication-sms/src/constants.ts
+++ b/sdk/communication/communication-sms/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "1.2.0-beta.4";
+export const SDK_VERSION: string = "1.2.0-beta.5";

--- a/sdk/communication/communication-sms/src/generated/src/smsApiClient.ts
+++ b/sdk/communication/communication-sms/src/generated/src/smsApiClient.ts
@@ -38,7 +38,7 @@ export class SmsApiClient extends coreClient.ServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-communication-sms/1.2.0-beta.4`;
+    const packageDetails = `azsdk-js-communication-sms/1.2.0-beta.5`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/communication/communication-sms/src/generated/src/tracing.ts
+++ b/sdk/communication/communication-sms/src/generated/src/tracing.ts
@@ -11,5 +11,5 @@ import { createTracingClient } from "@azure/core-tracing";
 export const tracingClient = createTracingClient({
   namespace: "Microsoft.Communication",
   packageName: "@azure/communication-sms",
-  packageVersion: "1.2.0-beta.4",
+  packageVersion: "1.2.0-beta.5",
 });

--- a/sdk/communication/communication-sms/swagger/README.md
+++ b/sdk/communication/communication-sms/swagger/README.md
@@ -19,7 +19,7 @@ use-extension:
   "@autorest/typescript": "6.0.34"
 azure-arm: false
 add-credentials: false
-package-version: 1.2.0-beta.4
+package-version: 1.2.0-beta.5
 v3: true
 tracing-info:
   namespace: "Microsoft.Communication"

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 4.11.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 4.11.2 (2026-04-27)
 
 ### Bugs Fixed

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/keyvault-secrets",
-  "version": "4.11.2",
+  "version": "4.11.3",
   "description": "Azure Key Vault Secrets",
   "engines": {
     "node": ">=22.0.0"

--- a/sdk/keyvault/keyvault-secrets/src/constants.ts
+++ b/sdk/keyvault/keyvault-secrets/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "4.11.2";
+export const SDK_VERSION: string = "4.11.3";

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -16,18 +16,18 @@
 
 - Includes all features released in 12.32.0-beta.1.
 
-## 12.31.0 (2026-05-22)
-
-### Features Added
-
-- Includes all features released in 12.31.0-beta.1.
-
 ## 12.32.0-beta.1 (2026-04-29)
 
 ### Features Added
 
 - Added support for service version 2026-06-06.
 - Added support for uploading up to 4 MiB of data with shareFileClient.create().
+
+## 12.31.0 (2026-05-22)
+
+### Features Added
+
+- Includes all features released in 12.31.0-beta.1.
 
 ## 12.31.0-beta.1 (2026-03-05)
 

--- a/sdk/storage/storage-file-share/CHANGELOG.md
+++ b/sdk/storage/storage-file-share/CHANGELOG.md
@@ -1,10 +1,26 @@
 # Release History
 
+## 12.32.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 12.32.0 (2026-06-24)
 
 ### Features Added
 
 - Includes all features released in 12.32.0-beta.1.
+
+## 12.31.0 (2026-05-22)
+
+### Features Added
+
+- Includes all features released in 12.31.0-beta.1.
 
 ## 12.32.0-beta.1 (2026-04-29)
 
@@ -12,12 +28,6 @@
 
 - Added support for service version 2026-06-06.
 - Added support for uploading up to 4 MiB of data with shareFileClient.create().
-
-## 12.31.0 (2026-05-22)
-
-### Features Added
-
-- Includes all features released in 12.31.0-beta.1.
 
 ## 12.31.0-beta.1 (2026-03-05)
 

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.32.0",
+  "version": "12.32.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.32.0";
+export const SDK_VERSION: string = "12.32.1";
 export const SERVICE_VERSION: string = "2026-06-06";
 
 export const FILE_MAX_SIZE_BYTES: number = 4 * 1024 * 1024 * 1024 * 1024; // 4TB

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -21,7 +21,7 @@ add-credentials: false
 core-http-compat-mode: true
 use-extension:
   "@autorest/typescript": "6.0.42"
-package-version: 12.31.0
+package-version: 12.32.1
 ```
 
 ## Customizations for Track 2 Generator


### PR DESCRIPTION
## Why

PR #39007 ("Re-export RestError and isRestError in non-management packages") changed `src/` files in many packages without incrementing their versions. PR #39127 later bumped most of them, but the `Check package version` CI task still flagged four packages whose published version no longer matches their changed source.

## What

Ran `dev-tool package increment-version` on the four packages that were still flagged:

| Package | Bump |
|---|---|
| `@azure/app-configuration` | 1.12.1 -> 1.12.2 |
| `@azure/communication-sms` | 1.2.0-beta.4 -> 1.2.0-beta.5 |
| `@azure/keyvault-secrets` | 4.11.2 -> 4.11.3 |
| `@azure/storage-file-share` | 12.32.0 -> 12.32.1 |

Each bump updates `package.json`, the in-source version constants, and adds a new `(Unreleased)` CHANGELOG section.

## Note for reviewers

For `app-configuration`, the tool updated `package.json` and `src/internal/constants.ts` but then errored out because the package's `//metadata.constantPaths` still references pre-modular generated paths (e.g. `src/generated/src/appConfiguration.ts`) that no longer exist after the package was regenerated to the modular layout. That crash happened before the CHANGELOG step, so I added the matching `## 1.12.2 (Unreleased)` entry by hand to keep it consistent with the other three. The stale `constantPaths` metadata is a pre-existing issue and is out of scope for this version-bump PR.