### PR TITLE
Surface pre-push format/lint checks for all packages, not just sdk/

### DIFF
--- a/.github/skills/sdk-workflow/SKILL.md
+++ b/.github/skills/sdk-workflow/SKILL.md
@@ -8,6 +8,26 @@ description: '**UTILITY SKILL** — Must be consulted for SDK development workfl
 This skill routes you to the correct tools and documentation for common SDK
 development tasks. Read the referenced docs — don't guess at commands.
 
+## Before you push (required for every change)
+
+Every code change must pass **build, format, lint, and test** checks locally
+before you push or open a PR — CI enforces all of these and will fail
+otherwise. This applies to **every workspace package**, not just `sdk/*`:
+changes under `common/tools/*` (e.g. `dev-tool`, `warp`) and `eng/*` have
+their own `check-format` / `lint` CI jobs too.
+
+From the directory of the package you changed:
+
+- `pnpm format` — auto-format with Prettier (this is what fixes a
+  `check-format` CI failure).
+- `pnpm check-format` — verify formatting is clean (what CI runs).
+- `pnpm lint` — check lint (`pnpm lint:fix` to auto-fix where possible).
+- Build + unit tests: `npx dev-tool check --tag=local`, or the package's
+  `build` / `test` scripts.
+
+For `sdk/*` packages, `npx dev-tool check --fix` bundles format + lint +
+package.json validation in one step.
+
 ## Key Documentation
 
 | What you need | Where to look |
@@ -57,10 +77,6 @@ development tasks. Read the referenced docs — don't guess at commands.
   to be built — it runs via tsx after `pnpm install`.
 - **Checks**: `npx dev-tool check` runs format, lint, build, test, and package.json
   validation. Use `--fix` to auto-repair, `--tag` to select check categories.
-- **Pre-push checks**: All code changes must pass build, format, lint, and test
-  checks locally before pushing — CI will fail otherwise. Run `npx dev-tool check`
-  for format, lint, and package.json validation, then `npx dev-tool check --tag=local`
-  for build and unit tests.
 - **Versioning**: When there is a new change to `src/` after a release, the package
   version must be incremented. Use `npx dev-tool package increment-version` to bump
   the version in `package.json`, update tracked version constants, and add a new

--- a/.github/skills/sdk-workflow/SKILL.md
+++ b/.github/skills/sdk-workflow/SKILL.md
@@ -10,20 +10,22 @@ development tasks. Read the referenced docs — don't guess at commands.
 
 ## Before you push (required for every change)
 
-Every code change must pass **build, format, lint, and test** checks locally
-before you push or open a PR — CI enforces all of these and will fail
-otherwise. This applies to **every workspace package**, not just `sdk/*`:
-changes under `common/tools/*` (e.g. `dev-tool`, `warp`) and `eng/*` have
-their own `check-format` / `lint` CI jobs too.
+Every code change must pass the checks that CI defines for the affected package
+locally before you push or open a PR. This includes every pnpm workspace
+package, not just `sdk/*`, including `common/tools/*` and
+`eng/containers/turborepo-remote-cache`. Tools elsewhere under `eng/*` are not
+workspace packages and use package-specific managers and scripts, so follow
+their CI configuration.
 
-From the directory of the package you changed:
+For a pnpm workspace package, from its directory:
 
 - `pnpm format` — auto-format with Prettier (this is what fixes a
   `check-format` CI failure).
 - `pnpm check-format` — verify formatting is clean (what CI runs).
 - `pnpm lint` — check lint (`pnpm lint:fix` to auto-fix where possible).
-- Build + unit tests: `npx dev-tool check --tag=local`, or the package's
-  `build` / `test` scripts.
+- Build from the repository root: `pnpm turbo build --filter=<package-name>... --token 1`.
+- Unit tests: run the package's `test` script; for `sdk/*`,
+  `npx dev-tool check --tag=local` runs build and unit tests.
 
 For `sdk/*` packages, `npx dev-tool check --fix` bundles format + lint +
 package.json validation in one step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,11 @@ TypeScript / JavaScript SDKs for Azure services. Monorepo managed by
 | Authoritative API design guidelines | https://azure.github.io/azure-sdk/typescript_design.html |
 | Other deep dives | `documentation/` (browse the directory) |
 
+> **Before pushing any change** — including `common/tools/*` and `eng/*`,
+> not just `sdk/` — run the changed package's format, lint, build, and test
+> checks locally. CI enforces them and will fail otherwise. See
+> `.github/skills/sdk-workflow/SKILL.md` § "Before you push".
+
 The skills above carry workflow guidance the rest of this repo's
 contributor docs assume agents will find. Read them on demand — don't
 load them all up front.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ TypeScript / JavaScript SDKs for Azure services. Monorepo managed by
 | Authoritative API design guidelines | https://azure.github.io/azure-sdk/typescript_design.html |
 | Other deep dives | `documentation/` (browse the directory) |
 
-> **Before pushing any change** — including `common/tools/*` and `eng/*`,
-> not just `sdk/` — run the changed package's format, lint, build, and test
-> checks locally. CI enforces them and will fail otherwise. See
+> **Before pushing any code change** — including changes outside `sdk/` — run
+> the checks defined by CI for the affected package locally. Package managers
+> and scripts vary for non-workspace `eng/*` tools. See
 > `.github/skills/sdk-workflow/SKILL.md` § "Before you push".
 
 The skills above carry workflow guidance the rest of this repo's


### PR DESCRIPTION
## What

Docs-only change to improve agent discoverability of pre-push format/lint/build/test checks.

## Why

A PR that changed `common/tools/dev-tool` failed the `check-format` CI job because the code wasn't Prettier-formatted before pushing. The repo already documented the pre-push checks, but the guidance was **buried** (5th bullet under "Important Notes" in the `sdk-workflow` skill) and framed as **SDK-only**, so an agent editing an internal tools package under `common/tools/*` could easily miss it.

## Fix

- **`.github/skills/sdk-workflow/SKILL.md`** — Elevate the rule into a prominent new `## Before you push (required for every change)` section near the top, and make its scope explicit: it applies to `common/tools/*` (e.g. `dev-tool`, `warp`) and `eng/*`, not just `sdk/`. The now-redundant `Pre-push checks` bullet under "Important Notes" is removed (relocated, not duplicated).
- **`AGENTS.md`** — Add a one-line routing pointer right after the guidance table so the rule is visible without loading the skill.

Docs-only; no code changed.