### PR TITLE
[monitor-opentelemetry] Add console log collection via instrumentation-console

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22400,7 +22400,7 @@ importers:
         specifier: ^1.11.0
         version: link:../../core/core-util
       '@opentelemetry/api':
-        specifier: ^1.9.0
+        specifier: ^1.9.1
         version: 1.9.1
       '@opentelemetry/api-logs':
         specifier: ^0.220.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22278,6 +22278,9 @@ importers:
       '@opentelemetry/instrumentation-bunyan':
         specifier: ^0.65.0
         version: 0.65.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-console':
+        specifier: ^0.2.0
+        version: 0.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-http':
         specifier: ^0.220.0
         version: 0.220.0(@opentelemetry/api@1.9.1)
@@ -36957,6 +36960,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation-console@0.2.0':
+    resolution: {integrity: sha1-VYCKYTScPoLYR85W5cwlBCSzkOc=}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.1
+
   '@opentelemetry/instrumentation-http@0.220.0':
     resolution: {integrity: sha1-zYbJvJr+MZIyKtPhaDWNz8CuhYQ=}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -43721,6 +43730,14 @@ snapshots:
       '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
       '@types/bunyan': 1.8.11
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-console@0.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22264,7 +22264,7 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       '@opentelemetry/api':
-        specifier: ^1.9.0
+        specifier: ^1.9.1
         version: 1.9.1
       '@opentelemetry/api-logs':
         specifier: ^0.220.0

