### PR TITLE
Add @Kishp01 and @Nishanth-MS as Event Grid code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,7 +206,7 @@
 # ServiceLabel: %EngSys
 
 # PRLabel: %Event Grid
-/sdk/eventgrid/    @rajeshka @shankarsama
+/sdk/eventgrid/    @Kishp01 @rajeshka @shankarsama @Nishanth-MS
 
 # AzureSdkOwners: @rajeshka @shankarsama
 # ServiceLabel: %Event Grid


### PR DESCRIPTION
Adds **@Kishp01** and **@Nishanth-MS** as code owners for `/sdk/eventgrid/`, matching the ownership already in place in azure-sdk-for-net (where `@Kishp01` is an Event Grid code owner).

### Change
```
-/sdk/eventgrid/    @rajeshka @shankarsama
+/sdk/eventgrid/    @Kishp01 @rajeshka @shankarsama @Nishanth-MS
```