### PR TITLE
[monitor-opentelemetry] Release 1.18.2 distro and 1.0.0-beta.43 exporter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21946,8 +21946,8 @@ importers:
         specifier: ^1.3.0
         version: link:../../core/logger
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.1.0-beta.1
         version: link:../../instrumentation/opentelemetry-instrumentation-azure-sdk
@@ -22274,8 +22274,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../monitor-opentelemetry-exporter
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -22365,8 +22365,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../monitor-opentelemetry-exporter
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 1.0.0-beta.43 (Unreleased)
-
-### Features Added
+## 1.0.0-beta.43 (2026-07-01)
 
 ### Breaking Changes
 
@@ -14,8 +12,6 @@
 - Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk.
 - Clamp the server-controlled `Retry-After` header to a maximum of 24 hours, preventing a malformed value from overflowing `setTimeout` or stalling offline retries.
 - Refuse to follow server-issued 307/308 redirects whose `Location` header points outside the configured ingestion host or the known Azure Monitor / Application Insights ingestion domain suffixes. Previously a single attacker-controlled redirect could permanently re-point the exporter at a foreign host, causing every subsequent telemetry call (and the AAD bearer token attached by the auth policy) to be sent to the attacker.
-
-### Other Changes
 
 ## 1.0.0-beta.42 (2026-05-29)
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 1.18.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.18.2 (2026-07-01)
 
 ### Bugs Fixed
 
@@ -14,6 +10,8 @@
 - Hardened Live Metrics (QuickPulse) redirect handling so a `x-ms-qps-service-endpoint-redirect-v2` header is only followed when the target host matches the configured endpoint or a known Azure Monitor ingestion domain. This prevents an attacker-controlled redirect from causing the bearer auth token (and telemetry body) to be sent to an untrusted host.
 
 ### Other Changes
+
+- Updated to using exporter version 1.0.0-beta.43.
 
 ## 1.18.1 (2026-05-29)
 

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -87,7 +87,7 @@
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.1.0-beta.1",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -77,7 +77,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -66,7 +66,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-opentelemetry` — released as **1.18.2**
- `@azure/monitor-opentelemetry-exporter` — released as **1.0.0-beta.43**

### Describe the problem that is addressed by this PR

Prepares the next co-release of both Azure Monitor OpenTelemetry packages. This is a **release-prep only** change cut cleanly from `main`: it stamps release dates (2026-07-01) on the existing `Unreleased` CHANGELOG sections, bumps the exporter dep pin across the Monitor packages to `1.0.0-beta.43`, and refreshes the workspace lockfile. Follows the pattern used in the previous distro / exporter co-release (#38730).

### Notable changes

- `@azure/monitor-opentelemetry` **1.18.2** — CHANGELOG date stamped (2026-07-01), added `Updated to using exporter version 1.0.0-beta.43` bullet. Runtime version constant already at `1.18.2`.
- `@azure/monitor-opentelemetry-exporter` **1.0.0-beta.43** — CHANGELOG date stamped (2026-07-01); `packageVersion` constant already at `1.0.0-beta.43`.
- Updated the exporter dep pin to `1.0.0-beta.43` in the Monitor packages: `monitor-opentelemetry`, `monitor-query-logs`, `monitor-query-metrics`.
- `pnpm-lock.yaml` refreshed.

> Note: `sdk/ai/ai-agents` and `sdk/ai/ai-inference-rest` were intentionally left on the previous exporter pin. Bumping them pulls those packages into the CI format-check scope, where they have pre-existing prettier `^3.9.1` drift unrelated to this release.

### Are there test cases added in this PR?

No new tests; this is a release-prep change. Existing tests still apply.

### Verification

- `pnpm turbo build` for both packages: succeeds (19/19 tasks).
- Prettier `3.9.1` clean on all changed `package.json` files.

### Checklists

- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
