### PR TITLE
Enforce cfs clean

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -36,7 +36,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'js - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -36,7 +36,10 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive, CFSClean
+      ${{ if eq(variables['Build.DefinitionName'], 'js - npm-admin-tasks') }}:
+        networkIsolationPolicy: Permissive
+      ${{ else }}:
+        networkIsolationPolicy: Permissive, CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'js - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -82,18 +82,15 @@ stages:
                 steps:
                   - checkout: self
                   - download: current
+                  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
                   - template: /eng/common/pipelines/templates/steps/retain-run.yml
                   - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
                     parameters:
                       PackageName: '@azure/template'
                       ServiceDirectory: template
                       TestPipeline: ${{ parameters.TestPipeline }}
-                  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-                    parameters:
-                      npmrcPath: $(Agent.TempDirectory)/create-release-tag/.npmrc
-                      registryUrl: '$(PublicDevOpsRegistry)'
                   - script: >
-                      ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz && npm install --userconfig=$(Agent.TempDirectory)/create-release-tag/.npmrc `ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz`
+                      ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz && npm install `ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*.tgz`
                     displayName: Validating package can be installed
                   - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                     parameters:
@@ -116,7 +113,6 @@ stages:
                       ReleaseSha: $(Build.SourceVersion)
                       RepoId: Azure/azure-sdk-for-js
                       WorkingDirectory: $(System.DefaultWorkingDirectory)
-                      NpmConfigUserConfig: $(Agent.TempDirectory)/create-release-tag/.npmrc
                       AuthToken: ''
 
               - ${{ if ne(artifact.skipPublishPackage, 'true') }}:


### PR DESCRIPTION
This pull request updates the release pipeline templates to simplify npm authentication handling and adjust network isolation policies. The main changes involve streamlining how the `.npmrc` file is created and used during package validation and removing redundant parameters.

**Pipeline authentication and package installation:**

* Moved the inclusion of the `create-authenticated-npmrc.yml` template earlier in the steps to ensure npm authentication is set up before any package operations, and removed the custom parameters for `.npmrc` path and registry URL.
* Updated the `npm install` command to no longer use a custom `.npmrc` file, reflecting the earlier authentication step.
* Removed the `NpmConfigUserConfig` parameter from the package publishing step, as the custom `.npmrc` is no longer needed.

**Network policy configuration:**

* Changed the `networkIsolationPolicy` setting in `1es-redirect.yml` to include `CFSClean` in addition to `Permissive`, potentially improving security or compliance.

[js - bicep-warnings](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6569779&view=results)
[js - npm-admin-tasks](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6569855&view=results)
[js - identity - tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6569856&view=results)