### PR TITLE
test: fix Vite 8 rolldown browser-test hang by replacing @rollup/plugin-inject

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ catalogs:
       specifier: ^5.2.1
       version: 5.2.1
   testing:
-    '@rollup/plugin-inject':
-      specifier: ^5.0.5
-      version: 5.0.5
     '@types/chai-as-promised':
       specifier: ^8.0.2
       version: 8.0.2
@@ -8478,9 +8475,6 @@ importers:
       '@azure/eslint-plugin-azure-sdk':
         specifier: workspace:^
         version: link:../../../common/tools/eslint-plugin-azure-sdk
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.13
@@ -14159,9 +14153,6 @@ importers:
       '@azure/keyvault-secrets':
         specifier: ^4.9.0
         version: link:../../keyvault/keyvault-secrets
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/chai-as-promised':
         specifier: catalog:testing
         version: 8.0.2
@@ -14329,9 +14320,6 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/chai-as-promised':
         specifier: catalog:testing
         version: 8.0.2
@@ -14426,9 +14414,6 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/chai-as-promised':
         specifier: catalog:testing
         version: 8.0.2
@@ -28403,9 +28388,6 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -28540,9 +28522,6 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -29467,9 +29446,6 @@ importers:
       '@azure/identity':
         specifier: catalog:internal
         version: 4.13.0
-      '@rollup/plugin-inject':
-        specifier: catalog:testing
-        version: 5.0.5(rollup@4.62.2)
       '@types/chai-as-promised':
         specifier: catalog:testing
         version: 8.0.2
@@ -37326,15 +37302,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=}
 
-  '@rollup/plugin-inject@5.0.5':
-    resolution: {integrity: sha1-YW86c/4HV2X5HFvskBdmCL7Sd6M=}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/plugin-node-resolve@15.3.1':
     resolution: {integrity: sha1-ZgCJU8JSS+eGqjGdSeMvISgpang=}
     engines: {node: '>=14.0.0'}
