### PR TITLE
[core] fix nightly build

### DIFF
--- a/sdk/core/core-rest-pipeline/test/public/browser/proxyPolicy.spec.ts
+++ b/sdk/core/core-rest-pipeline/test/public/browser/proxyPolicy.spec.ts
@@ -5,9 +5,8 @@ import { describe, it, assert } from "vitest";
 import { proxyPolicy } from "../../../src/index.js";
 
 describe("proxyPolicy (browser)", function () {
-  it("Throws on creation", function () {
-    assert.throws(() => {
-      proxyPolicy();
-    }, /proxyPolicy is not supported in browser environment/);
+  it("returns a no-op policy", function () {
+    const policy = proxyPolicy();
+    assert.strictEqual(policy.name, "proxyPolicy");
   });
 });

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- make proxyPolicy a no-op when proxy is unsupported [PR #39084](https://github.com/Azure/azure-sdk-for-js/pull/39084)
+`proxyPolicy` no longer throws on platforms where proxies are not supported (such as browsers and React Native). Instead, it returns a no-op policy that forwards requests unchanged, and `getDefaultProxySettings` returns `undefined` [PR #39084](https://github.com/Azure/azure-sdk-for-js/pull/39084)
 
 ## 0.3.7 (2026-07-13)
 
@@ -20,7 +20,6 @@
 
 ### Other Changes
 
-- `proxyPolicy` no longer throws on platforms where proxies are not supported (such as browsers and React Native). Instead, it returns a no-op policy that forwards requests unchanged, and `getDefaultProxySettings` returns `undefined`.
 - Removed the internal `randomUUID` polyfill for Node.js and browsers, relying on `globalThis.crypto.randomUUID()` which is available on those platforms. React Native keeps a `Math.random()` based fallback since its JS engines do not provide `crypto.randomUUID()`.
 - Update `engines` to `"node": ">=22.0.0"`. Please refer to our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more information on our supported Node.js versions.
 

--- a/sdk/core/ts-http-runtime/CHANGELOG.md
+++ b/sdk/core/ts-http-runtime/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 0.3.8 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
+- make proxyPolicy a no-op when proxy is unsupported [PR #39084](https://github.com/Azure/azure-sdk-for-js/pull/39084)
+
 ## 0.3.7 (2026-07-13)
 
 ### Bugs Fixed

--- a/sdk/core/ts-http-runtime/package.json
+++ b/sdk/core/ts-http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typespec/ts-http-runtime",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Isomorphic client library for making HTTP requests in node.js and browser.",
   "sdk-type": "client",
   "type": "module",

--- a/sdk/core/ts-http-runtime/src/constants.ts
+++ b/sdk/core/ts-http-runtime/src/constants.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "0.3.7";
+export const SDK_VERSION: string = "0.3.8";
 
 export const DEFAULT_RETRY_POLICY_COUNT = 3;


### PR DESCRIPTION
- ts-http-runtime needs a version bump

- core-rest-pipeline: adapt browser test for the proxyPolicy changes in ts-http-runtime
