### PR TITLE
[EventGrid] Bump eventgrid-systemevents to 1.1.0 (new API surface)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,7 +206,7 @@
 # ServiceLabel: %EngSys
 
 # PRLabel: %Event Grid
-/sdk/eventgrid/    @Kishp01 @shankarsama @Nishanth-MS
+/sdk/eventgrid/    @shankarsama @Nishanth-MS
 
 # AzureSdkOwners: @rajeshka @shankarsama
 # ServiceLabel: %Event Grid

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,7 +206,7 @@
 # ServiceLabel: %EngSys
 
 # PRLabel: %Event Grid
-/sdk/eventgrid/    @rajeshka @shankarsama
+/sdk/eventgrid/    @Kishp01 @shankarsama @Nishanth-MS
 
 # AzureSdkOwners: @rajeshka @shankarsama
 # ServiceLabel: %Event Grid

--- a/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.0.3 (2026-06-25)
+## 1.1.0 (2026-06-25)
 
-### Bugs Fixed
+### Features Added
 
-- Add types that are missing from public API surface.
+- Added types that were missing from the public API surface.
 
 ## 1.0.1 (2025-06-27)
 

--- a/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/eventgrid-systemevents/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added types that were missing from the public API surface.
+- Added types that were missing from the public API surface. Refer [PR #39235](https://github.com/Azure/azure-sdk-for-js/pull/39235/) for further details.
 
 ## 1.0.1 (2025-06-27)
 

--- a/sdk/eventgrid/eventgrid-systemevents/package.json
+++ b/sdk/eventgrid/eventgrid-systemevents/package.json
@@ -3,7 +3,7 @@
   "sdk-type": "client",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure Event Grid service.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "keywords": [
     "node",
     "azure",


### PR DESCRIPTION
Addresses APIView reviewer feedback: the release adds **new public API surface** (types that were missing), so it warrants a **minor** version bump rather than a patch.

### Changes
- `package.json`: `1.0.3` -> `1.1.0`
- `CHANGELOG.md`: `## 1.0.3 (2026-06-25)` -> `## 1.1.0 (2026-06-25)`, and reclassified the note from **Bugs Fixed** to **Features Added** (new surface area, not a bug fix).

### Context
Per SemVer / Azure SDK versioning guidance, new features on a stable package increment the **minor** version. This matches the reviewer's request on the APIView.