### PR TITLE
Revert "[EngSys] report error for outdated node_modules before running scripts (#39155)"

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,5 +83,3 @@ allowBuilds:
   esbuild: false
   keytar: false
   protobufjs: false
-
-verifyDepsBeforeRun: error


### PR DESCRIPTION
This reverts commit df6b0d509bb118358ec4476c0a467acbe94bd68d.

This unblocks SDK generation automation.