### PR TITLE
[dev-tool] Surface actual failures in extract-api and test runner

### DIFF
--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -139,11 +139,17 @@ function customMessageCallback(message: ExtractorMessage): void {
   }
 }
 
+interface ExtractApiResult {
+  succeeded: boolean;
+  errorCount: number;
+  warningCount: number;
+}
+
 function extractApi(
   configObject: IConfigFile,
   configObjectFullPath: string,
   packageJsonFullPath: string,
-): boolean {
+): ExtractApiResult {
   const config = ExtractorConfig.prepare({
     configObject,
     configObjectFullPath,
@@ -160,7 +166,11 @@ function extractApi(
       `API Extractor completed with ${result.errorCount} errors and ${result.warningCount} warnings`,
     );
   }
-  return result.succeeded;
+  return {
+    succeeded: result.succeeded,
+    errorCount: result.errorCount,
+    warningCount: result.warningCount,
+  };
 }
 
 function createApiDiff(
@@ -265,7 +275,14 @@ async function extractApiForEntry(
     };
   }
 
-  extractApi(newConfig, configPath, pkgPath);
+  const extractResult = extractApi(newConfig, configPath, pkgPath);
+  if (!extractResult.succeeded) {
+    throw new Error(
+      `API Extractor failed for entry '${createNameWithRuntime(entry)}' ` +
+        `(mainEntryPoint: ${entry.mainEntryPointFilePath}) with ${extractResult.errorCount} errors ` +
+        `and ${extractResult.warningCount} warnings. Expected report at ${tempReportPath}.`,
+    );
+  }
 
   const content = await readFile(tempReportPath, "utf-8");
   await unlink(tempReportPath);
@@ -430,7 +447,7 @@ export default leafCommand(commandInfo, async () => {
       );
     }
   } else {
-    success = extractApi(baseConfig, configPath, pkgPath);
+    success = extractApi(baseConfig, configPath, pkgPath).succeeded;
   }
 
   return success;

--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -301,7 +301,9 @@ async function writeRuntimeApiFiles(
       const isNodeRuntime = runtime === "node";
       const filename = `${packageName}${pathSuffix}-${runtime}${isNodeRuntime ? ".api.md" : ".api.diff.md"}`;
       const filePath = path.join(reviewDirPath, filename);
-      await writeFile(filePath, content);
+      await withFsRetry(`writing ${runtime} API review file ${filePath}`, () =>
+        writeFile(filePath, content),
+      );
       log.info(`Written ${runtime} API ${isNodeRuntime ? "file" : "diff"} to ${filename}`);
     }
   }
