### PR TITLE
[ai-projects] Clean up weather OpenAPI sample assets

### DIFF
--- a/sdk/ai/ai-projects/samples-dev/agents/assets/weather_openapi.json
+++ b/sdk/ai/ai-projects/samples-dev/agents/assets/weather_openapi.json
@@ -10,7 +10,6 @@
       "url": "https://wttr.in"
     }
   ],
-  "auth": [],
   "paths": {
     "/{location}": {
       "get": {
@@ -55,8 +54,5 @@
         "deprecated": false
       }
     }
-  },
-  "components": {
-    "schemes": {}
   }
 }

--- a/sdk/ai/ai-projects/samples/v2-beta/javascript/agents/assets/weather_openapi.json
+++ b/sdk/ai/ai-projects/samples/v2-beta/javascript/agents/assets/weather_openapi.json
@@ -10,7 +10,6 @@
       "url": "https://wttr.in"
     }
   ],
-  "auth": [],
   "paths": {
     "/{location}": {
       "get": {
@@ -55,8 +54,5 @@
         "deprecated": false
       }
     }
-  },
-  "components": {
-    "schemes": {}
   }
 }

--- a/sdk/ai/ai-projects/samples/v2-beta/typescript/agents/assets/weather_openapi.json
+++ b/sdk/ai/ai-projects/samples/v2-beta/typescript/agents/assets/weather_openapi.json
@@ -10,7 +10,6 @@
       "url": "https://wttr.in"
     }
   ],
-  "auth": [],
   "paths": {
     "/{location}": {
       "get": {
@@ -55,8 +54,5 @@
         "deprecated": false
       }
     }
-  },
-  "components": {
-    "schemes": {}
   }
 }

--- a/sdk/ai/ai-projects/samples/v2/javascript/agents/assets/weather_openapi.json
+++ b/sdk/ai/ai-projects/samples/v2/javascript/agents/assets/weather_openapi.json
@@ -10,7 +10,6 @@
       "url": "https://wttr.in"
     }
   ],
-  "auth": [],
   "paths": {
     "/{location}": {
       "get": {
@@ -55,8 +54,5 @@
         "deprecated": false
       }
     }
-  },
-  "components": {
-    "schemes": {}
   }
 }

--- a/sdk/ai/ai-projects/samples/v2/typescript/agents/assets/weather_openapi.json
+++ b/sdk/ai/ai-projects/samples/v2/typescript/agents/assets/weather_openapi.json
@@ -10,7 +10,6 @@
       "url": "https://wttr.in"
     }
   ],
-  "auth": [],
   "paths": {
     "/{location}": {
       "get": {
@@ -55,8 +54,5 @@
         "deprecated": false
       }
     }
-  },
-  "components": {
-    "schemes": {}
   }
 }


### PR DESCRIPTION
## Description

Ports the weather OpenAPI cleanup from [Azure/azure-sdk-for-python#47980](https://github.com/Azure/azure-sdk-for-python/pull/47980) to the JavaScript SDK.

- Removes the non-standard top-level `auth` field.
- Removes the empty invalid `components.schemes` block.
- Updates the canonical sample asset and all stable/beta JavaScript and TypeScript published copies.

The package `assets.json` tag is unchanged because it points to JavaScript test recordings, which this sample-only change does not modify.

## Testing

- Passed JSON parsing, removed-field assertions, and byte-for-byte parity checks across all five assets.
- Passed `git diff --check`.
- `npm run generate-samples` is blocked by the existing unsupported dynamic import in `samples-dev/agents/agentBasicWithConsoleTracing.ts`.
- `npm run build:samples` is blocked by 64 existing API/type errors across 16 unrelated sample files.