### PR TITLE
[identity] Remove pinned AKS version 

### DIFF
--- a/sdk/identity/test-resources-managed-identity.bicep
+++ b/sdk/identity/test-resources-managed-identity.bicep
@@ -20,9 +20,6 @@ param tenantId string
 @description('Provide a globally unique name of the Azure Container Registry')
 param acrName string = 'acr${uniqueString(resourceGroup().id)}'
 
-@description('The latest AKS version available in the region.')
-param latestAksVersion string
-
 @description('The SSH public key to use for the Linux VMs.')
 param sshPubKey string
 
@@ -37,9 +34,6 @@ var blobContributor = subscriptionResourceId('Microsoft.Authorization/roleDefini
 var serviceOwner = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')
 var acrPull = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d') // ACR Pull
 var websiteContributor = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772') // Website Contributor
-
-// Cluster parameters
-var kubernetesVersion = latestAksVersion
 
 resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
   name: baseName
@@ -298,7 +292,6 @@ resource kubernetesCluster 'Microsoft.ContainerService/managedClusters@2023-06-0
     type: 'SystemAssigned'
   }
   properties: {
-    kubernetesVersion: kubernetesVersion
     enableRBAC: true
     dnsPrefix: 'identitytest'
     agentPoolProfiles: [
@@ -311,7 +304,6 @@ resource kubernetesCluster 'Microsoft.ContainerService/managedClusters@2023-06-0
         kubeletDiskType: 'OS'
         type: 'VirtualMachineScaleSets'
         enableAutoScaling: false
-        orchestratorVersion: kubernetesVersion
         mode: 'System'
         osType: 'Linux'
         osSKU: 'Ubuntu'

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -24,11 +24,6 @@ $sshKey = Get-Content $PSScriptRoot/sshKey.pub
 
 $templateFileParameters['sshPubKey'] = $sshKey
 
-# Get the max version that is not preview and then get the name of the patch version with the max value
-$latestAksVersion = Get-AzAksVersion -Location westus | Where-Object { $_.isPreview -eq $null } | Select-Object -ExpandProperty OrchestratorVersion | Sort-Object -Descending | Select-Object -First 1
-Write-Host "Latest AKS version: $latestAksVersion"
-$templateFileParameters['latestAksVersion'] = $latestAksVersion
-
 if (!$CI) {
     # TODO: Remove this once auto-cloud config downloads are supported locally
     Write-Host "Skipping cert setup in local testing mode"

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -20,9 +20,6 @@ param tenantId string
 @description('Provide a globally unique name of the Azure Container Registry')
 param acrName string = 'acr${uniqueString(resourceGroup().id)}'
 
-@description('The latest AKS version available in the region.')
-param latestAksVersion string
-
 @description('The SSH public key to use for the Linux VMs.')
 param sshPubKey string
 
@@ -44,7 +41,6 @@ module managedIdentityModule 'test-resources-managed-identity.bicep' = if (deplo
     testApplicationId: testApplicationId
     tenantId: tenantId
     acrName: acrName
-    latestAksVersion: latestAksVersion
     sshPubKey: sshPubKey
     adminUserName: adminUserName
     principalUserType: principalUserType


### PR DESCRIPTION
The pinned AKS version forces the newest GA version that would trigger the failure for heavy usage & the version might not match the deploy region