### PR TITLE
[monitor-opentelemetry] Track on-by-default features/instrumentations as SDKStats opt-out flags

### DIFF
--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.18.3 (Unreleased)
+
+### Other Changes
+
+- SDKStats now tracks on-by-default features/instrumentations (disk retry, live metrics, Azure SDK, MongoDB, MySQL, PostgreSQL, Redis) as opt-out flags that are set only when the customer disables them.
+
 ## 1.18.2 (2026-07-01)
 
 ### Bugs Fixed

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/monitor-opentelemetry",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "Azure Monitor OpenTelemetry (Node.js)",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -79,7 +79,11 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     disableMongoDb: config.instrumentationOptions?.mongoDb?.enabled === false,
     disableMySql: config.instrumentationOptions?.mySql?.enabled === false,
     disablePostgreSql: config.instrumentationOptions?.postgreSql?.enabled === false,
-    disableRedis: config.instrumentationOptions?.redis?.enabled === false,
+    // redis and redis4 share the same underlying Redis instrumentation, which is
+    // registered when either is enabled. Only count Redis as disabled when both are off.
+    disableRedis:
+      config.instrumentationOptions?.redis?.enabled === false &&
+      config.instrumentationOptions?.redis4?.enabled === false,
     bunyan: config.instrumentationOptions?.bunyan?.enabled,
     winston: config.instrumentationOptions?.winston?.enabled,
   };

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -73,12 +73,13 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   const config = new InternalConfig(options);
   patchOpenTelemetryInstrumentationEnable();
   const statsbeatInstrumentations: StatsbeatInstrumentations = {
-    // Instrumentations
-    azureSdk: config.instrumentationOptions?.azureSdk?.enabled,
-    mongoDb: config.instrumentationOptions?.mongoDb?.enabled,
-    mySql: config.instrumentationOptions?.mySql?.enabled,
-    postgreSql: config.instrumentationOptions?.postgreSql?.enabled,
-    redis: config.instrumentationOptions?.redis?.enabled,
+    // On-by-default instrumentations: the flag is set only when the customer
+    // disables the instrumentation. Order must match the Kusto bit map.
+    disableAzureSdk: config.instrumentationOptions?.azureSdk?.enabled === false,
+    disableMongoDb: config.instrumentationOptions?.mongoDb?.enabled === false,
+    disableMySql: config.instrumentationOptions?.mySql?.enabled === false,
+    disablePostgreSql: config.instrumentationOptions?.postgreSql?.enabled === false,
+    disableRedis: config.instrumentationOptions?.redis?.enabled === false,
     bunyan: config.instrumentationOptions?.bunyan?.enabled,
     winston: config.instrumentationOptions?.winston?.enabled,
   };
@@ -92,9 +93,14 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   const statsbeatFeatures: StatsbeatFeatures = {
     browserSdkLoader: config.browserSdkLoaderOptions.enabled,
     aadHandling: !!config.azureMonitorExporterOptions?.credential,
-    diskRetry: !config.azureMonitorExporterOptions?.disableOfflineStorage,
     customerSdkStats: process.env[APPLICATIONINSIGHTS_SDKSTATS_DISABLED]?.toLowerCase() === "true",
     aksResourceDetectorPopulation: aksResourceDetected,
+    // On-by-default features: the flag is set only when the customer disables the feature.
+    disableDiskRetry: !!config.azureMonitorExporterOptions?.disableOfflineStorage,
+    // Live metrics counts as "enabled" only when actually accessed (a live metrics
+    // session is established). At init it has not been accessed, so it starts as
+    // disabled; activateMetrics() clears this flag when a session connects.
+    disableLiveMetrics: true,
   };
   getInstance().setStatsbeatFeatures(statsbeatInstrumentations, statsbeatFeatures);
 