@@ -44204,14 +44171,6 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
-
-  '@rollup/plugin-inject@5.0.5(rollup@4.62.2)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-    optionalDependencies:
-      rollup: 4.62.2
 
   '@rollup/plugin-node-resolve@15.3.1(rollup@4.62.2)':
     dependencies:

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -87,7 +87,6 @@
   "devDependencies": {
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/debug": "^4.1.12",
     "@types/node": "catalog:",
     "@types/react": "catalog:testing",

--- a/sdk/core/core-amqp/test/browser-polyfills.ts
+++ b/sdk/core/core-amqp/test/browser-polyfills.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` and
+// `process` globals to be present. In the browser these are provided by npm
+// polyfills and installed onto `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` / `process` references into
+// per-module imports of the `buffer` / `process` polyfills. Under Vite 8 the
+// dependency optimizer is rolldown (not esbuild), and injecting an import of
+// `buffer` into the optimized `buffer` module itself creates a self-referential
+// graph that deadlocks the optimizer, so the browser test run hangs forever
+// after the tester pages connect. Assigning the globals from a setup file is
+// bundler-agnostic and avoids that transform entirely.
+import { Buffer } from "buffer";
+import process from "process";
+
+const globals = globalThis as typeof globalThis & {
+  Buffer: typeof Buffer;
+  process: NodeJS.Process;
+};
+
+globals.Buffer ??= Buffer;
+
+// The browser test environment provides a partial `process` shim whose `env`
+// is populated (e.g. RECORDINGS_RELATIVE_PATH for the test recorder) but which
+// lacks members such as `process.nextTick` that the runtime dependency graph
+// relies on. Install the full polyfill for those members while preserving the
+// environment's populated `env`.
+if (globals.process?.env) {
+  process.env = globals.process.env;
+}
+globals.process = process as unknown as NodeJS.Process;

--- a/sdk/core/core-amqp/vitest.browser.config.ts
+++ b/sdk/core/core-amqp/vitest.browser.config.ts
@@ -3,7 +3,6 @@
 
 import { defineConfig, mergeConfig } from "vitest/config";
 import base from "../../../eng/vitestconfigs/browser.config.ts";
-import inject from "@rollup/plugin-inject";
 
 export default mergeConfig(
   base,
@@ -11,6 +10,11 @@ export default mergeConfig(
     optimizeDeps: {
       include: ["process", "buffer"],
     },
-    plugins: [inject({ process: "process", Buffer: ["buffer", "Buffer"] })],
+    test: {
+      // Provide the `Buffer` / `process` globals expected by the runtime
+      // dependency graph. See test/browser-polyfills.ts for why this replaces
+      // the previous `@rollup/plugin-inject` based approach.
+      setupFiles: ["./test/browser-polyfills.ts"],
+    },
   }),
 );

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -106,7 +106,6 @@
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
     "@azure/keyvault-secrets": "^4.9.0",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/chai-as-promised": "catalog:testing",
     "@types/debug": "^4.1.12",
     "@types/node": "catalog:",

--- a/sdk/eventhub/event-hubs/test/browser-polyfills.ts
+++ b/sdk/eventhub/event-hubs/test/browser-polyfills.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` and
+// `process` globals to be present. In the browser these are provided by npm
+// polyfills and installed onto `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` / `process` references into
+// per-module imports of the `buffer` / `process` polyfills. Under Vite 8 the
+// dependency optimizer is rolldown (not esbuild), and injecting an import of
+// `buffer` into the optimized `buffer` module itself creates a self-referential
+// graph that deadlocks the optimizer, so the browser test run hangs forever
+// after the tester pages connect. Assigning the globals from a setup file is
+// bundler-agnostic and avoids that transform entirely.
+import { Buffer } from "buffer";
+import process from "process";
+
+const globals = globalThis as typeof globalThis & {
+  Buffer: typeof Buffer;
+  process: NodeJS.Process;
+};
+
+globals.Buffer ??= Buffer;
+
+// The browser test environment provides a partial `process` shim whose `env`
+// is populated (e.g. RECORDINGS_RELATIVE_PATH for the test recorder) but which
+// lacks members such as `process.nextTick` that the runtime dependency graph
+// relies on. Install the full polyfill for those members while preserving the
+// environment's populated `env`.
+if (globals.process?.env) {
+  process.env = globals.process.env;
+}
+globals.process = process as unknown as NodeJS.Process;

--- a/sdk/eventhub/event-hubs/vitest.browser.config.ts
+++ b/sdk/eventhub/event-hubs/vitest.browser.config.ts
@@ -4,7 +4,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.browser.base.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
-import inject from "@rollup/plugin-inject";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -17,16 +16,17 @@ const config = mergeConfig(
     optimizeDeps: {
       include: ["process", "buffer"],
     },
-    plugins: [
-      browserMap(),
-      inject({ process: "process", Buffer: ["buffer", "Buffer"], stream: ["stream", "stream"] }),
-    ],
+    plugins: [browserMap()],
     test: {
       testTimeout: 6000000,
       hookTimeout: 6000000,
       fileParallelism: false,
       globalSetup: [path.resolve(__dirname, "test/utils/setup.ts")],
-      setupFiles: ["./test/utils/logging.ts"],
+      // browser-polyfills.ts installs the `Buffer` / `process` globals the
+      // runtime dependency graph expects, replacing the previous
+      // `@rollup/plugin-inject` approach that hangs under Vite 8's rolldown
+      // dependency optimizer. See test/browser-polyfills.ts for details.
+      setupFiles: ["./test/browser-polyfills.ts", "./test/utils/logging.ts"],
       env: process.env,
     },
   }),

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -68,7 +68,6 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/chai-as-promised": "catalog:testing",
     "@types/debug": "^4.1.12",
     "@types/node": "catalog:",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/browser-polyfills.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/browser-polyfills.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` and
+// `process` globals to be present. In the browser these are provided by npm
+// polyfills and installed onto `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` / `process` references into
+// per-module imports of the `buffer` / `process` polyfills. Under Vite 8 the
+// dependency optimizer is rolldown (not esbuild), and injecting an import of
+// `buffer` into the optimized `buffer` module itself creates a self-referential
+// graph that deadlocks the optimizer, so the browser test run hangs forever
+// after the tester pages connect. Assigning the globals from a setup file is
+// bundler-agnostic and avoids that transform entirely.
+import { Buffer } from "buffer";
+import process from "process";
+
+const globals = globalThis as typeof globalThis & {
+  Buffer: typeof Buffer;
+  process: NodeJS.Process;
+};
+
+globals.Buffer ??= Buffer;
+
+// The browser test environment provides a partial `process` shim whose `env`
+// is populated (e.g. RECORDINGS_RELATIVE_PATH for the test recorder) but which
+// lacks members such as `process.nextTick` that the runtime dependency graph
+// relies on. Install the full polyfill for those members while preserving the
+// environment's populated `env`.
+if (globals.process?.env) {
+  process.env = globals.process.env;
+}
+globals.process = process as unknown as NodeJS.Process;

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/vitest.browser.config.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/vitest.browser.config.ts
@@ -4,7 +4,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.browser.shared.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
-import inject from "@rollup/plugin-inject";
 import { relativeRecordingsPath } from "@azure-tools/test-recorder";
 import { resolve } from "node:path";
 
@@ -16,13 +15,17 @@ export default mergeConfig(
     optimizeDeps: {
       include: ["@azure-tools/test-recorder", "process", "buffer", "stream"],
     },
-    plugins: [
-      browserMap(),
-      inject({ process: "process", Buffer: ["buffer", "Buffer"], stream: ["stream", "stream"] }),
-    ],
+    plugins: [browserMap()],
     test: {
       fileParallelism: false,
-      setupFiles: !process.env["AZURE_LOG_LEVEL"] ? [] : ['./test/activate-browser-logging.ts'],
+      // browser-polyfills.ts installs the `Buffer` / `process` globals the
+      // runtime dependency graph expects, replacing the previous
+      // `@rollup/plugin-inject` approach that hangs under Vite 8's rolldown
+      // dependency optimizer. See test/browser-polyfills.ts for details.
+      setupFiles: [
+        "./test/browser-polyfills.ts",
+        ...(!process.env["AZURE_LOG_LEVEL"] ? [] : ["./test/activate-browser-logging.ts"]),
+      ],
     },
   })
 );

--- a/sdk/eventhub/eventhubs-checkpointstore-table/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/package.json
@@ -65,7 +65,6 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/chai-as-promised": "catalog:testing",
     "@types/debug": "^4.1.4",
     "@types/node": "catalog:",

--- a/sdk/eventhub/eventhubs-checkpointstore-table/test/browser-polyfills.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/test/browser-polyfills.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` and
+// `process` globals to be present. In the browser these are provided by npm
+// polyfills and installed onto `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` / `process` references into
+// per-module imports of the `buffer` / `process` polyfills. Under Vite 8 the
+// dependency optimizer is rolldown (not esbuild), and injecting an import of
+// `buffer` into the optimized `buffer` module itself creates a self-referential
+// graph that deadlocks the optimizer, so the browser test run hangs forever
+// after the tester pages connect. Assigning the globals from a setup file is
+// bundler-agnostic and avoids that transform entirely.
+import { Buffer } from "buffer";
+import process from "process";
+
+const globals = globalThis as typeof globalThis & {
+  Buffer: typeof Buffer;
+  process: NodeJS.Process;
+};
+
+globals.Buffer ??= Buffer;
+
+// The browser test environment provides a partial `process` shim whose `env`
+// is populated (e.g. RECORDINGS_RELATIVE_PATH for the test recorder) but which
+// lacks members such as `process.nextTick` that the runtime dependency graph
+// relies on. Install the full polyfill for those members while preserving the
+// environment's populated `env`.
+if (globals.process?.env) {
+  process.env = globals.process.env;
+}
+globals.process = process as unknown as NodeJS.Process;

