### PR TITLE
[js-release-tool] do not use lockfile when generating packages

### DIFF
--- a/eng/tools/js-sdk-release-tools-src/package.json
+++ b/eng/tools/js-sdk-release-tools-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.16.12",
+  "version": "2.16.13",
   "description": "",
   "files": [
     "dist"

--- a/eng/tools/js-sdk-release-tools-src/src/common/rushUtils.ts
+++ b/eng/tools/js-sdk-release-tools-src/src/common/rushUtils.ts
@@ -98,8 +98,8 @@ export async function buildPackage(
   const { name } = await getNpmPackageInfo(relativePackageDirectoryToSdkRoot);
   let buildStatus = `succeeded`;
   await ensurePnpmInstalled();
-  logger.info(`Start to pnpm install.`);
-  await runCommand(`pnpm`, ["install"], runCommandOptions, false);
+  logger.info(`Start to pnpm install --no-frozen-lockfile.`);
+  await runCommand(`pnpm`, ["install", "--no-frozen-lockfile"], runCommandOptions, false);
   logger.info(`Pnpm install successfully.`);
 
   if (options.runMode === RunMode.Local || options.runMode === RunMode.Release) {

--- a/eng/tools/js-sdk-release-tools-src/src/hlc/generateMgmt.ts
+++ b/eng/tools/js-sdk-release-tools-src/src/hlc/generateMgmt.ts
@@ -143,8 +143,8 @@ export async function generateMgmt(options: {
       }
       let changelog: ChangelogResult | undefined;
       await ensurePnpmInstalled();
-      logger.info(`Start to run command: 'pnpm install'.`);
-      execSync("pnpm install", { stdio: "inherit" });
+      logger.info(`Start to run command: 'pnpm install --no-frozen-lockfile'.`);
+      execSync("pnpm install --no-frozen-lockfile", { stdio: "inherit" });
 
       if (options.runMode === RunMode.Local || options.runMode === RunMode.Release) {
         await lintFix(packagePath);


### PR DESCRIPTION
As package.json files are usually created or updated, which requires generating
new lock files. In CI environment `pnpm install` defaults to use lock file so we
need to override the behavior using `--no-frozen-lockfile` option