### PR TITLE
Fix release tool dependency refresh after version bump

### DIFF
--- a/eng/tools/js-sdk-release-tools-src/src/common/rushUtils.ts
+++ b/eng/tools/js-sdk-release-tools-src/src/common/rushUtils.ts
@@ -85,6 +85,13 @@ export function isRushRepo(sdkRepoRoot: string): boolean {
   );
 }
 
+export async function installDependencies() {
+  await ensurePnpmInstalled();
+  logger.info(`Start to pnpm install.`);
+  await runCommand(`pnpm`, ["install"], runCommandOptions, false);
+  logger.info(`Pnpm install successfully.`);
+}
+
 export async function buildPackage(
   packageDirectory: string,
   options: ModularClientPackageOptions,
@@ -97,10 +104,7 @@ export async function buildPackage(
   logger.info(`Start to build package in '${relativePackageDirectoryToSdkRoot}'.`);
   const { name } = await getNpmPackageInfo(relativePackageDirectoryToSdkRoot);
   let buildStatus = `succeeded`;
-  await ensurePnpmInstalled();
-  logger.info(`Start to pnpm install.`);
-  await runCommand(`pnpm`, ["install"], runCommandOptions, false);
-  logger.info(`Pnpm install successfully.`);
+  await installDependencies();
 
   if (options.runMode === RunMode.Local || options.runMode === RunMode.Release) {
     await lintFix(packageDirectory);

--- a/eng/tools/js-sdk-release-tools-src/src/mlc/clientGenerator/modularClientPackageGenerator.ts
+++ b/eng/tools/js-sdk-release-tools-src/src/mlc/clientGenerator/modularClientPackageGenerator.ts
@@ -1,5 +1,10 @@
 import { ModularClientPackageOptions, NpmPackageInfo, PackageResult } from "../../common/types.js";
-import { buildPackage, createArtifact, tryBuildSamples } from "../../common/rushUtils.js";
+import {
+  buildPackage,
+  createArtifact,
+  installDependencies,
+  tryBuildSamples,
+} from "../../common/rushUtils.js";
 import {
   initPackageResult,
   updateChangelogResult,
@@ -70,6 +75,7 @@ export async function generateAzureSDKPackage(
     const changelog = await generateChangelogAndBumpVersion(relativePackageDirToSdkRoot, options);
     updateChangelogResult(packageResult, changelog);
     changeReadmeMd(packageDirectory);
+    await installDependencies();
     await tryBuildSamples(packageDirectory, options.sdkRepoRoot, options.runMode);
 
     const npmPackageInfo = await getNpmPackageInfo(packageDirectory);

--- a/eng/tools/js-sdk-release-tools-src/src/test/pipeline/modularClientPackageGenerator.test.ts
+++ b/eng/tools/js-sdk-release-tools-src/src/test/pipeline/modularClientPackageGenerator.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as string[],
+  packageResult: {
+    artifacts: [] as string[],
+    path: [] as string[],
+    result: "pending",
+  },
+}));
+
+vi.mock("../../common/rushUtils.js", () => ({
+  buildPackage: vi.fn(async () => mocks.calls.push("build")),
+  installDependencies: vi.fn(async () => mocks.calls.push("install")),
+  tryBuildSamples: vi.fn(async () => mocks.calls.push("samples")),
+  createArtifact: vi.fn(async () => "/sdk/pkg/test.tgz"),
+}));
+
+vi.mock("../../common/packageResultUtils.js", () => ({
+  initPackageResult: vi.fn(() => mocks.packageResult),
+  updateChangelogResult: vi.fn(),
+  updateNpmPackageResult: vi.fn(),
+}));
+
+vi.mock("../../common/ciYamlUtils.js", () => ({
+  createOrUpdateCiYaml: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../common/changelog/automaticGenerateChangeLogAndBumpVersion.js", () => ({
+  generateChangelogAndBumpVersion: vi.fn(async () => {
+    mocks.calls.push("changelog");
+    return undefined;
+  }),
+}));
+
+vi.mock("../../mlc/clientGenerator/utils/typeSpecUtils.js", () => ({
+  generateTypeScriptCodeFromTypeSpec: vi.fn(),
+}));
+
+vi.mock("../../common/utils.js", () => ({
+  getGeneratedPackageDirectory: vi.fn(async () => "/sdk/pkg"),
+  specifyApiVersionToGenerateSDKByTypeSpec: vi.fn(),
+  cleanUpPackageDirectory: vi.fn(),
+}));
+
+vi.mock("../../common/npmUtils.js", () => ({
+  getNpmPackageInfo: vi.fn(async () => ({
+    name: "@azure/test",
+    version: "1.0.0-beta.1",
+  })),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("fs-extra", () => ({
+  exists: vi.fn(async () => false),
+}));
+
+vi.mock("../../common/codeOwnersAndIgnoreLink/codeOwnersAndIgnoreLinkGenerator.js", () => ({
+  codeOwnersAndIgnoreLinkGenerator: vi.fn(),
+}));
+
+vi.mock("../../hlc/utils/changeReadmeMd.js", () => ({
+  changeReadmeMd: vi.fn(),
+}));
+
+describe("generateAzureSDKPackage", () => {
+  beforeEach(() => {
+    mocks.calls.length = 0;
+    mocks.packageResult.artifacts.length = 0;
+    mocks.packageResult.path.length = 0;
+    mocks.packageResult.result = "pending";
+  });
+
+  test("reinstalls dependencies after package metadata changes", async () => {
+    const { generateAzureSDKPackage } =
+      await import("../../mlc/clientGenerator/modularClientPackageGenerator.js");
+
+    await generateAzureSDKPackage({
+      typeSpecDirectory: "/spec/project",
+      sdkRepoRoot: "/sdk",
+      specRepoRoot: "/spec",
+      runMode: "spec-pull-request",
+    } as never);
+
+    expect(mocks.calls).toEqual(["build", "changelog", "install", "samples"]);
+  });
+});


### PR DESCRIPTION
## Problem

JavaScript SDK validation for Azure/azure-rest-api-specs#44825 fails after SDK generation succeeds. `generateAzureSDKPackage` runs `pnpm install`, then changelog generation rewrites `package.json`, and subsequently invokes `pnpm run build:samples` and `pnpm pack`. With `verifyDepsBeforeRun: error`, pnpm rejects the stale workspace state.

Failed runs:
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=6610114
- https://dev.azure.com/azure-sdk/public/_build/results?buildId=6610228

## Fix

Re-run the shared dependency installation step after changelog/version metadata changes and before samples/packing. Add a regression test for the required operation order.

The release tool package will need to be published and the wrapper dependency updated before the spec validation can consume this fix.