### PR TITLE
[monitor-opentelemetry] Release 1.18.2 distro and 1.0.0-beta.43 exporter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,8 +826,8 @@ importers:
         specifier: ^1.11.1
         version: link:../../monitor/monitor-opentelemetry
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../../monitor/monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
         version: 1.0.0
@@ -932,8 +932,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../../monitor/monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.0.0
         version: 1.0.0
@@ -21946,8 +21946,8 @@ importers:
         specifier: ^1.3.0
         version: link:../../core/logger
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../monitor-opentelemetry-exporter
       '@azure/opentelemetry-instrumentation-azure-sdk':
         specifier: ^1.1.0-beta.1
         version: link:../../instrumentation/opentelemetry-instrumentation-azure-sdk
@@ -22274,8 +22274,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../monitor-opentelemetry-exporter
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -22365,8 +22365,8 @@ importers:
         specifier: catalog:internal
         version: 4.13.0
       '@azure/monitor-opentelemetry-exporter':
-        specifier: 1.0.0-beta.42
-        version: 1.0.0-beta.42
+        specifier: 1.0.0-beta.43
+        version: link:../monitor-opentelemetry-exporter
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -35368,10 +35368,6 @@ packages:
     resolution: {integrity: sha1-Cey+hAiSgQAjgn7y2DjyGaUcHDU=}
     engines: {node: '>=14.0.0'}
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.42':
-    resolution: {integrity: sha1-26M1nCAaf9tazyR+cF+QD9X1cFQ=}
-    engines: {node: '>=20.0.0'}
-
   '@azure/msal-browser@4.30.0':
     resolution: {integrity: sha1-MPuveuJtmrdnGqvKPUH5xS0qOTc=}
     engines: {node: '>=0.8.0'}
@@ -36658,10 +36654,6 @@ packages:
     resolution: {integrity: sha1-fldzPjeRRg/n1XL9hMr+bXtx3hg=}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/api-logs@0.218.0':
-    resolution: {integrity: sha1-e5gY6N/fHT3KuIv+TWck8vgx9+w=}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api-logs@0.219.0':
     resolution: {integrity: sha1-MwPxD0Pm/xdB+PYBnkOpJyN4FjA=}
     engines: {node: '>=8.0.0'}
@@ -36704,12 +36696,6 @@ packages:
 
   '@opentelemetry/core@2.0.0':
     resolution: {integrity: sha1-N+nw6d3sRHmyZ6ym8y2IdXyUGzo=}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha1-Fiv6tG1v9Nob7yQOpS4jqSaw/bw=}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -36928,12 +36914,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha1-OyqRefYRm7Hyzd7+QbqbKFVQSl0=}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/resources@2.8.0':
     resolution: {integrity: sha1-m8tlirYlTzMJn0qVVEtA1vU8yUY=}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -36942,12 +36922,6 @@ packages:
 
   '@opentelemetry/sdk-logs@0.200.0':
     resolution: {integrity: sha1-iT2GzvpvLAKnzQPVy0qVnu02U9E=}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-logs@0.218.0':
-    resolution: {integrity: sha1-eIhv4wC4KALO6ZYyCLKvMmuSivU=}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
@@ -41629,25 +41603,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/monitor-opentelemetry-exporter@1.0.0-beta.42':
-    dependencies:
-      '@azure-rest/core-client': 2.7.0
-      '@azure/core-auth': 1.10.1
-      '@azure/core-client': 1.10.2
-      '@azure/core-rest-pipeline': link:sdk/core/core-rest-pipeline
-      '@azure/core-util': 1.13.1
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure/msal-browser@4.30.0':
     dependencies:
       '@azure/msal-common': 15.17.0
@@ -42944,10 +42899,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/api-logs@0.218.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@opentelemetry/api-logs@0.219.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -42982,11 +42933,6 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/core@2.0.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -43294,12 +43240,6 @@ snapshots:
       '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
-
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -43312,14 +43252,6 @@ snapshots:
       '@opentelemetry/api-logs': 0.200.0
       '@opentelemetry/core': 2.0.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.0.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.218.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/sdk/ai/ai-agents/package.json
+++ b/sdk/ai/ai-agents/package.json
@@ -66,7 +66,7 @@
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
     "@azure/monitor-opentelemetry": "^1.11.1",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "0.57.0",

--- a/sdk/ai/ai-agents/src/models/models.ts
+++ b/sdk/ai/ai-agents/src/models/models.ts
@@ -1534,11 +1534,7 @@ export function aiSearchIndexResourceDeserializer(item: any): AISearchIndexResou
 
 /** Available query types for Azure AI Search tool. */
 export type AzureAISearchQueryType =
