### PR TITLE
[EngSys] use "workspace:^" version specifier for internal packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1837,7 +1837,7 @@ importers:
   sdk/appconfiguration/app-configuration-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/app-configuration':
         specifier: 1.8.0
@@ -4600,7 +4600,7 @@ importers:
   sdk/cognitivelanguage/ai-language-text-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/ai-language-text':
         specifier: ^1.1.0
@@ -7783,7 +7783,7 @@ importers:
   sdk/containerregistry/container-registry-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/container-registry':
         specifier: ^1.1.0
@@ -8879,7 +8879,7 @@ importers:
   sdk/core/core-rest-pipeline-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/core-auth':
         specifier: ^1.10.0
@@ -9389,7 +9389,7 @@ importers:
         version: link:../../core/core-util
       '@azure/keyvault-keys':
         specifier: ^4.9.0
-        version: link:../../keyvault/keyvault-keys
+        version: 4.10.0(@azure/core-client@sdk+core+core-client)
       '@azure/logger':
         specifier: ^1.1.4
         version: link:../../core/logger
@@ -13671,7 +13671,7 @@ importers:
   sdk/eventgrid/eventgrid-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/eventgrid':
         specifier: ^5.11.0
@@ -13967,7 +13967,7 @@ importers:
         version: 0.12.5
     devDependencies:
       '@azure-tools/mock-hub':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../mock-hub
       '@azure-tools/test-credential':
         specifier: workspace:^
@@ -14072,7 +14072,7 @@ importers:
   sdk/eventhub/event-hubs-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/core-amqp':
         specifier: ^4.3.6
@@ -14914,7 +14914,7 @@ importers:
   sdk/formrecognizer/ai-form-recognizer-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/ai-form-recognizer':
         specifier: ^5.0.0
@@ -16437,7 +16437,7 @@ importers:
   sdk/identity/identity-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -17497,7 +17497,7 @@ importers:
         version: 4.13.0
       '@azure/keyvault-keys':
         specifier: ^4.9.0
-        version: link:../keyvault-keys
+        version: 4.10.0(@azure/core-client@sdk+core+core-client)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.0
@@ -17629,7 +17629,7 @@ importers:
   sdk/keyvault/keyvault-certificates-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -17827,14 +17827,14 @@ importers:
   sdk/keyvault/keyvault-keys-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
         version: 4.13.1
       '@azure/keyvault-keys':
         specifier: ^4.9.0
-        version: link:../keyvault-keys
+        version: 4.10.0(@azure/core-client@sdk+core+core-client)
       dotenv:
         specifier: ^16.0.0
         version: 16.6.1
@@ -17961,7 +17961,7 @@ importers:
   sdk/keyvault/keyvault-secrets-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -21891,7 +21891,7 @@ importers:
   sdk/monitor/monitor-ingestion-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -22179,7 +22179,7 @@ importers:
   sdk/monitor/monitor-opentelemetry-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/monitor-opentelemetry':
         specifier: ^1.17.0
@@ -28286,7 +28286,7 @@ importers:
   sdk/schemaregistry/schema-registry-avro-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -28654,7 +28654,7 @@ importers:
   sdk/search/search-documents-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -29374,7 +29374,7 @@ importers:
   sdk/servicebus/service-bus-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/service-bus':
         specifier: ^7.9.5
@@ -30679,7 +30679,7 @@ importers:
         specifier: workspace:^
         version: link:../../test-utils/test-credential
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure-tools/test-recorder':
         specifier: workspace:^
@@ -30769,7 +30769,7 @@ importers:
         specifier: ^12.26.0
         version: link:../storage-blob
       '@azure/storage-internal-avro':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../storage-internal-avro
       tslib:
         specifier: ^2.8.1
@@ -30833,7 +30833,7 @@ importers:
   sdk/storage/storage-blob-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/core-rest-pipeline':
         specifier: link:../../core/core-rest-pipeline
@@ -30995,7 +30995,7 @@ importers:
         specifier: workspace:^
         version: link:../../test-utils/test-credential
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure-tools/test-recorder':
         specifier: workspace:^
@@ -31052,7 +31052,7 @@ importers:
   sdk/storage/storage-file-datalake-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/storage-file-datalake':
         specifier: ^12.26.0
@@ -31135,7 +31135,7 @@ importers:
         specifier: workspace:^
         version: link:../../test-utils/test-credential
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure-tools/test-recorder':
         specifier: workspace:^
@@ -31195,7 +31195,7 @@ importers:
   sdk/storage/storage-file-share-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/storage-file-share':
         specifier: ^12.27.0
@@ -32904,7 +32904,7 @@ importers:
   sdk/tables/data-tables-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/data-tables':
         specifier: ^13.3.0
@@ -33099,7 +33099,7 @@ importers:
   sdk/template/template-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/identity':
         specifier: ^4.8.0
@@ -33690,7 +33690,7 @@ importers:
   sdk/textanalytics/ai-text-analytics-perf-tests:
     dependencies:
       '@azure-tools/test-perf':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../../test-utils/perf
       '@azure/ai-text-analytics':
         specifier: ^5.1.0

--- a/sdk/appconfiguration/app-configuration-perf-tests/package.json
+++ b/sdk/appconfiguration/app-configuration-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/app-configuration": "1.8.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/cognitivelanguage/ai-language-text-perf-tests/package.json
+++ b/sdk/cognitivelanguage/ai-language-text-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/ai-language-text": "^1.1.0",
     "@azure/identity": "^4.5.0",
     "dotenv": "^16.0.0",

--- a/sdk/containerregistry/container-registry-perf-tests/package.json
+++ b/sdk/containerregistry/container-registry-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/container-registry": "^1.1.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/core/core-rest-pipeline-perf-tests/package.json
+++ b/sdk/core/core-rest-pipeline-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/core-auth": "^1.10.0",
     "@azure/core-rest-pipeline": "^1.22.0",
     "dotenv": "^16.0.0",

