### PR TITLE
[Cosmos] Bump @azure/cosmos version to 4.10.0

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.4 (Unreleased)
+## 4.10.0 (Unreleased)
 
 ### Features Added
 

--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.10.0 (Unreleased)
+## 4.10.0 (2026-07-21)
 
 ### Features Added
 

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "4.9.4",
+  "version": "4.10.0",
   "description": "Microsoft Azure Cosmos DB Service Node.js SDK for NOSQL API",
   "sdk-type": "client",
   "keywords": [

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -224,7 +224,7 @@ export const Constants = {
   AzureNamespace: "Azure.Cosmos",
   AzurePackageName: "@azure/cosmos",
   SDKName: "azure-cosmos-js",
-  SDKVersion: "4.9.4",
+  SDKVersion: "4.10.0",
 
   // Diagnostics
   CosmosDbDiagnosticLevelEnvVarName: "AZURE_COSMOSDB_DIAGNOSTICS_LEVEL",


### PR DESCRIPTION
Bumps `@azure/cosmos` from `4.9.4` to `4.10.0` (minor) for the next release.

### Changes
- `package.json`: `version` 4.9.4 -> 4.10.0
- `src/common/constants.ts`: `SDKVersion` 4.9.4 -> 4.10.0
- `CHANGELOG.md`: renamed the pending `## 4.9.4 (Unreleased)` section to `## 4.10.0 (Unreleased)` (entries preserved)

Version-only change; the public API surface is unchanged.