### PR TITLE
Add upload-llm-artifacts common template step + pipelineArtifact output

### DIFF
--- a/eng/pipelines/templates/jobs/ci.tests.yml
+++ b/eng/pipelines/templates/jobs/ci.tests.yml
@@ -58,6 +58,15 @@ jobs:
         # Add a default so the job doesn't fail when the matrix is empty
         container: $[ variables['Container'] ]
 
+    templateContext:
+      # See eng/common/pipelines/templates/steps/upload-llm-artifacts.yml for corresponding file copy step
+      outputs:
+        - output: pipelineArtifact
+          targetPath: '$(Build.ArtifactStagingDirectory)/llm-artifacts'
+          artifactName: "LLM Artifacts - $(System.JobName) - $(System.JobAttempt)"
+          condition: eq(variables['uploadLlmArtifacts'], 'true')
+          sbomEnabled: false
+
     variables:
       - template: ../variables/globals.yml
 

--- a/eng/pipelines/templates/steps/test.yml
+++ b/eng/pipelines/templates/steps/test.yml
@@ -90,6 +90,11 @@ steps:
     condition: and(always(),eq(variables['TestType'], 'browser'))
     displayName: "Publish browser unit test results"
 
+  - template: /eng/common/pipelines/templates/steps/upload-llm-artifacts.yml
+    parameters:
+      TestResultsGlob: 'test-results*.xml'
+      SearchFolder: '$(System.DefaultWorkingDirectory)/sdk'
+
   - ${{ if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
       parameters:


### PR DESCRIPTION
This pull request introduces a new pipeline step to collect and upload test result files as "LLM Artifacts" to support downstream LLM tooling (such as GitHub Copilot) for test analysis. The changes add a reusable, language-agnostic template for staging test result files and update the CI test job to use this template and publish the artifacts when available.