### PR TITLE
[confidential-ledger-rest] Release 2.0.0-beta.1

### DIFF
--- a/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
+++ b/sdk/confidentialledger/confidential-ledger-rest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0 (2026-07-13)
+## 2.0.0-beta.1 (2026-07-13)
 
 ### Features Added
 

--- a/sdk/confidentialledger/confidential-ledger-rest/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-rest/confidential-ledger",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.1",
   "description": "An isomorphic rest level client library for the Azure Confidential Ledger service.",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
Releases `@azure-rest/confidential-ledger` as `2.0.0-beta.1` (dated).

Reverts the earlier beta->GA promotion: a GA (`2.0.0`) release requires APIView architect approval, which is not yet in place. Shipping as a beta avoids that gate and allows the release to proceed now.

Two-line changelog/version change only.