### PR TITLE
Resolve <package>/package.json self-import in shared vitest aliases

### DIFF
--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -32,6 +32,7 @@ export function packageNameFrom(rootDir: string): string {
 
 /**
  * Creates standard alias mappings for tests given a root directory and outputs.
+ * - Maps "<packageName>/package.json" to the real package.json at the package root
  * - Maps the package name (from package.json) to the given distDir/indexFile
  * - Maps "$internal/..." to the same distDir
  */
@@ -52,6 +53,14 @@ export function makeAliases(
   } = options;
 
   return [
+    // Must precede the package-name alias below: the first matching alias wins, and
+    // the bare package-name alias would otherwise shadow the "/package.json" subpath.
+    // Some generated clients import "<packageName>/package.json" to read their version
+    // at runtime; keep that resolving to the real file rather than the aliased entry point.
+    {
+      find: `${packageName}/package.json`,
+      replacement: resolve(rootDir, "package.json"),
+    },
     {
       find: packageName,
       replacement: resolve(rootDir, `${distDir}/${indexFile}`),


### PR DESCRIPTION
### Packages impacted by this PR

All packages that consume the repository-root `vitest.shared.config.ts`, including Node and browser test targets.

### Issues associated with this PR

N/A

### Describe the problem that is addressed by this PR

Clients generated by `@azure-tools/typespec-ts` now import their own `<packageName>/package.json` self-export to read the user-agent version at runtime. Under Vitest, the existing bare package-name alias also matches that subpath, redirects it toward the source or dist entry point, and prevents normal package JSON resolution.

### What are the possible designs available to address the problem? If there are more than one possible design, why was the one in this PR chosen?

Prepend a specific `<packageName>/package.json` alias that resolves to the package-root `package.json`. This preserves the existing package-name and `$internal` alias behavior while relying on first-match-wins ordering to prevent the broader package alias from shadowing the JSON subpath. Both Node and browser configurations inherit the fix through `makeAliases`.

### Are there test cases added in this PR? _(If not, why?)_

No committed fixture was added because the repository-root shared config has no existing unit-test harness. The failure and fix were verified with a minimal Vitest package in both source (`./src/index.ts`) and built (`./dist/esm/index.js`) alias modes. The existing `@azure/core-util` Node Vitest suite also passed all 37 tests.

### Provide a list of related PRs _(if any)_

- Azure/typespec-azure#4859

### Command used to generate this PR:**_(Applicable only to SDK release request PRs)_

N/A

### Checklists
- [x] Added impacted package name to the issue description (N/A: no associated issue; impact is repository-wide)
- [x] Does this PR need any fixes in the SDK Generator? No; the related upstream emitter change is Azure/typespec-azure#4859.
- [x] Added a changelog (not necessary for shared test infrastructure)