### PR TITLE
Update CODEOWNERS for communication-common and communication-identity to match ACS Auth roster

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -127,7 +127,7 @@
 
 # ServiceLabel: %Communication - Common
 # PRLabel: %Communication - Common
-/sdk/communication/communication-common/    @anjulgarg @Joeleniqs @tsohoni-msft @kasasan_microsoft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20
+/sdk/communication/communication-common/    @anjulgarg @Joeleniqs @tsohoni-msft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20
 
 # ServiceLabel: %Communication - Email
 # PRLabel: %Communication - Email
@@ -135,7 +135,7 @@
 
 # ServiceLabel: %Communication - Identity
 # PRLabel: %Communication - Identity
-/sdk/communication/communication-identity/    @anjulgarg @Joeleniqs @tsohoni-msft @kasasan_microsoft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20
+/sdk/communication/communication-identity/    @anjulgarg @Joeleniqs @tsohoni-msft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20
 
 # ServiceLabel: %Communication - Job Router
 # PRLabel: %Communication - Job Router

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,7 +135,7 @@
 
 # ServiceLabel: %Communication - Identity
 # PRLabel: %Communication - Identity
-/sdk/communication/communication-identity/    @anjulgarg @Joeleniqs @alvinjiang-msft
+/sdk/communication/communication-identity/    @anjulgarg @Joeleniqs @tsohoni-msft @kasasan_microsoft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20
 
 # ServiceLabel: %Communication - Job Router
 # PRLabel: %Communication - Job Router

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -127,7 +127,7 @@
 
 # ServiceLabel: %Communication - Common
 # PRLabel: %Communication - Common
-/sdk/communication/communication-common/    @anjulgarg @Joeleniqs @alvinjiang-msft
+/sdk/communication/communication-common/    @anjulgarg @Joeleniqs @tsohoni-msft @kasasan_microsoft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20
 
 # ServiceLabel: %Communication - Email
 # PRLabel: %Communication - Email


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/communication-common`
- `@azure/communication-identity`

(CODEOWNERS-only change — no shipped code in these packages is modified.)

### Issues associated with this PR

- N/A

### Describe the problem that is addressed by this PR

The `communication-common` and `communication-identity` CODEOWNERS entries listed only a subset of the ACS Auth team, so several team members weren't being auto-requested for review or able to approve PRs to these packages. This mirrors the iOS SDK update in Azure/azure-sdk-for-ios#2475 and follows the team decision (standup 2026-07-08) to align CODEOWNERS across all ACS repos.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Add the full ACS Auth roster to both team-owned entries: `@anjulgarg @Joeleniqs @tsohoni-msft @kasasan_microsoft @JohnRFraser @alvinjiang-msft @jorge-beauregard @preetkaran20`. An alternative was a GitHub team handle instead of individual aliases, but the existing entries and the iOS change use individual handles, so this keeps the two repos consistent and avoids creating/managing a new team.

### Are there test cases added in this PR? _(If not, why?)_

No — CODEOWNERS is configuration, not code. Validity is enforced by the repository's `codeowners-linter` check (verifies each handle has write access and public org membership).

### Provide a list of related PRs _(if any)_

- Azure/azure-sdk-for-ios#2475 (the equivalent iOS SDK change)

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

- N/A

### Checklists
- [x] Added impacted package name to the issue description
- [ ] Does this PR needs any fixes in the SDK Generator?** _(If so, create an Issue in the [Autorest/typescript](https://github.com/Azure/autorest.typescript) repository and link it here)_ — N/A, not a generated package
- [x] Added a changelog (if necessary) — N/A, CODEOWNERS-only change