### PR TITLE
Fix custom agent guideline links in Copilot App

### DIFF
--- a/.github/agents/archie.agent.md
+++ b/.github/agents/archie.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search", "bash"]
 
 # Archie — Architecture Review Agent
 
-Follow the full guidelines in [architecture-review-guidelines.md](../prompts/architecture-review-guidelines.md).
+Follow the full guidelines in [architecture-review-guidelines.md](.github/prompts/architecture-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/.github/agents/dash.agent.md
+++ b/.github/agents/dash.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search", "bash"]
 
 # Dash — Performance Review Agent
 
-Follow the full guidelines in [performance-review-guidelines.md](../prompts/performance-review-guidelines.md).
+Follow the full guidelines in [performance-review-guidelines.md](.github/prompts/performance-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/.github/agents/dexter.agent.md
+++ b/.github/agents/dexter.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search", "bash"]
 
 # Dexter — Dependency Review Agent
 
-Follow the full guidelines in [dependency-review-guidelines.md](../prompts/dependency-review-guidelines.md).
+Follow the full guidelines in [dependency-review-guidelines.md](.github/prompts/dependency-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/.github/agents/mgmt-breaking-change-analysis.agent.md
+++ b/.github/agents/mgmt-breaking-change-analysis.agent.md
@@ -11,7 +11,7 @@ Analyze breaking changes in Azure SDK for JS PRs that migrate **ARM management S
 
 Before performing any analysis, you **MUST**:
 
-1. **Read** [mgmt-breaking-change-analysis-guidelines.md](../prompts/mgmt-breaking-change-analysis-guidelines.md) in full
+1. **Read** [mgmt-breaking-change-analysis-guidelines.md](.github/prompts/mgmt-breaking-change-analysis-guidelines.md) in full
 2. **Extract and restate** the phases and required steps from the guidelines
 3. **Follow the phases exactly in order** -- do not skip or reorder
 
@@ -93,7 +93,7 @@ Entry: "Operation Foo.get has a new signature"
 
 ## Mandatory Pattern Matching Step
 
-After root cause classification, match **Type 2 entries only** against architect-approved patterns in [mgmt-breaking-change-patterns.md](../prompts/mgmt-breaking-change-patterns.md). Type 1 entries are NOT covered by patterns -- skip them. Full procedure is in the guidelines Phase 4.
+After root cause classification, match **Type 2 entries only** against architect-approved patterns in [mgmt-breaking-change-patterns.md](.github/prompts/mgmt-breaking-change-patterns.md). Type 1 entries are NOT covered by patterns -- skip them. Full procedure is in the guidelines Phase 4.
 
 Do NOT skip this step. Do NOT consult patterns before completing independent investigation.
 

--- a/.github/agents/mgmt-review.agent.md
+++ b/.github/agents/mgmt-review.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search", "bash"]
 
 # Management SDK Review Agent
 
-Follow the guidelines in [mgmt-review-guidelines.md](../prompts/mgmt-review-guidelines.md).
+Follow the guidelines in [mgmt-review-guidelines.md](.github/prompts/mgmt-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/.github/agents/scribe.agent.md
+++ b/.github/agents/scribe.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search"]
 
 # Scribe — Documentation Review Agent
 
-Follow the full guidelines in [documentation-review-guidelines.md](../prompts/documentation-review-guidelines.md).
+Follow the full guidelines in [documentation-review-guidelines.md](.github/prompts/documentation-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/.github/agents/sentinel.agent.md
+++ b/.github/agents/sentinel.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search", "bash"]
 
 # Sentinel — Security Review Agent
 
-Follow the full guidelines in [security-review-guidelines.md](../prompts/security-review-guidelines.md).
+Follow the full guidelines in [security-review-guidelines.md](.github/prompts/security-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -5,7 +5,7 @@ tools: ["read", "search", "bash"]
 
 # Tester — Test Review Agent
 
-Follow the full guidelines in [test-review-guidelines.md](../prompts/test-review-guidelines.md).
+Follow the full guidelines in [test-review-guidelines.md](.github/prompts/test-review-guidelines.md).
 
 ## Quick-Reference Checklist
 

--- a/documentation/reviewer-agents.md
+++ b/documentation/reviewer-agents.md
@@ -162,7 +162,9 @@ Agent definitions and their detailed review guidelines are stored in:
 ```
 
 - **`.github/agents/*.agent.md`** — Defines the agent persona, checklist, scope,
-  and output format. Used by both VS Code Copilot Chat and CI workflows.
+  and output format. Used by both VS Code Copilot Chat and CI workflows. Links
+  in agent profiles are resolved from the repository root, so reference
+  guidelines as `.github/prompts/<file>.md`, not `../prompts/<file>.md`.
 - **`.github/prompts/*-review-guidelines.md`** — Comprehensive review guidelines
   referenced by each agent. Edit these to update review criteria.
 - **`.github/workflows/*.md`** — Agentic Workflow source files that define the


### PR DESCRIPTION
### Packages impacted by this PR

N/A — this changes repository-level Copilot agent configuration.

### Issues associated with this PR

N/A.

### Describe the problem that is addressed by this PR

Custom agent profiles linked their detailed guidelines with paths relative to `.github/agents`, such as `../prompts/architecture-review-guidelines.md`. The Copilot App resolves agent-profile links from the repository root, so those links were interpreted as `prompts/...` and the guidelines failed to load.

This PR uses repository-root-relative `.github/prompts/...` targets in every affected agent profile and documents that resolver behavior.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

The prompt files could be moved or duplicated under a root-level `prompts/` directory, but that would split or relocate the existing canonical guidance. Repository-root-relative links preserve the current layout and match the Copilot App resolver.

### Are there test cases added in this PR? _(If not, why?)_

No automated tests were added because this is Markdown-based agent configuration. All nine links were checked against existing repository files, and a newly launched Archie agent successfully loaded `.github/prompts/architecture-review-guidelines.md`.

### Provide a list of related PRs _(if any)_

N/A.

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A.

### Checklists
- [x] N/A — no SDK package is impacted.
- [x] No SDK Generator fixes are needed.
- [x] No changelog is necessary.