### PR TITLE
Fix stale and broken //metadata version mappings

### DIFF
--- a/sdk/ai/ai-agents/package.json
+++ b/sdk/ai/ai-agents/package.json
@@ -36,7 +36,7 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/agentsClient.ts",
+        "path": "src/api/agentsContext.ts",
         "prefix": "userAgentInfo"
       },
       {

--- a/sdk/ai/ai-agents/src/api/agentsContext.ts
+++ b/sdk/ai/ai-agents/src/api/agentsContext.ts
@@ -27,7 +27,7 @@ export function createAgents(
 ): AgentsContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-ai-agents/1.2.0-beta.2`;
+  const userAgentInfo = `azsdk-js-ai-agents/1.2.0-beta.3`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/ai/ai-inference-rest/package.json
+++ b/sdk/ai/ai-inference-rest/package.json
@@ -63,7 +63,11 @@
     "constantPaths": [
       {
         "path": "src/modelClient.ts",
-        "prefix": "package-version"
+        "prefix": "userAgentInfo"
+      },
+      {
+        "path": "src/constants.ts",
+        "prefix": "SDK_VERSION"
       }
     ]
   },

--- a/sdk/ai/ai-inference-rest/src/constants.ts
+++ b/sdk/ai/ai-inference-rest/src/constants.ts
@@ -7,4 +7,4 @@
  *
  * If you need to make changes, please do so in the original source file, \{project-root\}/sources/custom
  */
-export const SDK_VERSION: string = "1.0.0-beta.4";
+export const SDK_VERSION: string = "1.0.0-beta.7";

--- a/sdk/ai/ai-projects/package.json
+++ b/sdk/ai/ai-projects/package.json
@@ -36,10 +36,6 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/aiProjectClient.ts",
-        "prefix": "userAgentInfo"
-      },
-      {
         "path": "src/constants.ts",
         "prefix": "SDK_VERSION"
       }

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -58,11 +58,7 @@
         "prefix": "packageVersion"
       },
       {
-        "path": "src/generated/src/appConfiguration.ts",
-        "prefix": "packageDetails"
-      },
-      {
-        "path": "src/generated/api/azureAppConfigurationContext.ts",
+        "path": "src/generated/api/appConfigurationContext.ts",
         "prefix": "userAgentInfo"
       }
     ]

--- a/sdk/appconfiguration/app-configuration/src/generated/api/appConfigurationContext.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/api/appConfigurationContext.ts
@@ -28,7 +28,7 @@ export function createAppConfiguration(
 ): AppConfigurationContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-app-configuration/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-app-configuration/1.12.2`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/communication/communication-call-automation/package.json
+++ b/sdk/communication/communication-call-automation/package.json
@@ -104,7 +104,7 @@
     "constantPaths": [
       {
         "path": "src/models/constants.ts",
-        "prefix": "packageVersion"
+        "prefix": "SDK_VERSION"
       },
       {
         "path": "src/generated/src/callAutomationApiClient.ts",

--- a/sdk/communication/communication-call-automation/src/models/constants.ts
+++ b/sdk/communication/communication-call-automation/src/models/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "1.5.0";
+export const SDK_VERSION: string = "1.6.1";

--- a/sdk/communication/communication-messages-rest/package.json
+++ b/sdk/communication/communication-messages-rest/package.json
@@ -91,7 +91,7 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/messagesServiceClient.ts",
+        "path": "src/generated/src/messagesServiceClient.ts",
         "prefix": "userAgentInfo"
       }
     ]

--- a/sdk/communication/communication-messages-rest/src/generated/src/messagesServiceClient.ts
+++ b/sdk/communication/communication-messages-rest/src/generated/src/messagesServiceClient.ts
@@ -29,7 +29,7 @@ export default function createClient(
   }: MessagesServiceClientOptions = {},
 ): MessagesServiceClient {
   const endpointUrl = options.endpoint ?? options.baseUrl ?? `${endpointParam}`;
-  const userAgentInfo = `azsdk-js-communication-messages-rest/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-communication-messages-rest/2.2.0-beta.2`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -67,6 +67,10 @@
       {
         "path": "src/confidentialLedgerClient.ts",
         "prefix": "userAgentInfo"
+      },
+      {
+        "path": "src/confidentialLedgerCustomized.ts",
+        "prefix": "userAgentInfo"
       }
     ]
   },

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerClient.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerClient.ts
@@ -22,7 +22,7 @@ export default function createClient(
   { apiVersion = "2026-02-23", ...options }: ConfidentialLedgerClientOptions = {},
 ): ConfidentialLedgerClient {
   const endpointUrl = options.endpoint ?? `${ledgerEndpoint}`;
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/2.0.0-beta.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerCustomized.ts
+++ b/sdk/confidentialledger/confidential-ledger-rest/src/confidentialLedgerCustomized.ts
@@ -199,7 +199,7 @@ export default function ConfidentialLedger(
 
   const apiVersion = options.apiVersion ?? "2026-02-23";
   const endpointUrl = options.endpoint ?? `${ledgerEndpoint}`;
-  const userAgentInfo = `azsdk-js-confidential-ledger-rest/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-confidential-ledger-rest/2.0.0-beta.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/healthdataaiservices/health-deidentification-rest/src/deidentificationClient.ts
+++ b/sdk/healthdataaiservices/health-deidentification-rest/src/deidentificationClient.ts
@@ -25,7 +25,7 @@ export default function createClient(
   { apiVersion = "2025-07-15-preview", ...options }: DeidentificationClientOptions = {},
 ): DeidentificationClient {
   const endpointUrl = options.endpoint ?? `${endpointParam}`;
-  const userAgentInfo = `azsdk-js-health-deidentification-rest/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-health-deidentification-rest/1.1.0-beta.1`;
   const userAgentPrefix =
     options.userAgentOptions && options.userAgentOptions.userAgentPrefix
       ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`

--- a/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
+++ b/sdk/onlineexperimentation/onlineexperimentation-rest/package.json
@@ -40,7 +40,7 @@
   "//metadata": {
     "constantPaths": [
       {
-        "path": "src/Azure\\sdk-repos\\azure-sdk-for-js\\sdk\\onlineexperimentation\\onlineexperimentation-rest\\generated/onlineExperimentationClient.ts",
+        "path": "src/onlineExperimentationClient.ts",
         "prefix": "userAgentInfo"
       }
     ]

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -62,7 +62,7 @@
     "constantPaths": [
       {
         "path": "src/generated/src/storageClient.ts",
-        "prefix": "packageVersion"
+        "prefix": "packageDetails"
       },
       {
         "path": "src/utils/constants.ts",

--- a/sdk/storage/storage-blob/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClient.ts
@@ -48,7 +48,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-azure-storage-blob/12.33.0`;
+    const packageDetails = `azsdk-js-azure-storage-blob/12.33.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -62,7 +62,7 @@
     "constantPaths": [
       {
         "path": "src/generated/src/storageClient.ts",
-        "prefix": "packageVersion"
+        "prefix": "packageDetails"
       },
       {
         "path": "src/utils/constants.ts",

--- a/sdk/storage/storage-file-datalake/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-file-datalake/src/generated/src/storageClient.ts
@@ -44,7 +44,7 @@ export class StorageClient extends coreHttpCompat.ExtendedServiceClient {
       requestContentType: "application/json; charset=utf-8",
     };
 
-    const packageDetails = `azsdk-js-azure-storage-datalake/12.31.0`;
+    const packageDetails = `azsdk-js-azure-storage-datalake/12.31.1`;
     const userAgentPrefix =
       options.userAgentOptions && options.userAgentOptions.userAgentPrefix
         ? `${options.userAgentOptions.userAgentPrefix} ${packageDetails}`

--- a/sdk/storage/storage-file-share/src/generated/api/fileContext.ts
+++ b/sdk/storage/storage-file-share/src/generated/api/fileContext.ts
@@ -25,7 +25,7 @@ export function createFile(
 ): FileContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-storage-file-share/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-storage-file-share/12.33.0-beta.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;

--- a/sdk/storage/storage-queue/src/generated/api/queuesContext.ts
+++ b/sdk/storage/storage-queue/src/generated/api/queuesContext.ts
@@ -23,7 +23,7 @@ export function createQueues(
 ): QueuesContext {
   const endpointUrl = options.endpoint ?? String(endpointParam);
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
-  const userAgentInfo = `azsdk-js-storage-queue/1.0.0-beta.1`;
+  const userAgentInfo = `azsdk-js-storage-queue/12.32.0-beta.1`;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api ${userAgentInfo}`
     : `azsdk-js-api ${userAgentInfo}`;


### PR DESCRIPTION
## What

Cleans up out-of-date and broken `//metadata.constantPaths` entries in `package.json` files across `sdk/`. These entries tell the `increment-version` tool where a package's version string is embedded so it can bump it on release. Some mappings pointed at missing files, used prefixes that no longer matched, or pointed at files that no longer held the version — so the tool was silently failing to update those literals, letting them drift.

## Why

`increment-version` builds a `(prefix.*?)(semver)` regex per mapping and replaces the semver. There's no error when a prefix doesn't match or the version lives in an unmapped file — the bump just silently no-ops and the literal drifts out of sync with `package.json`. This PR both repairs the mappings (durable fix) and corrects the literals that had already drifted (where safe to do so).

## Changes

**`package.json` mapping fixes (durable):**
- `ai-inference-rest` — corrected `prefix`, and added an `src/constants.ts` / `SDK_VERSION` entry (that constant feeds the tracing package version)
- `communication-call-automation` — corrected `prefix`
- `storage-blob`, `storage-file-datalake` — corrected `prefix` (`packageVersion` → `packageDetails`)
- `onlineexperimentation-rest` — fixed a leaked absolute path
- `communication-messages-rest` — repointed to the real generated client
- `app-configuration` — removed a dead entry, repointed to the generated context
- `ai-projects` — removed a dead entry
- `ai-agents` — repointed to `src/api/agentsContext.ts`
- `confidential-ledger-rest` — added an `src/confidentialLedgerCustomized.ts` entry so the default (public) client path is bumped alongside the low-level client

**Stale literal corrections (present drift):**
Realigned version strings the broken/incomplete mappings had let drift, across generated context/client files, tracing constants, and hand-authored clients: `ai-agents`, `ai-inference-rest`, `communication-call-automation`, `communication-messages-rest`, `storage-blob`, `storage-file-datalake`, `storage-file-share`, `storage-queue`, `app-configuration`, `confidential-ledger-rest`, `health-deidentification-rest`.

## Notes

- Several literal corrections are in **generated** files. They'll be overwritten on the next `tsp-client`/autorest regen — that's fine; they fix present drift, and the durable value is the `package.json` mapping fixes so the *next* `increment-version` lands correctly. This whole `//metadata` convention is expected to go away once the emitter/generator imports the version from `package.json` directly.
- Stale-literal corrections are limited to packages whose current version is **not yet published**. A couple of packages (`arm-appinsights`, `planetarycomputer`) already published at their current version had correct mappings but stale literals; those are left to self-correct on their next version bump, since `check-package-version` (correctly) rejects modifying already-shipped source without a version bump.
- Swagger README fixes for soon-to-be-removed dead packages were deliberately left out.