### PR TITLE
Use 'none' environment for auto-release publish

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -122,6 +122,11 @@ stages:
                       DeploymentName: PublishPackage_${{ replace(artifact.name, '-', '_') }}
                       ArtifactName: ${{ parameters.ArtifactName }}
                       ArtifactSubPath: '${{ artifact.name }}'
+                      # Auto-release is post-merge CI on main, so it must not wait for manual package-publish approvals.
+                      ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+                        Environment: 'none'
+                      ${{ else }}:
+                        Environment: 'package-publish'
 
                   - template: /eng/common/pipelines/templates/jobs/npm-publish.yml
                     parameters:


### PR DESCRIPTION
**What**: The public npm publish deployment now targets the `none` environment for auto-release runs.

**Why**: Auto-release is fully automated post-merge CI on `main`; a manual approval gate would block it.

**Impact**: Manual releases are unaffected and keep the existing approval-gated `package-publish` environment.

**Note**: `none` must be, or will be auto-created as, an Azure DevOps environment with no approvals/checks.