--- a/sdk/eventhub/eventhubs-checkpointstore-table/vitest.browser.config.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-table/vitest.browser.config.ts
@@ -4,7 +4,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.browser.shared.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
-import inject from "@rollup/plugin-inject";
 import { relativeRecordingsPath } from "@azure-tools/test-recorder";
 
 process.env.RECORDINGS_RELATIVE_PATH = relativeRecordingsPath();
@@ -15,13 +14,17 @@ export default mergeConfig(
     optimizeDeps: {
       include: ["@azure-tools/test-recorder", "process", "buffer", "stream"],
     },
-    plugins: [
-      browserMap(),
-      inject({ process: "process", Buffer: ["buffer", "Buffer"], stream: ["stream", "stream"] }),
-    ],
+    plugins: [browserMap()],
     test: {
       fileParallelism: false,
-      setupFiles: !process.env["AZURE_LOG_LEVEL"] ? [] : ['./test/activate-browser-logging.ts'],
+      // browser-polyfills.ts installs the `Buffer` / `process` globals the
+      // runtime dependency graph expects, replacing the previous
+      // `@rollup/plugin-inject` approach that hangs under Vite 8's rolldown
+      // dependency optimizer. See test/browser-polyfills.ts for details.
+      setupFiles: [
+        "./test/browser-polyfills.ts",
+        ...(!process.env["AZURE_LOG_LEVEL"] ? [] : ["./test/activate-browser-logging.ts"]),
+      ],
     },
   })
 );

