### PR TITLE
[test] fix core test type checking errors

### DIFF
--- a/sdk/core/core-client/test/internal/serializationPolicy.spec.ts
+++ b/sdk/core/core-client/test/internal/serializationPolicy.spec.ts
@@ -11,11 +11,13 @@ import {
 } from "../../src/index.js";
 import { serializeHeaders, serializeRequestBody } from "../../src/serializationPolicy.js";
 import { Mappers } from "../testMappers1.js";
+import type { NodeReadableStream } from "@azure/core-rest-pipeline";
 import {
   createEmptyPipeline,
   createHttpHeaders,
   createPipelineRequest,
 } from "@azure/core-rest-pipeline";
+import { stringToUint8Array } from "@azure/core-util";
 import { stringifyXML } from "@azure/core-xml";
 
 describe("serializationPolicy", function () {
@@ -849,7 +851,7 @@ describe("serializationPolicy", function () {
 });
 
 function stringToByteArray(str: string): Uint8Array {
-  return new TextEncoder().encode(str);
+  return stringToUint8Array(str, "utf-8");
 }
 
 describe("serializationPolicy", () => {
@@ -1185,7 +1187,7 @@ describe("serializationPolicy - XML serialization", () => {
   });
 
   it("should serialize Stream body without JSON.stringify in non-XML", async () => {
-    const streamBody = { pipe: vi.fn(), on: vi.fn() } as unknown as NodeJS.ReadableStream;
+    const streamBody = { pipe: vi.fn(), on: vi.fn() } as unknown as NodeReadableStream;
     let capturedRequest: OperationRequest | undefined;
     const pipeline = createEmptyPipeline();
     pipeline.addPolicy(serializationPolicy(), { phase: "Serialize" });
@@ -1329,7 +1331,7 @@ describe("serializationPolicy - prepareXMLRootList non-array", () => {
 
 describe("serializationPolicy - XML Stream body should not be stringified", () => {
   it("should pass stream through in XML mode", async () => {
-    const streamBody = { pipe: vi.fn(), on: vi.fn() } as unknown as NodeJS.ReadableStream;
+    const streamBody = { pipe: vi.fn(), on: vi.fn() } as unknown as NodeReadableStream;
     let capturedRequest: OperationRequest | undefined;
     const pipeline = createEmptyPipeline();
     pipeline.addPolicy(

--- a/sdk/core/core-client/test/internal/utils.spec.ts
+++ b/sdk/core/core-client/test/internal/utils.spec.ts
@@ -7,6 +7,7 @@ import type {
   FullOperationResponse,
   OperationResponseMap,
 } from "../../src/index.js";
+import type { NodeReadableStream } from "@azure/core-rest-pipeline";
 import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
 import { flattenResponse } from "../../src/utils.js";
 
@@ -69,7 +70,7 @@ describe("flattenResponse", () => {
 
 describe("flattenResponse - Stream response", () => {
   it("should return stream properties for Stream body type", () => {
-    const mockStream = { pipe: () => {} } as unknown as NodeJS.ReadableStream;
+    const mockStream = { pipe: () => {} } as unknown as NodeReadableStream;
     const fullResponse: FullOperationResponse = {
       request: defaultRequest(),
       status: 200,

--- a/sdk/core/core-client/test/public/serializer.spec.ts
+++ b/sdk/core/core-client/test/public/serializer.spec.ts
@@ -16,12 +16,13 @@ import type {
 } from "../../src/index.js";
 import { createSerializer } from "../../src/index.js";
 import { Mappers } from "../testMappers1.js";
+import { stringToUint8Array } from "@azure/core-util";
 
 const Serializer = createSerializer(Mappers);
 const valid_uuid = "ceaafd1e-f936-429f-bbfc-82ee75dddc33";
 
 function stringToByteArray(str: string): Uint8Array {
-  return new TextEncoder().encode(str);
+  return stringToUint8Array(str, "utf-8");
 }
 
 describe("Serializer", function () {

--- a/sdk/core/ts-http-runtime/test/internal/client/sendRequest.spec.ts
+++ b/sdk/core/ts-http-runtime/test/internal/client/sendRequest.spec.ts
@@ -2,15 +2,15 @@
 // Licensed under the MIT License.
 
 import { describe, it, assert } from "vitest";
+import type { InternalRequestParameters } from "../../../src/client/sendRequest.js";
 import { sendRequest } from "../../../src/client/sendRequest.js";
-import {
-  RestError,
-  type MultipartRequestBody,
-  type PipelineResponse,
-  type Pipeline,
-  createEmptyPipeline,
-  createHttpHeaders,
+import type {
+  PipelineRequest,
+  MultipartRequestBody,
+  PipelineResponse,
+  Pipeline,
 } from "../../../src/index.js";
+import { RestError, createEmptyPipeline, createHttpHeaders } from "../../../src/index.js";
 import { stringToUint8Array } from "../../../src/util/internal.js";
 import type { PartDescriptor } from "../../../src/client/multipart.js";
 
@@ -686,17 +686,22 @@ describe("sendRequest", () => {
     const tracingOptions = { tracingContext: {} as any };
     const mockPipeline: Pipeline = createEmptyPipeline();
     mockPipeline.sendRequest = async (_client, request) => {
-      assert.deepEqual(request.tracingOptions, tracingOptions);
+      assert.deepEqual(
+        (request as PipelineRequest & Record<string, unknown>).tracingOptions,
+        tracingOptions,
+      );
       return { headers: createHttpHeaders() } as PipelineResponse;
     };
 
-    await sendRequest("GET", mockBaseUrl, mockPipeline, { tracingOptions });
+    await sendRequest("GET", mockBaseUrl, mockPipeline, {
+      tracingOptions,
+    } as InternalRequestParameters);
   });
 
   it("should not set tracingOptions on the pipeline request when not provided", async () => {
     const mockPipeline: Pipeline = createEmptyPipeline();
     mockPipeline.sendRequest = async (_client, request) => {
-      assert.isUndefined(request.tracingOptions);
+      assert.isUndefined((request as PipelineRequest & Record<string, unknown>).tracingOptions);
       return { headers: createHttpHeaders() } as PipelineResponse;
     };
 


### PR DESCRIPTION
Currently our CI only runs "test:node" and "test:browser" with vitest typecheck enabled.  However, it appears that some errors are not caught.  This PR fixes the compilation errors in the tests in two core packages.