### PR TITLE
fix(build): update pnpm install command to use npmjs registry for optional native bindings

### DIFF
--- a/eng/tools/js-sdk-release-tools-src/src/common/rushUtils.ts
+++ b/eng/tools/js-sdk-release-tools-src/src/common/rushUtils.ts
@@ -99,7 +99,21 @@ export async function buildPackage(
   let buildStatus = `succeeded`;
   await ensurePnpmInstalled();
   logger.info(`Start to pnpm install.`);
-  await runCommand(`pnpm`, ["install"], runCommandOptions, false);
+  // The azure-sdk-for-js root .npmrc resolves packages through the Azure DevOps feed
+  // mirror, which only ingests a version on its first *authenticated* request. When this
+  // runs without an ADO identity, resolving an un-ingested optional native binding (e.g.
+  // rolldown's non-host platform bindings) returns 401 and fails the lockfile supply-chain
+  // check. npmjs serves identical tarballs with matching integrity hashes, so pointing the
+  // install at it keeps the lockfile stable. Mirrors .github/workflows/warp-ci.yml.
+  await runCommand(
+    `pnpm`,
+    ["install"],
+    {
+      ...runCommandOptions,
+      env: { ...process.env, npm_config_registry: "https://registry.npmjs.org/" },
+    },
+    false,
+  );
   logger.info(`Pnpm install successfully.`);
 
   if (options.runMode === RunMode.Local || options.runMode === RunMode.Release) {


### PR DESCRIPTION
This pull request updates the package installation process in `rushUtils.ts` to improve reliability and stability when running `pnpm install` in environments without Azure DevOps (ADO) authentication. The main change is to explicitly set the npm registry to `https://registry.npmjs.org/` during installation, which avoids errors related to private feed authentication and ensures consistent lockfile generation.

Dependency installation reliability:

* Modified the `buildPackage` function in `rushUtils.ts` to set the `npm_config_registry` environment variable to `https://registry.npmjs.org/` when running `pnpm install`. This change prevents failures caused by unauthenticated requests to the Azure DevOps feed and ensures the lockfile remains stable by always resolving packages from the public npm registry.

test pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6591522&view=results