### PR TITLE
[ai-voicelive] Add Voice Agent support to the web sample

### DIFF
--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/package.json
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/package.json
@@ -18,9 +18,12 @@
     "@azure/core-auth": "^1.11.0"
   },
   "devDependencies": {
+    "@azure/identity": "^4.13.0",
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
     "typescript": "~6.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.4",
+    "ws": "^8.21.1"
   },
   "browserslist": [
     "> 1%",

--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/server/localAzureDevelopmentPlugin.ts
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/server/localAzureDevelopmentPlugin.ts
@@ -1,0 +1,331 @@
+import { AzureCliCredential } from "@azure/identity";
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+import type { Plugin } from "vite";
+import WebSocket, { WebSocketServer, type RawData } from "ws";
+
+const voiceLiveScope = "https://ai.azure.com/.default";
+const voiceAgentProxyPath = "/voice";
+const voiceAgentUrlParameter = "voice-agent-url";
+const voiceAgentFeatureHeader = "VoiceAgents=V1Preview";
+const maxMessageSize = 16 * 1024 * 1024;
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function isFoundryHost(hostname: string): boolean {
+  return /^[a-z0-9-]+\.services\.ai\.azure\.com$/i.test(hostname);
+}
+
+function parseVoiceAgentUrl(rawUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("The voice agent WebSocket URL is invalid.");
+  }
+
+  if (url.protocol !== "wss:") {
+    throw new Error("The voice agent URL must use wss://.");
+  }
+  if (url.username || url.password) {
+    throw new Error("Credentials are not allowed in the voice agent URL.");
+  }
+
+  if (!isFoundryHost(url.hostname)) {
+    throw new Error("The voice agent URL must target an Azure AI Foundry resource endpoint.");
+  }
+  const isFoundryVoicePath =
+    /^\/api\/projects\/[^/]+\/agents\/[^/]+\/endpoint\/protocols\/voice$/.test(url.pathname);
+  if (!isFoundryVoicePath) {
+    throw new Error("The URL is not an Agents protocols/voice WebSocket endpoint.");
+  }
+
+  url.hash = "";
+  if (!url.searchParams.has("api-version")) {
+    url.searchParams.set("api-version", "v1");
+  }
+  if (!url.searchParams.has("agent_session_id")) {
+    url.searchParams.set(
+      "agent_session_id",
+      `voice-live-sdk-${randomUUID().replace(/-/g, "").slice(0, 12)}`,
+    );
+  }
+  return url;
+}
+
+function rejectUpgrade(socket: Duplex, statusCode: number, message: string): void {
+  if (socket.destroyed) {
+    return;
+  }
+
+  const body = `${message}\n`;
+  socket.write(
+    [
+      `HTTP/1.1 ${statusCode} Bad Gateway`,
+      "Connection: close",
+      "Content-Type: text/plain; charset=utf-8",
+      `Content-Length: ${Buffer.byteLength(body)}`,
+      "",
+      body,
+    ].join("\r\n"),
+  );
+  socket.destroy();
+}
+
+function validateBrowserOrigin(request: IncomingMessage): void {
+  const origin = request.headers.origin;
+  if (!origin) {
+    return;
+  }
+
+  let originUrl: URL;
+  try {
+    originUrl = new URL(origin);
+  } catch {
+    throw new Error("The WebSocket request origin is invalid.");
+  }
+
+  if (!isLoopbackHost(originUrl.hostname) || originUrl.host !== request.headers.host) {
+    throw new Error("Voice agent proxy requests must originate from this loopback Vite server.");
+  }
+}
+
+function closePeer(socket: WebSocket, code: number, reason: Buffer): void {
+  if (socket.readyState !== WebSocket.OPEN && socket.readyState !== WebSocket.CONNECTING) {
+    return;
+  }
+
+  if (code === 1005 || code === 1006) {
+    socket.terminate();
+    return;
+  }
+
+  socket.close(code, reason.toString());
+}
+
+function bridgeSockets(
+  browserSocket: WebSocket,
+  upstreamSocket: WebSocket,
+  bufferedMessages: Array<{ data: RawData; isBinary: boolean }>,
+  stopBuffering: () => void,
+): void {
+  browserSocket.on("message", (data, isBinary) => {
+    if (upstreamSocket.readyState === WebSocket.OPEN) {
+      upstreamSocket.send(data, { binary: isBinary });
+    }
+  });
+  const forwardUpstreamMessage = (data: RawData, isBinary: boolean): void => {
+    if (browserSocket.readyState === WebSocket.OPEN) {
+      browserSocket.send(data, { binary: isBinary });
+    }
+  };
+  upstreamSocket.on("message", forwardUpstreamMessage);
+
+  // Register the forwarding listener before removing the temporary buffer.
+  // Both operations are synchronous, so no upstream event can be lost between them.
+  stopBuffering();
+  for (const message of bufferedMessages) {
+    browserSocket.send(message.data, { binary: message.isBinary });
+  }
+
+  browserSocket.on("close", (code, reason) => closePeer(upstreamSocket, code, reason));
+  upstreamSocket.on("close", (code, reason) => closePeer(browserSocket, code, reason));
+  browserSocket.on("error", () => upstreamSocket.terminate());
+  upstreamSocket.on("error", () => browserSocket.terminate());
+}
+
+async function openVoiceAgentSocket(
+  targetUrl: URL,
+  accessToken: string,
+): Promise<{
+  socket: WebSocket;
+  bufferedMessages: Array<{ data: RawData; isBinary: boolean }>;
+  stopBuffering: () => void;
+}> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+    "Foundry-Features": voiceAgentFeatureHeader,
+  };
+
+  const socket = new WebSocket(targetUrl, {
+    headers,
+    handshakeTimeout: 60_000,
+    maxPayload: maxMessageSize,
+    perMessageDeflate: false,
+  });
+  const bufferedMessages: Array<{ data: RawData; isBinary: boolean }> = [];
+  const bufferMessage = (data: RawData, isBinary: boolean): void => {
+    bufferedMessages.push({ data, isBinary });
+  };
+  socket.on("message", bufferMessage);
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("unexpected-response", (_request, response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        if (body.length < 4_000) {
+          body += chunk;
+        }
+      });
+      response.on("end", () => {
+        reject(
+          new Error(
+            `Voice agent handshake failed with HTTP ${response.statusCode}${
+              body ? `: ${body}` : ""
+            }`,
+          ),
+        );
+      });
+      response.resume();
+    });
+    socket.once("error", reject);
+  });
+
+  return {
+    socket,
+    bufferedMessages,
+    stopBuffering: () => socket.off("message", bufferMessage),
+  };
+}
+
+/**
+ * Local-only development support for browser authentication and Voice Agent WebSockets.
+ *
+ * Browser WebSockets cannot set Authorization or Foundry-Features headers.
+ * The proxy accepts the Voice Live SDK connection on loopback, opens the supplied voice-agent
+ * URL with those headers, and relays the Voice Live protocol frames unchanged.
+ */
+export function localAzureDevelopmentPlugin(): Plugin {
+  const credential = new AzureCliCredential();
+  const webSocketServer = new WebSocketServer({
+    noServer: true,
+    maxPayload: maxMessageSize,
+    perMessageDeflate: false,
+  });
+  const upstreamSockets = new Set<WebSocket>();
+
+  const tokenEndpoint = async (
+    request: IncomingMessage,
+    response: ServerResponse,
+    next: () => void,
+  ): Promise<void> => {
+    if (request.url?.split("?")[0] !== "/api/azure-token") {
+      next();
+      return;
+    }
+
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Content-Type", "application/json");
+    response.setHeader("X-Content-Type-Options", "nosniff");
+
+    if (request.method !== "GET") {
+      response.statusCode = 405;
+      response.setHeader("Allow", "GET");
+      response.end(JSON.stringify({ error: "Method not allowed" }));
+      return;
+    }
+
+    try {
+      const token = await credential.getToken(voiceLiveScope);
+      if (!token) {
+        throw new Error("AzureCliCredential returned no access token");
+      }
+
+      response.statusCode = 200;
+      response.end(
+        JSON.stringify({
+          token: token.token,
+          expiresOnTimestamp: token.expiresOnTimestamp,
+        }),
+      );
+    } catch (error) {
+      console.error("Failed to acquire a Voice Live access token:", error);
+      response.statusCode = 500;
+      response.end(
+        JSON.stringify({
+          error: 'Unable to acquire an Azure CLI access token. Run "az login" and restart Vite.',
+        }),
+      );
+    }
+  };
+
+  const upgradeHandler = (request: IncomingMessage, socket: Duplex, head: Buffer): void => {
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+    } catch {
+      return;
+    }
+
+    const rawTargetUrl = requestUrl.searchParams.get(voiceAgentUrlParameter);
+    if (requestUrl.pathname !== voiceAgentProxyPath || !rawTargetUrl) {
+      return;
+    }
+
+    void (async () => {
+      let upstreamSocket: WebSocket | undefined;
+      try {
+        validateBrowserOrigin(request);
+        const targetUrl = parseVoiceAgentUrl(rawTargetUrl);
+        const token = await credential.getToken(voiceLiveScope);
+        if (!token) {
+          throw new Error("AzureCliCredential returned no access token");
+        }
+
+        const upstream = await openVoiceAgentSocket(targetUrl, token.token);
+        upstreamSocket = upstream.socket;
+        upstreamSockets.add(upstreamSocket);
+        upstreamSocket.once("close", () => upstreamSockets.delete(upstreamSocket!));
+
+        webSocketServer.handleUpgrade(request, socket, head, (browserSocket) => {
+          bridgeSockets(
+            browserSocket,
+            upstreamSocket!,
+            upstream.bufferedMessages,
+            upstream.stopBuffering,
+          );
+        });
+      } catch (error) {
+        upstreamSocket?.terminate();
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("Voice agent proxy connection failed:", message);
+        rejectUpgrade(socket, 502, message);
+      }
+    })();
+  };
+
+  const closeProxy = (): void => {
+    for (const socket of upstreamSockets) {
+      socket.terminate();
+    }
+    upstreamSockets.clear();
+    for (const socket of webSocketServer.clients) {
+      socket.terminate();
+    }
+  };
+
+  return {
+    name: "local-azure-development",
+    configureServer(server) {
+      server.middlewares.use(tokenEndpoint);
+      server.httpServer?.on("upgrade", upgradeHandler);
+      server.httpServer?.once("close", () => {
+        server.httpServer?.off("upgrade", upgradeHandler);
+        closeProxy();
+      });
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(tokenEndpoint);
+      server.httpServer?.on("upgrade", upgradeHandler);
+      server.httpServer?.once("close", () => {
+        server.httpServer?.off("upgrade", upgradeHandler);
+        closeProxy();
+      });
+    },
+  };
+}

