### PR TITLE
[monitor-query-logs] Fix malformed URL with double slash in queryResource

### DIFF
--- a/sdk/monitor/monitor-query-logs/CHANGELOG.md
+++ b/sdk/monitor/monitor-query-logs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `LogsQueryClient.queryResource()` building a malformed URL with a double slash (e.g. `.../v1//subscriptions/...`) when the resource ID starts with a leading slash (the standard ARM resource ID format). The leading slash is now normalized so the request URL is well-formed. [#39361](https://github.com/Azure/azure-sdk-for-js/issues/39361)
+
 ### Other Changes
 
 ## 1.0.0 (2025-07-29)

--- a/sdk/monitor/monitor-query-logs/src/logsQueryClient.ts
+++ b/sdk/monitor/monitor-query-logs/src/logsQueryClient.ts
@@ -135,7 +135,14 @@ export class LogsQueryClient {
       timespan: convertTimespanToInterval(timespan),
       workspaces: options?.additionalWorkspaces,
     };
-    return executeWithResourceId(this._client, resourceId, body, internalOptions);
+    // ARM resource IDs conventionally start with a leading slash. The request path
+    // template already supplies the separator between the endpoint and the resource
+    // ID, so a leading slash here would produce a malformed URL with a double slash
+    // (e.g. ".../v1//subscriptions/..."), which the service rejects with a misleading
+    // 403. Strip any leading slash so both "/subscriptions/..." and "subscriptions/..."
+    // resolve to the same, correct URL.
+    const normalizedResourceId = resourceId.replace(/^\/+/, "");
+    return executeWithResourceId(this._client, normalizedResourceId, body, internalOptions);
   }
 
   /**

--- a/sdk/monitor/monitor-query-logs/test/internal/unit/logsQueryClient.unittest.spec.ts
+++ b/sdk/monitor/monitor-query-logs/test/internal/unit/logsQueryClient.unittest.spec.ts
@@ -130,4 +130,48 @@ describe("LogsQueryClient unit tests", () => {
       testOptions,
     );
   });
+
+  it("normalizes a leading slash in queryResource resourceId", async () => {
+    const requestUrls: string[] = [];
+    const client = new LogsQueryClient(
+      {
+        getToken: async () => Promise.resolve({ token: "token", expiresOnTimestamp: 1234567890 }),
+      },
+      {
+        endpoint: "https://customEndpoint1/v1",
+      },
+    );
+    const testPipelinePolicy = {
+      name: "captureUrlPolicy",
+      sendRequest: async (request: any) => {
+        requestUrls.push(request.url);
+        return {
+          request,
+          status: 200,
+          headers: createHttpHeaders(),
+          bodyAsText: `{ "tables": [] }`,
+        };
+      },
+    };
+    client.pipeline.addPolicy(testPipelinePolicy, { afterPhase: "Sign" });
+
+    const resourceId =
+      "/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/comp";
+
+    await client.queryResource(resourceId, "query", { duration: Durations.fiveMinutes });
+    await client.queryResource(resourceId.slice(1), "query", { duration: Durations.fiveMinutes });
+
+    assert.lengthOf(requestUrls, 2);
+    // A leading slash on the resource ID must not produce a double slash after the
+    // API version segment (regression test for the malformed-URL 403 bug).
+    for (const url of requestUrls) {
+      assert.notInclude(url, "/v1//", `URL should not contain a double slash: ${url}`);
+      assert.include(
+        url,
+        "/v1/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/comp/query",
+      );
+    }
+    // Both a leading-slash and a no-leading-slash resource ID resolve to the same URL.
+    assert.equal(requestUrls[0], requestUrls[1]);
+  });
 });


### PR DESCRIPTION
## Why

`LogsQueryClient.queryResource()` built a malformed request URL with a double slash (e.g. `https://api.loganalytics.io/v1//subscriptions/...`) whenever the resource ID started with a leading slash, which is the standard ARM resource ID format (`/subscriptions/{sub}/resourceGroups/{rg}/providers/...`). The service rejected the malformed URL with a misleading `403 InsufficientAccessError`, sending users down an unnecessary path of auditing RBAC permissions instead of pointing at the real bug.

## Approach

The request path template (`/{+resourceId}/query`) already supplies the separator between the endpoint and the resource ID, so a resource ID that also starts with `/` produced the double slash. The fix normalizes the leading slash off `resourceId` in the hand-written `queryResource` wrapper before it is expanded into the path. Both `/subscriptions/...` and `subscriptions/...` now resolve to the same well-formed URL.

The normalization lives in `src/logsQueryClient.ts` (not in the generated `src/api/operations.ts`, which is regenerated by `tsp-client`).

Note: `@azure/monitor-query-metrics` does not need a similar fix. Its `queryResources()` sends resource IDs in the request body and only uses a subscription GUID (extracted from the first resource ID) in the URL path, so it never constructs a resource-scoped path that could double-slash.

## Testing

Added a regression unit test that asserts the request URL never contains `/v1//` and that a leading-slash and a no-leading-slash resource ID resolve to the same URL. All 4 unit tests in the file pass.

Fixes #39361