--- a/sdk/schemaregistry/schema-registry-avro/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/package.json
@@ -78,7 +78,6 @@
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/event-hubs": "^6.0.0-beta.1",
     "@azure/identity": "catalog:internal",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/schemaregistry/schema-registry-avro/test/browser-polyfills.ts
+++ b/sdk/schemaregistry/schema-registry-avro/test/browser-polyfills.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` and
+// `process` globals to be present. In the browser these are provided by npm
+// polyfills and installed onto `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` / `process` references into
+// per-module imports of the `buffer` / `process` polyfills. Under Vite 8 the
+// dependency optimizer is rolldown (not esbuild), and injecting an import of
+// `buffer` into the optimized `buffer` module itself creates a self-referential
+// graph that deadlocks the optimizer, so the browser test run hangs forever
+// after the tester pages connect. Assigning the globals from a setup file is
+// bundler-agnostic and avoids that transform entirely.
+import { Buffer } from "buffer";
+import process from "process";
+
+const globals = globalThis as typeof globalThis & {
+  Buffer: typeof Buffer;
+  process: NodeJS.Process;
+};
+
+globals.Buffer ??= Buffer;
+
+// The browser test environment provides a partial `process` shim whose `env`
+// is populated (e.g. RECORDINGS_RELATIVE_PATH for the test recorder) but which
+// lacks members such as `process.nextTick` that the runtime dependency graph
+// relies on. Install the full polyfill for those members while preserving the
+// environment's populated `env`.
+if (globals.process?.env) {
+  process.env = globals.process.env;
+}
+globals.process = process as unknown as NodeJS.Process;

--- a/sdk/schemaregistry/schema-registry-avro/vitest.browser.config.ts
+++ b/sdk/schemaregistry/schema-registry-avro/vitest.browser.config.ts
@@ -4,7 +4,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.browser.shared.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
-import inject from "@rollup/plugin-inject";
 
 export default mergeConfig(
   viteConfig,
@@ -12,9 +11,14 @@ export default mergeConfig(
     optimizeDeps: {
       include: ["buffer", "process"],
     },
-    plugins: [browserMap(), inject({ process: "process", Buffer: ["buffer", "Buffer"] })],
+    plugins: [browserMap()],
     test: {
       fileParallelism: false,
+      // browser-polyfills.ts installs the `Buffer` / `process` globals the
+      // runtime dependency graph expects, replacing the previous
+      // `@rollup/plugin-inject` approach that hangs under Vite 8's rolldown
+      // dependency optimizer. See test/browser-polyfills.ts for details.
+      setupFiles: ["./test/browser-polyfills.ts"],
     },
   }),
 );

--- a/sdk/schemaregistry/schema-registry-json/package.json
+++ b/sdk/schemaregistry/schema-registry-json/package.json
@@ -75,7 +75,6 @@
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/event-hubs": "^6.0.0-beta.1",
     "@azure/identity": "catalog:internal",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/node": "catalog:",
     "@vitest/browser-playwright": "catalog:testing",
     "@vitest/coverage-istanbul": "catalog:testing",

--- a/sdk/schemaregistry/schema-registry-json/test/browser-polyfills.ts
+++ b/sdk/schemaregistry/schema-registry-json/test/browser-polyfills.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` global to be
+// present. In the browser it is provided by an npm polyfill and installed onto
+// `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` references into per-module
+// imports of the `buffer` polyfill. Under Vite 8 the dependency optimizer is
+// rolldown (not esbuild), and injecting an import of `buffer` into the optimized
+// `buffer` module itself creates a self-referential graph that deadlocks the
+// optimizer, so the browser test run hangs forever after the tester pages
+// connect. Assigning the global from a setup file is bundler-agnostic and avoids
+// that transform entirely.
+import { Buffer } from "buffer";
+
+const globals = globalThis as typeof globalThis & { Buffer: typeof Buffer };
+
+globals.Buffer = Buffer;

