### PR TITLE
Keep mgmt-review agent job alive despite gh-aw checkout bug (gh-aw#30791)

### DIFF
--- a/.github/workflows/mgmt-review.lock.yml
+++ b/.github/workflows/mgmt-review.lock.yml
@@ -551,6 +551,10 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clone_repo_memory_branch.sh"
       - name: Checkout PR branch
         id: checkout-pr
+        # STOPGAP: gh-aw emits this step even with `checkout: false`, so it fails with
+        # "not a git repository". Agent uses GitHub MCP (no clone needed), so tolerate it.
+        # Guarded by eng/scripts/verify-agentic-checkout-guard.ps1. Drop once gh-aw#30791 is fixed.
+        continue-on-error: true
         if: |
           github.event.pull_request || github.event.issue.pull_request || github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.aw_context || '{}').item_type == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/verify-agentic-checkout-guard.yml
+++ b/.github/workflows/verify-agentic-checkout-guard.yml
@@ -1,0 +1,34 @@
+name: verify-agentic-checkout-guard
+
+# Fails when the `continue-on-error: true` stopgap on the "Checkout PR branch"
+# step of guarded agentic reviewer workflows is missing. This stopgap keeps those
+# `checkout: false` PR-triggered workflows from aborting on a gh-aw compiler bug
+# (https://github.com/github/gh-aw/issues/30791). Because `*.lock.yml` files are
+# compiled artifacts, a gh-aw recompile/upgrade silently drops the line; this guard
+# catches that regression at PR time.
+#
+# See eng/scripts/verify-agentic-checkout-guard.ps1 for details and removal steps.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/mgmt-review.lock.yml"
+      - ".github/workflows/mgmt-review.md"
+      - "eng/scripts/verify-agentic-checkout-guard.ps1"
+      - ".github/workflows/verify-agentic-checkout-guard.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Verify agentic checkout stopgap
+        shell: pwsh
+        run: ./eng/scripts/verify-agentic-checkout-guard.ps1