--- a/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/metrics/quickpulse/liveMetrics.ts
@@ -318,9 +318,9 @@ export class LiveMetrics {
     if (this.meterProvider) {
       return;
     }
-    // Turn on live metrics active collection for statsbeat
+    // Live metrics is now being accessed, so clear the "disabled" opt-out flag for statsbeat.
     if (!this.statsbeatOptionsUpdated) {
-      getInstance().setStatsbeatFeatures({}, { liveMetrics: true });
+      getInstance().setStatsbeatFeatures({}, { disableLiveMetrics: false });
       this.statsbeatOptionsUpdated = true;
     }
     this.totalDependencyCount = 0;

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -70,11 +70,11 @@ export interface InstrumentationOptions {
  * @internal
  */
 export interface StatsbeatFeatures {
-  diskRetry?: boolean;
+  disableDiskRetry?: boolean;
   aadHandling?: boolean;
   browserSdkLoader?: boolean;
   distro?: boolean;
-  liveMetrics?: boolean;
+  disableLiveMetrics?: boolean;
   shim?: boolean;
   customerSdkStats?: boolean;
   multiIkey?: boolean;
@@ -86,11 +86,11 @@ export interface StatsbeatFeatures {
  * @internal
  */
 export const StatsbeatFeaturesMap = new Map<string, number>([
-  ["diskRetry", 1],
+  ["disableDiskRetry", 1],
   ["aadHandling", 2],
   ["browserSdkLoader", 4],
   ["distro", 8],
-  ["liveMetrics", 16],
+  ["disableLiveMetrics", 16],
   ["shim", 32],
   ["customerSdkStats", 64],
   ["multiIkey", 128],
@@ -102,12 +102,13 @@ export const StatsbeatFeaturesMap = new Map<string, number>([
  * @internal
  */
 export interface StatsbeatInstrumentations {
-  /** Azure Monitor Supported Instrumentations */
-  azureSdk?: boolean;
-  mongoDb?: boolean;
-  mySql?: boolean;
-  postgreSql?: boolean;
-  redis?: boolean;
+  /** Azure Monitor Supported Instrumentations. These are on-by-default, so the
+   * flag is set only when the customer disables the instrumentation. */
+  disableAzureSdk?: boolean;
+  disableMongoDb?: boolean;
+  disableMySql?: boolean;
+  disablePostgreSql?: boolean;
+  disableRedis?: boolean;
   bunyan?: boolean;
   winston?: boolean;
   /** OpenTelemetry Community Instrumentations */
@@ -160,7 +161,7 @@ export interface BrowserSdkLoaderOptions {
   connectionString?: string;
 }
 
-export const AZURE_MONITOR_OPENTELEMETRY_VERSION = "1.18.2";
+export const AZURE_MONITOR_OPENTELEMETRY_VERSION = "1.18.3";
 export const AZURE_MONITOR_STATSBEAT_FEATURES = "AZURE_MONITOR_STATSBEAT_FEATURES";
 export const AZURE_MONITOR_PREFIX = "AZURE_MONITOR_PREFIX";
 export const AZURE_MONITOR_AUTO_ATTACH = "AZURE_MONITOR_AUTO_ATTACH";
@@ -202,11 +203,11 @@ export const APPLICATIONINSIGHTS_SDKSTATS_DISABLED = "APPLICATIONINSIGHTS_SDKSTA
 
 export enum StatsbeatFeature {
   NONE = 0,
-  DISK_RETRY = 1,
+  DISABLE_DISK_RETRY = 1,
   AAD_HANDLING = 2,
   BROWSER_SDK_LOADER = 4,
   DISTRO = 8,
-  LIVE_METRICS = 16,
+  DISABLE_LIVE_METRICS = 16,
   SHIM = 32,
   CUSTOMER_SDKSTATS = 64,
   MULTI_IKEY = 128,
@@ -216,11 +217,11 @@ export enum StatsbeatFeature {
 export enum StatsbeatInstrumentation {
   /** Azure Monitor Supported Instrumentations */
   NONE = 0,
-  AZURE_CORE_TRACING = 1,
-  MONGODB = 2,
-  MYSQL = 4,
-  REDIS = 8,
-  POSTGRES = 16,
+  DISABLE_AZURE_SDK = 1,
+  DISABLE_MONGODB = 2,
+  DISABLE_MYSQL = 4,
+  DISABLE_POSTGRESQL = 8,
+  DISABLE_REDIS = 16,
   BUNYAN = 32,
   WINSTON = 64,
   /** OpenTelemetry Supported Instrumentations */

--- a/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
@@ -121,10 +121,6 @@ class StatsbeatConfiguration {
       this.currentStatsbeatFeatures.distro = true;
     }
 
-    if (statsbeatFeatures.liveMetrics) {
-      this.currentStatsbeatFeatures.liveMetrics = true;
-    }
-
     const featureArray: Array<StatsbeatOption> = Object.entries(this.currentStatsbeatFeatures).map(
       (entry) => {
         return { option: entry[0], value: entry[1] };

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -339,7 +339,9 @@ describe("Main functions", () => {
         mongoDb: { enabled: false },
         mySql: { enabled: false },
         postgreSql: { enabled: false },
+        // redis and redis4 share the same instrumentation; both must be off to count as disabled.
         redis: { enabled: false },
+        redis4: { enabled: false },
       },
     };
     useAzureMonitor(config);
@@ -371,6 +373,27 @@ describe("Main functions", () => {
         StatsbeatInstrumentation.DISABLE_MYSQL |
         StatsbeatInstrumentation.DISABLE_POSTGRESQL |
         StatsbeatInstrumentation.DISABLE_REDIS,
+    );
+  });
+
+  it("should not set DISABLE_REDIS when redis is disabled but redis4 is still enabled", () => {
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      instrumentationOptions: {
+        // redis and redis4 share the same underlying instrumentation, which stays
+        // enabled while redis4 is on, so Redis must not be counted as disabled.
+        redis: { enabled: false },
+        redis4: { enabled: true },
+      },
+    };
+    useAzureMonitor(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const instrumentations = Number(output["instrumentation"]);
+    assert.notOk(
+      instrumentations & StatsbeatInstrumentation.DISABLE_REDIS,
+      "DISABLE_REDIS should not be set while redis4 is still enabled",
     );
   });
 

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -307,24 +307,97 @@ describe("Main functions", () => {
     const features = Number(output["feature"]);
     const instrumentations = Number(output["instrumentation"]);
     assert.notOk(features & StatsbeatFeature.AAD_HANDLING, "AAD_HANDLING is set");
-    assert.notOk(features & StatsbeatFeature.DISK_RETRY, "DISK_RETRY is set");
     assert.notOk(features & StatsbeatFeature.BROWSER_SDK_LOADER, "BROWSER_SDK_LOADER is set");
     assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO is not set");
-    assert.strictEqual(features, 8);
-    assert.ok(
-      instrumentations & StatsbeatInstrumentation.AZURE_CORE_TRACING,
-      "AZURE_CORE_TRACING not set",
+    // Offline storage is disabled, so the opt-out DISABLE_DISK_RETRY feature is set.
+    assert.ok(features & StatsbeatFeature.DISABLE_DISK_RETRY, "DISABLE_DISK_RETRY is not set");
+    // Live metrics has not been accessed, so it counts as disabled until a session is established.
+    assert.ok(features & StatsbeatFeature.DISABLE_LIVE_METRICS, "DISABLE_LIVE_METRICS is not set");
+    assert.strictEqual(
+      features,
+      StatsbeatFeature.DISTRO |
+        StatsbeatFeature.DISABLE_DISK_RETRY |
+        StatsbeatFeature.DISABLE_LIVE_METRICS,
     );
     assert.notOk(features & StatsbeatFeature.SHIM, "SHIM is set");
     assert.notOk(
       features & StatsbeatFeature.AKS_RESOURCE_DETECTOR_POPULATION,
       "AKS_RESOURCE_DETECTOR_POPULATION should not be set",
     );
-    assert.ok(instrumentations & StatsbeatInstrumentation.MONGODB, "MONGODB not set");
-    assert.ok(instrumentations & StatsbeatInstrumentation.MYSQL, "MYSQL not set");
-    assert.ok(instrumentations & StatsbeatInstrumentation.POSTGRES, "POSTGRES not set");
-    assert.ok(instrumentations & StatsbeatInstrumentation.REDIS, "REDIS not set");
-    assert.strictEqual(instrumentations, 31);
+    // On-by-default instrumentations are enabled, so none of the DISABLE_* instrumentation bits set.
+    assert.strictEqual(instrumentations, 0);
+  });
+
+  it("should set DISABLE_* opt-out flags when on-by-default features/instrumentations are disabled", () => {
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      enableLiveMetrics: false,
+      instrumentationOptions: {
+        azureSdk: { enabled: false },
+        mongoDb: { enabled: false },
+        mySql: { enabled: false },
+        postgreSql: { enabled: false },
+        redis: { enabled: false },
+      },
+    };
+    useAzureMonitor(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const features = Number(output["feature"]);
+    const instrumentations = Number(output["instrumentation"]);
+    // Live metrics disabled -> feature bit set. Offline storage enabled (default) -> not set.
+    assert.ok(features & StatsbeatFeature.DISABLE_LIVE_METRICS, "DISABLE_LIVE_METRICS is not set");
+    assert.notOk(features & StatsbeatFeature.DISABLE_DISK_RETRY, "DISABLE_DISK_RETRY is set");
+    // Disabled instrumentations -> their DISABLE_* instrumentation bits are set.
+    assert.ok(
+      instrumentations & StatsbeatInstrumentation.DISABLE_AZURE_SDK,
+      "DISABLE_AZURE_SDK is not set",
+    );
+    assert.ok(
+      instrumentations & StatsbeatInstrumentation.DISABLE_MONGODB,
+      "DISABLE_MONGODB not set",
+    );
+    assert.ok(instrumentations & StatsbeatInstrumentation.DISABLE_MYSQL, "DISABLE_MYSQL not set");
+    assert.ok(
+      instrumentations & StatsbeatInstrumentation.DISABLE_POSTGRESQL,
+      "DISABLE_POSTGRESQL is not set",
+    );
+    assert.ok(instrumentations & StatsbeatInstrumentation.DISABLE_REDIS, "DISABLE_REDIS not set");
+    assert.strictEqual(
+      instrumentations,
+      StatsbeatInstrumentation.DISABLE_AZURE_SDK |
+        StatsbeatInstrumentation.DISABLE_MONGODB |
+        StatsbeatInstrumentation.DISABLE_MYSQL |
+        StatsbeatInstrumentation.DISABLE_POSTGRESQL |
+        StatsbeatInstrumentation.DISABLE_REDIS,
+    );
+  });
+
+  it("should clear DISABLE_LIVE_METRICS once live metrics is accessed", () => {
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      enableLiveMetrics: true,
+    };
+    useAzureMonitor(config);
+    let features = Number(
+      JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]))["feature"],
+    );
+    // Not accessed yet -> counts as disabled.
+    assert.ok(features & StatsbeatFeature.DISABLE_LIVE_METRICS, "DISABLE_LIVE_METRICS is not set");
+
+    // Simulate a live metrics session being established (LiveMetrics.activateMetrics).
+    getInstance().setStatsbeatFeatures({}, { disableLiveMetrics: false });
+    features = Number(
+      JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]))["feature"],
+    );
+    assert.notOk(
+      features & StatsbeatFeature.DISABLE_LIVE_METRICS,
+      "DISABLE_LIVE_METRICS should be cleared once live metrics is accessed",
+    );
+    assert.ok(features & StatsbeatFeature.DISTRO, "DISTRO should remain set");
   });
 
   it("should set shim feature in statsbeat if env var is populated", () => {
@@ -378,8 +451,8 @@ describe("Main functions", () => {
     const env = <{ [id: string]: string }>{};
     let current = 0;
     current |= StatsbeatFeature.AAD_HANDLING;
-    current |= StatsbeatFeature.DISK_RETRY;
-    current |= StatsbeatFeature.LIVE_METRICS;
+    current |= StatsbeatFeature.DISABLE_DISK_RETRY;
+    current |= StatsbeatFeature.DISABLE_LIVE_METRICS;
     env.AZURE_MONITOR_STATSBEAT_FEATURES = current.toString();
     process.env = env;
     const config: AzureMonitorOpenTelemetryOptions = {
@@ -391,10 +464,13 @@ describe("Main functions", () => {
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const numberOutput = Number(output["feature"]);
     assert.ok(numberOutput & StatsbeatFeature.AAD_HANDLING, "AAD_HANDLING not set");
-    assert.ok(numberOutput & StatsbeatFeature.DISK_RETRY, "DISK_RETRY not set");
+    assert.ok(numberOutput & StatsbeatFeature.DISABLE_DISK_RETRY, "DISABLE_DISK_RETRY not set");
     assert.ok(numberOutput & StatsbeatFeature.DISTRO, "DISTRO not set");
     assert.notOk(numberOutput & StatsbeatFeature.BROWSER_SDK_LOADER, "BROWSER_SDK_LOADER is set");
-    assert.ok(numberOutput & StatsbeatFeature.LIVE_METRICS, "LIVE_METRICS is not set");
+    assert.ok(
+      numberOutput & StatsbeatFeature.DISABLE_LIVE_METRICS,
+      "DISABLE_LIVE_METRICS is not set",
+    );
   });
 
   it("should capture the app service SDK prefix correctly", () => {
@@ -530,13 +606,15 @@ describe("Main functions", () => {
         connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
       },
       instrumentationOptions: {
-        azureSdk: { enabled: false },
+        // Keep on-by-default instrumentations enabled so no DISABLE_* bits are set
+        // and the base instrumentation bitmap is 0 before the dynamic update.
+        azureSdk: { enabled: true },
         http: { enabled: false },
-        mongoDb: { enabled: false },
-        mySql: { enabled: false },
-        postgreSql: { enabled: false },
-        redis: { enabled: false },
-        redis4: { enabled: false },
+        mongoDb: { enabled: true },
+        mySql: { enabled: true },
+        postgreSql: { enabled: true },
+        redis: { enabled: true },
+        redis4: { enabled: true },
         bunyan: { enabled: false },
         winston: { enabled: false },
       },


### PR DESCRIPTION
## Summary
Reworks Azure Monitor SDKStats tracking for on-by-default features/instrumentations so they are recorded as **opt-out** flags — the bit is set only when the customer has **disabled** the capability (tracking an always-on enabled state gives no signal).

Affected (existing bit values reused, just renamed + inverted):
- Features: `DISK_RETRY` -> `DISABLE_DISK_RETRY`, `LIVE_METRICS` -> `DISABLE_LIVE_METRICS`
- Instrumentations: `AZURE_CORE_TRACING` -> `DISABLE_AZURE_SDK`, `MONGODB` -> `DISABLE_MONGODB`, `MYSQL` -> `DISABLE_MYSQL`, and the bit-3/bit-4 labels corrected to match what the SDK actually emits (`DISABLE_POSTGRESQL` = bit 3, `DISABLE_REDIS` = bit 4)

**Live metrics** counts as enabled only when actually **accessed** (a live metrics session is established) — not merely turned on in settings. `DISABLE_LIVE_METRICS` starts set at init and is cleared by `activateMetrics()`.

## Testing
- Unit tests updated + added (incl. "clears once live metrics is accessed").
- End-to-end verification: real SDK -> `AZURE_MONITOR_STATSBEAT_FEATURES` -> exporter split -> Kusto bit-map decode, all decode to the correct `DISABLE_*` names.

Coordinated with matching changes in the Microsoft distro and the SDKStats Kusto pipeline.
