### PR TITLE
docs: document MessagingError constructor and RetryMode members

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 4.5.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- Add reference documentation for the `MessagingError` constructor and for the `RetryMode` enum members. [#34916](https://github.com/Azure/azure-sdk-for-js/issues/34916)
+
 ## 4.5.0 (2026-07-13)
 
 ### Other Changes

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-amqp/review/core-amqp-node.api.md
+++ b/sdk/core/core-amqp/review/core-amqp-node.api.md
@@ -517,9 +517,7 @@ export interface RetryConfig<T> {
 
 // @public
 export enum RetryMode {
-    // (undocumented)
     Exponential = 0,
-    // (undocumented)
     Fixed = 1
 }
 

--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -528,6 +528,8 @@ export class MessagingError extends Error {
    */
   info?: any;
   /**
+   * Creates a new `MessagingError`.
+   *
    * @param message - The error message that provides more information about the error.
    * @param originalError - An error whose properties will be copied to the MessagingError if the
    * property matches one found on the Node.js `SystemError`.

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -32,7 +32,15 @@ function isDelivery(obj: any): boolean {
  * Describes the Retry Mode type
  */
 export enum RetryMode {
+  /**
+   * Increases the delay between retries. The delay grows exponentially with each
+   * attempt, and it is capped at the `maxRetryDelayInMs` value in the retry options.
+   */
   Exponential,
+  /**
+   * Keeps the delay between retries constant. Each retry waits for the
+   * `retryDelayInMs` value in the retry options.
+   */
   Fixed,
 }
 


### PR DESCRIPTION
## Summary

The reference docs for `@azure/event-hubs` show no description for the `MessagingError` constructor. They also show no description for the `RetryMode` enum members. Both types come from `@azure/core-amqp` and are re-exported, so the missing TSDoc lives in `core-amqp`.

Fixes #34916

## Motivation

`MessagingError` had `@param` tags but no summary line. The generated constructor entry was therefore blank. `RetryMode.Exponential` and `RetryMode.Fixed` had no doc comments at all. A reader could not tell the two modes apart without reading `calculateDelay` in `sdk/core/core-amqp/src/retry.ts`.

## Changes

- Add a summary line to the `MessagingError` constructor in `sdk/core/core-amqp/src/errors.ts`.
- Add doc comments to `RetryMode.Exponential` and `RetryMode.Fixed` in `sdk/core/core-amqp/src/retry.ts`. The text matches the behavior in `calculateDelay`: `Exponential` grows the delay and caps it at `maxRetryDelayInMs`; `Fixed` waits `retryDelayInMs` each time.
- Refresh `review/core-amqp-node.api.md`. api-extractor drops the `// (undocumented)` markers on the two `RetryMode` members now that they carry doc comments.
- Bump the package to 4.5.1 and add the matching Unreleased changelog section. 4.5.0 is already published, so the Build job requires a bump for any change to the package sources.

## Validation

The change adds comments only. No signature, type, or emitted value changes. A declaration emit of both source files shows the new comments in the `.d.ts` output, which is what the docs pipeline and IntelliSense read. Prettier reports all changed files as correctly formatted.
