### PR TITLE
[event-hubs] Add skipConvertingDate option to SubscribeOptions

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 6.0.5 (Unreleased)
+## 6.1.0 (Unreleased)
 
 ### Features Added
+
+- Added the `skipConvertingDate` option to `SubscribeOptions`. When it is set to `true`, Date typed values in the application properties and the message annotations of received events are returned as `Date` objects instead of numbers that represent UNIX epoch milliseconds. [#30809](https://github.com/Azure/azure-sdk-for-js/issues/30809)
 
 ### Breaking Changes
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "6.0.5",
+  "version": "6.1.0",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/review/event-hubs-node.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs-node.api.md
@@ -351,6 +351,7 @@ export interface SubscribeOptions {
     maxWaitTimeInSeconds?: number;
     ownerLevel?: number;
     prefetchCount?: number;
+    skipConvertingDate?: boolean;
     skipParsingBodyAsJson?: boolean;
     startPosition?: EventPosition | {
         [partitionId: string]: EventPosition;

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -172,11 +172,14 @@ const messagePropertiesMap = {
  * Converts the AMQP message to an EventData.
  * @param msg - The AMQP message that needs to be converted to EventData.
  * @param skipParsingBodyAsJson - Boolean to skip running JSON.parse() on message body when body type is `content`.
+ * @param skipConvertingDate - Boolean to skip converting Date type on properties of message annotations or application
+ * properties into numbers. Defaults to `false`, which converts Date type into UNIX epoch number for compatibility.
  * @internal
  */
 export function fromRheaMessage(
   msg: RheaMessage,
   skipParsingBodyAsJson: boolean,
+  skipConvertingDate: boolean = false,
 ): EventDataInternal {
   const rawMessage = AmqpAnnotatedMessage.fromRheaMessage(msg);
   const { body, bodyType } = defaultDataTransformer.decode(msg.body, skipParsingBodyAsJson);
@@ -208,15 +211,17 @@ export function fromRheaMessage(
           if (!data.systemProperties) {
             data.systemProperties = {};
           }
-          data.systemProperties[annotationKey] = convertDatesToNumbers(
-            msg.message_annotations[annotationKey],
-          );
+          data.systemProperties[annotationKey] = skipConvertingDate
+            ? msg.message_annotations[annotationKey]
+            : convertDatesToNumbers(msg.message_annotations[annotationKey]);
           break;
       }
     }
   }
   if (msg.application_properties) {
-    data.properties = convertDatesToNumbers(msg.application_properties);
+    data.properties = skipConvertingDate
+      ? msg.application_properties
+      : convertDatesToNumbers(msg.application_properties);
   }
   if (msg.delivery_annotations) {
     data.lastEnqueuedOffset = msg.delivery_annotations.last_enqueued_offset;
@@ -235,9 +240,9 @@ export function fromRheaMessage(
       data.systemProperties = {};
     }
     if (msg[messageProperty] != null) {
-      data.systemProperties[messagePropertiesMap[messageProperty]] = convertDatesToNumbers(
-        msg[messageProperty],
-      );
+      data.systemProperties[messagePropertiesMap[messageProperty]] = skipConvertingDate
+        ? msg[messageProperty]
+        : convertDatesToNumbers(msg[messageProperty]);
     }
   }
 

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -205,6 +205,13 @@ export interface SubscribeOptions {
    */
   skipParsingBodyAsJson?: boolean;
   /**
+   * Whether to skip converting Date type on properties of message annotations
+   * or application properties into numbers when receiving the message. By
+   * default, properties of Date type is converted into UNIX epoch number for
+   * compatibility.
+   */
+  skipConvertingDate?: boolean;
+  /**
    * The count of events requested eagerly and queued without regard to whether a read was requested.
    */
   prefetchCount?: number;

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -82,6 +82,9 @@ export interface CommonEventProcessorOptions
  * - `skipParsingBodyAsJson` : Option to disable the client from running JSON.parse() on the message body when receiving the message.
  * Not applicable if the message was sent with AMQP body type value or sequence. Use this option when you prefer to work directly with
  * the bytes present in the message body than have the client attempt to parse it.
+ * - `skipConvertingDate` : Whether to skip converting Date type on properties of message annotations or application
+ * properties into numbers when receiving the message. By default, properties of Date type is converted into UNIX epoch
+ * number for compatibility.
  *
  * Example usage:
  * ```ts snippet:ignore
@@ -126,6 +129,13 @@ export interface PartitionReceiverOptions {
    * prefer to work directly with the bytes present in the message body than have the client attempt to parse it.
    */
   skipParsingBodyAsJson?: boolean;
+  /**
+   * Whether to skip converting Date type on properties of message annotations
+   * or application properties into numbers when receiving the message. By
+   * default, properties of Date type is converted into UNIX epoch number for
+   * compatibility.
+   */
+  skipConvertingDate?: boolean;
   /**
    * The count of events requested eagerly and queued without regard to whether a read was requested.
    */

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -92,6 +92,7 @@ export class PartitionPump {
         trackLastEnqueuedEventProperties: this._processorOptions.trackLastEnqueuedEventProperties,
         retryOptions: this._processorOptions.retryOptions,
         skipParsingBodyAsJson: this._processorOptions.skipParsingBodyAsJson,
+        skipConvertingDate: this._processorOptions.skipConvertingDate,
         prefetchCount: this._processorOptions.prefetchCount,
       },
     );

--- a/sdk/eventhub/event-hubs/src/partitionReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/partitionReceiver.ts
@@ -490,7 +490,11 @@ function onMessage(
   if (!context.message) {
     return;
   }
-  const data = fromRheaMessage(context.message, !!options.skipParsingBodyAsJson);
+  const data = fromRheaMessage(
+    context.message,
+    !!options.skipParsingBodyAsJson,
+    !!options.skipConvertingDate,
+  );
   const receivedEventData = convertAMQPMesage(data);
   obj.checkpoint = receivedEventData.sequenceNumber;
   if (options.trackLastEnqueuedEventProperties) {

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,7 +6,7 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "6.0.5",
+  version: "6.1.0",
 };
 
 /**

--- a/sdk/eventhub/event-hubs/test/internal/eventHubConsumerClientUnitTests.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventHubConsumerClientUnitTests.spec.ts
@@ -107,6 +107,32 @@ describe("EventHubConsumerClient", () => {
         );
       });
 
+      it("passes skipConvertingDate from SubscribeOptions to the event processor", async () => {
+        let sawOption: boolean | undefined;
+        validateOptions = (options) => {
+          sawOption = options.skipConvertingDate;
+        };
+
+        const subscription = client.subscribe("0", subscriptionHandlers, {
+          skipConvertingDate: true,
+        });
+
+        should.equal(sawOption, true);
+        await subscription.close();
+      });
+
+      it("leaves skipConvertingDate unset when SubscribeOptions omits it", async () => {
+        let sawOption: boolean | undefined = true;
+        validateOptions = (options) => {
+          sawOption = options.skipConvertingDate;
+        };
+
+        const subscription = client.subscribe("0", subscriptionHandlers);
+
+        should.not.exist(sawOption);
+        await subscription.close();
+      });
+
       it("subscribe to single partition, no checkpoint store, no loadBalancingOptions", async () => {
         validateOptions = (options) => {
           // when the user doesn't pass a checkpoint store we give them a really simple set of

--- a/sdk/eventhub/event-hubs/test/internal/eventdata.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/eventdata.spec.ts
@@ -198,6 +198,58 @@ describe("EventData", () => {
         },
       });
     });
+
+    it("preserves Dates in properties and annotations when skipConvertingDate is true", async () => {
+      const timestamp = new Date();
+      const extraAnnotations = {
+        "x-date": timestamp,
+        "x-number": timestamp.getTime(),
+      };
+      const rheaMessage = {
+        body: testBody,
+        application_properties: {
+          topLevelDate: timestamp,
+          child: {
+            nestedDate: timestamp,
+            children: [timestamp, { deepDate: timestamp }],
+          },
+        },
+        message_annotations: {
+          ...testAnnotations,
+          ...extraAnnotations,
+        },
+        creation_time: timestamp,
+      };
+
+      const testEventData = fromRheaMessage(rheaMessage, false, true);
+
+      testEventData.enqueuedTimeUtc!.getTime().should.equal(testAnnotations["x-opt-enqueued-time"]);
+      testEventData.offset!.should.equal(testAnnotations["x-opt-offset"]);
+      testEventData.sequenceNumber!.should.equal(testAnnotations["x-opt-sequence-number"]);
+      testEventData.partitionKey!.should.equal(testAnnotations["x-opt-partition-key"]);
+      testEventData.systemProperties!["x-date"].should.eql(timestamp);
+      testEventData.systemProperties!["x-number"].should.eql(extraAnnotations["x-number"]);
+      testEventData.systemProperties!["creationTime"].should.eql(timestamp);
+      testEventData.properties!.should.eql({
+        topLevelDate: timestamp,
+        child: {
+          nestedDate: timestamp,
+          children: [timestamp, { deepDate: timestamp }],
+        },
+      });
+
+      // The default keeps converting Dates into numbers.
+      const defaultEventData = fromRheaMessage(rheaMessage, false);
+      defaultEventData.systemProperties!["x-date"].should.eql(timestamp.getTime());
+      defaultEventData.systemProperties!["creationTime"].should.eql(timestamp.getTime());
+      defaultEventData.properties!.should.eql({
+        topLevelDate: timestamp.getTime(),
+        child: {
+          nestedDate: timestamp.getTime(),
+          children: [timestamp.getTime(), { deepDate: timestamp.getTime() }],
+        },
+      });
+    });
   });
   describe("toAmqpMessage", () => {
     it("populates body with the message body encoded", async () => {

--- a/sdk/eventhub/event-hubs/test/internal/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/internal/partitionPump.spec.ts
@@ -1,12 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { toProcessingSpanOptions } from "../../src/partitionPump.js";
+import { PartitionPump, toProcessingSpanOptions } from "../../src/partitionPump.js";
 import { tracingClient } from "../../src/diagnostics/tracing.js";
 import type { TracingContext } from "@azure/core-tracing";
 import { TRACEPARENT_PROPERTY } from "../../src/diagnostics/instrumentEventData.js";
+import type { CommonEventProcessorOptions } from "../../src/models/private.js";
+import type { ConnectionContext } from "../../src/connectionContext.js";
+import type { PartitionProcessor } from "../../src/partitionProcessor.js";
+import { createReceiver } from "../../src/partitionReceiver.js";
 import { assert } from "../utils/chai.js";
-import { describe, it, vi } from "vitest";
+import { describe, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/partitionReceiver.js", () => ({
+  createReceiver: vi.fn(() => ({}) as any),
+}));
 
 describe("telemetry", () => {
   describe("#getProcessingSpanOptions", () => {
@@ -52,5 +60,46 @@ describe("telemetry", () => {
       assert.equal(spanLink.attributes!["enqueuedTime"], enqueuedTimeUtc.getTime());
       assert.equal(spanLink!.tracingContext, fakeContext);
     });
+  });
+});
+
+describe("PartitionPump", () => {
+  beforeEach(() => {
+    vi.mocked(createReceiver).mockClear();
+  });
+
+  function createPump(options: Partial<CommonEventProcessorOptions>): PartitionPump {
+    const partitionProcessor = {
+      consumerGroup: "$Default",
+      eventProcessorId: "processor-id",
+      partitionId: "0",
+    } as PartitionProcessor;
+
+    return new PartitionPump(
+      {} as ConnectionContext,
+      partitionProcessor,
+      { sequenceNumber: 0, isInclusive: false },
+      options as CommonEventProcessorOptions,
+    );
+  }
+
+  it("passes skipConvertingDate through to the receiver", async () => {
+    const pump = createPump({ skipConvertingDate: true });
+
+    // `_setOrReplaceReceiver` is private, and it holds the explicit field copy under test.
+    (pump as any)["_setOrReplaceReceiver"]("0", -1);
+
+    assert.isTrue(vi.mocked(createReceiver).mock.calls.length === 1);
+    const receiverOptions = vi.mocked(createReceiver).mock.calls[0][5];
+    assert.isTrue(receiverOptions!.skipConvertingDate);
+  });
+
+  it("leaves skipConvertingDate undefined when the option is not set", async () => {
+    const pump = createPump({});
+
+    (pump as any)["_setOrReplaceReceiver"]("0", -1);
+
+    const receiverOptions = vi.mocked(createReceiver).mock.calls[0][5];
+    assert.isUndefined(receiverOptions!.skipConvertingDate);
   });
 });

--- a/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
+++ b/sdk/eventhub/event-hubs/test/public/eventData.spec.ts
@@ -8,6 +8,7 @@ import type {
   EventHubProducerClient,
   EventPosition,
   ReceivedEventData,
+  SubscribeOptions,
   Subscription,
 } from "../../src/index.js";
 import { randomUUID } from "@azure/core-util";
@@ -46,9 +47,12 @@ describe("EventData", () => {
    * Note: Call this after sending a single event to Event Hubs to validate
    * @internal
    */
-  async function receiveEvent(startingPositions: {
-    [partitionId: string]: EventPosition;
-  }): Promise<ReceivedEventData> {
+  async function receiveEvent(
+    startingPositions: {
+      [partitionId: string]: EventPosition;
+    },
+    options: SubscribeOptions = {},
+  ): Promise<ReceivedEventData> {
     return new Promise<ReceivedEventData>((resolve, reject) => {
       const subscription: Subscription = consumerClient.subscribe(
         {
@@ -64,6 +68,7 @@ describe("EventData", () => {
           },
         },
         {
+          ...options,
           startPosition: startingPositions,
         },
       );
@@ -108,6 +113,65 @@ describe("EventData", () => {
 
       const event = await receiveEvent(startingPositions);
       should.equal(event.body, testEvent.body, "Unexpected body on the received event.");
+    });
+  });
+
+  describe("Date properties", () => {
+    function getDateEventData(timestamp: Date): EventData {
+      return {
+        body: "date property test",
+        messageId: randomUUID(),
+        properties: {
+          topLevelDate: timestamp,
+          child: { nestedDate: timestamp },
+        },
+      };
+    }
+
+    it("converts Dates into numbers by default", async () => {
+      const startingPositions = await getStartingPositionsForTests(consumerClient);
+      const timestamp = new Date();
+      await producerClient.sendBatch([getDateEventData(timestamp)]);
+
+      const event = await receiveEvent(startingPositions);
+      should.equal(
+        event.properties!["topLevelDate"],
+        timestamp.getTime(),
+        "Unexpected top level property on the received event.",
+      );
+      should.equal(
+        (event.properties!["child"] as any).nestedDate,
+        timestamp.getTime(),
+        "Unexpected nested property on the received event.",
+      );
+    });
+
+    it("keeps Dates when skipConvertingDate is true", async () => {
+      const startingPositions = await getStartingPositionsForTests(consumerClient);
+      const timestamp = new Date();
+      await producerClient.sendBatch([getDateEventData(timestamp)]);
+
+      const event = await receiveEvent(startingPositions, { skipConvertingDate: true });
+      should.equal(
+        (event.properties!["topLevelDate"] as Date) instanceof Date,
+        true,
+        "The top level property is not a Date.",
+      );
+      should.equal(
+        (event.properties!["topLevelDate"] as Date).getTime(),
+        timestamp.getTime(),
+        "Unexpected top level property on the received event.",
+      );
+      should.equal(
+        (event.properties!["child"] as any).nestedDate instanceof Date,
+        true,
+        "The nested property is not a Date.",
+      );
+      should.equal(
+        ((event.properties!["child"] as any).nestedDate as Date).getTime(),
+        timestamp.getTime(),
+        "Unexpected nested property on the received event.",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

`@azure/event-hubs` converts every `Date` in the AMQP application properties and message annotations of a received event into a UNIX epoch number. A caller that wants the `Date` objects has no way to turn the conversion off. `@azure/service-bus` already ships a `skipConvertingDate` option for the same problem. This change adds that option to Event Hubs.

Fixes #30809.

## Motivation

`fromRheaMessage` calls a private `convertDatesToNumbers` helper at three sites: the message annotations copied into `systemProperties`, the `application_properties` copied into `properties`, and the AMQP message properties copied into `systemProperties`. The conversion is unconditional, so an AMQP `timestamp` application property reaches the caller as a number.

The Azure Portal consumes this package to render received events. Without the option, the Portal shows a raw UNIX timestamp where the .NET SDK and the Service Bus JS SDK both show a date. The reporter asked for the same escape hatch that `@azure/service-bus` provides.

## Changes

- Added `skipConvertingDate?: boolean` to the public `SubscribeOptions`, with the TSDoc wording used by `@azure/service-bus`.
- Added the same option to the internal `PartitionReceiverOptions`, and to the option list in the interface doc comment.
- Added a third optional parameter `skipConvertingDate` to the internal `fromRheaMessage`, which defaults to `false`. When it is `true`, the function skips all three `convertDatesToNumbers` calls.
- Threaded the option from `PartitionPump` into `createReceiver`, and from `PartitionReceiverOptions` into `fromRheaMessage`. `CommonEventProcessorOptions` picks the key up from `SubscribeOptions` automatically.
- Regenerated `review/event-hubs-node.api.md`.
- Bumped the unreleased version from 6.0.5 to 6.1.0, because the change adds a public API member.

The default stays `false`, so the current behavior does not change. The option covers the application properties and both `systemProperties` sources, which matches the Service Bus scope. `enqueuedTimeUtc`, `lastEnqueuedTime`, and `retrievalTime` stay `Date` objects in both modes.

## Test plan

- `eventdata.spec.ts`: a new test builds a rhea message with `Date` values at the top level, in a nested object, in an array, in the message annotations, and in `creation_time`. It asserts that `skipConvertingDate: true` keeps every one of them a `Date`, then asserts that the default call on the same message still returns numbers.
- `partitionPump.spec.ts`: two new tests assert that `PartitionPump` passes `skipConvertingDate` to `createReceiver`, and that the field stays `undefined` when the option is not set. Removing the line from `partitionPump.ts` makes the first test fail.
- `eventHubConsumerClientUnitTests.spec.ts`: two new tests assert that `subscribe()` passes the option through to the event processor options, and that it stays unset when the caller omits it.
- `test/public/eventData.spec.ts`: two new live tests send an event that carries a top level `Date` application property and a nested `Date` application property, then receive it through `subscribe`. The first test asserts that the default returns numbers. The second test asserts that `skipConvertingDate: true` returns `Date` objects with the same time value. These tests run against the mock hub in mock mode and against a real Event Hubs namespace in live mode.

## Validation

Run from `sdk/eventhub/event-hubs`.

- `npm run build`: passes. The API report diff adds one line.
- `npm run lint`: 0 errors. The 46 warnings are pre-existing.
- `npm run check-format`: passes with no listed files.
- `npm run test:node`: 430 passed, 30 skipped, 0 failed, across 38 test files.
- `test/public/eventData.spec.ts` in live mode against a real Event Hubs namespace: 4 passed, 0 failed. Removing the `skipConvertingDate` line from `partitionPump.ts` makes the live test fail, so the test is not vacuous.

