### PR TITLE
fix(warp-ci): resolve install against npmjs to avoid ADO feed 401 on optional bindings

### DIFF
--- a/.github/workflows/warp-ci.yml
+++ b/.github/workflows/warp-ci.yml
@@ -39,8 +39,17 @@ jobs:
           PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[1]")
           npm install -g "pnpm@${PNPM_VERSION}"
 
+      # The repo root .npmrc points at the Azure DevOps feed mirror of npmjs, but this
+      # GitHub-hosted runner has no ADO service identity to authenticate with. The feed only
+      # lazily ingests package versions on the first authenticated request, so anonymously
+      # requesting an un-ingested optional native binding (e.g. rolldown's exotic-platform
+      # bindings) returns 401. Resolve against npmjs directly instead: it hosts the same
+      # tarballs with matching integrity hashes, so --frozen-lockfile stays happy with no
+      # lockfile churn.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          npm_config_registry: https://registry.npmjs.org/
 
       - name: Build
         run: pnpm --filter @microsoft/warp... build


### PR DESCRIPTION
## Problem

The `Warp CI` workflow runs `pnpm install --frozen-lockfile` on a GitHub-hosted `ubuntu-latest` runner. The repo root `.npmrc` points the registry at the Azure DevOps feed mirror (`pkgs.dev.azure.com/azure-sdk/public/...`).

pnpm 11's supply-chain policy check enumerates **all** lockfile entries and fetches their metadata. A recent upgrade pulled in `rolldown@1.1.5`, whose optional platform bindings include exotic platforms (`@rolldown/binding-openharmony-arm64`, `-freebsd-x64`, `-linux-s390x-gnu`, `-wasm32-wasi`, etc.).

The ADO feed only lazily ingests a package version on the **first authenticated request**. ADO pipeline agents only run on linux-x64/arm64, darwin, and win32, so only those bindings were ever cached. The Warp job runs on a GitHub runner **anonymously** (no ADO service identity), so requesting an un-ingested binding returns:

```
✗ Lockfile failed supply-chain policy check
[ERR_PNPM_FETCH_401] GET .../@rolldown%2Fbinding-openharmony-arm64: Unauthorized - 401
```

## Fix

Override `npm_config_registry` to `https://registry.npmjs.org/` on the `Install dependencies` step only. The lockfile stores resolutions by integrity hash (no hardcoded ADO tarball URLs), and the ADO feed merely mirrors npmjs, so the same tarballs have identical integrity. Resolving this job against npmjs is fully compatible with `--frozen-lockfile` and produces **no lockfile churn**.

`supportedArchitectures` does not help here because the supply-chain check ignores it and enumerates every lockfile entry. A GitHub runner can't authenticate to the ADO feed (no service identity, and a PAT secret in a public repo is undesirable).

## Scope

Only `.github/workflows/warp-ci.yml` is modified. `.npmrc`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, and the `@jsr:` scoped registry are untouched.