--- a/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Updated OpenTelemetry experimental dependencies from `^0.219.0` to `^0.220.0` (`@opentelemetry/api-logs`, `@opentelemetry/sdk-logs`, `@opentelemetry/instrumentation`, `@opentelemetry/instrumentation-http`) and stable dependencies from `^2.8.0` to `^2.9.0` (`@opentelemetry/core`, `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-trace-node`). [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
 - Added internal scaffolding for OneSettings-based dynamic configuration (`ConfigurationManager`). This is groundwork with no user-facing behavior yet. [#39295](https://github.com/Azure/azure-sdk-for-js/pull/39295)
+- Raised the minimum `@opentelemetry/api` version from `^1.9.0` to `^1.9.1`. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
 ## 1.0.0-beta.43 (2026-07-01)
 

--- a/sdk/monitor/monitor-opentelemetry-exporter/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/package.json
@@ -89,7 +89,7 @@
     "@azure/core-auth": "^1.9.0",
     "@azure/core-client": "^1.9.2",
     "@azure/core-rest-pipeline": "^1.19.0",
-    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.220.0",
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/resources": "^2.9.0",

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). Internal diagnostic logging is routed through the console captured before instrumentation so console log collection does not create a self-telemetry loop. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.19.0 (Unreleased)
 
+### Features Added
+
+- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
+
 ### Other Changes
 
 - Updated OpenTelemetry experimental dependencies from `^0.219.0` to `^0.220.0` (`@opentelemetry/api-logs`, `@opentelemetry/instrumentation`, `@opentelemetry/instrumentation-http`, `@opentelemetry/sdk-logs`, `@opentelemetry/sdk-node`, `@opentelemetry/exporter-metrics-otlp-http`, `@opentelemetry/exporter-trace-otlp-http`) and stable dependencies from `^2.8.0` to `^2.9.0` (`@opentelemetry/core`, `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-trace-node`). Updated the bundled contrib instrumentations and resource detector to their latest versions. [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). Internal diagnostic logging is routed through the console captured before instrumentation so console log collection does not create a self-telemetry loop. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
+### Bugs Fixed
+
+- Fixed `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE` still exporting severe application logs. `NONE` previously mapped to a severity threshold that the Bunyan and Winston instrumentations normalized back to a real level (`fatal`/`error`), so severe logs were still collected; the log instrumentations are now skipped entirely when the level is `NONE`, so no logs are collected. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+
 ### Other Changes
 
 - Encode the Statsbeat instrumentation bit map from an explicit instrumentation-to-bit mapping instead of the positional order of the options object, so adding an instrumentation (such as `console`) no longer shifts the reported bit of other instrumentations. Statsbeat instrumentation flags are now encoded and decoded with Number-safe arithmetic so flags above `2 ** 32` (such as `pino`, `restify`, `router`, and `amqplib`) are no longer dropped. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE` still exporting severe application logs. `NONE` previously mapped to a severity threshold that the Bunyan and Winston instrumentations normalized back to a real level (`fatal`/`error`), so severe logs were still collected; the log instrumentations are now skipped entirely when the level is `NONE`, so no logs are collected. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+- Fixed `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE` not disabling log collection. Previously `NONE` resolved to an `UNSPECIFIED` (`0`) severity, which the Bunyan and Winston instrumentations treat as "no filter", so all logs were still collected. `NONE` now skips registering the log instrumentations entirely, so no logs are collected. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
+- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
 ### Other Changes
 

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Features Added
 
-- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). Internal diagnostic logging is routed through the console captured before instrumentation so console log collection does not create a self-telemetry loop. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+- Added support for collecting `console` logs via the `@opentelemetry/instrumentation-console` package. Enable it with `instrumentationOptions: { console: { enabled: true } }` (disabled by default). [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
 ### Bugs Fixed
 
-- Fixed `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE` not disabling log collection. Previously `NONE` resolved to an `UNSPECIFIED` (`0`) severity, which the Bunyan and Winston instrumentations treat as "no filter", so all logs were still collected. `NONE` now skips registering the log instrumentations entirely, so no logs are collected. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+- Fixed `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE` not disabling log collection. `NONE` now skips registering the log instrumentations entirely, so no logs are collected. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 
 ### Other Changes
 
-- Encode the Statsbeat instrumentation bit map from an explicit instrumentation-to-bit mapping instead of the positional order of the options object, so adding an instrumentation (such as `console`) no longer shifts the reported bit of other instrumentations. Statsbeat instrumentation flags are now encoded and decoded with Number-safe arithmetic so flags above `2 ** 32` (such as `pino`, `restify`, `router`, and `amqplib`) are no longer dropped. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+- Fixed Statsbeat instrumentation encoding so adding an instrumentation no longer shifts the reported bits of others, and flags above `2 ** 32` (such as `pino`, `restify`, `router`, and `amqplib`) are no longer dropped. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 - Updated OpenTelemetry experimental dependencies from `^0.219.0` to `^0.220.0` (`@opentelemetry/api-logs`, `@opentelemetry/instrumentation`, `@opentelemetry/instrumentation-http`, `@opentelemetry/sdk-logs`, `@opentelemetry/sdk-node`, `@opentelemetry/exporter-metrics-otlp-http`, `@opentelemetry/exporter-trace-otlp-http`) and stable dependencies from `^2.8.0` to `^2.9.0` (`@opentelemetry/core`, `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-trace-node`). Updated the bundled contrib instrumentations and resource detector to their latest versions. [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
 
 ## 1.18.2 (2026-07-01)

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Other Changes
 
+- Encode the Statsbeat instrumentation bit map from an explicit instrumentation-to-bit mapping instead of the positional order of the options object, so adding an instrumentation (such as `console`) no longer shifts the reported bit of other instrumentations. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 - Updated OpenTelemetry experimental dependencies from `^0.219.0` to `^0.220.0` (`@opentelemetry/api-logs`, `@opentelemetry/instrumentation`, `@opentelemetry/instrumentation-http`, `@opentelemetry/sdk-logs`, `@opentelemetry/sdk-node`, `@opentelemetry/exporter-metrics-otlp-http`, `@opentelemetry/exporter-trace-otlp-http`) and stable dependencies from `^2.8.0` to `^2.9.0` (`@opentelemetry/core`, `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-trace-node`). Updated the bundled contrib instrumentations and resource detector to their latest versions. [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
 
 ## 1.18.2 (2026-07-01)

--- a/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/monitor-opentelemetry/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Other Changes
 
-- Encode the Statsbeat instrumentation bit map from an explicit instrumentation-to-bit mapping instead of the positional order of the options object, so adding an instrumentation (such as `console`) no longer shifts the reported bit of other instrumentations. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
+- Encode the Statsbeat instrumentation bit map from an explicit instrumentation-to-bit mapping instead of the positional order of the options object, so adding an instrumentation (such as `console`) no longer shifts the reported bit of other instrumentations. Statsbeat instrumentation flags are now encoded and decoded with Number-safe arithmetic so flags above `2 ** 32` (such as `pino`, `restify`, `router`, and `amqplib`) are no longer dropped. [#39400](https://github.com/Azure/azure-sdk-for-js/pull/39400)
 - Updated OpenTelemetry experimental dependencies from `^0.219.0` to `^0.220.0` (`@opentelemetry/api-logs`, `@opentelemetry/instrumentation`, `@opentelemetry/instrumentation-http`, `@opentelemetry/sdk-logs`, `@opentelemetry/sdk-node`, `@opentelemetry/exporter-metrics-otlp-http`, `@opentelemetry/exporter-trace-otlp-http`) and stable dependencies from `^2.8.0` to `^2.9.0` (`@opentelemetry/core`, `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-trace-base`, `@opentelemetry/sdk-trace-node`). Updated the bundled contrib instrumentations and resource detector to their latest versions. [#39389](https://github.com/Azure/azure-sdk-for-js/pull/39389)
 
 ## 1.18.2 (2026-07-01)

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -111,6 +111,8 @@ const options: AzureMonitorOpenTelemetryOptions = {
     // Instrumentations generating logs
     bunyan: { enabled: true },
     winston: { enabled: true },
+    // Console log collection is opt-in (disabled by default)
+    console: { enabled: false },
   },
   enableLiveMetrics: true,
   enableStandardMetrics: true,
@@ -161,7 +163,8 @@ useAzureMonitor(options);
   redis: { enabled: true },
   redis4: { enabled: true },
   bunyan: { enabled: false }, 
-  winston: { enabled: false } 
+  winston: { enabled: false }, 
+  console: { enabled: false } 
 }
       </code></pre>
     </td>
@@ -272,6 +275,8 @@ The following OpenTelemetry Instrumentation libraries are included as part of Az
 - [Bunyan](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-bunyan)
 
 - [Winston](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston)
+
+- [Console](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-console) (disabled by default; enable with `instrumentationOptions: { console: { enabled: true } }`)
 
 Other OpenTelemetry Instrumentations are available [here](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages) and could be added using TracerProvider in AzureMonitorOpenTelemetryClient.
 

--- a/sdk/monitor/monitor-opentelemetry/README.md
+++ b/sdk/monitor/monitor-opentelemetry/README.md
@@ -278,6 +278,8 @@ The following OpenTelemetry Instrumentation libraries are included as part of Az
 
 - [Console](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-console) (disabled by default; enable with `instrumentationOptions: { console: { enabled: true } }`)
 
+  Once enabled, the set of `console` methods collected is filtered by the `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` environment variable (`NONE`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `VERBOSE`, `ALL`; see [Self-diagnostics](#self-diagnostics)). For example, `WARN` collects only `console.warn` and `console.error`, while `NONE` disables collection of `console` (and all other) logs entirely.
+
 Other OpenTelemetry Instrumentations are available [here](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages) and could be added using TracerProvider in AzureMonitorOpenTelemetryClient.
 
 ```ts snippet:ReadmeSampleCustomInstrumentation

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -90,7 +90,7 @@
     "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.44",
     "@azure/opentelemetry-instrumentation-azure-sdk": "^1.1.0-beta.1",
     "@microsoft/applicationinsights-web-snippet": "^1.2.3",
-    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/api-logs": "^0.220.0",
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/instrumentation": "^0.220.0",

--- a/sdk/monitor/monitor-opentelemetry/package.json
+++ b/sdk/monitor/monitor-opentelemetry/package.json
@@ -95,6 +95,7 @@
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/instrumentation": "^0.220.0",
     "@opentelemetry/instrumentation-bunyan": "^0.65.0",
+    "@opentelemetry/instrumentation-console": "^0.2.0",
     "@opentelemetry/instrumentation-http": "^0.220.0",
     "@opentelemetry/instrumentation-mongodb": "^0.73.0",
     "@opentelemetry/instrumentation-mysql": "^0.66.0",

--- a/sdk/monitor/monitor-opentelemetry/review/monitor-opentelemetry-node.api.md
+++ b/sdk/monitor/monitor-opentelemetry/review/monitor-opentelemetry-node.api.md
@@ -44,6 +44,7 @@ export function _getSdkInstance(): NodeSDK | undefined;
 export interface InstrumentationOptions {
     azureSdk?: InstrumentationConfig;
     bunyan?: InstrumentationConfig;
+    console?: InstrumentationConfig;
     http?: InstrumentationConfig;
     mongoDb?: InstrumentationConfig;
     mySql?: InstrumentationConfig;

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -3,6 +3,7 @@
 
 import { metrics, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
+import type { Instrumentation } from "@opentelemetry/instrumentation";
 import type { NodeSDKConfiguration } from "@opentelemetry/sdk-node";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import type { MetricReader, ViewOptions } from "@opentelemetry/sdk-metrics";
@@ -45,6 +46,10 @@ process.env["AZURE_MONITOR_DISTRO_VERSION"] = AZURE_MONITOR_OPENTELEMETRY_VERSIO
 
 let sdk: NodeSDK;
 let browserSdkLoader: BrowserSdkLoader | undefined;
+// Retained so instrumentations (e.g. ConsoleInstrumentation, which patches the
+// global console) can be disabled on shutdown; NodeSDK.shutdown() does not
+// disable instrumentations.
+let activeInstrumentations: Instrumentation[] = [];
 
 /**
  * Check if auto-attach (autoinstrumentation) is enabled and warn about double instrumentation.
@@ -81,6 +86,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     redis: config.instrumentationOptions?.redis?.enabled,
     bunyan: config.instrumentationOptions?.bunyan?.enabled,
     winston: config.instrumentationOptions?.winston?.enabled,
+    console: config.instrumentationOptions?.console?.enabled,
   };
   // Check if the AKS resource detector successfully populated specific resource attributes
   // (k8s.cluster.name or cloud.resource_id) beyond the basic cloud.platform/cloud.provider
@@ -105,6 +111,10 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   metrics.disable();
   trace.disable();
   logs.disable();
+  // Disable any instrumentations from a previous initialization so global
+  // patches (e.g. console) are restored before re-instrumenting.
+  activeInstrumentations.forEach((instrumentation) => instrumentation.disable());
+  activeInstrumentations = [];
 
   // Clear the entire OpenTelemetry API global state to avoid version conflicts.
   // The disable() calls above remove individual providers but leave the `version` field
@@ -124,6 +134,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   const instrumentations = traceHandler
     .getInstrumentations()
     .concat(logHandler.getInstrumentations());
+  activeInstrumentations = instrumentations;
 
   const resourceDetectorsList = parseResourceDetectorsFromEnvVar();
 
@@ -176,6 +187,10 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
  */
 export function shutdownAzureMonitor(): Promise<void> {
   browserSdkLoader?.dispose();
+  // NodeSDK.shutdown() does not disable instrumentations, so restore any global
+  // patches (e.g. console) explicitly.
+  activeInstrumentations.forEach((instrumentation) => instrumentation.disable());
+  activeInstrumentations = [];
   return sdk?.shutdown();
 }
 

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -47,10 +47,7 @@ process.env["AZURE_MONITOR_DISTRO_VERSION"] = AZURE_MONITOR_OPENTELEMETRY_VERSIO
 
 let sdk: NodeSDK;
 let browserSdkLoader: BrowserSdkLoader | undefined;
-// The ConsoleInstrumentation patches the global console. It must be disabled on
-// shutdown/re-init to restore console, since NodeSDK.shutdown() does not disable
-// instrumentations. Only the console instrumentation is tracked here; module
-// instrumentations are left to the SDK.
+// Track the global console patch because NodeSDK does not disable instrumentations.
 let consoleInstrumentation: Instrumentation | undefined;
 
 /**
@@ -79,8 +76,7 @@ function sendAttachWarning(): void {
 export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): void {
   const config = new InternalConfig(options);
   patchOpenTelemetryInstrumentationEnable();
-  // When log collection is disabled the log instrumentations are not registered,
-  // so Statsbeat must not report them as enabled.
+  // Omit disabled log instrumentations from Statsbeat.
   const logInstrumentationsEnabled = !isLogCollectionDisabled();
   const statsbeatInstrumentations: StatsbeatInstrumentations = {
     // Instrumentations
@@ -116,7 +112,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   metrics.disable();
   trace.disable();
   logs.disable();
-  // Restore the console patch from a previous initialization before re-instrumenting.
+  // Restore any console patch from the previous initialization.
   consoleInstrumentation?.disable();
   consoleInstrumentation = undefined;
 
@@ -191,8 +187,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
  */
 export function shutdownAzureMonitor(): Promise<void> {
   browserSdkLoader?.dispose();
-  // NodeSDK.shutdown() does not disable instrumentations, so restore the global
-  // console patch explicitly.
+  // NodeSDK.shutdown() does not restore the global console.
   consoleInstrumentation?.disable();
   consoleInstrumentation = undefined;
   return sdk?.shutdown();

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -30,6 +30,7 @@ import { getInstance } from "./utils/statsbeat.js";
 import { patchOpenTelemetryInstrumentationEnable } from "./utils/opentelemetryInstrumentationPatcher.js";
 import { ensureAzureSdkTracingBridge } from "./utils/azureSdkTracingBridge.js";
 import { isFunctionApp, parseResourceDetectorsFromEnvVar } from "./utils/common.js";
+import { isLogCollectionDisabled } from "./utils/logUtils.js";
 import { Logger } from "./shared/logging/index.js";
 import { AZURE_MONITOR_AUTO_ATTACH } from "./types.js";
 import { SEMRESATTRS_K8S_CLUSTER_NAME } from "@opentelemetry/semantic-conventions";
@@ -78,6 +79,9 @@ function sendAttachWarning(): void {
 export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): void {
   const config = new InternalConfig(options);
   patchOpenTelemetryInstrumentationEnable();
+  // When log collection is disabled the log instrumentations are not registered,
+  // so Statsbeat must not report them as enabled.
+  const logInstrumentationsEnabled = !isLogCollectionDisabled();
   const statsbeatInstrumentations: StatsbeatInstrumentations = {
     // Instrumentations
     azureSdk: config.instrumentationOptions?.azureSdk?.enabled,
@@ -85,9 +89,9 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
     mySql: config.instrumentationOptions?.mySql?.enabled,
     postgreSql: config.instrumentationOptions?.postgreSql?.enabled,
     redis: config.instrumentationOptions?.redis?.enabled,
-    bunyan: config.instrumentationOptions?.bunyan?.enabled,
-    winston: config.instrumentationOptions?.winston?.enabled,
-    console: config.instrumentationOptions?.console?.enabled,
+    bunyan: logInstrumentationsEnabled && config.instrumentationOptions?.bunyan?.enabled,
+    winston: logInstrumentationsEnabled && config.instrumentationOptions?.winston?.enabled,
+    console: logInstrumentationsEnabled && config.instrumentationOptions?.console?.enabled,
   };
   // Check if the AKS resource detector successfully populated specific resource attributes
   // (k8s.cluster.name or cloud.resource_id) beyond the basic cloud.platform/cloud.provider

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -46,10 +46,13 @@ process.env["AZURE_MONITOR_DISTRO_VERSION"] = AZURE_MONITOR_OPENTELEMETRY_VERSIO
 
 let sdk: NodeSDK;
 let browserSdkLoader: BrowserSdkLoader | undefined;
-// Retained so instrumentations (e.g. ConsoleInstrumentation, which patches the
-// global console) can be disabled on shutdown; NodeSDK.shutdown() does not
-// disable instrumentations.
-let activeInstrumentations: Instrumentation[] = [];
+// Retained so the ConsoleInstrumentation (which patches the global console) can
+// be disabled on shutdown/re-init; NodeSDK.shutdown() does not disable
+// instrumentations. Only the console (global-patch) instrumentation is tracked
+// here: module-based instrumentations must NOT be force-disabled on re-init, or
+// a subsequent useAzureMonitor() call may fail to re-patch already-cached module
+// loads and silently lose telemetry.
+let consoleInstrumentation: Instrumentation | undefined;
 
 /**
  * Check if auto-attach (autoinstrumentation) is enabled and warn about double instrumentation.
@@ -111,10 +114,11 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   metrics.disable();
   trace.disable();
   logs.disable();
-  // Disable any instrumentations from a previous initialization so global
-  // patches (e.g. console) are restored before re-instrumenting.
-  activeInstrumentations.forEach((instrumentation) => instrumentation.disable());
-  activeInstrumentations = [];
+  // Disable the console instrumentation from a previous initialization so the
+  // global console patch is restored before re-instrumenting. Module-based
+  // instrumentations are intentionally left untouched.
+  consoleInstrumentation?.disable();
+  consoleInstrumentation = undefined;
 
   // Clear the entire OpenTelemetry API global state to avoid version conflicts.
   // The disable() calls above remove individual providers but leave the `version` field
@@ -134,7 +138,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   const instrumentations = traceHandler
     .getInstrumentations()
     .concat(logHandler.getInstrumentations());
-  activeInstrumentations = instrumentations;
+  consoleInstrumentation = logHandler.getConsoleInstrumentation();
 
   const resourceDetectorsList = parseResourceDetectorsFromEnvVar();
 
@@ -187,10 +191,10 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
  */
 export function shutdownAzureMonitor(): Promise<void> {
   browserSdkLoader?.dispose();
-  // NodeSDK.shutdown() does not disable instrumentations, so restore any global
-  // patches (e.g. console) explicitly.
-  activeInstrumentations.forEach((instrumentation) => instrumentation.disable());
-  activeInstrumentations = [];
+  // NodeSDK.shutdown() does not disable instrumentations, so restore the global
+  // console patch explicitly.
+  consoleInstrumentation?.disable();
+  consoleInstrumentation = undefined;
   return sdk?.shutdown();
 }
 

--- a/sdk/monitor/monitor-opentelemetry/src/index.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/index.ts
@@ -46,12 +46,10 @@ process.env["AZURE_MONITOR_DISTRO_VERSION"] = AZURE_MONITOR_OPENTELEMETRY_VERSIO
 
 let sdk: NodeSDK;
 let browserSdkLoader: BrowserSdkLoader | undefined;
-// Retained so the ConsoleInstrumentation (which patches the global console) can
-// be disabled on shutdown/re-init; NodeSDK.shutdown() does not disable
-// instrumentations. Only the console (global-patch) instrumentation is tracked
-// here: module-based instrumentations must NOT be force-disabled on re-init, or
-// a subsequent useAzureMonitor() call may fail to re-patch already-cached module
-// loads and silently lose telemetry.
+// The ConsoleInstrumentation patches the global console. It must be disabled on
+// shutdown/re-init to restore console, since NodeSDK.shutdown() does not disable
+// instrumentations. Only the console instrumentation is tracked here; module
+// instrumentations are left to the SDK.
 let consoleInstrumentation: Instrumentation | undefined;
 
 /**
@@ -114,9 +112,7 @@ export function useAzureMonitor(options?: AzureMonitorOpenTelemetryOptions): voi
   metrics.disable();
   trace.disable();
   logs.disable();
-  // Disable the console instrumentation from a previous initialization so the
-  // global console patch is restored before re-instrumenting. Module-based
-  // instrumentations are intentionally left untouched.
+  // Restore the console patch from a previous initialization before re-instrumenting.
   consoleInstrumentation?.disable();
   consoleInstrumentation = undefined;
 

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -4,6 +4,7 @@
 import { AzureMonitorLogExporter } from "@azure/monitor-opentelemetry-exporter";
 import type { Instrumentation } from "@opentelemetry/instrumentation";
 import { BunyanInstrumentation } from "@opentelemetry/instrumentation-bunyan";
+import { ConsoleInstrumentation } from "@opentelemetry/instrumentation-console";
 import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
 import type { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
 import type { InternalConfig } from "../shared/config.js";
@@ -70,6 +71,19 @@ export class LogHandler {
       this._instrumentations.push(
         new WinstonInstrumentation({
           ...this._config.instrumentationOptions.winston,
+          logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
+        }),
+      );
+    }
+    if (this._config.instrumentationOptions.console?.enabled) {
+      // Construct disabled and let the SDK enable it during registration.
+      // Enabling ConsoleInstrumentation via its constructor patches console
+      // before its field initializers run, wiping the saved originals so
+      // disable() can no longer restore console.
+      this._instrumentations.push(
+        new ConsoleInstrumentation({
+          ...this._config.instrumentationOptions.console,
+          enabled: false,
           logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
         }),
       );

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -23,6 +23,7 @@ export class LogHandler {
   private _metricHandler: MetricHandler;
   private _config: InternalConfig;
   private _instrumentations: Instrumentation[];
+  private _consoleInstrumentation: Instrumentation | undefined;
 
   /**
    * Initializes a new instance of the TraceHandler class.
@@ -54,16 +55,36 @@ export class LogHandler {
   }
 
   /**
+   * The console instrumentation patches the global `console` object rather than a
+   * required module. It must be disabled explicitly on shutdown/re-initialization
+   * to restore the original console methods, so expose it for that purpose.
+   */
+  public getConsoleInstrumentation(): Instrumentation | undefined {
+    return this._consoleInstrumentation;
+  }
+
+  /**
    * Start auto collection of telemetry
    */
   private _initializeInstrumentations(): void {
     const logLevelEnv = process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
 
+    // A logging level of "NONE" means no logs should be collected from the log
+    // instrumentations. Skip registering them entirely rather than encoding
+    // "NONE" as a severity threshold: the Bunyan and Winston instrumentations
+    // normalize an out-of-range threshold back to a real level (fatal/error) and
+    // would still export severe application logs.
+    if (logLevelEnv === "NONE") {
+      return;
+    }
+
+    const logSeverity = logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined;
+
     if (this._config.instrumentationOptions.bunyan?.enabled) {
       this._instrumentations.push(
         new BunyanInstrumentation({
           ...this._config.instrumentationOptions.bunyan,
-          logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
+          logSeverity,
         }),
       );
     }
@@ -71,7 +92,7 @@ export class LogHandler {
       this._instrumentations.push(
         new WinstonInstrumentation({
           ...this._config.instrumentationOptions.winston,
-          logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
+          logSeverity,
         }),
       );
     }
@@ -80,13 +101,13 @@ export class LogHandler {
       // Enabling ConsoleInstrumentation via its constructor patches console
       // before its field initializers run, wiping the saved originals so
       // disable() can no longer restore console.
-      this._instrumentations.push(
-        new ConsoleInstrumentation({
-          ...this._config.instrumentationOptions.console,
-          enabled: false,
-          logSeverity: logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined,
-        }),
-      );
+      const consoleInstrumentation = new ConsoleInstrumentation({
+        ...this._config.instrumentationOptions.console,
+        enabled: false,
+        logSeverity,
+      });
+      this._consoleInstrumentation = consoleInstrumentation;
+      this._instrumentations.push(consoleInstrumentation);
     }
   }
 }

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -55,9 +55,8 @@ export class LogHandler {
   }
 
   /**
-   * The console instrumentation patches the global `console` object rather than a
-   * required module. It must be disabled explicitly on shutdown/re-initialization
-   * to restore the original console methods, so expose it for that purpose.
+   * Returns the console instrumentation, which patches the global `console` and
+   * must be disabled explicitly to restore the original methods.
    */
   public getConsoleInstrumentation(): Instrumentation | undefined {
     return this._consoleInstrumentation;
@@ -69,11 +68,7 @@ export class LogHandler {
   private _initializeInstrumentations(): void {
     const logLevelEnv = process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
 
-    // A logging level of "NONE" means no logs should be collected from the log
-    // instrumentations. Skip registering them entirely rather than encoding
-    // "NONE" as a severity threshold: the Bunyan and Winston instrumentations
-    // normalize an out-of-range threshold back to a real level (fatal/error) and
-    // would still export severe application logs.
+    // "NONE" collects no logs, so no log instrumentation is registered.
     if (logLevelEnv === "NONE") {
       return;
     }
@@ -97,10 +92,9 @@ export class LogHandler {
       );
     }
     if (this._config.instrumentationOptions.console?.enabled) {
-      // Construct disabled and let the SDK enable it during registration.
-      // Enabling ConsoleInstrumentation via its constructor patches console
-      // before its field initializers run, wiping the saved originals so
-      // disable() can no longer restore console.
+      // Construct disabled; enabling via the constructor patches console before
+      // field initializers run, wiping the saved originals so disable() can no
+      // longer restore it. The SDK enables it during registration.
       const consoleInstrumentation = new ConsoleInstrumentation({
         ...this._config.instrumentationOptions.console,
         enabled: false,

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -11,7 +11,7 @@ import type { InternalConfig } from "../shared/config.js";
 import type { MetricHandler } from "../metrics/handler.js";
 import { AzureLogRecordProcessor } from "./logRecordProcessor.js";
 import { AzureBatchLogRecordProcessor } from "./batchLogRecordProcessor.js";
-import { logLevelToSeverityNumber } from "../utils/logUtils.js";
+import { isLogCollectionDisabled, logLevelToSeverityNumber } from "../utils/logUtils.js";
 
 /**
  * Azure Monitor OpenTelemetry Log Handler
@@ -66,13 +66,12 @@ export class LogHandler {
    * Start auto collection of telemetry
    */
   private _initializeInstrumentations(): void {
-    const logLevelEnv = process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
-
     // "NONE" collects no logs, so no log instrumentation is registered.
-    if (logLevelEnv === "NONE") {
+    if (isLogCollectionDisabled()) {
       return;
     }
 
+    const logLevelEnv = process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
     const logSeverity = logLevelEnv ? logLevelToSeverityNumber(logLevelEnv) : undefined;
 
     if (this._config.instrumentationOptions.bunyan?.enabled) {

--- a/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/logs/handler.ts
@@ -54,10 +54,7 @@ export class LogHandler {
     return this._instrumentations;
   }
 
-  /**
-   * Returns the console instrumentation, which patches the global `console` and
-   * must be disabled explicitly to restore the original methods.
-   */
+  /** Returns the console instrumentation for explicit lifecycle management. */
   public getConsoleInstrumentation(): Instrumentation | undefined {
     return this._consoleInstrumentation;
   }
@@ -66,7 +63,6 @@ export class LogHandler {
    * Start auto collection of telemetry
    */
   private _initializeInstrumentations(): void {
-    // "NONE" collects no logs, so no log instrumentation is registered.
     if (isLogCollectionDisabled()) {
       return;
     }
@@ -91,9 +87,7 @@ export class LogHandler {
       );
     }
     if (this._config.instrumentationOptions.console?.enabled) {
-      // Construct disabled; enabling via the constructor patches console before
-      // field initializers run, wiping the saved originals so disable() can no
-      // longer restore it. The SDK enables it during registration.
+      // Defer patching until registration so construction preserves the original methods.
       const consoleInstrumentation = new ConsoleInstrumentation({
         ...this._config.instrumentationOptions.console,
         enabled: false,

--- a/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/config.ts
@@ -88,6 +88,7 @@ export class InternalConfig implements AzureMonitorOpenTelemetryOptions {
       postgreSql: { enabled: true },
       redis: { enabled: true },
       redis4: { enabled: true },
+      console: { enabled: false },
     };
     this._setDefaultResource();
     this.browserSdkLoaderOptions = {

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -255,7 +255,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       const backupPath = path.join(this._tempDir, `${new Date().getTime()}.${this._logFileName}`);
       await writeFileAsync(backupPath, buffer);
     } catch (err: any) {
-      this._writeToConsole("Failed to generate backup log file", err);
+      this._writeToConsole(this._TAG, "Failed to generate backup log file", err);
     } finally {
       // Store logs
       await writeFileAsync(this._fileFullPath, data);

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -16,10 +16,10 @@ import {
   unlinkAsync,
 } from "../../utils/index.js";
 
-// The console instrumentation (when enabled) patches the global console. Capture
-// console.log at module load, before instrumentation runs, so internal
-// diagnostics bypass the patched console; otherwise exporting a collected console
-// record emits diag output that is itself collected, creating a self-telemetry loop.
+// Capture console.log at module load, before the console instrumentation patches
+// the global console. Internal diagnostics route through this reference so they
+// bypass console log collection; otherwise exporting a collected console record
+// emits diag output that is itself collected, creating a self-telemetry loop.
 // eslint-disable-next-line no-console
 const originalConsoleLog: (...args: any[]) => void = console.log.bind(console);
 
@@ -143,11 +143,22 @@ export class DiagFileConsoleLogger implements DiagLogger {
         await this._storeToDisk(args);
       }
       if (this._logToConsole) {
-        originalConsoleLog(...args);
+        this._writeToConsole(...args);
       }
     } catch (err: any) {
-      originalConsoleLog(this._TAG, `Failed to log to file: ${err && err.message}`);
+      this._writeToConsole(this._TAG, `Failed to log to file: ${err && err.message}`);
     }
+  }
+
+  /**
+   * Writes internal diagnostics through the console reference captured before the
+   * console instrumentation patched the global console, keeping diagnostics out of
+   * console log collection and avoiding a self-telemetry loop with the exporter's
+   * own diagnostic logging.
+   */
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  private _writeToConsole(...args: any[]): void {
+    originalConsoleLog(...args);
   }
 
   /**
@@ -218,7 +229,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
     try {
       await confirmDirExists(this._tempDir);
     } catch (err: any) {
-      originalConsoleLog(this._TAG, `Failed to create directory for log file: ${err && err.message}`);
+      this._writeToConsole(this._TAG, `Failed to create directory for log file: ${err && err.message}`);
       return;
     }
     try {
@@ -228,7 +239,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       try {
         await appendFileAsync(this._fileFullPath, data);
       } catch (appendError: any) {
-        originalConsoleLog(
+        this._writeToConsole(
           this._TAG,
           `Failed to put log into file: ${appendError && appendError.message}`,
         );
@@ -250,7 +261,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       const backupPath = path.join(this._tempDir, `${new Date().getTime()}.${this._logFileName}`);
       await writeFileAsync(backupPath, buffer);
     } catch (err: any) {
-      originalConsoleLog("Failed to generate backup log file", err);
+      this._writeToConsole("Failed to generate backup log file", err);
     } finally {
       // Store logs
       await writeFileAsync(this._fileFullPath, data);
@@ -279,7 +290,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
         await unlinkAsync(pathToDelete);
       }
     } catch (err: any) {
-      originalConsoleLog(this._TAG, `Failed to cleanup log files: ${err && err.message}`);
+      this._writeToConsole(this._TAG, `Failed to cleanup log files: ${err && err.message}`);
     }
   }
 }

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -16,6 +16,13 @@ import {
   unlinkAsync,
 } from "../../utils/index.js";
 
+// The console instrumentation (when enabled) patches the global console. Capture
+// console.log at module load, before instrumentation runs, so internal
+// diagnostics bypass the patched console; otherwise exporting a collected console
+// record emits diag output that is itself collected, creating a self-telemetry loop.
+// eslint-disable-next-line no-console
+const originalConsoleLog: (...args: any[]) => void = console.log.bind(console);
+
 export class DiagFileConsoleLogger implements DiagLogger {
   private _TAG = "DiagFileConsoleLogger:";
   private _cleanupTimeOut = 60 * 30 * 1000; // 30 minutes;
@@ -136,12 +143,10 @@ export class DiagFileConsoleLogger implements DiagLogger {
         await this._storeToDisk(args);
       }
       if (this._logToConsole) {
-        // eslint-disable-next-line no-console
-        console.log(...args);
+        originalConsoleLog(...args);
       }
     } catch (err: any) {
-      // eslint-disable-next-line no-console
-      console.log(this._TAG, `Failed to log to file: ${err && err.message}`);
+      originalConsoleLog(this._TAG, `Failed to log to file: ${err && err.message}`);
     }
   }
 
@@ -213,8 +218,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
     try {
       await confirmDirExists(this._tempDir);
     } catch (err: any) {
-      // eslint-disable-next-line no-console
-      console.log(this._TAG, `Failed to create directory for log file: ${err && err.message}`);
+      originalConsoleLog(this._TAG, `Failed to create directory for log file: ${err && err.message}`);
       return;
     }
     try {
@@ -224,8 +228,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       try {
         await appendFileAsync(this._fileFullPath, data);
       } catch (appendError: any) {
-        // eslint-disable-next-line no-console
-        console.log(
+        originalConsoleLog(
           this._TAG,
           `Failed to put log into file: ${appendError && appendError.message}`,
         );
@@ -247,8 +250,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
       const backupPath = path.join(this._tempDir, `${new Date().getTime()}.${this._logFileName}`);
       await writeFileAsync(backupPath, buffer);
     } catch (err: any) {
-      // eslint-disable-next-line no-console
-      console.log("Failed to generate backup log file", err);
+      originalConsoleLog("Failed to generate backup log file", err);
     } finally {
       // Store logs
       await writeFileAsync(this._fileFullPath, data);
@@ -277,8 +279,7 @@ export class DiagFileConsoleLogger implements DiagLogger {
         await unlinkAsync(pathToDelete);
       }
     } catch (err: any) {
-      // eslint-disable-next-line no-console
-      console.log(this._TAG, `Failed to cleanup log files: ${err && err.message}`);
+      originalConsoleLog(this._TAG, `Failed to cleanup log files: ${err && err.message}`);
     }
   }
 }

--- a/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/shared/logging/diagFileConsoleLogger.ts
@@ -16,10 +16,7 @@ import {
   unlinkAsync,
 } from "../../utils/index.js";
 
-// Capture console.log at module load, before the console instrumentation patches
-// the global console. Internal diagnostics route through this reference so they
-// bypass console log collection; otherwise exporting a collected console record
-// emits diag output that is itself collected, creating a self-telemetry loop.
+// Capture the unpatched sink to prevent recursive diagnostic collection.
 // eslint-disable-next-line no-console
 const originalConsoleLog: (...args: any[]) => void = console.log.bind(console);
 
@@ -150,12 +147,6 @@ export class DiagFileConsoleLogger implements DiagLogger {
     }
   }
 
-  /**
-   * Writes internal diagnostics through the console reference captured before the
-   * console instrumentation patched the global console, keeping diagnostics out of
-   * console log collection and avoiding a self-telemetry loop with the exporter's
-   * own diagnostic logging.
-   */
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   private _writeToConsole(...args: any[]): void {
     originalConsoleLog(...args);
@@ -229,7 +220,10 @@ export class DiagFileConsoleLogger implements DiagLogger {
     try {
       await confirmDirExists(this._tempDir);
     } catch (err: any) {
-      this._writeToConsole(this._TAG, `Failed to create directory for log file: ${err && err.message}`);
+      this._writeToConsole(
+        this._TAG,
+        `Failed to create directory for log file: ${err && err.message}`,
+      );
       return;
     }
     try {

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -295,20 +295,10 @@ export const StatsbeatInstrumentationMap = new Map<string, number>([
 ]);
 
 /**
- * Maps each Statsbeat instrumentation *option name* (the keys of
- * {@link StatsbeatInstrumentations}) to its canonical {@link StatsbeatInstrumentation}
- * bit.
- *
- * The Statsbeat instrumentation bit map is encoded from this explicit mapping
- * rather than from the positional order of the options object. Positional
- * encoding (`2 ** index`) tied each bit to a key's position, so inserting a new
- * option (e.g. `console`) shifted the emitted bit of every option after it and
- * corrupted community instrumentation bits when they were read back from
- * `AZURE_MONITOR_STATSBEAT_FEATURES`. An explicit name-to-bit map keeps each
- * instrumentation's bit stable regardless of key order.
- *
- * Note: unlike {@link StatsbeatInstrumentationMap}, which is keyed by the
- * OpenTelemetry package name, this map is keyed by the option/config name.
+ * Maps each Statsbeat instrumentation option name (the keys of
+ * {@link StatsbeatInstrumentations}) to its {@link StatsbeatInstrumentation} bit.
+ * Keyed by option/config name, unlike {@link StatsbeatInstrumentationMap}, which
+ * is keyed by OpenTelemetry package name.
  * @internal
  */
 export const StatsbeatInstrumentationsMap = new Map<string, number>([

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -63,6 +63,8 @@ export interface InstrumentationOptions {
   bunyan?: InstrumentationConfig;
   /** Winston Instrumentation Config */
   winston?: InstrumentationConfig;
+  /** Console Instrumentation Config */
+  console?: InstrumentationConfig;
 }
 
 /**
@@ -110,6 +112,7 @@ export interface StatsbeatInstrumentations {
   redis?: boolean;
   bunyan?: boolean;
   winston?: boolean;
+  console?: boolean;
   /** OpenTelemetry Community Instrumentations */
   amqplib?: boolean;
   cucumber?: boolean;
@@ -223,8 +226,8 @@ export enum StatsbeatInstrumentation {
   POSTGRES = 16,
   BUNYAN = 32,
   WINSTON = 64,
+  CONSOLE = 128,
   /** OpenTelemetry Supported Instrumentations */
-  // Console instrumentation is not supported here - occupies 128
   CUCUMBER = 256,
   DATALOADER = 512,
   FS = 1024,
@@ -260,6 +263,7 @@ export enum StatsbeatInstrumentation {
  * @internal
  */
 export const StatsbeatInstrumentationMap = new Map<string, number>([
+  ["@opentelemetry/instrumentation-console", StatsbeatInstrumentation.CONSOLE],
   ["@opentelemetry/instrumentation-amqplib", StatsbeatInstrumentation.AMQPLIB],
   ["@opentelemetry/instrumentation-cucumber", StatsbeatInstrumentation.CUCUMBER],
   ["@opentelemetry/instrumentation-dataloader", StatsbeatInstrumentation.DATALOADER],

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -295,10 +295,7 @@ export const StatsbeatInstrumentationMap = new Map<string, number>([
 ]);
 
 /**
- * Maps each Statsbeat instrumentation option name (the keys of
- * {@link StatsbeatInstrumentations}) to its {@link StatsbeatInstrumentation} bit.
- * Keyed by option/config name, unlike {@link StatsbeatInstrumentationMap}, which
- * is keyed by OpenTelemetry package name.
+ * Maps Statsbeat instrumentation option names to their assigned bits.
  * @internal
  */
 export const StatsbeatInstrumentationsMap = new Map<string, number>([

--- a/sdk/monitor/monitor-opentelemetry/src/types.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/types.ts
@@ -294,6 +294,62 @@ export const StatsbeatInstrumentationMap = new Map<string, number>([
   ["@opentelemetry/instrumentation-router", StatsbeatInstrumentation.ROUTER],
 ]);
 
+/**
+ * Maps each Statsbeat instrumentation *option name* (the keys of
+ * {@link StatsbeatInstrumentations}) to its canonical {@link StatsbeatInstrumentation}
+ * bit.
+ *
+ * The Statsbeat instrumentation bit map is encoded from this explicit mapping
+ * rather than from the positional order of the options object. Positional
+ * encoding (`2 ** index`) tied each bit to a key's position, so inserting a new
+ * option (e.g. `console`) shifted the emitted bit of every option after it and
+ * corrupted community instrumentation bits when they were read back from
+ * `AZURE_MONITOR_STATSBEAT_FEATURES`. An explicit name-to-bit map keeps each
+ * instrumentation's bit stable regardless of key order.
+ *
+ * Note: unlike {@link StatsbeatInstrumentationMap}, which is keyed by the
+ * OpenTelemetry package name, this map is keyed by the option/config name.
+ * @internal
+ */
+export const StatsbeatInstrumentationsMap = new Map<string, number>([
+  ["azureSdk", StatsbeatInstrumentation.AZURE_CORE_TRACING],
+  ["mongoDb", StatsbeatInstrumentation.MONGODB],
+  ["mySql", StatsbeatInstrumentation.MYSQL],
+  ["postgreSql", StatsbeatInstrumentation.POSTGRES],
+  ["redis", StatsbeatInstrumentation.REDIS],
+  ["bunyan", StatsbeatInstrumentation.BUNYAN],
+  ["winston", StatsbeatInstrumentation.WINSTON],
+  ["console", StatsbeatInstrumentation.CONSOLE],
+  ["amqplib", StatsbeatInstrumentation.AMQPLIB],
+  ["cucumber", StatsbeatInstrumentation.CUCUMBER],
+  ["dataloader", StatsbeatInstrumentation.DATALOADER],
+  ["fs", StatsbeatInstrumentation.FS],
+  ["lruMemoizer", StatsbeatInstrumentation.LRU_MEMOIZER],
+  ["mongoose", StatsbeatInstrumentation.MONGOOSE],
+  ["runtimeNode", StatsbeatInstrumentation.RUNTIME_NODE],
+  ["socketIo", StatsbeatInstrumentation.SOCKET_IO],
+  ["tedious", StatsbeatInstrumentation.TEDIOUS],
+  ["undici", StatsbeatInstrumentation.UNDICI],
+  ["cassandra", StatsbeatInstrumentation.CASSANDRA],
+  ["connect", StatsbeatInstrumentation.CONNECT],
+  ["dns", StatsbeatInstrumentation.DNS],
+  ["express", StatsbeatInstrumentation.EXPRESS],
+  ["fastify", StatsbeatInstrumentation.FASTIFY],
+  ["genericPool", StatsbeatInstrumentation.GENERIC_POOL],
+  ["graphql", StatsbeatInstrumentation.GRAPHQL],
+  ["hapi", StatsbeatInstrumentation.HAPI],
+  ["ioredis", StatsbeatInstrumentation.IOREDIS],
+  ["knex", StatsbeatInstrumentation.KNEX],
+  ["koa", StatsbeatInstrumentation.KOA],
+  ["memcached", StatsbeatInstrumentation.MEMCACHED],
+  ["mysql2", StatsbeatInstrumentation.MYSQL2],
+  ["nestjsCore", StatsbeatInstrumentation.NESTJS_CORE],
+  ["net", StatsbeatInstrumentation.NET],
+  ["pino", StatsbeatInstrumentation.PINO],
+  ["restify", StatsbeatInstrumentation.RESTIFY],
+  ["router", StatsbeatInstrumentation.ROUTER],
+]);
+
 export interface StatsbeatEnvironmentConfig {
   instrumentation: StatsbeatInstrumentation;
   feature: StatsbeatFeature;

--- a/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
@@ -17,6 +17,25 @@ import {
   azureVmDetector,
 } from "@opentelemetry/resource-detector-azure";
 
+/**
+ * Number-safe bit-flag helpers for Statsbeat masks. JavaScript bitwise operators
+ * coerce operands to 32-bit integers, which drops flags at or above `2 ** 32`.
+ * Statsbeat flags are distinct powers of two within `Number.MAX_SAFE_INTEGER`,
+ * so membership and addition are done with arithmetic instead.
+ * @internal
+ */
+export function hasNumberFlag(mask: number, flag: number): boolean {
+  return flag > 0 && Math.floor(mask / flag) % 2 === 1;
+}
+
+/**
+ * Returns `mask` with `flag` set, without using 32-bit bitwise operators.
+ * @internal
+ */
+export function addNumberFlag(mask: number, flag: number): number {
+  return flag > 0 && !hasNumberFlag(mask, flag) ? mask + flag : mask;
+}
+
 export function ignoreOutgoingRequestHook(request: http.RequestOptions): boolean {
   if (request && request.headers && !Array.isArray(request.headers)) {
     const outgoingHeaders = request.headers as http.OutgoingHttpHeaders;

--- a/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/common.ts
@@ -18,10 +18,7 @@ import {
 } from "@opentelemetry/resource-detector-azure";
 
 /**
- * Number-safe bit-flag helpers for Statsbeat masks. JavaScript bitwise operators
- * coerce operands to 32-bit integers, which drops flags at or above `2 ** 32`.
- * Statsbeat flags are distinct powers of two within `Number.MAX_SAFE_INTEGER`,
- * so membership and addition are done with arithmetic instead.
+ * Tests a flag without 32-bit coercion.
  * @internal
  */
 export function hasNumberFlag(mask: number, flag: number): boolean {
@@ -29,7 +26,7 @@ export function hasNumberFlag(mask: number, flag: number): boolean {
 }
 
 /**
- * Returns `mask` with `flag` set, without using 32-bit bitwise operators.
+ * Sets a flag without 32-bit coercion.
  * @internal
  */
 export function addNumberFlag(mask: number, flag: number): number {

--- a/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
@@ -28,13 +28,6 @@ export function logLevelToSeverityNumber(logLevel: string): SeverityNumber {
     case "WARN":
       severityNumber = SeverityNumber.WARN;
       break;
-    case "NONE":
-      // Map "NONE" to a threshold above every severity emitted by the console
-      // instrumentation (its highest is `console.error` -> ERROR). Using a value
-      // greater than all console severities ensures no console record passes the
-      // `severityNumber < logSeverity` filter, so nothing is collected.
-      severityNumber = SeverityNumber.FATAL4;
-      break;
   }
   return severityNumber;
 }

--- a/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
@@ -28,6 +28,13 @@ export function logLevelToSeverityNumber(logLevel: string): SeverityNumber {
     case "WARN":
       severityNumber = SeverityNumber.WARN;
       break;
+    case "NONE":
+      // Map "NONE" to a threshold above every severity emitted by the console
+      // instrumentation (its highest is `console.error` -> ERROR). Using a value
+      // greater than all console severities ensures no console record passes the
+      // `severityNumber < logSeverity` filter, so nothing is collected.
+      severityNumber = SeverityNumber.FATAL4;
+      break;
   }
   return severityNumber;
 }

--- a/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
@@ -4,6 +4,15 @@
 import { SeverityNumber } from "@opentelemetry/api-logs";
 
 /**
+ * Returns true when log collection is disabled via
+ * `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE`.
+ * @internal
+ */
+export function isLogCollectionDisabled(): boolean {
+  return process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL === "NONE";
+}
+
+/**
  * Convert log level to severity number.
  * @internal
  */

--- a/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/logUtils.ts
@@ -4,8 +4,7 @@
 import { SeverityNumber } from "@opentelemetry/api-logs";
 
 /**
- * Returns true when log collection is disabled via
- * `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE`.
+ * Checks whether the instrumentation logging level disables collection.
  * @internal
  */
 export function isLogCollectionDisabled(): boolean {

--- a/sdk/monitor/monitor-opentelemetry/src/utils/opentelemetryInstrumentationPatcher.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/opentelemetryInstrumentationPatcher.ts
@@ -5,6 +5,7 @@ import type { Instrumentation } from "@opentelemetry/instrumentation";
 import type { StatsbeatEnvironmentConfig } from "../types.js";
 import { AZURE_MONITOR_STATSBEAT_FEATURES, StatsbeatInstrumentationMap } from "../types.js";
 import { Logger } from "../shared/logging/index.js";
+import { addNumberFlag } from "./common.js";
 
 /**
  * Patch OpenTelemetry Instrumentation enablement to update the statsbeat environment variable with the enabled instrumentations
@@ -27,9 +28,12 @@ export function patchOpenTelemetryInstrumentationEnable(): void {
         );
         let updatedStatsbeat = {};
         for (let i = 0; i < instrumentations.length; i++) {
+          statsbeatOptions.instrumentation = addNumberFlag(
+            statsbeatOptions.instrumentation,
+            StatsbeatInstrumentationMap.get(instrumentations[i].instrumentationName) || 0,
+          );
           updatedStatsbeat = {
-            instrumentation: (statsbeatOptions.instrumentation |=
-              StatsbeatInstrumentationMap.get(instrumentations[i].instrumentationName) || 0),
+            instrumentation: statsbeatOptions.instrumentation,
             feature: statsbeatOptions.feature,
           };
         }

--- a/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
@@ -12,6 +12,7 @@ import {
   StatsbeatFeature,
   StatsbeatFeaturesMap,
   StatsbeatInstrumentation,
+  StatsbeatInstrumentationsMap,
 } from "../types.js";
 import { Logger as InternalLogger } from "../shared/logging/index.js";
 
@@ -105,10 +106,17 @@ class StatsbeatConfiguration {
       return { option: entry[0], value: entry[1] };
     });
 
-    // Map the instrumentation options to a bit map
+    // Map the instrumentation options to a bit map using the explicit
+    // option-name -> bit mapping rather than the positional order of the options
+    // object. Positional encoding shifted every subsequent instrumentation's bit
+    // whenever a new option was inserted (e.g. `console`), corrupting community
+    // instrumentation bits read back from the environment variable.
     for (let i = 0; i < instrumentationArray.length; i++) {
       if (instrumentationArray[i].value) {
-        instrumentationBitMap |= 2 ** i;
+        const instrumentationBit = StatsbeatInstrumentationsMap.get(instrumentationArray[i].option);
+        if (instrumentationBit !== undefined) {
+          instrumentationBitMap |= instrumentationBit;
+        }
       }
     }
 

--- a/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
@@ -103,8 +103,7 @@ class StatsbeatConfiguration {
       return { option: entry[0], value: entry[1] };
     });
 
-    // Map each enabled instrumentation option to its bit via the explicit
-    // name -> bit map, so bits are independent of the options object's key order.
+    // Map enabled option names to their assigned bits.
     for (let i = 0; i < instrumentationArray.length; i++) {
       if (instrumentationArray[i].value) {
         const instrumentationBit = StatsbeatInstrumentationsMap.get(instrumentationArray[i].option);

--- a/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
@@ -15,6 +15,7 @@ import {
   StatsbeatInstrumentationsMap,
 } from "../types.js";
 import { Logger as InternalLogger } from "../shared/logging/index.js";
+import { addNumberFlag, hasNumberFlag } from "./common.js";
 
 let instance: StatsbeatConfiguration;
 
@@ -61,41 +62,37 @@ class StatsbeatConfiguration {
     this.currentStatsbeatFeatures = { ...this.currentStatsbeatFeatures, ...statsbeatFeatures };
 
     // Set the statsbeat options for community instrumentations based on the environment variable
+    const envInstrumentation = statsbeatEnv!.instrumentation;
     statsbeatInstrumentations = {
       ...this.currentStatsbeatInstrumentations,
-      amqplib: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.AMQPLIB ? true : false,
-      cucumber: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.CUCUMBER ? true : false,
-      dataloader:
-        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.DATALOADER ? true : false,
-      fs: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.FS ? true : false,
-      lruMemoizer:
-        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.LRU_MEMOIZER ? true : false,
-      mongoose: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.MONGOOSE ? true : false,
-      runtimeNode:
-        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.RUNTIME_NODE ? true : false,
-      socketIo: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.SOCKET_IO ? true : false,
-      tedious: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.TEDIOUS ? true : false,
-      undici: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.UNDICI ? true : false,
-      cassandra: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.CASSANDRA ? true : false,
-      connect: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.CONNECT ? true : false,
-      dns: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.DNS ? true : false,
-      express: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.EXPRESS ? true : false,
-      fastify: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.FASTIFY ? true : false,
-      genericPool:
-        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.GENERIC_POOL ? true : false,
-      graphql: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.GRAPHQL ? true : false,
-      hapi: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.HAPI ? true : false,
-      ioredis: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.IOREDIS ? true : false,
-      knex: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.KNEX ? true : false,
-      koa: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.KOA ? true : false,
-      memcached: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.MEMCACHED ? true : false,
-      mysql2: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.MYSQL2 ? true : false,
-      nestjsCore:
-        statsbeatEnv!.instrumentation & StatsbeatInstrumentation.NESTJS_CORE ? true : false,
-      net: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.NET ? true : false,
-      pino: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.PINO ? true : false,
-      restify: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.RESTIFY ? true : false,
-      router: statsbeatEnv!.instrumentation & StatsbeatInstrumentation.ROUTER ? true : false,
+      amqplib: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.AMQPLIB),
+      cucumber: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.CUCUMBER),
+      dataloader: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.DATALOADER),
+      fs: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.FS),
+      lruMemoizer: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.LRU_MEMOIZER),
+      mongoose: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.MONGOOSE),
+      runtimeNode: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.RUNTIME_NODE),
+      socketIo: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.SOCKET_IO),
+      tedious: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.TEDIOUS),
+      undici: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.UNDICI),
+      cassandra: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.CASSANDRA),
+      connect: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.CONNECT),
+      dns: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.DNS),
+      express: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.EXPRESS),
+      fastify: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.FASTIFY),
+      genericPool: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.GENERIC_POOL),
+      graphql: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.GRAPHQL),
+      hapi: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.HAPI),
+      ioredis: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.IOREDIS),
+      knex: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.KNEX),
+      koa: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.KOA),
+      memcached: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.MEMCACHED),
+      mysql2: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.MYSQL2),
+      nestjsCore: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.NESTJS_CORE),
+      net: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.NET),
+      pino: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.PINO),
+      restify: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.RESTIFY),
+      router: hasNumberFlag(envInstrumentation, StatsbeatInstrumentation.ROUTER),
     };
 
     let instrumentationBitMap = StatsbeatInstrumentation.NONE;
@@ -112,7 +109,7 @@ class StatsbeatConfiguration {
       if (instrumentationArray[i].value) {
         const instrumentationBit = StatsbeatInstrumentationsMap.get(instrumentationArray[i].option);
         if (instrumentationBit !== undefined) {
-          instrumentationBitMap |= instrumentationBit;
+          instrumentationBitMap = addNumberFlag(instrumentationBitMap, instrumentationBit);
         }
       }
     }

--- a/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
+++ b/sdk/monitor/monitor-opentelemetry/src/utils/statsbeat.ts
@@ -106,11 +106,8 @@ class StatsbeatConfiguration {
       return { option: entry[0], value: entry[1] };
     });
 
-    // Map the instrumentation options to a bit map using the explicit
-    // option-name -> bit mapping rather than the positional order of the options
-    // object. Positional encoding shifted every subsequent instrumentation's bit
-    // whenever a new option was inserted (e.g. `console`), corrupting community
-    // instrumentation bits read back from the environment variable.
+    // Map each enabled instrumentation option to its bit via the explicit
+    // name -> bit map, so bits are independent of the options object's key order.
     for (let i = 0; i < instrumentationArray.length; i++) {
       if (instrumentationArray[i].value) {
         const instrumentationBit = StatsbeatInstrumentationsMap.get(instrumentationArray[i].option);

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
@@ -15,6 +15,7 @@ import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
 import type { BunyanInstrumentationConfig } from "@opentelemetry/instrumentation-bunyan";
 import type { WinstonInstrumentationConfig } from "@opentelemetry/instrumentation-winston";
+import type { ConsoleInstrumentationConfig } from "@opentelemetry/instrumentation-console";
 import type { MockInstance } from "vitest";
 import {
   afterAll,
@@ -222,6 +223,115 @@ describe("LogHandler", () => {
           .logSeverity,
         SeverityNumber.ERROR,
       );
+    });
+
+    it("should add console instrumentation", () => {
+      const config = new InternalConfig();
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+      config.instrumentationOptions.console = {
+        enabled: true,
+      };
+      const logHandler = new LogHandler(config, metricHandler);
+      assert.isTrue(logHandler.getInstrumentations().length > 0, "Log instrumentations not added");
+      assert.strictEqual(
+        logHandler.getInstrumentations()[0].instrumentationName,
+        "@opentelemetry/instrumentation-console",
+        "Console instrumentation not added",
+      );
+    });
+
+    it("should set console log level with the APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL env var", () => {
+      process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "WARN";
+      const config = new InternalConfig();
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+      config.instrumentationOptions.console = {
+        enabled: true,
+      };
+      const logHandler = new LogHandler(config, metricHandler);
+      assert.strictEqual(
+        (logHandler.getInstrumentations()[0].getConfig() as ConsoleInstrumentationConfig)
+          .logSeverity,
+        SeverityNumber.WARN,
+      );
+    });
+
+    it("should map a NONE logging level to a threshold above all console severities", () => {
+      process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "NONE";
+      const config = new InternalConfig();
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+      config.instrumentationOptions.console = {
+        enabled: true,
+      };
+      const logHandler = new LogHandler(config, metricHandler);
+      // The console instrumentation's highest severity is `console.error` -> ERROR (17).
+      // NONE must map above every console severity so nothing is collected.
+      assert.strictEqual(
+        (logHandler.getInstrumentations()[0].getConfig() as ConsoleInstrumentationConfig)
+          .logSeverity,
+        SeverityNumber.FATAL4,
+      );
+      delete process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
+    });
+  });
+
+  describe("#console collection", () => {
+    it("emits a LogRecord for console output that reaches the exporter", async () => {
+      delete process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
+      const config = new InternalConfig();
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+      config.instrumentationOptions.console = {
+        enabled: true,
+      };
+      const logHandler = new LogHandler(config, metricHandler);
+      const consoleInstrumentation = logHandler.getInstrumentations()[0];
+      consoleInstrumentation.enable();
+      try {
+        console.error("console-error-message");
+        await (logs.getLoggerProvider() as LoggerProvider).forceFlush();
+        expect(exportStub).toHaveBeenCalled();
+        const emitted = exportStub.mock.calls.flatMap((call) => call[0]);
+        const record = emitted.find((r) => r.body === "console-error-message");
+        assert.isDefined(record, "Console LogRecord was not exported");
+        assert.strictEqual(record.severityNumber, SeverityNumber.ERROR);
+      } finally {
+        consoleInstrumentation.disable();
+      }
+    });
+
+    it("filters console output below the configured severity threshold", async () => {
+      process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "ERROR";
+      const config = new InternalConfig();
+      config.azureMonitorExporterOptions.connectionString =
+        "InstrumentationKey=1aa11111-bbbb-1ccc-8ddd-eeeeffff3333";
+      config.instrumentationOptions.console = {
+        enabled: true,
+      };
+      const logHandler = new LogHandler(config, metricHandler);
+      const consoleInstrumentation = logHandler.getInstrumentations()[0];
+      consoleInstrumentation.enable();
+      try {
+        // WARN (13) is below the configured ERROR (17) threshold -> dropped.
+        console.warn("console-warn-filtered");
+        // ERROR (17) is at the threshold -> collected.
+        console.error("console-error-collected");
+        await (logs.getLoggerProvider() as LoggerProvider).forceFlush();
+        const emitted = exportStub.mock.calls.flatMap((call) => call[0]);
+        assert.isUndefined(
+          emitted.find((r) => r.body === "console-warn-filtered"),
+          "Filtered console.warn should not be exported",
+        );
+        assert.isDefined(
+          emitted.find((r) => r.body === "console-error-collected"),
+          "console.error at the threshold should be exported",
+        );
+      } finally {
+        consoleInstrumentation.disable();
+        delete process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
+      }
     });
   });
 });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
@@ -272,7 +272,6 @@ describe("LogHandler", () => {
         enabled: true,
       };
       const logHandler = new LogHandler(config, metricHandler);
-      // "NONE" registers no log instrumentations.
       assert.strictEqual(
         logHandler.getInstrumentations().length,
         0,
@@ -323,9 +322,7 @@ describe("LogHandler", () => {
       const consoleInstrumentation = logHandler.getInstrumentations()[0];
       consoleInstrumentation.enable();
       try {
-        // WARN (13) is below the configured ERROR (17) threshold -> dropped.
         console.warn("console-warn-filtered");
-        // ERROR (17) is at the threshold -> collected.
         console.error("console-error-collected");
         await (logs.getLoggerProvider() as LoggerProvider).forceFlush();
         const emitted = exportStub.mock.calls.flatMap((call) => call[0]);

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
@@ -257,7 +257,7 @@ describe("LogHandler", () => {
       );
     });
 
-    it("should map a NONE logging level to a threshold above all console severities", () => {
+    it("should not register log instrumentations when the logging level is NONE", () => {
       process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "NONE";
       const config = new InternalConfig();
       config.azureMonitorExporterOptions.connectionString =
@@ -265,13 +265,24 @@ describe("LogHandler", () => {
       config.instrumentationOptions.console = {
         enabled: true,
       };
+      config.instrumentationOptions.bunyan = {
+        enabled: true,
+      };
+      config.instrumentationOptions.winston = {
+        enabled: true,
+      };
       const logHandler = new LogHandler(config, metricHandler);
-      // The console instrumentation's highest severity is `console.error` -> ERROR (17).
-      // NONE must map above every console severity so nothing is collected.
+      // "NONE" must suppress all log collection. Rather than encoding it as a
+      // severity threshold (which Bunyan/Winston normalize back to a real level),
+      // no log instrumentation should be registered at all.
       assert.strictEqual(
-        (logHandler.getInstrumentations()[0].getConfig() as ConsoleInstrumentationConfig)
-          .logSeverity,
-        SeverityNumber.FATAL4,
+        logHandler.getInstrumentations().length,
+        0,
+        "No log instrumentations should be registered when the logging level is NONE",
+      );
+      assert.isUndefined(
+        logHandler.getConsoleInstrumentation(),
+        "Console instrumentation should not be created when the logging level is NONE",
       );
       delete process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL;
     });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/logs/logHandler.test.ts
@@ -272,9 +272,7 @@ describe("LogHandler", () => {
         enabled: true,
       };
       const logHandler = new LogHandler(config, metricHandler);
-      // "NONE" must suppress all log collection. Rather than encoding it as a
-      // severity threshold (which Bunyan/Winston normalize back to a real level),
-      // no log instrumentation should be registered at all.
+      // "NONE" registers no log instrumentations.
       assert.strictEqual(
         logHandler.getInstrumentations().length,
         0,

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -205,6 +205,22 @@ describe("Main functions", () => {
     assert.strictEqual(meterProvider["_shutdown"], true);
   });
 
+  it("should restore console after shutdown when console instrumentation is enabled", async () => {
+    const originalLog = console.log;
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      instrumentationOptions: {
+        console: { enabled: true },
+      },
+    };
+    useAzureMonitor(config);
+    assert.notStrictEqual(console.log, originalLog, "console.log should be patched while enabled");
+    await shutdownAzureMonitor();
+    assert.strictEqual(console.log, originalLog, "console.log should be restored after shutdown");
+  });
+
   it("should add custom spanProcessors", () => {
     const processor: SpanProcessor = {
       forceFlush: () => {
@@ -325,6 +341,31 @@ describe("Main functions", () => {
     assert.ok(instrumentations & StatsbeatInstrumentation.POSTGRES, "POSTGRES not set");
     assert.ok(instrumentations & StatsbeatInstrumentation.REDIS, "REDIS not set");
     assert.strictEqual(instrumentations, 31);
+  });
+
+  it("should record the Console instrumentation Statsbeat bit when console collection is enabled", async () => {
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      instrumentationOptions: {
+        console: {
+          enabled: true,
+        },
+      },
+    };
+    useAzureMonitor(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const instrumentations = Number(output["instrumentation"]);
+    assert.ok(
+      instrumentations & StatsbeatInstrumentation.CONSOLE,
+      "CONSOLE instrumentation bit (128) not set",
+    );
+    assert.strictEqual(
+      StatsbeatInstrumentationMap.get("@opentelemetry/instrumentation-console"),
+      StatsbeatInstrumentation.CONSOLE,
+    );
+    await shutdownAzureMonitor();
   });
 
   it("should set shim feature in statsbeat if env var is populated", () => {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -394,6 +394,38 @@ describe("Main functions", () => {
     await shutdownAzureMonitor();
   });
 
+  it("should not report log instrumentations in Statsbeat when the logging level is NONE", async () => {
+    const env = <{ [id: string]: string }>{};
+    env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "NONE";
+    process.env = env;
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      instrumentationOptions: {
+        console: { enabled: true },
+        bunyan: { enabled: true },
+        winston: { enabled: true },
+      },
+    };
+    useAzureMonitor(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const instrumentations = Number(output["instrumentation"]);
+    assert.notOk(
+      instrumentations & StatsbeatInstrumentation.CONSOLE,
+      "CONSOLE should not be reported when the logging level is NONE",
+    );
+    assert.notOk(
+      instrumentations & StatsbeatInstrumentation.BUNYAN,
+      "BUNYAN should not be reported when the logging level is NONE",
+    );
+    assert.notOk(
+      instrumentations & StatsbeatInstrumentation.WINSTON,
+      "WINSTON should not be reported when the logging level is NONE",
+    );
+    await shutdownAzureMonitor();
+  });
+
   it("should preserve a seeded community instrumentation bit across initialization", async () => {
     // Seed the CUCUMBER bit as a prior initialization would, then verify it is
     // re-emitted as CUCUMBER (256), not a neighboring bit.

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -237,14 +237,9 @@ describe("Main functions", () => {
       originalLog,
       "console.log should be patched after the first init",
     );
-    // Re-initialize: the previous console instrumentation must be disabled so the
-    // global console is re-patched from the true original rather than layered on
-    // top of the previous patch.
     useAzureMonitor(config);
     assert.notStrictEqual(console.log, originalLog, "console.log should be patched after re-init");
     await shutdownAzureMonitor();
-    // If the previous console patch had leaked, this single shutdown would leave a
-    // stale patch in place instead of the true original.
     assert.strictEqual(
       console.log,
       originalLog,
@@ -400,10 +395,8 @@ describe("Main functions", () => {
   });
 
   it("should preserve a seeded community instrumentation bit across initialization", async () => {
-    // Simulate a prior initialization that recorded the CUCUMBER community bit.
-    // Encoding must map `cucumber` back to its canonical bit (256) rather than
-    // shifting it to a neighbor (e.g. DATALOADER, 512) as positional encoding did
-    // once `console` was inserted among the built-in options.
+    // Seed the CUCUMBER bit as a prior initialization would, then verify it is
+    // re-emitted as CUCUMBER (256), not a neighboring bit.
     const env = <{ [id: string]: string }>{};
     env.AZURE_MONITOR_STATSBEAT_FEATURES = JSON.stringify({
       instrumentation: StatsbeatInstrumentation.CUCUMBER,

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -221,6 +221,37 @@ describe("Main functions", () => {
     assert.strictEqual(console.log, originalLog, "console.log should be restored after shutdown");
   });
 
+  it("should not leak the console patch across re-initialization", async () => {
+    const originalLog = console.log;
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      instrumentationOptions: {
+        console: { enabled: true },
+      },
+    };
+    useAzureMonitor(config);
+    assert.notStrictEqual(
+      console.log,
+      originalLog,
+      "console.log should be patched after the first init",
+    );
+    // Re-initialize: the previous console instrumentation must be disabled so the
+    // global console is re-patched from the true original rather than layered on
+    // top of the previous patch.
+    useAzureMonitor(config);
+    assert.notStrictEqual(console.log, originalLog, "console.log should be patched after re-init");
+    await shutdownAzureMonitor();
+    // If the previous console patch had leaked, this single shutdown would leave a
+    // stale patch in place instead of the true original.
+    assert.strictEqual(
+      console.log,
+      originalLog,
+      "console.log should be fully restored after shutdown following re-init",
+    );
+  });
+
   it("should add custom spanProcessors", () => {
     const processor: SpanProcessor = {
       forceFlush: () => {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -17,7 +17,7 @@ import {
   StatsbeatInstrumentation,
   StatsbeatInstrumentationMap,
 } from "../../../src/types.js";
-import { getOsPrefix } from "../../../src/utils/common.js";
+import { getOsPrefix, hasNumberFlag } from "../../../src/utils/common.js";
 import type { ReadableSpan, Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
 import type { LogRecordProcessor, SdkLogRecord } from "@opentelemetry/sdk-logs";
 import { getInstance } from "../../../src/utils/statsbeat.js";
@@ -426,12 +426,12 @@ describe("Main functions", () => {
     await shutdownAzureMonitor();
   });
 
-  it("should preserve a seeded community instrumentation bit across initialization", async () => {
-    // Seed the CUCUMBER bit as a prior initialization would, then verify it is
-    // re-emitted as CUCUMBER (256), not a neighboring bit.
+  it("should preserve seeded community instrumentation bits (including bits above 2**32) across initialization", async () => {
+    // Seed CUCUMBER (256) and AMQPLIB (2**35, beyond 32-bit range) as a prior
+    // initialization would, then verify both survive the round trip.
     const env = <{ [id: string]: string }>{};
     env.AZURE_MONITOR_STATSBEAT_FEATURES = JSON.stringify({
-      instrumentation: StatsbeatInstrumentation.CUCUMBER,
+      instrumentation: StatsbeatInstrumentation.CUCUMBER + StatsbeatInstrumentation.AMQPLIB,
       feature: 0,
     });
     process.env = env;
@@ -447,15 +447,19 @@ describe("Main functions", () => {
     const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
     const instrumentations = Number(output["instrumentation"]);
     assert.ok(
-      instrumentations & StatsbeatInstrumentation.CUCUMBER,
+      hasNumberFlag(instrumentations, StatsbeatInstrumentation.CUCUMBER),
       "Seeded CUCUMBER (256) bit should be preserved across initialization",
     );
     assert.notOk(
-      instrumentations & StatsbeatInstrumentation.DATALOADER,
+      hasNumberFlag(instrumentations, StatsbeatInstrumentation.DATALOADER),
       "CUCUMBER must not be re-encoded as DATALOADER (512)",
     );
     assert.ok(
-      instrumentations & StatsbeatInstrumentation.CONSOLE,
+      hasNumberFlag(instrumentations, StatsbeatInstrumentation.AMQPLIB),
+      "Seeded AMQPLIB (2**35) bit should be preserved and not truncated by 32-bit ops",
+    );
+    assert.ok(
+      hasNumberFlag(instrumentations, StatsbeatInstrumentation.CONSOLE),
       "CONSOLE (128) bit should be set",
     );
     await shutdownAzureMonitor();

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -399,6 +399,43 @@ describe("Main functions", () => {
     await shutdownAzureMonitor();
   });
 
+  it("should preserve a seeded community instrumentation bit across initialization", async () => {
+    // Simulate a prior initialization that recorded the CUCUMBER community bit.
+    // Encoding must map `cucumber` back to its canonical bit (256) rather than
+    // shifting it to a neighbor (e.g. DATALOADER, 512) as positional encoding did
+    // once `console` was inserted among the built-in options.
+    const env = <{ [id: string]: string }>{};
+    env.AZURE_MONITOR_STATSBEAT_FEATURES = JSON.stringify({
+      instrumentation: StatsbeatInstrumentation.CUCUMBER,
+      feature: 0,
+    });
+    process.env = env;
+    const config: AzureMonitorOpenTelemetryOptions = {
+      azureMonitorExporterOptions: {
+        connectionString: "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+      },
+      instrumentationOptions: {
+        console: { enabled: true },
+      },
+    };
+    useAzureMonitor(config);
+    const output = JSON.parse(String(process.env["AZURE_MONITOR_STATSBEAT_FEATURES"]));
+    const instrumentations = Number(output["instrumentation"]);
+    assert.ok(
+      instrumentations & StatsbeatInstrumentation.CUCUMBER,
+      "Seeded CUCUMBER (256) bit should be preserved across initialization",
+    );
+    assert.notOk(
+      instrumentations & StatsbeatInstrumentation.DATALOADER,
+      "CUCUMBER must not be re-encoded as DATALOADER (512)",
+    );
+    assert.ok(
+      instrumentations & StatsbeatInstrumentation.CONSOLE,
+      "CONSOLE (128) bit should be set",
+    );
+    await shutdownAzureMonitor();
+  });
+
   it("should set shim feature in statsbeat if env var is populated", () => {
     getInstance()["initializedByShim"] = true;
     const config: AzureMonitorOpenTelemetryOptions = {

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/main.test.ts
@@ -427,8 +427,7 @@ describe("Main functions", () => {
   });
 
   it("should preserve seeded community instrumentation bits (including bits above 2**32) across initialization", async () => {
-    // Seed CUCUMBER (256) and AMQPLIB (2**35, beyond 32-bit range) as a prior
-    // initialization would, then verify both survive the round trip.
+    // Preserve seeded flags below and above the 32-bit range.
     const env = <{ [id: string]: string }>{};
     env.AZURE_MONITOR_STATSBEAT_FEATURES = JSON.stringify({
       instrumentation: StatsbeatInstrumentation.CUCUMBER + StatsbeatInstrumentation.AMQPLIB,

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -9,12 +9,18 @@ import { DiagFileConsoleLogger } from "../../../../../src/shared/logging/diagFil
 
 // These tests use real SDK diagnostics instead of fabricated log strings.
 describe("DiagFileConsoleLogger filtering", () => {
-  let originalConsoleLog: typeof console.log;
   let loggedMessages: any[];
   let originalEnv: NodeJS.ProcessEnv;
 
   const setDiagLogger = (): void => {
-    diag.setLogger(new DiagFileConsoleLogger(), {
+    const logger = new DiagFileConsoleLogger();
+    // Capture post-filter diagnostics at the console sink. The logger writes to
+    // the raw stdout stream (not the patchable console API), so spy the sink
+    // directly rather than reassigning console.log.
+    vi.spyOn(logger as any, "_writeToConsole").mockImplementation((...args: any[]) => {
+      loggedMessages.push(args);
+    });
+    diag.setLogger(logger, {
       logLevel: DiagLogLevel.ALL,
       suppressOverrideMessage: true,
     });
@@ -22,11 +28,7 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env };
-    originalConsoleLog = console.log;
     loggedMessages = [];
-    console.log = vi.fn((...args: any[]) => {
-      loggedMessages.push(args);
-    });
     setDiagLogger();
     // Ignore any diagnostics emitted by setLogger itself
     loggedMessages.length = 0;
@@ -34,7 +36,6 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   afterEach(() => {
     process.env = originalEnv;
-    console.log = originalConsoleLog;
     diag.disable();
     vi.restoreAllMocks();
   });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.filter.test.ts
@@ -14,9 +14,7 @@ describe("DiagFileConsoleLogger filtering", () => {
 
   const setDiagLogger = (): void => {
     const logger = new DiagFileConsoleLogger();
-    // Capture post-filter diagnostics at the console sink. The logger writes to
-    // the raw stdout stream (not the patchable console API), so spy the sink
-    // directly rather than reassigning console.log.
+    // Spy on the internal sink because console.log is intentionally bypassed.
     vi.spyOn(logger as any, "_writeToConsole").mockImplementation((...args: any[]) => {
       loggedMessages.push(args);
     });

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
@@ -71,9 +71,7 @@ describe("Library/DiagFileConsoleLogger", () => {
     it("should write console output through the console captured before instrumentation patched it", async () => {
       logger["_logToFile"] = false;
       logger["_logToConsole"] = true;
-      // Simulate the console instrumentation patching the global console after this
-      // module loaded. Diagnostics must not route through the patch, or exporting a
-      // collected console record would loop back into collection.
+      // Replace console.log after module initialization to simulate instrumentation.
       const patchedConsoleLog = vi.fn();
       const realConsoleLog = console.log;
       // eslint-disable-next-line no-console

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
@@ -68,6 +68,25 @@ describe("Library/DiagFileConsoleLogger", () => {
       expect(appendFileAsyncStub.mock.lastCall![1]).toEqual("testMessage\r\n");
     });
 
+    it("should write console output through the console captured before instrumentation patched it", async () => {
+      logger["_logToFile"] = false;
+      logger["_logToConsole"] = true;
+      // Simulate the console instrumentation patching the global console.log after
+      // this module was loaded. Diagnostics must not route through the patch, or
+      // exporting a collected console record would loop back into collection.
+      const patchedConsoleLog = vi.fn();
+      const realConsoleLog = console.log;
+      // eslint-disable-next-line no-console
+      console.log = patchedConsoleLog;
+      try {
+        await logger["logMessage"]("diagMessage");
+      } finally {
+        // eslint-disable-next-line no-console
+        console.log = realConsoleLog;
+      }
+      expect(patchedConsoleLog).not.toHaveBeenCalled();
+    });
+
     it("should create backup file", async () => {
       vi.spyOn(fileHelper, "confirmDirExists").mockImplementation(async () => {});
       vi.spyOn(fileHelper, "accessAsync").mockImplementation(async () => {});

--- a/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/internal/unit/shared/logging/diagFileConsoleLogger.test.ts
@@ -71,9 +71,9 @@ describe("Library/DiagFileConsoleLogger", () => {
     it("should write console output through the console captured before instrumentation patched it", async () => {
       logger["_logToFile"] = false;
       logger["_logToConsole"] = true;
-      // Simulate the console instrumentation patching the global console.log after
-      // this module was loaded. Diagnostics must not route through the patch, or
-      // exporting a collected console record would loop back into collection.
+      // Simulate the console instrumentation patching the global console after this
+      // module loaded. Diagnostics must not route through the patch, or exporting a
+      // collected console record would loop back into collection.
       const patchedConsoleLog = vi.fn();
       const realConsoleLog = console.log;
       // eslint-disable-next-line no-console

--- a/sdk/monitor/monitor-opentelemetry/test/snippets.spec.ts
+++ b/sdk/monitor/monitor-opentelemetry/test/snippets.spec.ts
@@ -67,6 +67,8 @@ describe("snippets", () => {
         // Instrumentations generating logs
         bunyan: { enabled: true },
         winston: { enabled: true },
+        // Console log collection is opt-in (disabled by default)
+        console: { enabled: false },
       },
       enableLiveMetrics: true,
       enableStandardMetrics: true,


### PR DESCRIPTION
### Summary

Re-introduces the **console log collection** feature that was split out of the OpenTelemetry 0.220/2.9 upgrade (#39389) so it can land on its own now that the upgrade has merged.

Enables collecting `console` logs via the `@opentelemetry/instrumentation-console` package. It is **opt-in / disabled by default**; enable with:

```ts
useAzureMonitor({
  instrumentationOptions: { console: { enabled: true } },
});
```

The set of console methods collected is filtered by the existing `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` env var (`NONE`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `VERBOSE`, `ALL`).

### Changes

**`@azure/monitor-opentelemetry`**
- Add `@opentelemetry/instrumentation-console` dependency and wire `ConsoleInstrumentation` into `LogHandler`, gated on `instrumentationOptions.console.enabled`.
- Track the `ConsoleInstrumentation` (the global `console` patch) and disable it on shutdown / re-init so the original `console` methods are restored (`NodeSDK.shutdown()` does not disable instrumentations). Only the console instrumentation is disabled here; module-based instrumentations are intentionally left untouched so a repeated `useAzureMonitor()` call does not lose their telemetry.
- Add `console` to `InstrumentationOptions` and the Statsbeat `CONSOLE` bit + `StatsbeatInstrumentationMap` entry.
- **Encode the Statsbeat instrumentation bit map from an explicit option-name -> bit map (`StatsbeatInstrumentationsMap`) instead of the positional order of the options object.** See "Statsbeat encoding fix" below.
- Treat `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=NONE` as "collect no logs" by skipping registration of the log instrumentations entirely (rather than encoding it as a severity threshold, which Bunyan/Winston normalize back to a real level).
- Raise the `@opentelemetry/api` range from `^1.9.0` to `^1.9.1` to satisfy the `instrumentation-console` peer dependency.
- README docs, snippet, CHANGELOG entry, and unit tests (re-initialization test, `NONE` test, and a Statsbeat round-trip regression test).

**`@azure/monitor-opentelemetry-exporter`**
- Raise the `@opentelemetry/api` range from `^1.9.0` to `^1.9.1` to stay aligned with the distro. CHANGELOG entry added.

### Statsbeat encoding fix (why)

`setStatsbeatFeatures` built the instrumentation bit map **positionally** — `instrumentationBitMap |= 2 ** i`, where `i` is each key's index in the options object — while it **decodes** community bits from `AZURE_MONITOR_STATSBEAT_FEATURES` using fixed `StatsbeatInstrumentation` enum values. Round-tripping is only stable when every key's position equals `log2(enumValue)`.

Adding `console` at index 7 (correctly bit `128 = CONSOLE`) pushed `amqplib` and every community instrumentation one position higher, so a community bit read back from the env var was **re-encoded as its neighbor** (e.g. `CUCUMBER` 256 -> `DATALOADER` 512), corrupting the mask on re-initialization. `console` occupying bit 128 is correct; the real issue was that positional encoding coupled every bit to key order.

Fix: encode from an explicit `StatsbeatInstrumentationsMap` (option name -> canonical enum bit), mirroring the existing `StatsbeatFeaturesMap`. Bits are now stable regardless of key order, and this also corrects a pre-existing `postgreSql`/`redis` positional swap. A regression test seeds a community bit and asserts it survives another `useAzureMonitor()` init.

### Validation

- `pnpm turbo build --filter=@azure/monitor-opentelemetry... --token 1` and `--filter=@azure/monitor-opentelemetry-exporter...` - both pass; API reports in sync.
- `pnpm --filter @azure/monitor-opentelemetry lint` - 0 errors.
- Affected unit tests pass (`logHandler.test.ts`, `main.test.ts`).
- End-to-end: exercised console collection at every `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` against a live Application Insights resource - `NONE`=0 records, `ERROR`=error only, `WARN`=warn+error, `INFO`=log/info/warn/error, `ALL`=all six severities.
- `pnpm-lock.yaml` diff vs main adds only `@opentelemetry/instrumentation-console@0.2.0` plus the two `@opentelemetry/api` specifier bumps - no dependency downgrades.
