### PR TITLE
[dev-tool] Log real tsc failure detail instead of [object Object]

### DIFF
--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -140,8 +140,14 @@ async function runTypeScript(tsConfig: string): Promise<boolean> {
     cwd: process.cwd(),
   });
 
+  if (res.error) {
+    log.error(`Failed to run the TypeScript compiler for ${tsConfig}: ${res.error.message}`);
+    return false;
+  }
+
   if (res.status || res.signal) {
-    log.error(`TypeScript compilation failed for ${tsConfig}:`, res);
+    const detail = res.signal ? `signal ${res.signal}` : `exit code ${res.status}`;
+    log.error(`TypeScript compilation failed for ${tsConfig} (${detail}). See the tsc errors above.`);
     return false;
   }
 

--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -147,7 +147,9 @@ export async function runTypeScript(tsConfig: string): Promise<boolean> {
 
   if (res.status || res.signal) {
     const detail = res.signal ? `signal ${res.signal}` : `exit code ${res.status}`;
-    log.error(`TypeScript compilation failed for ${tsConfig} (${detail}). See the tsc errors above.`);
+    log.error(
+      `TypeScript compilation failed for ${tsConfig} (${detail}). See the tsc errors above.`,
+    );
     return false;
   }
 

--- a/common/tools/dev-tool/src/commands/run/build-test.ts
+++ b/common/tools/dev-tool/src/commands/run/build-test.ts
@@ -133,7 +133,7 @@ export default leafCommand(commandInfo, async (options) => {
   return true;
 });
 
-async function runTypeScript(tsConfig: string): Promise<boolean> {
+export async function runTypeScript(tsConfig: string): Promise<boolean> {
   const res = spawnSync(`tsc -b ${tsConfig}`, [], {
     stdio: "inherit",
     shell: true,

--- a/common/tools/dev-tool/test/build-test.spec.ts
+++ b/common/tools/dev-tool/test/build-test.spec.ts
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Config, ResolvedConfigResult } from "../src/util/resolveTsConfig.ts";
-import { configIncludesSrc } from "../src/commands/run/build-test.ts";
+import { configIncludesSrc, runTypeScript } from "../src/commands/run/build-test.ts";
+import { updateBackend } from "../src/util/printer.ts";
+import * as childProcess from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -52,5 +58,88 @@ describe("configIncludesSrc", () => {
     };
 
     expect(configIncludesSrc(resolved)).toBe(true);
+  });
+});
+
+describe("runTypeScript", () => {
+  const errorSpy = vi.fn();
+
+  beforeEach(() => {
+    errorSpy.mockReset();
+    updateBackend({ error: errorSpy });
+  });
+
+  afterEach(() => {
+    updateBackend({ error: console.error });
+  });
+
+  it("returns false and logs the error message when spawn itself fails", async () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(""),
+      status: null,
+      signal: null,
+      error: new Error("ENOENT: tsc not found"),
+    });
+
+    const result = await runTypeScript("tsconfig.json");
+
+    expect(result).toBe(false);
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).toContain("ENOENT: tsc not found");
+  });
+
+  it("returns false and includes the exit code (not [object Object]) when tsc exits nonzero", async () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(""),
+      status: 2,
+      signal: null,
+    });
+
+    const result = await runTypeScript("tsconfig.json");
+
+    expect(result).toBe(false);
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).toContain("exit code 2");
+    expect(logged).not.toContain("[object Object]");
+  });
+
+  it("returns false and includes the signal name when tsc is killed by a signal", async () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(""),
+      status: null,
+      signal: "SIGTERM",
+    });
+
+    const result = await runTypeScript("tsconfig.json");
+
+    expect(result).toBe(false);
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).toContain("signal SIGTERM");
+    expect(logged).not.toContain("[object Object]");
+  });
+
+  it("returns true when tsc succeeds", async () => {
+    vi.mocked(childProcess.spawnSync).mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(""),
+      status: 0,
+      signal: null,
+    });
+
+    const result = await runTypeScript("tsconfig.json");
+
+    expect(result).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`runTypeScript` in `common/tools/dev-tool/src/commands/run/build-test.ts` logged the whole `SpawnSyncReturns` object on failure via `log.error(..., res)`, which rendered uselessly as `[object Object]`.

## Fix

Since `tsc` runs with `stdio: "inherit"`, its diagnostics are already printed to the log. So instead of dumping the object, the failure branch now logs the actual exit code or signal. It also handles the spawn-error case (`res.error`) — e.g. when `tsc` can't be spawned, `status`/`signal` are `null` so the previous check missed it entirely.

## Verification

From `common/tools/dev-tool`, `npx tsc -p . --noEmit` passes (exit code 0).

Small standalone follow-up to the dev-tool logging improvements in #39238.
