### PR TITLE
[EngSys] fix check-external-dependency.ps1

### DIFF
--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -77,12 +77,20 @@ function Set-GitHubIssue($Package) {
 
 # do a update first so we don't report on upgrades that will be in azure sdk bot PR
 Write-Host "Running pnpm update --recursive --no-save"
-pnpm update --recursive --no-save
+pnpm update --recursive --no-save --no-color
 
 Write-Host "Running 'pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-*  outdated --format json --recursive'"
 $env:NODE_OPTIONS = "--max-old-space-size=16384"
-$pnpmOutdatedOutput = & pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-* outdated --format json --recursive | Where-Object { -not ($_.StartsWith(" WARN ", [System.StringComparison]::OrdinalIgnoreCase)) }
+$pnpmOutdatedOutput = & pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-* outdated --format json --recursive --no-color | Where-Object { -not ($_.Contains("[WARN]", [System.StringComparison]::OrdinalIgnoreCase)) }
 
+try {
+  $pnpmOutdatedOutput | ConvertFrom-Json | Out-Null
+}
+catch {
+  Write-Host "Error parsing pnpm outdated output as JSON. Output was:"
+  Write-Host $pnpmOutdatedOutput
+  throw $_
+}
 $availableUpdates = $pnpmOutdatedOutput | ConvertFrom-Json
 
 foreach ($update in $availableUpdates.PSObject.Properties) {

--- a/eng/scripts/check-external-dependency.ps1
+++ b/eng/scripts/check-external-dependency.ps1
@@ -76,23 +76,22 @@ function Set-GitHubIssue($Package) {
 }
 
 # do a update first so we don't report on upgrades that will be in azure sdk bot PR
-Write-Host "Running pnpm update --recursive --no-save"
+Write-Host "Running pnpm update --recursive --no-save --no-color"
 pnpm update --recursive --no-save --no-color
 
-Write-Host "Running 'pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-*  outdated --format json --recursive'"
+Write-Host "Running 'pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-*  outdated --format json --recursive --no-color'"
 $env:NODE_OPTIONS = "--max-old-space-size=16384"
 $pnpmOutdatedOutput = & pnpm --filter=!@azure/arm-* --filter=!@azure-rest/arm-* outdated --format json --recursive --no-color | Where-Object { -not ($_.Contains("[WARN]", [System.StringComparison]::OrdinalIgnoreCase)) }
 
 try {
-  $pnpmOutdatedOutput | ConvertFrom-Json | Out-Null
+  $pnpmOutdatedJson = $pnpmOutdatedOutput -join "`n"
+  $availableUpdates = $pnpmOutdatedJson | ConvertFrom-Json
 }
 catch {
   Write-Host "Error parsing pnpm outdated output as JSON. Output was:"
-  Write-Host $pnpmOutdatedOutput
-  throw $_
+  Write-Host ($pnpmOutdatedOutput -join "`n")
+  throw
 }
-$availableUpdates = $pnpmOutdatedOutput | ConvertFrom-Json
-
 foreach ($update in $availableUpdates.PSObject.Properties) {
   if ($update.Name -notmatch '^@azure') {
     $p = New-Object PSObject -Property @{


### PR DESCRIPTION
The `pnpm outdated` output in v11 contains ascii color control codes and the
warning prefix is slightly different

This PR

- uses `--no-color` option
- filters out `Contains("[WARN]")` lines
- logs output that does not parse as JSON