--- a/eng/scripts/verify-agentic-checkout-guard.ps1
+++ b/eng/scripts/verify-agentic-checkout-guard.ps1
@@ -1,0 +1,112 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Guards the `continue-on-error` stopgap on the "Checkout PR branch" step of
+    agentic reviewer workflows that run with `checkout: false`.
+
+.DESCRIPTION
+    gh-aw has a compiler bug (https://github.com/github/gh-aw/issues/30791):
+    when a PR-triggered workflow sets `checkout: false`, the compiler still emits
+    a "Checkout PR branch" helper step. With no `actions/checkout` having run there
+    is no `.git`, so the helper aborts with "fatal: not a git repository" (git exit
+    128) and, since gh-aw v0.81.6 removed the tolerant `continue-on-error`, that
+    failure now aborts the whole agent job.
+
+    The affected reviewer agents fetch everything through the GitHub MCP and do not
+    need a local checkout, so `checkout: false` is the correct, secure setting (it
+    keeps untrusted fork code off disk). The fix is therefore to keep `checkout: false`
+    and mark the phantom helper step `continue-on-error: true` so it stays non-fatal.
+
+    Because `*.lock.yml` files are compiled artifacts, any gh-aw recompile/upgrade
+    silently drops that hand-applied line. This guard fails CI when the stopgap is
+    missing so a recompile cannot silently re-break the workflow.
+
+    Remove this guard and the `continue-on-error` line once gh-aw ships a fix for
+    issue #30791 and the workflow is recompiled against it.
+
+.NOTES
+    Extend $GuardedWorkflows when the stopgap is applied to additional workflows.
+#>
+
+[CmdletBinding()]
+param(
+    [string] $WorkflowDir = (Join-Path $PSScriptRoot '..' '..' '.github' 'workflows')
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Workflow ids (basename without extension) whose lock file must keep the stopgap.
+$GuardedWorkflows = @(
+    'mgmt-review'
+)
+
+$issueUrl = 'https://github.com/github/gh-aw/issues/30791'
+$failures = New-Object System.Collections.Generic.List[string]
+
+foreach ($id in $GuardedWorkflows) {
+    $mdPath = Join-Path $WorkflowDir "$id.md"
+    $lockPath = Join-Path $WorkflowDir "$id.lock.yml"
+
+    if (-not (Test-Path $mdPath)) {
+        $failures.Add("[$id] source file not found: $mdPath")
+        continue
+    }
+    if (-not (Test-Path $lockPath)) {
+        $failures.Add("[$id] lock file not found: $lockPath")
+        continue
+    }
+
+    # Only workflows that disable checkout are affected by the gh-aw bug.
+    $mdLines = Get-Content -LiteralPath $mdPath
+    $hasCheckoutFalse = $mdLines | Where-Object { $_ -match '^\s*checkout:\s*false\s*$' }
+    if (-not $hasCheckoutFalse) {
+        $failures.Add("[$id] expected 'checkout: false' in $id.md but did not find it; " +
+            "the guard's assumptions no longer hold. Re-evaluate the stopgap for $id.")
+        continue
+    }
+
+    # Locate the "Checkout PR branch" step and confirm continue-on-error is set on it
+    # (before the next '- name:' step begins).
+    $lockLines = Get-Content -LiteralPath $lockPath
+    $stepIndex = -1
+    for ($i = 0; $i -lt $lockLines.Count; $i++) {
+        if ($lockLines[$i] -match '^\s*-\s*name:\s*Checkout PR branch\s*$') {
+            $stepIndex = $i
+            break
+        }
+    }
+
+    if ($stepIndex -lt 0) {
+        # The helper step is gone entirely (e.g. gh-aw fixed the bug). Then the stopgap
+        # is obsolete: drop this workflow from $GuardedWorkflows and remove the guard.
+        $failures.Add("[$id] no 'Checkout PR branch' step found in $id.lock.yml. If gh-aw " +
+            "issue #30791 is fixed, remove '$id' from `$GuardedWorkflows and delete this guard.")
+        continue
+    }
+
+    $found = $false
+    for ($j = $stepIndex + 1; $j -lt $lockLines.Count; $j++) {
+        if ($lockLines[$j] -match '^\s*-\s*name:\s*') { break } # next step
+        if ($lockLines[$j] -match '^\s*continue-on-error:\s*true\s*$') { $found = $true; break }
+    }
+
+    if (-not $found) {
+        $failures.Add("[$id] '$id.lock.yml' is missing 'continue-on-error: true' on the " +
+            "'Checkout PR branch' step. A gh-aw recompile likely dropped it. Re-apply the line " +
+            "(see the comment on that step) to keep the '$id' agent job from aborting on the " +
+            "known gh-aw bug $issueUrl.")
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "verify-agentic-checkout-guard: FAILED" -ForegroundColor Red
+    foreach ($f in $failures) {
+        Write-Host "  - $f" -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "Context: $issueUrl" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "verify-agentic-checkout-guard: OK ($($GuardedWorkflows.Count) workflow(s) checked)" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## What & why

The `mgmt-review` agent job currently **fails before the review runs**. gh-aw emits a `Checkout PR branch` step even when the workflow sets `checkout: false`; with no `actions/checkout` having run there is no `.git`, so the step aborts with `fatal: not a git repository` (git exit 128), which aborts the whole agent job (e.g. [run 28997043740](https://github.com/Azure/azure-sdk-for-js/actions/runs/28997043740)).

This is upstream gh-aw bug **[github/gh-aw#30791](https://github.com/github/gh-aw/issues/30791)** (still open).

`checkout: false` is the *correct, secure* setting here: the agent reads the PR entirely through the GitHub MCP and needs no local clone. Removing `checkout: false` would "fix" the failure only by re-enabling an insecure fork-code checkout under `pull_request_target` (a "pwn request" — the gh-aw compiler explicitly warns against it).

## Changes

- **`mgmt-review.lock.yml`** — re-apply `continue-on-error: true` to the generated `Checkout PR branch` step so the phantom helper stays non-fatal. `checkout: false` is kept (no fork code on disk). Only the `.lock.yml` is touched (not the `.md`), so the timestamp-based stale-lock check stays green.
- **`eng/scripts/verify-agentic-checkout-guard.ps1`** (new) — guard that fails if `mgmt-review.lock.yml`'s `Checkout PR branch` step loses `continue-on-error: true`. Because `*.lock.yml` are compiled artifacts, a gh-aw recompile/upgrade silently drops the line — the guard catches that regression.
- **`verify-agentic-checkout-guard.yml`** (new) — runs the guard on PRs touching mgmt-review's files or the guard itself.

Scoped to `mgmt-review` only.

## Follow-up

Remove the `continue-on-error` line and this guard once gh-aw fixes #30791 and the workflow is recompiled against the fix.