### PR TITLE
[confidential-ledger] fix build

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/review/confidential-ledger-node.api.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/review/confidential-ledger-node.api.md
@@ -1391,8 +1391,6 @@ export interface ReceiptLeafComponentsOutput {
     writeSetDigest?: string;
 }
 
-export { RestError }
-
 // @public
 export type RedirectionStrategy = string;
 

--- a/sdk/confidentialledger/confidential-ledger-rest/src/index.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/index.ts
@@ -13,4 +13,3 @@ export * from "./paginateHelper.js";
 export { RestError, isRestError } from "@azure/core-rest-pipeline";
 export { type LedgerIdentity, getLedgerIdentity } from "./getLedgerIdentity.js";
 export default ConfidentialLedger;
-export { RestError, isRestError } from "@azure/core-rest-pipeline";


### PR DESCRIPTION
The duplicated RestError/isRestError was introduced due to two in-flight pull
requests both added the same export and passed their checks. This PR remove the
one that was added manually in favor of the generated one.