### PR TITLE
[core-amqp] prepare for upcoming rhea-promise new version

### DIFF
--- a/sdk/core/core-amqp/config/tsconfig.src.browser.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.browser.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../../../eng/tsconfigs/src.browser.json",
-  "include": ["../src/index.ts"]
+  "include": ["../src/index.ts"],
+  "compilerOptions": {
+    // rhea and rhea-promise stop including `///` reference to "node", but their source
+    // still use NodeJS types, which caused error now that TypeScript v7 no longer includes
+    // @types/node implicitly.
+    "types": ["node"]
+  }
+
 }

--- a/sdk/core/core-amqp/config/tsconfig.src.browser.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.browser.json
@@ -2,9 +2,8 @@
   "extends": "../../../../eng/tsconfigs/src.browser.json",
   "include": ["../src/index.ts"],
   "compilerOptions": {
-    // rhea and rhea-promise stop including `///` reference to "node", but their source
-    // still use NodeJS types, which caused error now that TypeScript v7 no longer includes
-    // @types/node implicitly.
+    // rhea and rhea-promise no longer include `/// <reference types="node" />` in their .d.ts, but they still use NodeJS types.
+    // Since our base browser tsconfig sets `"types": []`, we explicitly include @types/node here.
     "types": ["node"]
   }
 

--- a/sdk/core/core-amqp/config/tsconfig.src.react-native.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.react-native.json
@@ -4,7 +4,7 @@
     // rhea and rhea-promise stop including `///` reference to "node", but their source
     // still use NodeJS types, which caused error now that TypeScript v7 no longer includes
     // @types/node implicitly.
-    "types": ["node"],
+    "types": ["react-native","node"],
     // Also react-native's EventEmitter type is incompatible with NodeJS'
     "skipLibCheck": true
   },

--- a/sdk/core/core-amqp/config/tsconfig.src.react-native.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.react-native.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../../../eng/tsconfigs/src.react-native.json",
   "compilerOptions": {
-    // rhea's .d.ts files contain `/// <reference types="node" />` directives,
-    // which pull in @types/node globals that conflict with react-native globals.
-    "skipLibCheck": true
+    // rhea and rhea-promise stop including `///` reference to "node", but their source
+    // still use NodeJS types, which caused error now that TypeScript v7 no longer includes
+    // @types/node implicitly.
+    "types": ["node"],
+    // Also react-native's EventEmitter type is incompatible with NodeJS'
+    "skipLibCheck": true,
   },
   "include": ["../src/index.ts"]
 }

--- a/sdk/core/core-amqp/config/tsconfig.src.react-native.json
+++ b/sdk/core/core-amqp/config/tsconfig.src.react-native.json
@@ -6,7 +6,7 @@
     // @types/node implicitly.
     "types": ["node"],
     // Also react-native's EventEmitter type is incompatible with NodeJS'
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
   "include": ["../src/index.ts"]
 }


### PR DESCRIPTION
The follow two PRs removed the `///` references to node types in `rhea` and `rhea-promise` code:

- https://github.com/amqp/rhea/pull/447
- https://github.com/amqp/rhea-promise/pull/121

Prior to these changes, because of the triple-slash reference to node types, `@types/node` will be pulled in when building core-amqp even for browsers and react-native, which helped because `rhea` and `rhea-promise` use NodeJS types/APIs in their code. Browser/react-native customers can polyfill them.

After these changes, NodeJS types are no longer pulled in, and since TypeScript v7 won't implicitly add types either, our browser and react-native builds are failing. This PR adds `"types": ["node"]` in browser and react-native tsconfig so that their builds continue to work like before.


### Packages impacted by this PR
@azure/core-amqp
