### PR TITLE
[confidential-ledger-rest] Release 2.0.0

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.1 (Unreleased)
+## 2.0.0 (2026-07-13)
 
 ### Features Added
 

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/confidential-ledger",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
Sets the changelog release date and promotes `@azure-rest/confidential-ledger` from `2.0.0-beta.1` to stable `2.0.0`.

Fixes the `Verify ChangeLogEntry` failure in release pipeline 2123 (release builds require a dated changelog entry, not `(Unreleased)`).

The 2.0.0 regeneration is already on main (via #38958); this is a two-line changelog/version change only.