### PR TITLE
Add Code Coverage for Storage CI

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -45,6 +45,9 @@ parameters:
   - name: oneESTemplateTag
     type: string
     default: release
+  - name: EnableCiCodeCoverage
+    type: boolean
+    default: false
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -88,7 +91,8 @@ extends:
               MatrixFilters:
                 - TestType=node|browser
                 - DependencyVersion=^$
-                - PublishCodeCoverage=^$
+                - ${{ if ne(parameters.EnableCiCodeCoverage, true) }}:
+                  - PublishCodeCoverage=^$
                 - ${{ each filter in parameters.MatrixFilters }}:
                     - ${{ filter}}
               MatrixReplace: ${{ parameters.MatrixReplace }}

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -96,9 +96,9 @@ steps:
     inputs:
       summaryFileLocation: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/cobertura-coverage.xml"
 
-  #- template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-  #  parameters:
-  #    ArtifactPath: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/coverage-browser"
-  #    ArtifactName: BrowserCodeCoverageReport
-  #    CustomCondition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
-  #    SbomEnabled: false
+  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+    parameters:
+      ArtifactPath: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/coverage-browser"
+      ArtifactName: BrowserCodeCoverageReport
+      CustomCondition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
+      SbomEnabled: false

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -88,3 +88,17 @@ steps:
         ArtifactPath: '$(Build.ArtifactStagingDirectory)/test-proxy.log'
         ArtifactName: 'test proxy logs $(Agent.JobName)'
         SbomEnabled: false
+
+  - task: PublishCodeCoverageResults@2
+    displayName: "Publish NodeJs Code Coverage to DevOps"
+    continueOnError: true
+    condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], true))
+    inputs:
+      summaryFileLocation: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/cobertura-coverage.xml"
+
+  #- template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+  #  parameters:
+  #    ArtifactPath: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/coverage-browser"
+  #    ArtifactName: BrowserCodeCoverageReport
+  #    CustomCondition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
+  #    SbomEnabled: false

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -93,9 +93,27 @@ steps:
         ArtifactName: 'test proxy logs $(Agent.JobName)'
         SbomEnabled: false
 
-  - task: PublishCodeCoverageResults@2
-    displayName: "Publish NodeJs Code Coverage to DevOps"
+  - pwsh: |
+      $coverageRoot = "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}"
+      $pathToSources = "$(System.DefaultWorkingDirectory)"
+      $coverageFiles = Get-ChildItem -Path $coverageRoot -Recurse -File -Filter "*cobertura*.xml"
+
+      if (-not $coverageFiles) {
+        Write-Host "No cobertura coverage files found under $coverageRoot"
+        exit 0
+      }
+
+      foreach ($coverageFile in $coverageFiles) {
+        $coverageDirectory = Split-Path -Parent $coverageFile.FullName
+        $packageDirectory = Split-Path -Parent $coverageDirectory
+        $packageName = Split-Path -Leaf $packageDirectory
+        $summaryFile = $coverageFile.FullName.Replace("\\", "/")
+        $reportDirectory = $coverageDirectory.Replace("\\", "/")
+        $sourceDirectory = $pathToSources.Replace("\\", "/")
+
+        Write-Host "Publishing coverage for '$packageName' from '$summaryFile'"
+        Write-Host "##vso[codecoverage.publish codecoveragetool=Cobertura;summaryfile=$summaryFile;reportdirectory=$reportDirectory;pathToSources=$sourceDirectory;]$packageName"
+      }
+    displayName: "Publish NodeJs Code Coverage to DevOps (per package)"
     continueOnError: true