--- a/sdk/schemaregistry/schema-registry-json/vitest.browser.config.ts
+++ b/sdk/schemaregistry/schema-registry-json/vitest.browser.config.ts
@@ -4,7 +4,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.browser.shared.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
-import inject from "@rollup/plugin-inject";
 
 export default mergeConfig(
   viteConfig,
@@ -12,9 +11,14 @@ export default mergeConfig(
     optimizeDeps: {
       include: ["buffer"],
     },
-    plugins: [browserMap(), inject({ Buffer: ["buffer", "Buffer"] })],
+    plugins: [browserMap()],
     test: {
       fileParallelism: false,
+      // browser-polyfills.ts installs the `Buffer` global the runtime
+      // dependency graph expects, replacing the previous
+      // `@rollup/plugin-inject` approach that hangs under Vite 8's rolldown
+      // dependency optimizer. See test/browser-polyfills.ts for details.
+      setupFiles: ["./test/browser-polyfills.ts"],
     },
   }),
 );

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -109,7 +109,6 @@
     "@azure/dev-tool": "workspace:^",
     "@azure/eslint-plugin-azure-sdk": "workspace:^",
     "@azure/identity": "catalog:internal",
-    "@rollup/plugin-inject": "catalog:testing",
     "@types/chai-as-promised": "catalog:testing",
     "@types/debug": "^4.1.4",
     "@types/is-buffer": "^2.0.0",

--- a/sdk/servicebus/service-bus/test/browser-polyfills.ts
+++ b/sdk/servicebus/service-bus/test/browser-polyfills.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This package's runtime dependency graph expects Node's `Buffer` and
+// `process` globals to be present. In the browser these are provided by npm
+// polyfills and installed onto `globalThis` here.
+//
+// This setup file replaces the previous `@rollup/plugin-inject` approach.
+// `@rollup/plugin-inject` rewrites bare `Buffer` / `process` references into
+// per-module imports of the `buffer` / `process` polyfills. Under Vite 8 the
+// dependency optimizer is rolldown (not esbuild), and injecting an import of
+// `buffer` into the optimized `buffer` module itself creates a self-referential
+// graph that deadlocks the optimizer, so the browser test run hangs forever
+// after the tester pages connect. Assigning the globals from a setup file is
+// bundler-agnostic and avoids that transform entirely.
+import { Buffer } from "buffer";
+import process from "process";
+
+const globals = globalThis as typeof globalThis & {
+  Buffer: typeof Buffer;
+  process: NodeJS.Process;
+};
+
+globals.Buffer ??= Buffer;
+
+// The browser test environment provides a partial `process` shim whose `env`
+// is populated (e.g. RECORDINGS_RELATIVE_PATH for the test recorder) but which
+// lacks members such as `process.nextTick` that the runtime dependency graph
+// relies on. Install the full polyfill for those members while preserving the
+// environment's populated `env`.
+if (globals.process?.env) {
+  process.env = globals.process.env;
+}
+globals.process = process as unknown as NodeJS.Process;