-  | "simple"
-  | "semantic"
-  | "vector"
-  | "vector_simple_hybrid"
-  | "vector_semantic_hybrid";
+  "simple" | "semantic" | "vector" | "vector_simple_hybrid" | "vector_semantic_hybrid";
 
 export function mcpToolResourceArraySerializer(result: Array<MCPToolResource>): any[] {
   return result.map((item) => {
@@ -1721,10 +1717,7 @@ export function toolDefinitionUnionArrayDeserializer(result: Array<ToolDefinitio
 
 /** Alias for AgentsResponseFormatOption */
 export type AgentsResponseFormatOption =
-  | string
-  | AgentsResponseFormatMode
-  | AgentsResponseFormat
-  | ResponseFormatJsonSchemaType;
+  string | AgentsResponseFormatMode | AgentsResponseFormat | ResponseFormatJsonSchemaType;
 
 export function agentsResponseFormatOptionSerializer(item: AgentsResponseFormatOption): any {
   if (typeof item === "object" && item.type === "json_schema") {
@@ -2136,8 +2129,7 @@ export function messageAttachmentToolDefinitionArrayDeserializer(
 
 /** Alias for MessageAttachmentToolDefinition */
 export type MessageAttachmentToolDefinition =
-  | CodeInterpreterToolDefinition
-  | FileSearchToolDefinition;
+  CodeInterpreterToolDefinition | FileSearchToolDefinition;
 
 export function messageAttachmentToolDefinitionSerializer(
   item: MessageAttachmentToolDefinition,
@@ -2381,9 +2373,7 @@ export function requiredActionDeserializer(item: any): RequiredAction {
 
 /** Alias for RequiredActionUnion */
 export type RequiredActionUnion =
-  | SubmitToolOutputsAction
-  | SubmitToolApprovalAction
-  | RequiredAction;
+  SubmitToolOutputsAction | SubmitToolApprovalAction | RequiredAction;
 
 export function requiredActionUnionDeserializer(item: any): RequiredActionUnion {
   switch (item.type) {
@@ -2451,9 +2441,7 @@ export function requiredToolCallDeserializer(item: any): RequiredToolCall {
 
 /** Alias for RequiredToolCallUnion */
 export type RequiredToolCallUnion =
-  | RequiredFunctionToolCall
-  | RequiredMcpToolCall
-  | RequiredToolCall;
+  RequiredFunctionToolCall | RequiredMcpToolCall | RequiredToolCall;
 
 export function requiredToolCallUnionDeserializer(item: any): RequiredToolCallUnion {
   switch (item.type) {
@@ -2748,11 +2736,7 @@ export function messageIncompleteDetailsDeserializer(item: any): MessageIncomple
 
 /** A set of reasons describing why a message is marked as incomplete. */
 export type MessageIncompleteDetailsReason =
-  | "content_filter"
-  | "max_tokens"
-  | "run_cancelled"
-  | "run_failed"
-  | "run_expired";
+  "content_filter" | "max_tokens" | "run_cancelled" | "run_failed" | "run_expired";
 
 export function messageContentUnionArrayDeserializer(result: Array<MessageContentUnion>): any[] {
   return result.map((item) => {
@@ -3209,10 +3193,7 @@ export function runStepDetailsDeserializer(item: any): RunStepDetails {
 
 /** Alias for RunStepDetailsUnion */
 export type RunStepDetailsUnion =
-  | RunStepMessageCreationDetails
-  | RunStepToolCallDetails
-  | RunStepActivityDetails
-  | RunStepDetails;
+  RunStepMessageCreationDetails | RunStepToolCallDetails | RunStepActivityDetails | RunStepDetails;
 
 export function runStepDetailsUnionDeserializer(item: any): RunStepDetailsUnion {
   switch (item.type) {
@@ -4194,13 +4175,7 @@ export function fileInfoDeserializer(item: any): FileInfo {
 export type FilePurpose = "assistants" | "assistants_output" | "vision";
 /** The state of the file. */
 export type FileState =
-  | "uploaded"
-  | "pending"
-  | "running"
-  | "processed"
-  | "error"
-  | "deleting"
-  | "deleted";
+  "uploaded" | "pending" | "running" | "processed" | "error" | "deleting" | "deleted";
 
 /** model interface _UploadFileRequest */
 export interface _UploadFileRequest {
@@ -4751,9 +4726,7 @@ export function messageDeltaContentDeserializer(item: any): MessageDeltaContent 
 
 /** Alias for MessageDeltaContentUnion */
 export type MessageDeltaContentUnion =
-  | MessageDeltaImageFileContent
-  | MessageDeltaTextContent
-  | MessageDeltaContent;
+  MessageDeltaImageFileContent | MessageDeltaTextContent | MessageDeltaContent;
 
 export function messageDeltaContentUnionDeserializer(item: any): MessageDeltaContentUnion {
   switch (item.type) {

--- a/sdk/ai/ai-agents/src/static-helpers/multipartHelpers.ts
+++ b/sdk/ai/ai-agents/src/static-helpers/multipartHelpers.ts
@@ -5,11 +5,7 @@
  * Valid values for the contents of a binary file.
  */
 export type FileContents =
-  | string
-  | NodeJS.ReadableStream
-  | ReadableStream<Uint8Array>
-  | Uint8Array
-  | Blob;
+  string | NodeJS.ReadableStream | ReadableStream<Uint8Array> | Uint8Array | Blob;
 
 export function createFilePartDescriptor(
   partName: string,

--- a/sdk/ai/ai-inference-rest/package.json
+++ b/sdk/ai/ai-inference-rest/package.json
@@ -86,7 +86,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/instrumentation": "^0.200.0",

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Release History
 
-## 1.0.0-beta.43 (Unreleased)
-
-### Features Added
+## 1.0.0-beta.43 (2026-07-01)
 
 ### Breaking Changes
 
@@ -14,8 +12,6 @@
 - Fixed customer SDK Stats not counting telemetry that was dropped while saving to disk.
 - Clamp the server-controlled `Retry-After` header to a maximum of 24 hours, preventing a malformed value from overflowing `setTimeout` or stalling offline retries.
 - Refuse to follow server-issued 307/308 redirects whose `Location` header points outside the configured ingestion host or the known Azure Monitor / Application Insights ingestion domain suffixes. Previously a single attacker-controlled redirect could permanently re-point the exporter at a foreign host, causing every subsequent telemetry call (and the AAD bearer token attached by the auth policy) to be sent to the attacker.
-
-### Other Changes
 
 ## 1.0.0-beta.42 (2026-05-29)
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Release History
 
-## 1.18.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.18.2 (2026-07-01)
 
 ### Bugs Fixed
 
@@ -14,6 +10,8 @@
 - Hardened Live Metrics (QuickPulse) redirect handling so a `x-ms-qps-service-endpoint-redirect-v2` header is only followed when the target host matches the configured endpoint or a known Azure Monitor ingestion domain. This prevents an attacker-controlled redirect from causing the bearer auth token (and telemetry body) to be sent to an untrusted host.
 
 ### Other Changes
+
+- Updated to using exporter version 1.0.0-beta.43.
 
 ## 1.18.1 (2026-05-29)
 

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -87,7 +87,7 @@
     "@azure/core-rest-pipeline": "^1.22.2",
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.3.0",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.1.0-beta.1",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
     "@opentelemetry/api": "^1.9.0",

--- a/sdk/monitor/monitor-query-logs/package.json
+++ b/sdk/monitor/monitor-query-logs/package.json
@@ -77,7 +77,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1",

--- a/sdk/monitor/monitor-query-metrics/package.json
+++ b/sdk/monitor/monitor-query-metrics/package.json
@@ -66,7 +66,7 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.42",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.43",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1",


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/monitor-opentelemetry` — released as **1.18.2**
- `@azure/monitor-opentelemetry-exporter` — released as **1.0.0-beta.43**

### Describe the problem that is addressed by this PR

Prepares the next co-release of both Azure Monitor OpenTelemetry packages. This is a **release-prep only** change cut cleanly from `main`: it stamps release dates (2026-07-01) on the existing `Unreleased` CHANGELOG sections, bumps the exporter dep pin to `1.0.0-beta.43` across all consuming packages, and refreshes the workspace lockfile.

### Notable changes

- `@azure/monitor-opentelemetry` **1.18.2** — CHANGELOG date stamped (2026-07-01), added `Updated to using exporter version 1.0.0-beta.43` bullet. Runtime version constant already at `1.18.2`.
- `@azure/monitor-opentelemetry-exporter` **1.0.0-beta.43** — CHANGELOG date stamped (2026-07-01); `packageVersion` constant already at `1.0.0-beta.43`.
- Bumped the exporter dep pin to `1.0.0-beta.43` in every consuming package: `monitor-opentelemetry`, `monitor-query-logs`, `monitor-query-metrics`, `ai-agents`, `ai-inference-rest`.
- Reformatted two pre-existing prettier-`3.9.1`-drifted files in `ai-agents` (`src/models/models.ts`, `src/static-helpers/multipartHelpers.ts`) so the format check stays green now that the package is in scope. Formatting-only, no semantic changes.
- `pnpm-lock.yaml` refreshed.

### Are there test cases added in this PR?

No new tests; this is a release-prep change. Existing tests still apply.

### Verification

- `pnpm turbo build` for both Monitor packages: succeeds (19/19 tasks).
- Prettier `3.9.1` clean on all changed files.

### Checklists

- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)