--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/src/main.ts
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/src/main.ts
@@ -219,7 +219,19 @@ class WebVoiceAssistantApp {
     const instructions = (document.getElementById('instructions') as HTMLTextAreaElement).value;
     const debugMode = (document.getElementById('debugMode') as HTMLInputElement).checked;
     const authMethodElement = document.querySelector('input[name="authMethod"]:checked') as HTMLInputElement;
-    const useTokenCredential = authMethodElement ? authMethodElement.value === 'token' : false;
+    const isVoiceAgentEndpoint = (() => {
+      try {
+        const url = new URL(endpoint);
+        return (
+          (url.protocol === 'ws:' || url.protocol === 'wss:') &&
+          url.pathname.endsWith('/endpoint/protocols/voice')
+        );
+      } catch {
+        return false;
+      }
+    })();
+    const useTokenCredential =
+      isVoiceAgentEndpoint || (authMethodElement ? authMethodElement.value === 'token' : false);
 
     if (!endpoint) {
       throw new Error('Endpoint is required');

--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/src/voiceAssistant.ts
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/src/voiceAssistant.ts
@@ -11,17 +11,63 @@ import {
   type SessionContext
 } from '@azure/ai-voicelive';
 import { AzureKeyCredential } from '@azure/core-auth';
-import type { TokenCredential, KeyCredential } from '@azure/core-auth';
+import type {
+  AccessToken,
+  GetTokenOptions,
+  KeyCredential,
+  TokenCredential
+} from '@azure/core-auth';
 import { SimpleAudioCapture } from './audioCapture.js';
 
-// Note: DefaultAzureCredential would come from @azure/identity package
-// For this demo, we'll create a mock implementation
-class MockDefaultAzureCredential implements TokenCredential {
-  async getToken(): Promise<{ token: string; expiresOnTimestamp: number } | null> {
-    console.warn('Mock DefaultAzureCredential used - implement proper Azure authentication for production');
+interface LocalTokenResponse {
+  token?: unknown;
+  expiresOnTimestamp?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Gets a development token from the local Vite server.
+ *
+ * The Vite server uses AzureCliCredential, which reuses an `az login` session
+ * without exposing Azure CLI files to browser code.
+ */
+class LocalAzureCredential implements TokenCredential {
+  async getToken(
+    _scopes: string | string[],
+    _options?: GetTokenOptions
+  ): Promise<AccessToken> {
+    const response = await fetch('/api/azure-token', {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json'
+      }
+    });
+    const body = (await response.json()) as LocalTokenResponse;
+
+    if (!response.ok) {
+      const details = typeof body.error === 'string' ? body.error : response.statusText;
+      throw new Error(`Local Azure authentication failed: ${details}`);
+    }
+
+    if (
+      typeof body.token !== 'string' ||
+      typeof body.expiresOnTimestamp !== 'number'
+    ) {
+      throw new Error('Local Azure token endpoint returned an invalid response');
+    }
+
     return {
-      token: 'mock-token-for-demo',
-      expiresOnTimestamp: Date.now() + 3600000 // 1 hour from now
+      token: body.token,
+      expiresOnTimestamp: body.expiresOnTimestamp
+    };
+  }
+}
+
+class LocalBridgeCredential implements TokenCredential {
+  async getToken(): Promise<AccessToken> {
+    return {
+      token: 'bridge-managed',
+      expiresOnTimestamp: Date.now() + 3600000
     };
   }
 }
@@ -37,6 +83,7 @@ export interface VoiceAssistantConfig {
 
 const OPENAI_VOICES = ['alloy', 'echo', 'shimmer', 'ash', 'ballad', 'coral', 'sage', 'verse', 'fable', 'onyx', 'nova'];
 const AZURE_REALTIME_NATIVE_VOICE_SUFFIX = '-native';
+const VOICE_LIVE_API_VERSION = '2025-10-01';
 
 export interface VoiceAssistantCallbacks {
   onConnectionStatusChange: (status: string) => void;
@@ -73,6 +120,7 @@ export class VoiceAssistant {
   private isPlayingAudio = false;
   private nextAudioStartTime = 0;
   private currentAudioSources: AudioBufferSourceNode[] = [];
+  private isVoiceAgentConnection = false;
 
   constructor() {
     this.audioCapture = new SimpleAudioCapture();
@@ -85,13 +133,20 @@ export class VoiceAssistant {
   async connect(config: VoiceAssistantConfig): Promise<void> {
     try {
       this.callbacks?.onConnectionStatusChange('connecting');
-      
+
+      this.isVoiceAgentConnection = this.isVoiceAgentWebSocketUrl(config.endpoint);
+      if (this.isVoiceAgentConnection) {
+        // A voice agent can emit a greeting immediately after connecting. Create
+        // playback while the Connect click still counts as a user gesture.
+        await this.ensurePlaybackAudioContext();
+      }
+
       // Create appropriate credential based on configuration
       const credential = this._createCredential(config);
-      
-      // Create session options
-      const sessionOptions: any = {
-        connectionTimeoutInMs: 30000,
+
+      // Voice Agent startup can include agent resolution and upstream Voice Live setup.
+      const sessionOptions = {
+        connectionTimeoutInMs: this.isVoiceAgentConnection ? 65000 : 30000,
       };
 
       console.log(`🔑 Using credential type: ${config.useTokenCredential ? 'TokenCredential' : 'API Key'}`);
@@ -103,20 +158,38 @@ export class VoiceAssistant {
         console.log('📡 Watch Events panel for real-time SDK events');
       }
 
-      // Create Voice Live client. `apiVersion` defaults to the latest known
-      // version; override only to pin a specific version.
-      this.client = new VoiceLiveClient(config.endpoint, credential, {
+      const clientEndpoint = this.isVoiceAgentConnection
+        ? this.createVoiceAgentProxyEndpoint(config.endpoint)
+        : config.endpoint;
+
+      // The local proxy preserves the supplied Voice Agent URL while the SDK
+      // continues to own the browser WebSocket and Voice Live protocol.
+      this.client = new VoiceLiveClient(clientEndpoint, credential, {
+        apiVersion: VOICE_LIVE_API_VERSION,
         defaultSessionOptions: sessionOptions
       });
-      
-      // Create and connect a session with a model compatible with the selected voice.
-      this.session = await this.client.startSession(this.getModelForVoice(config.voice), sessionOptions);
-      
-      // Setup handler-based event subscription (Azure SDK pattern)
+
+      // Subscribe before connecting so immediate session.created/session.updated
+      // events from the Voice Agent orchestrator are not missed.
+      this.session = this.client.createSession(
+        this.isVoiceAgentConnection ? 'voice-agent-proxy' : this.getModelForVoice(config.voice),
+        sessionOptions
+      );
       this.subscription = this.session.subscribe(this.createEventHandlers());
-      
-      // Configure session
-      await this.configureSession(config);
+      const restoreWebSocket = this.isVoiceAgentConnection
+        ? this.installVoiceAgentWebSocketAdapter()
+        : undefined;
+      try {
+        await this.session.connect();
+      } finally {
+        restoreWebSocket?.();
+      }
+
+      if (!this.isVoiceAgentConnection) {
+        // A Voice Live resource is configured per session. A Voice Agent already
+        // owns its model, instructions, voice, tools, and audio stack.
+        await this.configureSession(config);
+      }
       
       this.isConnected = true;
       this.callbacks?.onConnectionStatusChange('connected');
@@ -131,10 +204,14 @@ export class VoiceAssistant {
   }
 
   private _createCredential(config: VoiceAssistantConfig): TokenCredential | KeyCredential {
+    if (this.isVoiceAgentConnection) {
+      console.log('🔑 Authentication is managed by the local Voice Agent bridge');
+      return new LocalBridgeCredential();
+    }
+
     if (config.useTokenCredential) {
-      // Use Azure Default Credential (for production scenarios)
-      console.log('🔑 Using Azure Default Credential (token-based authentication)');
-      return new MockDefaultAzureCredential();
+      console.log('🔑 Using the local Vite AzureCliCredential token endpoint');
+      return new LocalAzureCredential();
     } else {
       // Use API Key (for development/simple scenarios)
       if (!config.apiKey) {
@@ -162,6 +239,7 @@ export class VoiceAssistant {
       }
       
       this.isConnected = false;
+      this.isVoiceAgentConnection = false;
       this.callbacks?.onConnectionStatusChange('disconnected');
       
       console.log('Disconnected from Voice Live service');
@@ -431,11 +509,10 @@ export class VoiceAssistant {
     }
 
     try {
+      await this.ensurePlaybackAudioContext();
+
       // Initialize audio capture
       await this.audioCapture.initialize();
-      
-      // Setup audio context for playback
-      this.audioContext = new AudioContext();
       
       // Start audio capture
       this.audioCapture.startCapture(
@@ -448,7 +525,9 @@ export class VoiceAssistant {
       
       this.callbacks?.onConversationMessage({
         role: 'system',
-        content: 'Conversation started. Start speaking to the assistant!',
+        content: this.isVoiceAgentConnection
+          ? 'Conversation started. Audio is streaming to the selected voice agent through the Voice Live SDK.'
+          : 'Conversation started. Start speaking to the assistant!',
         timestamp: new Date()
       });
       
@@ -533,6 +612,67 @@ export class VoiceAssistant {
     }
   }
 
+  private createVoiceAgentProxyEndpoint(voiceAgentUrl: string): string {
+    const proxyEndpoint = new URL(window.location.origin);
+    proxyEndpoint.searchParams.set('voice-agent-url', voiceAgentUrl);
+    return proxyEndpoint.toString();
+  }
+
+  private isVoiceAgentWebSocketUrl(endpoint: string): boolean {
+    try {
+      const url = new URL(endpoint);
+      return (
+        (url.protocol === 'ws:' || url.protocol === 'wss:') &&
+        url.pathname.endsWith('/endpoint/protocols/voice')
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private installVoiceAgentWebSocketAdapter(): () => void {
+    const NativeWebSocket = window.WebSocket;
+    const BridgeWebSocket = function (
+      url: string | URL,
+      protocols?: string | string[]
+    ): WebSocket {
+      const sdkUrl = new URL(url.toString());
+      const voiceAgentUrl = sdkUrl.searchParams.get('voice-agent-url');
+      if (
+        voiceAgentUrl &&
+        sdkUrl.hostname === window.location.hostname &&
+        sdkUrl.pathname === '/voice-live/realtime'
+      ) {
+        const bridgeUrl = new URL(window.location.origin);
+        bridgeUrl.protocol = bridgeUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+        bridgeUrl.pathname = '/voice';
+        bridgeUrl.searchParams.set('voice-agent-url', voiceAgentUrl);
+        return protocols === undefined
+          ? new NativeWebSocket(bridgeUrl)
+          : new NativeWebSocket(bridgeUrl, protocols);
+      }
+
+      return protocols === undefined
+        ? new NativeWebSocket(url)
+        : new NativeWebSocket(url, protocols);
+    } as unknown as typeof WebSocket;
+
+    BridgeWebSocket.prototype = NativeWebSocket.prototype;
+    Object.defineProperties(BridgeWebSocket, {
+      CONNECTING: { value: NativeWebSocket.CONNECTING },
+      OPEN: { value: NativeWebSocket.OPEN },
+      CLOSING: { value: NativeWebSocket.CLOSING },
+      CLOSED: { value: NativeWebSocket.CLOSED }
+    });
+    window.WebSocket = BridgeWebSocket;
+
+    return () => {
+      if (window.WebSocket === BridgeWebSocket) {
+        window.WebSocket = NativeWebSocket;
+      }
+    };
+  }
+
   private createVoiceObject(voiceName: string): any {
     if (voiceName.endsWith(AZURE_REALTIME_NATIVE_VOICE_SUFFIX)) {
       return {
@@ -583,6 +723,10 @@ export class VoiceAssistant {
     }
 
     try {
+      if (this.audioContext.state === 'suspended') {
+        await this.audioContext.resume();
+      }
+
       // VoiceLive sends raw PCM16 data, not encoded audio
       const sampleRate = 24000; // VoiceLive default output sample rate
       const numberOfChannels = 1; // Mono audio
@@ -697,5 +841,14 @@ export class VoiceAssistant {
     }
     
     console.log('🛑 Audio queue cleared and all sources stopped (barge-in or response change)');
+  }
+
+  private async ensurePlaybackAudioContext(): Promise<void> {
+    if (!this.audioContext || this.audioContext.state === 'closed') {
+      this.audioContext = new AudioContext();
+    }
+    if (this.audioContext.state === 'suspended') {
+      await this.audioContext.resume();
+    }
   }
 }

--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/tsconfig.json
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/tsconfig.json
@@ -19,6 +19,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "server/**/*", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/vite.config.ts
+++ b/sdk/voicelive/ai-voicelive/samples/basic-web-voice-assistant/vite.config.ts
@@ -1,28 +1,31 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from "vite";
+import { localAzureDevelopmentPlugin } from "./server/localAzureDevelopmentPlugin.js";
 
 export default defineConfig({
-  root: '.',
+  root: ".",
+  plugins: [localAzureDevelopmentPlugin()],
   build: {
-    target: 'es2020',
-    outDir: 'dist',
+    target: "es2020",
+    outDir: "dist",
     sourcemap: true,
     rollupOptions: {
       input: {
-        main: 'index.html'
-      }
-    }
+        main: "index.html",
+      },
+    },
   },
   server: {
     port: 3000,
-    host: true,
+    host: "127.0.0.1",
+    strictPort: true,
     // Enable file watching for SDK source changes
     watch: {
       usePolling: true,
-      interval: 300
-    }
+      interval: 300,
+    },
   },
   // Configure to watch node_modules changes
   optimizeDeps: {
-    force: true // Force dependency re-optimization on restart
-  }
+    force: true, // Force dependency re-optimization on restart
+  },
 });


### PR DESCRIPTION
Adds Voice Agent WebSocket support to the basic web assistant while retaining VoiceLiveClient/VoiceLiveSession for protocol and audio handling.

Highlights:
- Azure CLI AAD bridge for browser WebSocket authentication
- APIM-backed Voice Agent URL detection and session handling
- Exact `/voice` SDK WebSocket URL without bearer tokens in the query string
- Bridge-managed upstream authentication
- Public SDK options and unit coverage for exact WebSocket URLs

Validation:
- Turbo build: 29/29 packages
- Vitest: 435 passed, 115 skipped
- Sample production build passed
- Live Voice Agent text/audio validation passed