@@ -313,6 +315,30 @@ function getUnscopedPackageName(packageName: string): string {
 
 function isManagementPackage(packageName: string): boolean {
   return packageName.includes("/arm-");
+}
+
+const TRANSIENT_FS_CODES = new Set(["EBUSY", "EPERM", "ENOENT", "EMFILE", "EAGAIN", "UNKNOWN"]);
+
+async function withFsRetry<T>(
+  description: string,
+  op: () => Promise<T>,
+  attempts = 4,
+  baseDelayMs = 150,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      return await op();
+    } catch (err) {
+      lastErr = err;
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (i === attempts || !code || !TRANSIENT_FS_CODES.has(code)) break;
+      log.warn(`${description} failed (attempt ${i}/${attempts}) with ${code}; retrying...`);
+      await new Promise((r) => globalThis.setTimeout(r, baseDelayMs * i));
+    }
+  }
+  const code = (lastErr as NodeJS.ErrnoException)?.code ?? "unknown error";
+  throw new Error(`${description} failed after ${attempts} attempts (${code})`, { cause: lastErr });
 }
 
 async function loadApiJsonForSubPath(fullPath: string): Promise<ApiJson> {
@@ -343,7 +369,9 @@ async function buildMergedApiJson(
     return;
   }
 
-  const apiJson = await loadApiJsonForSubPath(mainApiJsonPath);
+  const apiJson = await withFsRetry(`reading API JSON ${mainApiJsonPath}`, () =>
+    loadApiJsonForSubPath(mainApiJsonPath),
+  );
   apiJson.metadata.dependencies = dependencies;
   apiJson.metadata.version = version;
   for (const subpath of exports) {
@@ -356,7 +384,9 @@ async function buildMergedApiJson(
     }
 
     log.debug(`loading api package for "${nameWithRuntime}"`);
-    const subpathApiJson = await loadApiJsonForSubPath(p);
+    const subpathApiJson = await withFsRetry(`reading API JSON ${p}`, () =>
+      loadApiJsonForSubPath(p),
+    );
     const entryPoint = subpathApiJson.members.filter((m) => m.kind === "EntryPoint")[0];
     if (!entryPoint) {
       log.debug(`No EntryPoint found in ${p}`);
@@ -366,14 +396,16 @@ async function buildMergedApiJson(
     entryPoint.canonicalReference = `${entryPoint.canonicalReference}/${subpath.baseName}`;
     apiJson.members.push(entryPoint);
     log.debug(`deleting ${p} after merging its entrypoint`);
-    await unlink(p);
+    await withFsRetry(`removing merged subpath temp file ${p}`, () => unlink(p));
   }
 
   const augmentedApiJsonPath = useMerged
     ? mainApiJsonPath
     : mainApiJsonPath.replace(".api.json", `.augmented.json`);
   log.info(`writing merged api to ${augmentedApiJsonPath}`);
-  await writeFile(augmentedApiJsonPath, JSON.stringify(apiJson, undefined, 2));
+  await withFsRetry(`writing merged API JSON to ${augmentedApiJsonPath}`, () =>
+    writeFile(augmentedApiJsonPath, JSON.stringify(apiJson, undefined, 2)),
+  );
   return augmentedApiJsonPath;
 }
 
@@ -432,19 +464,29 @@ export default leafCommand(commandInfo, async () => {
       }
     }
     const unscoped = getUnscopedPackageName(projectInfo.name);
-    await writeRuntimeApiFiles(runtimeApiFiles, reviewDir, unscoped);
+    try {
+      await writeRuntimeApiFiles(runtimeApiFiles, reviewDir, unscoped);
+    } catch (err) {
+      log.error(`[extract-api] Failed to write API review files for ${projectInfo.name}:`, err);
+      success = false;
+    }
 
     if (baseConfig.docModel?.enabled) {
       const reportTempDir = path.join(projectInfo.path, "temp");
       const nodeExports = exports.filter((e) => e.runtime === "node");
-      await buildMergedApiJson(
-        unscoped,
-        reportTempDir,
-        nodeExports,
-        pkgJson["dependencies"] || {},
-        pkgJson["version"],
-        true,
-      );
+      try {
+        await buildMergedApiJson(
+          unscoped,
+          reportTempDir,
+          nodeExports,
+          pkgJson["dependencies"] || {},
+          pkgJson["version"],
+          true,
+        );
+      } catch (err) {
+        log.error(`[extract-api] Failed to build merged API JSON for ${projectInfo.name}:`, err);
+        success = false;
+      }
     }
   } else {
     success = extractApi(baseConfig, configPath, pkgPath).succeeded;

--- a/common/tools/dev-tool/src/commands/run/extract-api.ts
+++ b/common/tools/dev-tool/src/commands/run/extract-api.ts
@@ -6,6 +6,7 @@ import type {
   IConfigDocModel,
   IConfigFile,
   ExtractorMessage,
+  ExtractorResult,
 } from "@microsoft/api-extractor";
 import {
   Extractor,
@@ -139,17 +140,11 @@ function customMessageCallback(message: ExtractorMessage): void {
   }
 }
 
-interface ExtractApiResult {
-  succeeded: boolean;
-  errorCount: number;
-  warningCount: number;
-}
-
 function extractApi(
   configObject: IConfigFile,
   configObjectFullPath: string,
   packageJsonFullPath: string,
-): ExtractApiResult {
+): ExtractorResult {
   const config = ExtractorConfig.prepare({
     configObject,
     configObjectFullPath,
@@ -166,11 +161,7 @@ function extractApi(
       `API Extractor completed with ${result.errorCount} errors and ${result.warningCount} warnings`,
     );
   }
-  return {
-    succeeded: result.succeeded,
-    errorCount: result.errorCount,
-    warningCount: result.warningCount,
-  };
+  return result;
 }
 
 function createApiDiff(
@@ -317,7 +308,7 @@ function isManagementPackage(packageName: string): boolean {
   return packageName.includes("/arm-");
 }
 
-const TRANSIENT_FS_CODES = new Set(["EBUSY", "EPERM", "ENOENT", "EMFILE", "EAGAIN", "UNKNOWN"]);
+const TRANSIENT_FS_CODES = new Set(["EBUSY", "EPERM", "EMFILE", "EAGAIN", "UNKNOWN"]);
 
 async function withFsRetry<T>(
   description: string,

--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -4,7 +4,7 @@
 import path from "node:path";
 import concurrently from "concurrently";
 import { leafCommand, makeCommandInfo } from "../../framework/command.ts";
-import { runTestsWithProxyTool } from "../../util/testUtils.ts";
+import { runTestsWithProxyTool, summarizeCloseEvents } from "../../util/testUtils.ts";
 import { createPrinter } from "../../util/printer.ts";
 import { shouldStartRelay, startRelayServer } from "../../util/browserRelayServer.ts";
 
@@ -107,8 +107,13 @@ export default leafCommand(commandInfo, async (options) => {
     }
 
     log.info("Running vitest without test-proxy");
-    await concurrently([command]).result;
-    return true;
+    try {
+      await concurrently([command]).result;
+      return true;
+    } catch (closeEvents: unknown) {
+      log.error(`vitest failed: ${summarizeCloseEvents(closeEvents)}`);
+      return false;
+    }
   } finally {
     stopRelayServer?.();
     if (typeof oldPath === "undefined") {

--- a/common/tools/dev-tool/src/index.ts
+++ b/common/tools/dev-tool/src/index.ts
@@ -7,11 +7,23 @@ import { baseCommand } from "./commands/index.ts";
 
 // The main command is implemented using the same `subCommand` method.
 baseCommand(...process.argv.slice(2)).catch((err) => {
-  console.error(chalk.red("[Internal Error]", err.message));
-  console.trace(chalk.red("[Internal Error]", err.stack));
-  if (err.cause) {
-    console.error(chalk.red("[Internal Error Cause]", err.cause.message));
-    console.trace(chalk.red("[Internal Error Cause]", err.cause.stack));
+  const format = (value: unknown): string => {
+    if (value instanceof Error) {
+      return value.stack ?? value.message;
+    }
+    if (typeof value === "object" && value !== null) {
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return String(value);
+      }
+    }
+    return String(value);
+  };
+
+  console.error(chalk.red("[Internal Error]", format(err)));
+  if (err && typeof err === "object" && "cause" in err && err.cause) {
+    console.error(chalk.red("[Internal Error Cause]", format(err.cause)));
   }
   process.exit(255);
 });

--- a/common/tools/dev-tool/src/index.ts
+++ b/common/tools/dev-tool/src/index.ts
@@ -22,7 +22,7 @@ baseCommand(...process.argv.slice(2)).catch((err) => {
   };
 
   console.error(chalk.red("[Internal Error]", format(err)));
-  if (err && typeof err === "object" && "cause" in err && err.cause) {
+  if (err && typeof err === "object" && "cause" in err && err.cause !== undefined) {
     console.error(chalk.red("[Internal Error Cause]", format(err.cause)));
   }
   process.exit(255);

--- a/common/tools/dev-tool/src/util/testUtils.ts
+++ b/common/tools/dev-tool/src/util/testUtils.ts
@@ -29,6 +29,33 @@ async function shouldRunProxyTool(): Promise<boolean> {
   }
 }
 
+/**
+ * `concurrently(...).result` rejects with an array of close-event objects
+ * (not an `Error`) when a command exits non-zero. This turns that value into a
+ * readable, actionable message describing which commands failed and their exit
+ * codes.
+ */
+export function summarizeCloseEvents(closeEvents: unknown): string {
+  const events = Array.isArray(closeEvents) ? closeEvents : [closeEvents];
+  const failed = events
+    .filter((e): e is { command?: { command?: string }; exitCode?: number } => Boolean(e))
+    .filter((e) => e.exitCode !== 0 && e.exitCode !== undefined)
+    .map((e) => `${e.command?.command ?? "command"} exited with code ${e.exitCode}`);
+
+  if (failed.length > 0) {
+    return failed.join("; ");
+  }
+  // Fallback: nothing matched the expected shape, surface the raw value.
+  if (closeEvents instanceof Error) {
+    return closeEvents.stack ?? closeEvents.message;
+  }
+  try {
+    return JSON.stringify(closeEvents);
+  } catch {
+    return String(closeEvents);
+  }
+}
+
 export async function runTestsWithProxyTool(
   testCommandObj: Partial<ConcurrentlyCommand> & { command: string },
 ): Promise<boolean> {
@@ -39,12 +66,18 @@ export async function runTestsWithProxyTool(
     testProxy = await startTestProxy();
   }
 
-  await concurrently([testCommandObj]).result;
+  let success = true;
+  try {
+    await concurrently([testCommandObj]).result;
+  } catch (closeEvents: unknown) {
+    log.error(`test command failed: ${summarizeCloseEvents(closeEvents)}`);
+    success = false;
+  }
 
   if (testProxy) {
     log("Stopping the test proxy");
     await testProxy.stop();
   }
 
-  return true;
+  return success;
 }

--- a/common/tools/dev-tool/src/util/testUtils.ts
+++ b/common/tools/dev-tool/src/util/testUtils.ts
@@ -38,9 +38,7 @@ async function shouldRunProxyTool(): Promise<boolean> {
 export function summarizeCloseEvents(closeEvents: unknown): string {
   const events = Array.isArray(closeEvents) ? closeEvents : [closeEvents];
   const failed = events
-    .filter((e): e is { command?: { command?: string }; exitCode?: string | number } =>
-      Boolean(e),
-    )
+    .filter((e): e is { command?: { command?: string }; exitCode?: string | number } => Boolean(e))
     .filter((e) => e.exitCode !== 0 && e.exitCode !== undefined)
     .map((e) => {
       const name = e.command?.command ?? "command";

--- a/common/tools/dev-tool/src/util/testUtils.ts
+++ b/common/tools/dev-tool/src/util/testUtils.ts
@@ -38,9 +38,16 @@ async function shouldRunProxyTool(): Promise<boolean> {
 export function summarizeCloseEvents(closeEvents: unknown): string {
   const events = Array.isArray(closeEvents) ? closeEvents : [closeEvents];
   const failed = events
-    .filter((e): e is { command?: { command?: string }; exitCode?: number } => Boolean(e))
+    .filter((e): e is { command?: { command?: string }; exitCode?: string | number } =>
+      Boolean(e),
+    )
     .filter((e) => e.exitCode !== 0 && e.exitCode !== undefined)
-    .map((e) => `${e.command?.command ?? "command"} exited with code ${e.exitCode}`);
+    .map((e) => {
+      const name = e.command?.command ?? "command";
+      return typeof e.exitCode === "string"
+        ? `${name} was killed by signal ${e.exitCode}`
+        : `${name} exited with code ${e.exitCode}`;
+    });
 
   if (failed.length > 0) {
     return failed.join("; ");


### PR DESCRIPTION
## Problem

Several `dev-tool` commands — most notably `extract-api` — could exit non-zero with no actionable message. Failures surfaced only as the generic `Errors occurred. See the output above.` (exit 1) or `[Internal Error] undefined`, which made CI **Build libraries** failures very hard to diagnose (an `extract-api` step failing with exit code 1 and no clear error).

This PR makes dev-tool surface the real underlying failure in three spots.

## Changes

### Gap 1 — `extract-api` ignored api-extractor's result
`commands/run/extract-api.ts` previously called `extractApi(...)` and discarded its return value, so a genuine api-extractor failure only manifested later as a bare `ENOENT` when reading the (never-written) temp report, and the exports branch kept `success = true`. Now:
- `extractApi` returns `{ succeeded, errorCount, warningCount }`.
- `extractApiForEntry` throws with the entry name/runtime, `mainEntryPointFilePath`, error/warning counts, and the expected report path **before** the downstream `readFile`.
- The non-exports branch folds `.succeeded` into `success`.

### Gap 4 — top-level catch mishandled non-Error throws
`index.ts` assumed `err` was an `Error` (`err.message` / `console.trace(err.stack)`), yielding `[Internal Error] undefined` for non-Error rejections and printing the callback's own stack rather than the error's. Now a `format(value)` helper handles `Error → stack ?? message`, `object → JSON.stringify` (guarded), else `String`, prints `err.cause` when present, and drops the misleading `console.trace`. Still exits 255.

### Gap 5 — vitest runner's `concurrently` rejection is not an Error
`concurrently([...]).result` rejects with an **array of close-event objects**, not an `Error`, so a failing test run propagated to the top-level catch as `[Internal Error] undefined`. Added `summarizeCloseEvents` (in `util/testUtils.ts`) that extracts the non-zero `exitCode` events into a readable message (e.g. `vitest exited with code 1`). Both `concurrently(...).result` await sites (`testVitest.ts` non-proxy path and `runTestsWithProxyTool`) now catch, log an actionable message, and `return false` (clean exit 1 with a message).

## Note for reviewers

The `extract-api` genuine-failure path now surfaces as **exit 255** (a thrown `Error` routed through the top-level catch) rather than the previous message-less exit 1. This is intentional — the throw carries the actionable context.

## Verification

- `pnpm build -F @azure/dev-tool` → success; `tsc --noEmit` in `common/tools/dev-tool` → clean.
- Manually forced each failure path against `sdk/alertrulerecommendations/arm-alertrulerecommendations` and confirmed clear output:
  - **Extractor reports errors** (temporarily escalating `ae-forgotten-export` to `error`): `API Extractor failed for entry 'node' (mainEntryPoint: ...\dist\esm\index.d.ts) with 1 errors and 1 warnings. Expected report at ...\review\arm-alertrulerecommendations-node.api.md.` → exit 255.
  - **Missing dist** (prepare throw): the real `The "mainEntryPointFilePath" path does not exist: ...` error with a proper stack → exit 255.
  - **Corrupted `.d.ts`** (internal extractor crash): full real stack under `[Internal Error]` → exit 255.