--- a/sdk/servicebus/service-bus/vitest.browser.config.ts
+++ b/sdk/servicebus/service-bus/vitest.browser.config.ts
@@ -4,7 +4,6 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import viteConfig from "../../../vitest.browser.shared.config.ts";
 import browserMap from "@azure-tools/vite-plugin-browser-test-map";
-import inject from "@rollup/plugin-inject";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -17,13 +16,15 @@ const config = mergeConfig(
     optimizeDeps: {
       include: ["process", "buffer"],
     },
-    plugins: [
-      browserMap(),
-      inject({ process: "process", Buffer: ["buffer", "Buffer"], stream: ["stream", "stream"] }),
-    ],
+    plugins: [browserMap()],
     test: {
       fileParallelism: false,
       globalSetup: [path.resolve(__dirname, "test/utils/setup.ts")],
+      // browser-polyfills.ts installs the `Buffer` / `process` globals the
+      // runtime dependency graph expects, replacing the previous
+      // `@rollup/plugin-inject` approach that hangs under Vite 8's rolldown
+      // dependency optimizer. See test/browser-polyfills.ts for details.
+      setupFiles: ["./test/browser-polyfills.ts"],
     },
   }),
 );


### PR DESCRIPTION
## Why

Bumping Vite to v8 in the browser test toolchain makes `vitest` browser runs **hang forever** across several packages. With `DEBUG=vitest*,vite*` the run stalls right after the tester pages report `Browser API connected to tester` and never makes progress. Downgrading to Vite 7 makes the hang disappear, which points at a Vite 8-specific behavior rather than our test code.

The cause is a toolchain interaction, not a bug in the tests:

- Vite 8 optimizes dependencies with **rolldown** instead of esbuild.
- We relied on `@rollup/plugin-inject` to supply the Node `Buffer` / `process` globals the AMQP/rhea runtime graph expects in the browser. That plugin rewrites bare `Buffer` / `process` references into per-module imports of the `buffer` / `process` polyfills.
- Injecting an `import ... from "buffer"` into the optimized `buffer` module itself produces a self-referential graph that **deadlocks rolldown's dependency optimizer**, so the run hangs.

Rather than pin Vite back to v7 (and block the upgrade for every affected package), this removes the dependency on the injection transform entirely. The globals are installed onto `globalThis` from a small `test/browser-polyfills.ts` setup file, which is bundler-agnostic and unaffected by how deps are optimized.

A subtle requirement drove the final shape of the setup file: the browser test environment already provides a partial `process` whose `env` is populated (the recorder reads `RECORDINGS_RELATIVE_PATH` from it), but it lacks members like `process.nextTick` that rhea needs. The setup therefore **merges**: it installs the full polyfill for the missing members while preserving the environment's populated `env`. schema-registry-json only ever needed `Buffer`, so it stays Buffer-only to match prior behavior.

## Verification

All affected browser suites run to completion with no hang:

| Package | Result |
| --- | --- |
| core-amqp | 204 passed |
| schema-registry-avro | 51 passed |
| schema-registry-json | 26 passed |
| service-bus | 379 passed |
| event-hubs | 28 passed |
| eventhubs-checkpointstore-blob | no hang (only fails on missing local `STORAGE_ENDPOINT` integration env) |
| eventhubs-checkpointstore-table | no hang (only fails on missing local `STORAGE_ACCOUNT_NAME` integration env) |

The checkpointstore failures are pre-existing environmental gaps (no local credentials/recordings), not related to this change — no `Buffer` / `process` / `nextTick` errors appear anywhere.
