### PR TITLE
ci: move browser test leg from Windows to Linux agent

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -39,7 +39,18 @@
         "sample": {
           "TestType": "sample",
           "TestResultsFiles": "**/test-results.xml"
-        },
+        }
+      }
+    },
+    {
+      "Agent": {
+        "ubuntu": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL"
+        }
+      },
+      "NodeTestVersion": "env:NODE_VERSION_LTS_MAINTENANCE",
+      "Scenario": {
         "browser": {
           "TestType": "browser",
           "TestResultsFiles": "**/test-results.browser.xml"


### PR DESCRIPTION
Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

## What

Moves the `browser` test leg in the CI build matrix (`eng/pipelines/templates/stages/platform-matrix.json`) from the Windows agent to the Ubuntu/Linux agent.

Previously, the `browser` scenario ran on the Windows agent.

## Motivation

Linux agents are faster/cheaper, so running the browser leg there should reduce wall-clock/agent time even though the leg already runs in parallel.