--- a/sdk/eventgrid/eventgrid-perf-tests/package.json
+++ b/sdk/eventgrid/eventgrid-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/eventgrid": "^5.11.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/eventhub/event-hubs-perf-tests/package.json
+++ b/sdk/eventhub/event-hubs-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/core-amqp": "^4.3.6",
     "@azure/event-hubs": "^6.0.0-beta.1",
     "dotenv": "^16.0.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -98,7 +98,7 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@azure-tools/mock-hub": "^1.0.0",
+    "@azure-tools/mock-hub": "workspace:^",
     "@azure-tools/test-credential": "workspace:^",
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure-tools/vite-plugin-browser-test-map": "workspace:^",

--- a/sdk/formrecognizer/ai-form-recognizer-perf-tests/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/ai-form-recognizer": "^5.0.0",
     "@azure/identity": "^4.8.0",
     "dotenv": "^16.0.0",

--- a/sdk/identity/identity-perf-tests/package.json
+++ b/sdk/identity/identity-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "dotenv": "^16.0.0",

--- a/sdk/keyvault/keyvault-certificates-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-certificates-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/keyvault-certificates": "^4.9.0",
     "dotenv": "^16.0.0",

--- a/sdk/keyvault/keyvault-keys-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-keys-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/keyvault-keys": "^4.9.0",
     "dotenv": "^16.0.0",

--- a/sdk/keyvault/keyvault-secrets-perf-tests/package.json
+++ b/sdk/keyvault/keyvault-secrets-perf-tests/package.json
@@ -46,7 +46,7 @@
   ],
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/keyvault-secrets": "^4.9.0",
     "dotenv": "^16.0.0",

--- a/sdk/monitor/monitor-ingestion-perf-tests/package.json
+++ b/sdk/monitor/monitor-ingestion-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/monitor-ingestion": "^1.1.0",
     "dotenv": "^16.0.0",

--- a/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
+++ b/sdk/monitor/monitor-opentelemetry-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/monitor-opentelemetry": "^1.17.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.200.0",

--- a/sdk/schemaregistry/schema-registry-avro-perf-tests/package.json
+++ b/sdk/schemaregistry/schema-registry-avro-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/schema-registry": "1.3.0",
     "@azure/schema-registry-avro": "^1.1.0",

--- a/sdk/search/search-documents-perf-tests/package.json
+++ b/sdk/search/search-documents-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/search-documents": "12.1.0",
     "dotenv": "^16.0.0",

--- a/sdk/servicebus/service-bus-perf-tests/package.json
+++ b/sdk/servicebus/service-bus-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/service-bus": "^7.9.5",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -75,7 +75,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@azure/logger": "^1.1.4",
     "@azure/storage-blob": "^12.26.0",
-    "@azure/storage-internal-avro": "^1.0.0",
+    "@azure/storage-internal-avro": "workspace:^",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/sdk/storage/storage-blob-perf-tests/package.json
+++ b/sdk/storage/storage-blob-perf-tests/package.json
@@ -47,7 +47,7 @@
   "private": true,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/core-rest-pipeline": "^1.19.1",
     "@azure/storage-blob": "^12.27.0",
     "dotenv": "^16.0.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -114,7 +114,7 @@
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure-tools/test-recorder": "workspace:^",
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",

--- a/sdk/storage/storage-file-datalake-perf-tests/package.json
+++ b/sdk/storage/storage-file-datalake-perf-tests/package.json
@@ -47,7 +47,7 @@
   "private": true,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/storage-file-datalake": "^12.26.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure-tools/test-recorder": "workspace:^",
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",

--- a/sdk/storage/storage-file-share-perf-tests/package.json
+++ b/sdk/storage/storage-file-share-perf-tests/package.json
@@ -47,7 +47,7 @@
   "private": true,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/storage-file-share": "^12.27.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -109,7 +109,7 @@
   },
   "devDependencies": {
     "@azure-tools/test-credential": "workspace:^",
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure-tools/test-recorder": "workspace:^",
     "@azure-tools/test-utils-vitest": "workspace:^",
     "@azure/dev-tool": "workspace:^",

--- a/sdk/tables/data-tables-perf-tests/package.json
+++ b/sdk/tables/data-tables-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/data-tables": "^13.3.0",
     "dotenv": "^16.0.0",
     "tslib": "^2.8.1"

--- a/sdk/template/template-perf-tests/package.json
+++ b/sdk/template/template-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/identity": "^4.8.0",
     "@azure/template": "workspace:^",
     "dotenv": "^16.0.0",

--- a/sdk/test-utils/perf/GettingStarted.md
+++ b/sdk/test-utils/perf/GettingStarted.md
@@ -43,7 +43,7 @@ To add perf tests for the `sdk/<service>/<service-sdk>` package, follow the step
     ```json
       "dependencies": {
          "@azure/<service-sdk>": "^<version-in-master-branch>",
-         "@azure-tools/test-perf": "^1.0.0"
+         "@azure-tools/test-perf": "workspace:^"
        }
     ```
 

--- a/sdk/textanalytics/ai-text-analytics-perf-tests/package.json
+++ b/sdk/textanalytics/ai-text-analytics-perf-tests/package.json
@@ -47,7 +47,7 @@
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "private": true,
   "dependencies": {
-    "@azure-tools/test-perf": "^1.0.0",
+    "@azure-tools/test-perf": "workspace:^",
     "@azure/ai-text-analytics": "^5.1.0",
     "@azure/identity": "^4.8.0",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
This fixes the error in `pnpm outdated` in pnpm v11

https://github.com/orgs/pnpm/discussions/12827