### PR TITLE
[event-hubs][service-bus] Import Buffer from the buffer package in public types

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Import `Buffer` from the `buffer` package instead of relying on the Node.js global in public-facing types (for example `EventData.correlationId` and `EventData.messageId`). This makes the emitted browser and react-native type declarations self-contained so they resolve without `@types/node`, fixing `error TS2304: Cannot find name 'Buffer'` for browser/react-native consumers using TypeScript's `types: []` default. [#39315](https://github.com/Azure/azure-sdk-for-js/pull/39315)
+
 ### Other Changes
 
 ## 6.0.4 (2026-04-22)

--- a/sdk/eventhub/event-hubs/review/event-hubs-node.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs-node.api.md
@@ -7,6 +7,7 @@
 import type { AbortSignalLike } from '@azure/abort-controller';
 import { AmqpAnnotatedMessage } from '@azure/core-amqp';
 import type { AzureLogger } from '@azure/logger';
+import { Buffer as Buffer_2 } from 'buffer';
 import { MessagingError } from '@azure/core-amqp';
 import type { NamedKeyCredential } from '@azure/core-auth';
 import type { OperationTracingOptions } from '@azure/core-tracing';
@@ -71,8 +72,8 @@ export interface EnqueueEventOptions extends SendBatchOptions {
 export interface EventData {
     body: any;
     contentType?: string;
-    correlationId?: string | number | Buffer;
-    messageId?: string | number | Buffer;
+    correlationId?: string | number | Buffer_2;
+    messageId?: string | number | Buffer_2;
     properties?: {
         [key: string]: any;
     };
@@ -80,8 +81,8 @@ export interface EventData {
 
 // @public
 export interface EventDataAdapterParameters {
-    correlationId?: string | number | Buffer;
-    messageId?: string | number | Buffer;
+    correlationId?: string | number | Buffer_2;
+    messageId?: string | number | Buffer_2;
     properties?: {
         [key: string]: any;
     };
@@ -320,10 +321,10 @@ export type ProcessInitializeHandler = (context: PartitionContext) => Promise<vo
 export interface ReceivedEventData {
     body: any;
     contentType?: string;
-    correlationId?: string | number | Buffer;
+    correlationId?: string | number | Buffer_2;
     enqueuedTimeUtc: Date;
     getRawAmqpMessage(): AmqpAnnotatedMessage;
-    messageId?: string | number | Buffer;
+    messageId?: string | number | Buffer_2;
     offset: string;
     partitionKey: string | null;
     properties?: {

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -10,6 +10,7 @@ import { isDefined, isObjectWithProperties, objectHasProperty } from "@azure/cor
 import type { PENDING_PUBLISH_SEQ_NUM_SYMBOL } from "./util/constants.js";
 import { idempotentProducerAmqpPropertyNames } from "./util/constants.js";
 import isBuffer from "is-buffer";
+import { Buffer } from "buffer";
 
 /**
  * Describes the delivery annotations.

--- a/sdk/eventhub/event-hubs/src/eventDataAdapter.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataAdapter.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import type { EventData } from "./eventData.js";
+import { Buffer } from "buffer";
 
 /**
  * A message with payload and content type fields

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -17,6 +17,7 @@ import type { OperationTracingOptions, TracingContext } from "@azure/core-tracin
 import { instrumentEventData } from "./diagnostics/instrumentEventData.js";
 import { throwTypeErrorIfParameterMissing } from "./util/error.js";
 import type { PartitionPublishingProperties } from "./models/private.js";
+import { Buffer } from "buffer";
 
 /**
  * The amount of bytes to reserve as overhead for a small message.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -10,6 +10,7 @@ import type {
   Message as RheaMessage,
 } from "rhea-promise";
 import { message, types } from "rhea-promise";
+import { Buffer } from "buffer";
 import type { RetryConfig, RetryOptions } from "@azure/core-amqp";
 import {
   ErrorNameConditionMapper,

--- a/sdk/eventhub/event-hubs/src/impl/partitionKeyToIdMapper.ts
+++ b/sdk/eventhub/event-hubs/src/impl/partitionKeyToIdMapper.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { Buffer } from "buffer";
+
 /* eslint-disable no-fallthrough */
 
 export function mapPartitionKeyToId(partitionKey: string, partitionCount: number): number {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -13,6 +13,7 @@ import {
 } from "@azure/core-amqp";
 import type { EventContext, Message, ReceiverOptions, SenderOptions } from "rhea-promise";
 import { ReceiverEvents, SenderEvents } from "rhea-promise";
+import { Buffer } from "buffer";
 import type { SimpleLogger } from "./logger.js";
 import {
   logErrorStackTrace,

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Read `com.microsoft:max-message-batch-size` vendor property from the AMQP sender link to correctly limit batch size on Premium large-message entities, where `max-message-size` can be up to 100 MB but the batch limit is 1 MB.
 - Fixed `TimeoutNegativeWarning` on Node.js v24+ when timeout budget is exceeded during CBS authentication by clamping remaining-time computations to a minimum of 0. [#38166](https://github.com/Azure/azure-sdk-for-js/pull/38166)
 - Fixed CBS token renewal stopping permanently after a single failed renewal. A transient credential error (for example a failed AAD `getToken` during a workload-identity rotation) no longer leaves the link's token un-renewed; renewal now retries with a capped exponential backoff until it succeeds or the link closes. [#38467](https://github.com/Azure/azure-sdk-for-js/issues/38467)
+- Import `Buffer` from the `buffer` package instead of relying on the Node.js global in public-facing types (for example `ServiceBusMessage.correlationId` and `ServiceBusMessage.messageId`). This makes the emitted browser and react-native type declarations self-contained so they resolve without `@types/node`, fixing `error TS2304: Cannot find name 'Buffer'` for browser/react-native consumers using TypeScript's `types: []` default. [#39315](https://github.com/Azure/azure-sdk-for-js/pull/39315)
 
 ### Other Changes
 

--- a/sdk/servicebus/service-bus/review/service-bus-node.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus-node.api.md
@@ -462,7 +462,7 @@ export interface ServiceBusMessage {
 export interface ServiceBusMessageBatch {
     readonly count: number;
     // @internal
-    _generateMessage(): Buffer;
+    _generateMessage(): Buffer_2;
     readonly maxSizeInBytes: number;
     // @internal
     readonly _messageSpanContexts: TracingContext[];

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -10,6 +10,7 @@ import type {
   OnAmqpEvent,
 } from "rhea-promise";
 import { message as RheaMessageUtil } from "rhea-promise";
+import { Buffer } from "buffer";
 import type {
   MessagingError,
   RetryConfig,

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import type { ServiceBusMessage } from "./serviceBusMessage.js";
+import { Buffer } from "buffer";
 import { toRheaMessage } from "./serviceBusMessage.js";
 import {
   errorInvalidMessageTypeSingle,

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -7,6 +7,7 @@ import { logger, receiverLogger, messageLogger } from "../log.js";
 import type { AmqpError } from "rhea-promise";
 import { OperationTimeoutError, generate_uuid } from "rhea-promise";
 import isBuffer from "is-buffer";
+import { Buffer } from "buffer";
 import * as Constants from "../util/constants.js";
 import type { AbortSignalLike } from "@azure/abort-controller";
 import { AbortError } from "@azure/abort-controller";


### PR DESCRIPTION
## Summary

Import `Buffer` from the `buffer` npm package instead of relying on the Node.js global wherever `Buffer` appears in the **public** type surface of `@azure/event-hubs` and `@azure/service-bus`.

## Why

`rhea-promise` 3.1.0 (and `rhea` 3.0.5) removed the `/// <reference types="node" />` triple-slash directive from their shipped `.d.ts`. That directive previously force-injected `@types/node` into any consumer's TypeScript program. With TypeScript 7's new default of `types: []` (no auto-inclusion of `@types/*`), browser/react-native consumers who reference our public types that use the **global** `Buffer` (e.g. `EventData.correlationId`, `EventData.messageId`, `ServiceBusMessage.correlationId`) now hit `error TS2304: Cannot find name 'Buffer'` unless they add `@types/node` or enable `skipLibCheck`.

The `buffer` package ships its own typings, so importing `Buffer` from it makes the emitted browser/react-native `.d.ts` self-contained and resolvable without `@types/node`. This mirrors the pattern `@azure/service-bus` already uses in `serviceBusMessage.ts`. Both packages already depend on `buffer` `^6.0.3`, so no new dependency is introduced.

## Changes

**event-hubs** (primary — previously emitted bare global `Buffer`): added `import { Buffer } from "buffer";` to `eventData.ts`, `eventDataAdapter.ts`, `eventDataBatch.ts`, `eventHubSender.ts`, `managementClient.ts`, `impl/partitionKeyToIdMapper.ts`.

**service-bus** (mop-up of remaining bare-global usages): added the import to `serviceBusMessageBatch.ts`, `util/utils.ts`, `core/messageSender.ts`.

Regenerated `review/*.api.md` (public `Buffer` → `import { Buffer as Buffer_2 } from 'buffer'`) and added CHANGELOG entries to both packages.

## Verification

- Built both packages (browser + react-native + node targets via warp / `dev-tool run build-package`).
- Confirmed emitted `dist/browser/eventData.d.ts` and `dist/react-native/eventData.d.ts` import `Buffer` from `buffer` and contain **no** new `/// <reference types="node" />`.
- `extract-api` regenerated the api.md reports; public `Buffer` is now `Buffer_2` (imported from `buffer`).
- Lint passes (0 errors), prettier formatting clean.

## Out of scope

- No `net`/`tls`/`events` rhea typing changes.
- No `@azure/core-amqp` changes (already handled separately).
- No `Buffer` → `Uint8Array` API change.
- No `@types/node` runtime dependency, no re-added `/// <reference types="node" />`.