-    condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], 'true'))
-    inputs:
-      summaryFileLocation: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/*cobertura*.xml"
+    condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),in(lower(variables['PublishCodeCoverage']), 'true', '1'))

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -93,27 +93,72 @@ steps:
         ArtifactName: 'test proxy logs $(Agent.JobName)'
         SbomEnabled: false
 
-  - pwsh: |
-      $coverageRoot = "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}"
-      $pathToSources = "$(System.DefaultWorkingDirectory)"
-      $coverageFiles = Get-ChildItem -Path $coverageRoot -Recurse -File -Filter "*cobertura*.xml"
+  - ${{ if gt(length(parameters.Artifacts), 0) }}:
+    - ${{ each artifact in parameters.Artifacts }}:
+      - pwsh: |
+          $packageInfoPath = "$(Build.ArtifactStagingDirectory)/PackageInfo/${{ artifact.name }}.json"
+          $reportVariable = "CoverageReport_${{ artifact.safename }}"
 
-      if (-not $coverageFiles) {
-        Write-Host "No cobertura coverage files found under $coverageRoot"
-        exit 0
-      }
+          Write-Host "##vso[task.setvariable variable=$reportVariable;]"
 
-      foreach ($coverageFile in $coverageFiles) {
-        $coverageDirectory = Split-Path -Parent $coverageFile.FullName
-        $packageDirectory = Split-Path -Parent $coverageDirectory
-        $packageName = Split-Path -Leaf $packageDirectory
-        $summaryFile = $coverageFile.FullName.Replace("\\", "/")
-        $reportDirectory = $coverageDirectory.Replace("\\", "/")
-        $sourceDirectory = $pathToSources.Replace("\\", "/")
+          if (-not (Test-Path $packageInfoPath)) {
+            Write-Warning "Package info file not found for '${{ artifact.name }}': $packageInfoPath"
+            exit 0
+          }
 
-        Write-Host "Publishing coverage for '$packageName' from '$summaryFile'"
-        Write-Host "##vso[codecoverage.publish codecoveragetool=Cobertura;summaryfile=$summaryFile;reportdirectory=$reportDirectory;pathToSources=$sourceDirectory;]$packageName"
-      }
-    displayName: "Publish NodeJs Code Coverage to DevOps (per package)"
+          $packageInfo = Get-Content -Raw -Path $packageInfoPath | ConvertFrom-Json
+          $packageDirectory = $packageInfo.DirectoryPath
+
+          if (-not [System.IO.Path]::IsPathRooted($packageDirectory)) {
+            $packageDirectory = Join-Path "$(System.DefaultWorkingDirectory)" $packageDirectory
+          }
+
+          $coverageDirectory = Join-Path $packageDirectory "coverage"
+          $primarySummary = Join-Path $coverageDirectory "cobertura-coverage.xml"
+          $summaryFile = $null
+
+          if (Test-Path $primarySummary) {
+            $summaryFile = $primarySummary
+          } else {
+            $summaryFile = (Get-ChildItem -Path $coverageDirectory -File -Filter "*cobertura*.xml" -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName)
+          }
+
+          if (-not $summaryFile) {
+            Write-Warning "No coverage file found for '${{ artifact.name }}' under $coverageDirectory"
+            exit 0
+          }
+
+          $summaryFile = $summaryFile.Replace("\\", "/")
+
+          Write-Host "Resolved coverage for '${{ artifact.name }}': $summaryFile"
+
+          # Prefix every <package name="..."> with the artifact name so DevOps groups
+          # coverage by package rather than showing a flat directory-path list.
+          try {
+            [xml]$coverageXml = Get-Content -Raw $summaryFile
+            foreach ($pkg in $coverageXml.coverage.packages.package) {
+              $pkg.name = "${{ artifact.name }}/$($pkg.name)"
+            }
+            $coverageXml.Save($summaryFile)
+            Write-Host "Prefixed package names in $summaryFile with '${{ artifact.name }}'"
+          } catch {
+            Write-Warning "Could not rewrite package names in cobertura XML: $_"
+          }
+
+          Write-Host "##vso[task.setvariable variable=$reportVariable;]$($coverageDirectory.Replace('\\', '/'))"
+        displayName: "Resolve coverage file (${{ artifact.name }})"
+        condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),in(lower(variables['PublishCodeCoverage']), 'true', '1'))
+
+      - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+        parameters:
+          ArtifactPath: "$(CoverageReport_${{ artifact.safename }})"
+          ArtifactName: "CodeCoverage-${{ artifact.safename }}"
+          CustomCondition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),in(lower(variables['PublishCodeCoverage']), 'true', '1'),ne(variables['CoverageReport_${{ artifact.safename }}'], ''))
+          SbomEnabled: false
+
+  - task: PublishCodeCoverageResults@2
+    displayName: "Publish Code Coverage to DevOps"
     continueOnError: true
     condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),in(lower(variables['PublishCodeCoverage']), 'true', '1'))
+    inputs:
+      summaryFileLocation: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/*cobertura*.xml"

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -40,11 +40,15 @@ steps:
 
   - script: |
       node eng/tools/ci-runner/index.js test:node $(ChangedServices) -packages "$(ArtifactPackageNames)" -packageInfo "$(Build.ArtifactStagingDirectory)/PackageInfo" -changeInfo "$(Build.ArtifactStagingDirectory)/diff/diff.json" --ci
+    env:
+      PUBLISHCODECOVERAGE: $(PublishCodeCoverage)
     displayName: "Test libraries node NodeJS $(NodeTestVersion)"
     condition: and(succeeded(),eq(variables['TestType'], 'node'))
 
   - script: |
       node eng/tools/ci-runner/index.js test:browser $(ChangedServices) -packages "$(ArtifactPackageNames)" -packageInfo "$(Build.ArtifactStagingDirectory)/PackageInfo" -changeInfo "$(Build.ArtifactStagingDirectory)/diff/diff.json" --ci
+    env:
+      PUBLISHCODECOVERAGE: $(PublishCodeCoverage)
     displayName: "Test libraries browser NodeJS $(NodeTestVersion)"
     condition: and(succeeded(),eq(variables['TestType'], 'browser'))
 
@@ -92,13 +96,6 @@ steps:
   - task: PublishCodeCoverageResults@2
     displayName: "Publish NodeJs Code Coverage to DevOps"
     continueOnError: true
-    condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], true))
+    condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], 'true'))
     inputs:
-      summaryFileLocation: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/cobertura-coverage.xml"
-
-  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-    parameters:
-      ArtifactPath: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/coverage-browser"
-      ArtifactName: BrowserCodeCoverageReport
-      CustomCondition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
-      SbomEnabled: false
+      summaryFileLocation: "$(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/**/coverage/*cobertura*.xml"

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -34,6 +34,7 @@ pr:
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
+    EnableCiCodeCoverage: true
     ServiceDirectory: storage
     Artifacts:
       - name: azure-storage-common

--- a/turbo.json
+++ b/turbo.json
@@ -54,10 +54,12 @@
       "dependsOn": ["build"]
     },
     "test:browser": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage"]
     },
     "test:node": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "passThroughEnv": ["PUBLISHCODECOVERAGE", "PublishCodeCoverage"]
     },
     "update-snippets": {
       "cache": false

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -79,6 +79,10 @@ function shouldCollectCoverage(rootDir: string) {
   );
 }
 
+function getCoverageProjectRoot(rootDir: string): string {
+  return process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] ?? rootDir;
+}
+
 function makeNodeAliases(rootDir: string) {
   const [dist, indexFile] = isInDevopsPipeline() ? ["dist/esm", "index.js"] : ["src", "index.ts"];
   return makeAliases(rootDir, { distDir: `./${dist}`, indexFile });
@@ -142,7 +146,11 @@ export default defineConfig({
         "test/snippets.spec.ts",
       ],
       provider: "istanbul",
-      reporter: ["text", "cobertura", "html"],
+      reporter: [
+        "text",
+        ["cobertura", { file: "cobertura-coverage.xml", projectRoot: getCoverageProjectRoot(process.cwd()) }],
+        "html",
+      ],
       reportsDirectory: "coverage",
     },
   },

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -64,8 +64,16 @@ export function makeAliases(
 }
 
 function shouldCollectCoverage(rootDir: string) {
+  const publishCodeCoverage =
+    (process.env["PublishCodeCoverage"] ?? process.env["PUBLISHCODECOVERAGE"] ?? "")
+      .toString()
+      .toLowerCase();
+
+  const ciCoverageEnabled = publishCodeCoverage === "true" || publishCodeCoverage === "1";
+
   return (
     process.env["TEST_MODE"] === "live" ||
+    ciCoverageEnabled ||
     rootDir.includes("/sdk/core/") ||
     rootDir.includes("\\sdk\\core\\")
   );


### PR DESCRIPTION
This pull request introduces support for conditional code coverage reporting in CI pipelines, particularly for Node.js and browser test runs. The changes add a new parameter to control code coverage publishing, propagate this configuration through the pipeline, and ensure that coverage results are published only when enabled. The implementation includes updates to pipeline templates, environment variable handling, and test configuration.

**Pipeline enhancements for code coverage:**

* Added a new `EnableCiCodeCoverage` boolean parameter to the `archetype-sdk-client.yml` pipeline template, allowing CI code coverage to be toggled per service (`eng/pipelines/templates/stages/archetype-sdk-client.yml`).
* Updated the storage pipeline (`sdk/storage/ci.yml`) to enable CI code coverage by setting `EnableCiCodeCoverage: true`.

**Test and coverage publishing logic:**

* Modified test steps in `test.yml` to set the `PUBLISHCODECOVERAGE` environment variable based on pipeline variables, and added steps to publish code coverage results for Node.js and browser tests only when code coverage is enabled (`eng/pipelines/templates/steps/test.yml`). [[1]](diffhunk://#diff-e61a63678b13f20bc104aa25133ae4ed1de7a97ed7cb045d568907b962fc73f2R43-R51) [[2]](diffhunk://#diff-e61a63678b13f20bc104aa25133ae4ed1de7a97ed7cb045d568907b962fc73f2R95-R108)
* Adjusted matrix filters in the pipeline template to conditionally include or exclude code coverage publishing based on the new parameter (`eng/pipelines/templates/stages/archetype-sdk-client.yml`).

**Build and test configuration updates:**

* Updated `turbo.json` to pass through the `PUBLISHCODECOVERAGE` and `PublishCodeCoverage` environment variables to `test:node` and `test:browser` scripts, ensuring the test runner is aware of the code coverage setting.
* Enhanced the `shouldCollectCoverage` function in `vitest.shared.config.ts` to respect the new environment variables and enable coverage collection when appropriate.