### PR TITLE
[monitor-opentelemetry-exporter] Retry when no response is received

### DIFF
--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Persist telemetry for later retry when no HTTP response is received.
+- Persist telemetry for later retry when no HTTP response is received. [#39277](https://github.com/Azure/azure-sdk-for-js/pull/39277)
 
 ## 1.0.0-beta.43 (2026-07-01)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.44 (Unreleased)
+
+### Bugs Fixed
+
+- Persist telemetry for later retry when no HTTP response is received.
+
 ## 1.0.0-beta.43 (2026-07-01)
 
 ### Breaking Changes

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/monitor-opentelemetry-exporter",
   "author": "Microsoft Corporation",
   "sdk-type": "client",
-  "version": "1.0.0-beta.43",
+  "version": "1.0.0-beta.44",
   "description": "Application Insights exporter for the OpenTelemetry JavaScript (Node.js) SDK",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
@@ -126,6 +126,14 @@ export enum RetriableRestErrorTypes {
   FILE_NOT_FOUND = "ENOENT",
   BROKEN_PIPE = "EPIPE",
 }
+
+/**
+ * The `name` an aborted/timed-out operation error carries. This value is fixed by the
+ * WHATWG `DOMException` contract and mirrored by `@azure/abort-controller` and the
+ * `@typespec/ts-http-runtime` transport (all set `error.name = "AbortError"`)
+ * @internal
+ */
+export const ABORT_ERROR_NAME = "AbortError";
 /**
  * Application Insights shim version.
  * @internal

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/Declarations/Constants.ts
@@ -118,6 +118,13 @@ export function isEnvVarTrue(envVarName: string): boolean {
 export enum RetriableRestErrorTypes {
   REQUEST_SEND_ERROR = "REQUEST_SEND_ERROR",
   DNS_LOOKUP_TIMEOUT = "EAI_AGAIN",
+  CONNECTION_TIMEOUT = "ETIMEDOUT",
+  SOCKET_TIMEOUT = "ESOCKETTIMEDOUT",
+  CONNECTION_REFUSED = "ECONNREFUSED",
+  CONNECTION_RESET = "ECONNRESET",
+  DNS_LOOKUP_FAILED = "ENOTFOUND",
+  FILE_NOT_FOUND = "ENOENT",
+  BROKEN_PIPE = "EPIPE",
 }
 /**
  * Application Insights shim version.

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -39,7 +39,7 @@ const DEFAULT_BATCH_SEND_RETRY_INTERVAL_MS = 60_000;
 const STARTUP_REPLAY_MAX_DELAY_MS = 60_000;
 const REPLAY_BATCH_BASE_DELAY_MS = 200;
 const REPLAY_BATCH_JITTER_MS = 200;
-// Match the Python exporter and prevent re-persisted files from creating an unbounded replay loop.
+// Prevent re-persisted files from creating an unbounded startup replay loop.
 const MAX_STARTUP_REPLAY_BATCHES = 10;
 
 /**

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -3,16 +3,17 @@
 
 import { diag } from "@opentelemetry/api";
 import type { PersistentStorage, SenderResult } from "../../types.js";
-import { ExceptionType } from "../../export/statsbeat/types.js";
 import type { AzureMonitorExporterOptions } from "../../config.js";
 import { FileSystemPersist } from "./persist/index.js";
 import type { ExportResult } from "@opentelemetry/core";
 import { ExportResultCode } from "@opentelemetry/core";
 import { NetworkStatsbeatMetrics } from "../../export/statsbeat/networkStatsbeatMetrics.js";
 import { LongIntervalStatsbeatMetrics } from "../../export/statsbeat/longIntervalStatsbeatMetrics.js";
+import { isRestError } from "@azure/core-rest-pipeline";
 import type { HttpHeaders, RestError } from "@azure/core-rest-pipeline";
 import {
   DropCode,
+  ExceptionType,
   RetryCode,
   MAX_STATSBEAT_FAILURES,
   isStatsbeatShutdownStatus,
@@ -38,6 +39,8 @@ const DEFAULT_BATCH_SEND_RETRY_INTERVAL_MS = 60_000;
 const STARTUP_REPLAY_MAX_DELAY_MS = 60_000;
 const REPLAY_BATCH_BASE_DELAY_MS = 200;
 const REPLAY_BATCH_JITTER_MS = 200;
+// Match the Python exporter and prevent re-persisted files from creating an unbounded replay loop.
+const MAX_STARTUP_REPLAY_BATCHES = 10;
 
 /**
  * Base sender class
@@ -298,6 +301,7 @@ export abstract class BaseSender {
       ) {
         this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
         this.customerSDKStatsMetrics?.countRetryItems(envelopes, restError.statusCode);
+        this.scheduleRetryTimer();
         return this.persist(envelopes);
       } else if (
         restError.statusCode === 400 &&
@@ -316,8 +320,9 @@ export abstract class BaseSender {
         return { code: ExportResultCode.SUCCESS };
       }
 
-      // For retriable REST errors
-      if (this.isRetriableRestError(restError) && !this.isStatsbeatSender) {
+      // Persist transport failures where no HTTP response was received.
+      if (this.isRetriableNoResponseError(error) && !this.isStatsbeatSender) {
+        this.networkStatsbeatMetrics?.countException(restError);
         if (this.customerSDKStatsMetrics?.isTimeoutError(restError) && !this.isStatsbeatSender) {
           this.customerSDKStatsMetrics?.countRetryItems(
             envelopes,
@@ -326,14 +331,19 @@ export abstract class BaseSender {
             ExceptionType.TIMEOUT_EXCEPTION,
           );
           diag.error("Request timed out. Error message:", restError.message);
-        } else if (restError.statusCode) {
-          this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
-          this.customerSDKStatsMetrics?.countRetryItems(envelopes, restError.statusCode);
+        } else {
+          this.customerSDKStatsMetrics?.countRetryItems(
+            envelopes,
+            RetryCode.CLIENT_EXCEPTION,
+            restError.message,
+            ExceptionType.NETWORK_EXCEPTION,
+          );
         }
         diag.error(
           "Retrying due to transient client side error. Error message:",
           restError.message,
         );
+        this.scheduleRetryTimer();
         return this.persist(envelopes);
       }
       // For non-retriable REST errors or client exceptions
@@ -426,7 +436,8 @@ export abstract class BaseSender {
 
       let envelopes = (await this.persister.shift()) as Envelope[] | null;
       let isFirstBatch = true;
-      while (envelopes) {
+      let replayedBatchCount = 0;
+      while (envelopes && replayedBatchCount < MAX_STARTUP_REPLAY_BATCHES) {
         // Space out batches (with jitter) so a single process doesn't fire its whole
         // backlog at Breeze back-to-back. No delay before the first batch.
         if (!isFirstBatch) {
@@ -436,11 +447,15 @@ export abstract class BaseSender {
           }
         }
         isFirstBatch = false;
+        replayedBatchCount++;
 
         const result = await this.exportEnvelopes(envelopes);
         if (result.code === ExportResultCode.FAILED) {
           // Stop processing — remaining files stay on disk for later retry
           diag.warn(`Failed to send persisted file during startup, will retry later`);
+          break;
+        }
+        if (replayedBatchCount >= MAX_STARTUP_REPLAY_BATCHES) {
           break;
         }
         envelopes = (await this.persister.shift()) as Envelope[] | null;
@@ -516,9 +531,26 @@ export abstract class BaseSender {
     }
   }
 
-  private isRetriableRestError(error: RestError): boolean {
-    const restErrorTypes: string[] = Object.values(RetriableRestErrorTypes);
-    if (error && error.code && restErrorTypes.includes(error.code)) {
+  private isRetriableNoResponseError(error: unknown): boolean {
+    if (!error || typeof error !== "object") {
+      return false;
+    }
+    const transportError = error as {
+      code?: string;
+      name?: string;
+      response?: { status?: number };
+      statusCode?: number;
+    };
+    if (transportError.statusCode || transportError.response?.status) {
+      return false;
+    }
+    if (isRestError(error)) {
+      const restErrorTypes: string[] = Object.values(RetriableRestErrorTypes);
+      return !!error.code && restErrorTypes.includes(error.code);
+    }
+    // The transport uses the same AbortError for timeouts and cancellation.
+    // Preserve the telemetry because those cases cannot be distinguished here.
+    if (transportError.name === "AbortError") {
       return true;
     }
     return false;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -26,6 +26,7 @@ import {
 } from "../../utils/breezeUtils.js";
 import type { TelemetryItem as Envelope } from "../../generated/index.js";
 import {
+  ABORT_ERROR_NAME,
   ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
   ENV_APPLICATIONINSIGHTS_SDK_STATS_LOGGING,
   ENV_DISABLE_SDKSTATS,
@@ -333,7 +334,7 @@ export abstract class BaseSender {
         // ("The operation was aborted...") isn't recognized by isTimeoutError. Treat it as a
         // timeout explicitly so it's classified as CLIENT_TIMEOUT rather than CLIENT_EXCEPTION.
         const isTimeout =
-          restError.name === "AbortError" ||
+          restError.name === ABORT_ERROR_NAME ||
           this.customerSDKStatsMetrics?.isTimeoutError(restError);
         if (isTimeout && !this.isStatsbeatSender) {
           this.customerSDKStatsMetrics?.countRetryItems(
@@ -562,7 +563,7 @@ export abstract class BaseSender {
     }
     // The transport uses the same AbortError for timeouts and cancellation.
     // Preserve the telemetry because those cases cannot be distinguished here.
-    if (transportError.name === "AbortError") {
+    if (transportError.name === ABORT_ERROR_NAME) {
       return true;
     }
     return false;

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/platform/nodejs/baseSender.ts
@@ -19,7 +19,11 @@ import {
   isStatsbeatShutdownStatus,
 } from "../../export/statsbeat/types.js";
 import type { BreezeResponse } from "../../utils/breezeUtils.js";
-import { isRetriable, isSamplingRejection } from "../../utils/breezeUtils.js";
+import {
+  isRetriable,
+  isSamplingRejection,
+  parseRetryAfterHeader,
+} from "../../utils/breezeUtils.js";
 import type { TelemetryItem as Envelope } from "../../generated/index.js";
 import {
   ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
@@ -301,7 +305,9 @@ export abstract class BaseSender {
       ) {
         this.networkStatsbeatMetrics?.countRetry(restError.statusCode);
         this.customerSDKStatsMetrics?.countRetryItems(envelopes, restError.statusCode);
-        this.scheduleRetryTimer();
+        // Honor a server-requested Retry-After so persisted telemetry isn't replayed too early.
+        const retryAfterMs = parseRetryAfterHeader(restError.response?.headers.get("retry-after"));
+        this.scheduleRetryTimer(retryAfterMs);
         return this.persist(envelopes);
       } else if (
         restError.statusCode === 400 &&
@@ -323,7 +329,13 @@ export abstract class BaseSender {
       // Persist transport failures where no HTTP response was received.
       if (this.isRetriableNoResponseError(error) && !this.isStatsbeatSender) {
         this.networkStatsbeatMetrics?.countException(restError);
-        if (this.customerSDKStatsMetrics?.isTimeoutError(restError) && !this.isStatsbeatSender) {
+        // A status-less AbortError is the transport's real timeout signal, but its message
+        // ("The operation was aborted...") isn't recognized by isTimeoutError. Treat it as a
+        // timeout explicitly so it's classified as CLIENT_TIMEOUT rather than CLIENT_EXCEPTION.
+        const isTimeout =
+          restError.name === "AbortError" ||
+          this.customerSDKStatsMetrics?.isTimeoutError(restError);
+        if (isTimeout && !this.isStatsbeatSender) {
           this.customerSDKStatsMetrics?.countRetryItems(
             envelopes,
             RetryCode.CLIENT_TIMEOUT,

--- a/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/constants/applicationinsights.ts
@@ -20,7 +20,7 @@ export const TIME_SINCE_ENQUEUED = "timeSinceEnqueued";
  * AzureMonitorTraceExporter version.
  * @internal
  */
-export const packageVersion = "1.0.0-beta.43";
+export const packageVersion = "1.0.0-beta.44";
 
 /**
  * Telemetry base data version.

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -11,8 +11,10 @@ import {
   ENV_APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
   ENV_DISABLE_SDKSTATS,
 } from "../../src/Declarations/Constants.js";
+import { ExceptionType, RetryCode } from "../../src/export/statsbeat/types.js";
 import type { SenderResult } from "../../src/types.js";
 import { CustomerSDKStatsMetrics } from "../../src/export/statsbeat/customerSDKStats.js";
+import { RestError } from "@azure/core-rest-pipeline";
 
 // Mock dependencies
 vi.mock("@opentelemetry/api", () => {
@@ -290,10 +292,18 @@ describe("BaseSender", () => {
     // Flush any async work started by the constructor (sendAllPersistedFiles)
     // then clear mock call counts so tests start from a clean slate
     await new Promise((resolve) => setTimeout(resolve, 0));
+    Object.defineProperty(sender, "customerSDKStatsMetrics", {
+      value: mockCustomerSDKStatsMetrics,
+      writable: true,
+    });
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    const retryTimer = (sender as any).retryTimer as NodeJS.Timeout | null;
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+    }
     vi.resetAllMocks();
   });
 
@@ -525,39 +535,87 @@ describe("BaseSender", () => {
       expect(diag.error).toHaveBeenCalled();
     });
 
-    it("should handle retriable REST errors", async () => {
-      const retriableError: any = new Error("Connection reset");
-      retriableError.code = RetriableRestErrorTypes.REQUEST_SEND_ERROR;
+    it.each(Object.values(RetriableRestErrorTypes))(
+      "should persist telemetry when transport error %s has no response",
+      async (code) => {
+        const retriableError = new RestError("No response received", { code });
+        const testEnvelopes = [{ name: "test", time: new Date() }];
+        sender.sendMock.mockRejectedValue(retriableError);
+        mockPersist.push.mockResolvedValue(true);
 
-      sender.sendMock.mockRejectedValue(retriableError);
+        const result = await sender.exportEnvelopes(testEnvelopes);
 
-      // Reset mocks for clean test
-      mockPersist.push.mockClear();
-      mockPersist.push.mockResolvedValue(true);
+        expect(sender.getPersister().push).toHaveBeenCalledWith(testEnvelopes);
+        expect(sender.getNetworkStats().countException).toHaveBeenCalledWith(retriableError);
+        expect(mockCustomerSDKStatsMetrics.countRetryItems).toHaveBeenCalledWith(
+          testEnvelopes,
+          RetryCode.CLIENT_EXCEPTION,
+          retriableError.message,
+          ExceptionType.NETWORK_EXCEPTION,
+        );
+        expect(mockCustomerSDKStatsMetrics.countDroppedItems).not.toHaveBeenCalled();
+        expect((sender as any).retryTimer).not.toBeNull();
+        expect(result.code).toBe(ExportResultCode.SUCCESS);
+      },
+    );
 
-      // Override the isRetriableRestError method for this test
-      const isRetriableRestErrorSpy = vi
-        .spyOn(sender as any, "isRetriableRestError")
-        .mockImplementation(() => true);
-
-      // Set up the spy to track if persist is called
-      const persistSpy = vi.spyOn(sender, "callPersist").mockResolvedValue({
-        code: ExportResultCode.SUCCESS,
+    it("should persist telemetry when a request timeout produces an AbortError", async () => {
+      const timeoutError = Object.assign(new Error("Request timed out"), {
+        name: "AbortError",
       });
+      const testEnvelopes = [{ name: "test", time: new Date() }];
+      sender.sendMock.mockRejectedValue(timeoutError);
+      mockPersist.push.mockResolvedValue(true);
+      mockCustomerSDKStatsMetrics.isTimeoutError.mockReturnValue(true);
 
-      const testEnvelope = [{ name: "test", time: new Date() }];
-      const result = await sender.exportEnvelopes(testEnvelope);
+      const result = await sender.exportEnvelopes(testEnvelopes);
 
-      // Make sure the push was called
-      if (!mockPersist.push.mock.calls.length) {
-        mockPersist.push(testEnvelope);
-      }
-
-      expect(sender.getPersister().push).toHaveBeenCalled();
+      expect(sender.getPersister().push).toHaveBeenCalledWith(testEnvelopes);
+      expect(sender.getNetworkStats().countException).toHaveBeenCalledWith(timeoutError);
+      expect(mockCustomerSDKStatsMetrics.countRetryItems).toHaveBeenCalledWith(
+        testEnvelopes,
+        RetryCode.CLIENT_TIMEOUT,
+        "timeout_exception",
+        ExceptionType.TIMEOUT_EXCEPTION,
+      );
+      expect(mockCustomerSDKStatsMetrics.countDroppedItems).not.toHaveBeenCalled();
+      expect((sender as any).retryTimer).not.toBeNull();
       expect(result.code).toBe(ExportResultCode.SUCCESS);
+    });
 
-      persistSpy.mockRestore();
-      isRetriableRestErrorSpy.mockRestore();
+    it("should not persist a non-RestError with a retriable error code", async () => {
+      const error = Object.assign(new Error("Envelope serialization failed"), {
+        code: RetriableRestErrorTypes.CONNECTION_RESET,
+      });
+      sender.sendMock.mockRejectedValue(error);
+
+      const result = await sender.exportEnvelopes([{ name: "test", time: new Date() }]);
+
+      expect(sender.getPersister().push).not.toHaveBeenCalled();
+      expect(sender.getNetworkStats().countException).toHaveBeenCalledWith(error);
+      expect(result.code).toBe(ExportResultCode.FAILED);
+    });
+
+    it.each([
+      new RestError("Response received", {
+        code: RetriableRestErrorTypes.CONNECTION_RESET,
+        statusCode: 400,
+      }),
+      new RestError("Response received", {
+        code: RetriableRestErrorTypes.CONNECTION_RESET,
+        response: { status: 400 } as any,
+      }),
+      Object.assign(new Error("Request aborted after response"), {
+        name: "AbortError",
+        response: { status: 400 },
+      }),
+    ])("should not persist a retriable error when an HTTP response exists", async (error) => {
+      sender.sendMock.mockRejectedValue(error);
+
+      const result = await sender.exportEnvelopes([{ name: "test", time: new Date() }]);
+
+      expect(sender.getPersister().push).not.toHaveBeenCalled();
+      expect(result.code).toBe(ExportResultCode.FAILED);
     });
 
     it("should not log errors for statsbeat sender with retriable errors", async () => {
@@ -570,8 +628,9 @@ describe("BaseSender", () => {
         isStatsbeatSender: true,
       });
 
-      const retriableError: any = new Error("Connection reset");
-      retriableError.code = RetriableRestErrorTypes.REQUEST_SEND_ERROR;
+      const retriableError = new RestError("Connection reset", {
+        code: RetriableRestErrorTypes.REQUEST_SEND_ERROR,
+      });
 
       sender.sendMock.mockRejectedValue(retriableError);
 
@@ -1668,6 +1727,17 @@ describe("BaseSender", () => {
       // Only file2's retriable envelope was re-persisted
       expect(mockPersist.push).toHaveBeenCalledTimes(1);
       expect(mockPersist.push).toHaveBeenCalledWith([file2[1]]);
+    });
+
+    it("should process at most ten persisted batches per startup replay", async () => {
+      const envelopes = [{ name: "persisted", time: new Date() }];
+      mockPersist.shift.mockResolvedValue(envelopes);
+      sender.sendMock.mockResolvedValue({ result: "success", statusCode: 200 });
+
+      await sender.callSendAllPersistedFiles();
+
+      expect(sender.sendMock).toHaveBeenCalledTimes(10);
+      expect(mockPersist.shift).toHaveBeenCalledTimes(10);
     });
   });
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -609,6 +609,7 @@ describe("BaseSender", () => {
     });
 
     it("should honor Retry-After when a retriable HTTP status is thrown as a RestError", async () => {
+      vi.useFakeTimers();
       const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
       vi.mocked(isRetriable).mockImplementation((statusCode) => statusCode === 503);
       const retriableError = new RestError("Service Unavailable", {
@@ -628,6 +629,7 @@ describe("BaseSender", () => {
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 45_000);
 
       setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
     });
 
     it("should not persist a non-RestError with a retriable error code", async () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/baseSender.spec.ts
@@ -14,7 +14,7 @@ import {
 import { ExceptionType, RetryCode } from "../../src/export/statsbeat/types.js";
 import type { SenderResult } from "../../src/types.js";
 import { CustomerSDKStatsMetrics } from "../../src/export/statsbeat/customerSDKStats.js";
-import { RestError } from "@azure/core-rest-pipeline";
+import { RestError, createHttpHeaders } from "@azure/core-rest-pipeline";
 
 // Mock dependencies
 vi.mock("@opentelemetry/api", () => {
@@ -581,6 +581,53 @@ describe("BaseSender", () => {
       expect(mockCustomerSDKStatsMetrics.countDroppedItems).not.toHaveBeenCalled();
       expect((sender as any).retryTimer).not.toBeNull();
       expect(result.code).toBe(ExportResultCode.SUCCESS);
+    });
+
+    it("should classify the transport's real AbortError timeout message as a timeout", async () => {
+      // The Node transport raises an AbortError whose message is only "The operation was
+      // aborted...", which isTimeoutError does not recognize. The AbortError name must still
+      // drive CLIENT_TIMEOUT classification.
+      const timeoutError = Object.assign(
+        new Error("The operation was aborted. Reason: Timeout of 10000ms exceeded"),
+        { name: "AbortError" },
+      );
+      const testEnvelopes = [{ name: "test", time: new Date() }];
+      sender.sendMock.mockRejectedValue(timeoutError);
+      mockPersist.push.mockResolvedValue(true);
+      mockCustomerSDKStatsMetrics.isTimeoutError.mockReturnValue(false);
+
+      const result = await sender.exportEnvelopes(testEnvelopes);
+
+      expect(sender.getPersister().push).toHaveBeenCalledWith(testEnvelopes);
+      expect(mockCustomerSDKStatsMetrics.countRetryItems).toHaveBeenCalledWith(
+        testEnvelopes,
+        RetryCode.CLIENT_TIMEOUT,
+        "timeout_exception",
+        ExceptionType.TIMEOUT_EXCEPTION,
+      );
+      expect(result.code).toBe(ExportResultCode.SUCCESS);
+    });
+
+    it("should honor Retry-After when a retriable HTTP status is thrown as a RestError", async () => {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      vi.mocked(isRetriable).mockImplementation((statusCode) => statusCode === 503);
+      const retriableError = new RestError("Service Unavailable", {
+        code: "SERVICE_UNAVAILABLE",
+        statusCode: 503,
+        response: {
+          headers: createHttpHeaders({ "retry-after": "45" }),
+        } as any,
+      });
+      sender.sendMock.mockRejectedValue(retriableError);
+      mockPersist.push.mockResolvedValue(true);
+
+      const result = await sender.exportEnvelopes([{ name: "test", time: new Date() }]);
+
+      expect(result.code).toBe(ExportResultCode.SUCCESS);
+      expect(mockPersist.push).toHaveBeenCalled();
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 45_000);
+
+      setTimeoutSpy.mockRestore();
     });
 
     it("should not persist a non-RestError with a retriable error code", async () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/httpSender.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/httpSender.spec.ts
@@ -12,8 +12,8 @@ import {
 } from "../utils/breezeTestUtils.js";
 import type { TelemetryItem as Envelope } from "../../src/generated/index.js";
 import nock from "nock";
-import type { PipelinePolicy, Pipeline } from "@azure/core-rest-pipeline";
-import { createEmptyPipeline } from "@azure/core-rest-pipeline";
+import type { HttpClient, PipelinePolicy, Pipeline } from "@azure/core-rest-pipeline";
+import { createEmptyPipeline, RestError } from "@azure/core-rest-pipeline";
 import { ExportResultCode } from "@opentelemetry/core";
 import { describe, it, assert, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { delay } from "@azure/core-util";
@@ -190,6 +190,47 @@ describe("HttpSender", () => {
       }, 1500);
 
       await delay(2000); // wait enough time for timeout callback
+    });
+
+    it.each([
+      [
+        "connection reset",
+        (request: Parameters<HttpClient["sendRequest"]>[0]) =>
+          new RestError("Connection reset before a response was received", {
+            code: "ECONNRESET",
+            request,
+          }),
+      ],
+      [
+        "request timeout",
+        () =>
+          Object.assign(new Error("Request timed out before a response was received"), {
+            name: "AbortError",
+          }),
+      ],
+    ])("should persist telemetry after a %s with no response", async (_name, createError) => {
+      const sendRequest = vi.fn<HttpClient["sendRequest"]>(async (request) => {
+        throw createError(request);
+      });
+      const sender = new HttpSender({
+        endpointUrl: DEFAULT_BREEZE_ENDPOINT,
+        instrumentationKey: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+        trackStatsbeat: false,
+        exporterOptions: {
+          httpClient: { sendRequest },
+          retryOptions: { maxRetries: 0 },
+        },
+      });
+      const persistSpy = vi.spyOn(sender["persister"], "push").mockResolvedValue(true);
+
+      const result = await sender.exportEnvelopes([envelope]);
+
+      assert.strictEqual(sendRequest.mock.calls.length, 1);
+      assert.deepStrictEqual(persistSpy.mock.calls[0][0], [envelope]);
+      assert.isNotNull(sender["retryTimer"]);
+      assert.strictEqual(result.code, ExportResultCode.SUCCESS);
+      clearTimeout(sender["retryTimer"]!);
+      sender["retryTimer"] = null;
     });
 
     it("should persist retriable failed telemetry 429", async () => {

--- a/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry-exporter/test/internal/statsbeat.spec.ts
@@ -691,8 +691,12 @@ describe("#AzureMonitorStatsbeatExporter", () => {
         const longIntervalStatsbeat = LongIntervalStatsbeatMetrics.getInstance(options);
         const mockExport = vi.spyOn(longIntervalStatsbeat["longIntervalAzureExporter"], "export");
 
-        await new Promise((resolve) => setTimeout(resolve, 120));
-        expect(mockExport).toHaveBeenCalled();
+        // The periodic reader exports on a ~100ms interval; poll rather than waiting a fixed
+        // window so the assertion isn't racy under CI load.
+        await vi.waitFor(() => expect(mockExport).toHaveBeenCalled(), {
+          timeout: 5000,
+          interval: 50,
+        });
         const resourceMetrics = mockExport.mock.calls[0][0];
         const scopeMetrics = resourceMetrics.scopeMetrics;
         assert.strictEqual(scopeMetrics.length, 1, "Scope Metrics count");


### PR DESCRIPTION
### Summary

Updates `@azure/monitor-opentelemetry-exporter` to comply with the no-response retry behavior defined in [Telemetry Collection Spec PR #1018](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/1018).

- Persists telemetry and schedules a later retry when a transient transport failure returns no HTTP status or response.
- Handles status-less `AbortError` timeouts separately while requiring coded network failures to be actual `RestError` instances.
- Preserves the response boundary: response-bearing errors and `PARSE_ERROR` are not classified as no-response failures.
- Caps startup storage replay at ten batches to avoid repeated drain/re-persist loops during outages.
- Records transport retries correctly in customer SDK Stats.

### Testing

- Added BaseSender coverage for supported transport failures, timeouts, response-bearing errors, plain coded errors, SDK Stats, and the startup replay cap.
- Added HttpSender coverage for persisted `ECONNRESET` and `AbortError` failures.
- Verified with an HTTPS endpoint that fully receives telemetry and closes without returning a status; the batch is persisted for retry.
- Package formatting, type checking, targeted tests, lint, and build pass.

---

- [x] Added impacted package name to the issue description
- [x] Added a changelog (if necessary)