### PR TITLE
[dev-tool] set max typescript version to v6

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -41,7 +41,7 @@
   "private": true,
   "prettier": "../eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@_ts/max": "npm:typescript@latest",
+    "@_ts/max": "npm:typescript@~6.0.3",
     "@_ts/min": "npm:typescript@~5.4.2",
     "@azure/identity": "catalog:internal",
     "@microsoft/api-extractor": "^7.52.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
   common/tools/dev-tool:
     dependencies:
       '@_ts/max':
-        specifier: npm:typescript@latest
+        specifier: npm:typescript@~6.0.3
         version: typescript@6.0.3
       '@_ts/min':
         specifier: npm:typescript@~5.4.2


### PR DESCRIPTION
until we fully resolve the dev-tool build error of

>@azure/dev-tool:build: src/commands/run/check-api.ts(6,19): error TS2307: Cannot find module '@_ts/max' or its corresponding type declarations.

in all JS build pipeline