### PR TITLE
ci(warp): pin pnpm version from packageManager and use frozen lockfile

### DIFF
--- a/.github/workflows/warp-ci.yml
+++ b/.github/workflows/warp-ci.yml
@@ -35,10 +35,12 @@ jobs:
           node-version: "24"
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: |
+          PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
+          npm install -g "pnpm@${PNPM_VERSION}"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm --filter @microsoft/warp... build


### PR DESCRIPTION
## Why

The Warp CI workflow installed pnpm with `npm install -g pnpm`, which always grabs the latest release. That can drift from the version the repo actually standardizes on (`packageManager` in the root `package.json`), leading to CI running a different pnpm than local/other pipelines. On top of that, `pnpm install` without `--frozen-lockfile` allows the lockfile to be silently updated in CI, which defeats the purpose of a committed lockfile.

## What

- Read the pnpm version from the root `package.json` `packageManager` field and install that exact version, so CI uses the same pnpm the repo pins.
- Pass `--frozen-lockfile` to `pnpm install` so CI fails fast if the lockfile is out of sync instead of mutating it.

Small, self-contained change to `.github/workflows/warp-ci.yml`.