### PR TITLE
[Cosmos] Test beta release 4.10.0-beta.1 - verify @beta preview-API docs

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.4 (Unreleased)
+## 4.10.0-beta.1 (2026-07-20)
 
 ### Features Added
 

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "4.9.4",
+  "version": "4.10.0-beta.1",
   "description": "Microsoft Azure Cosmos DB Service Node.js SDK for NOSQL API",
   "sdk-type": "client",
   "keywords": [

--- a/sdk/cosmosdb/cosmos/src/common/constants.ts
+++ b/sdk/cosmosdb/cosmos/src/common/constants.ts
@@ -224,7 +224,7 @@ export const Constants = {
   AzureNamespace: "Azure.Cosmos",
   AzurePackageName: "@azure/cosmos",
   SDKName: "azure-cosmos-js",
-  SDKVersion: "4.9.4",
+  SDKVersion: "4.10.0-beta.1",
 
   // Diagnostics
   CosmosDbDiagnosticLevelEnvVarName: "AZURE_COSMOSDB_DIAGNOSTICS_LEVEL",


### PR DESCRIPTION
## Purpose

**Test / docs-verification only.** Throwaway beta to confirm that `@beta` preview APIs render with the "preview" banner in the generated documentation.

Bumps `@azure/cosmos` to `4.10.0-beta.1` so the docs pipeline ingests the package under the **preview** moniker (`?view=azure-node-preview`) and renders the `@beta` **semantic rerank** preview API (`Container.semanticRerank`, `RerankScore`, `SemanticRerankResult`) with a preview alert box.

## Changes
- `package.json` -> `version: 4.10.0-beta.1`
- `src/common/constants.ts` -> `SDKVersion: "4.10.0-beta.1"`
- `CHANGELOG.md` -> dated `## 4.10.0-beta.1 (2026-07-20)` entry (semantic rerank under Features Added)

## Notes
- :warning: **Do not merge to `main` as-is** - this rewrites main's `## 4.9.4 (Unreleased)` header and skips the version trajectory. Intended for release/docs-pipeline verification; close after docs are verified.
- `@beta` markers are present in `review/cosmos-node.api.md` for the semantic-rerank surface.
