### PR TITLE
[EngSys] force installation of optional dependencies when upgrading dependency versions

### DIFF
--- a/eng/pipelines/scripts/sdk-regenerate.mjs
+++ b/eng/pipelines/scripts/sdk-regenerate.mjs
@@ -522,7 +522,7 @@ async function buildRegeneratedPackages(allPackages, successfullyRegenerated, tu
 
   const installResult = await runCommandCapturing(
     "pnpm",
-    ["install", "--no-frozen-lockfile"],
+    ["install", "--no-frozen-lockfile", "--force"],
     SDK_ROOT,
   );
   if (installResult.exitCode !== 0) {

--- a/eng/pipelines/weekly_automation.yml
+++ b/eng/pipelines/weekly_automation.yml
@@ -23,6 +23,10 @@ jobs:
     displayName: "Run Pnpm Update"
 
   - script: |
+      pnpm install --force
+    displayName: "Run Pnpm install --force to install all optional dependencies"
+
+  - script: |
       pnpm turbo build
     env:
       TURBO_TEAM: azsdkjs


### PR DESCRIPTION
Even though some optional dependencies are never used during runtime, `pnpm` still need to read their metadata during package resolution.

This PR forces mirroring of the optional dependencies to the azure devops feed when new dependency versions are introduced.
