### PR TITLE
Upgrade ESLint v9 → v10 (+ typescript-eslint 8.65, pnpm catalog cleanup)

### DIFF
--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -68,7 +68,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^10.0.1",
     "@types/express": "^5.0.1",
     "@types/express-serve-static-core": "^5.0.6",
     "@types/minimist": "^1.2.5",
@@ -82,7 +82,7 @@
     "eslint": "catalog:",
     "mkdirp": "^3.0.1",
     "rimraf": "catalog:",
-    "typescript-eslint": "~8.60.0",
+    "typescript-eslint": "~8.65.0",
     "vitest": "catalog:testing"
   }
 }

--- a/common/tools/dev-tool/package.json
+++ b/common/tools/dev-tool/package.json
@@ -68,7 +68,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "catalog:",
     "@types/express": "^5.0.1",
     "@types/express-serve-static-core": "^5.0.6",
     "@types/minimist": "^1.2.5",
@@ -82,7 +82,7 @@
     "eslint": "catalog:",
     "mkdirp": "^3.0.1",
     "rimraf": "catalog:",
-    "typescript-eslint": "~8.65.0",
+    "typescript-eslint": "catalog:",
     "vitest": "catalog:testing"
   }
 }

--- a/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
+++ b/common/tools/dev-tool/src/commands/samples/checkNodeVersions.ts
@@ -149,7 +149,7 @@ async function createDockerContextDirectory(
   }
   const envFileName = path.basename(envPath);
   await cp(samplesPath, path.join(dockerContextDirectory, "samples"), { recursive: true });
-  let artifactURL: string | undefined = undefined;
+  let artifactURL: string | undefined;
   try {
     await access(artifactPath);
     const artifactName = path.basename(artifactPath);

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -80,8 +80,7 @@
   },
   "dependencies": {
     "@eslint/compat": "^2.0.1",
-    "@eslint/js": "^10.0.1",
-    "@types/eslint": "^9.6.0",
+    "@eslint/js": "catalog:",
     "@types/estree": "~1.0.0",
     "@typescript-eslint/typescript-estree": "~8.65.0",
     "eslint-config-prettier": "^10.0.1",
@@ -89,11 +88,9 @@
     "js-yaml": "^4.1.1",
     "tslib": "^2.6.2",
     "typescript": "~6.0.2",
-    "typescript-eslint": "~8.65.0"
+    "typescript-eslint": "catalog:"
   },
   "devDependencies": {
-    "@types/eslint": "^9.6.0",
-    "@types/eslint-config-prettier": "6.11.3",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "catalog:",
     "@typescript-eslint/eslint-plugin": "~8.65.0",

--- a/common/tools/eslint-plugin-azure-sdk/package.json
+++ b/common/tools/eslint-plugin-azure-sdk/package.json
@@ -64,42 +64,42 @@
     "update-snippets": "echo skipped"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "prettier": "./prettier.json",
   "peerDependencies": {
     "@eslint/eslintrc": "^3.2.0",
-    "@typescript-eslint/eslint-plugin": "~8.60.0",
-    "@typescript-eslint/parser": "~8.60.0",
-    "eslint": "^9.22.0",
+    "@typescript-eslint/eslint-plugin": "~8.65.0",
+    "@typescript-eslint/parser": "~8.65.0",
+    "eslint": "^10.0.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-n": "^17.15.0",
     "eslint-plugin-no-only-tests": "^3.3.0",
-    "eslint-plugin-promise": "^7.2.1",
+    "eslint-plugin-promise": "^7.3.0",
     "eslint-plugin-tsdoc": "^0.5.0"
   },
   "dependencies": {
     "@eslint/compat": "^2.0.1",
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^10.0.1",
     "@types/eslint": "^9.6.0",
     "@types/estree": "~1.0.0",
-    "@typescript-eslint/typescript-estree": "~8.60.0",
+    "@typescript-eslint/typescript-estree": "~8.65.0",
     "eslint-config-prettier": "^10.0.1",
     "glob": "^13.0.0",
     "js-yaml": "^4.1.1",
     "tslib": "^2.6.2",
     "typescript": "~6.0.2",
-    "typescript-eslint": "~8.60.0"
+    "typescript-eslint": "~8.65.0"
   },
   "devDependencies": {
     "@types/eslint": "^9.6.0",
     "@types/eslint-config-prettier": "6.11.3",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "catalog:",
-    "@typescript-eslint/eslint-plugin": "~8.60.0",
-    "@typescript-eslint/parser": "~8.60.0",
-    "@typescript-eslint/rule-tester": "~8.60.0",
-    "@typescript-eslint/utils": "~8.60.0",
+    "@typescript-eslint/eslint-plugin": "~8.65.0",
+    "@typescript-eslint/parser": "~8.65.0",
+    "@typescript-eslint/rule-tester": "~8.65.0",
+    "@typescript-eslint/utils": "~8.65.0",
     "@vitest/coverage-istanbul": "catalog:testing",
     "cross-env": "catalog:",
     "eslint": "catalog:",

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/eslint-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/eslint-customized.ts
@@ -38,6 +38,12 @@ const rules: Record<string, SharedConfig.RuleEntry> = {
   "preserve-caught-error": "warn",
   "no-useless-assignment": "warn",
   "no-unassigned-vars": "warn",
+  // ESLint v10 flipped this rule's `reportGlobalThis` option default from
+  // false -> true, so it now flags `declare const globalThis` ambient
+  // TypeScript declarations (used to narrowly type `globalThis.*` without
+  // pulling in full lib types) as shadowing a restricted name. Restore the
+  // v9 behavior for globalThis while keeping the rest of the rule active.
+  "no-shadow-restricted-names": ["error", { reportGlobalThis: false }],
 };
 
 export default {

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/eslint-customized.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/eslint-customized.ts
@@ -30,6 +30,14 @@ const rules: Record<string, SharedConfig.RuleEntry> = {
   "no-redeclare": "off",
   "no-shadow": "off",
   "no-param-reassign": ["warn", { props: false }],
+  // ESLint v10 turned these three rules on by default in eslint:recommended.
+  // Downgrade them to "warn" so the v9 -> v10 upgrade does not break `lint`
+  // across the entire repo at once. They stay visible (matching the
+  // no-param-reassign precedent above) and can be promoted back to "error"
+  // once existing violations are cleaned up repo-wide.
+  "preserve-caught-error": "warn",
+  "no-useless-assignment": "warn",
+  "no-unassigned-vars": "warn",
 };
 
 export default {

--- a/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/configs/index.ts
@@ -85,6 +85,9 @@ export default (plugin: FlatConfig.Plugin) => ({
     {
       rules: {
         "@typescript-eslint/no-unused-vars": "off",
+        "preserve-caught-error": "warn",
+        "no-useless-assignment": "warn",
+        "no-unassigned-vars": "warn",
         "@azure/azure-sdk/github-source-headers": "warn",
         "@azure/azure-sdk/ts-apisurface-standardized-verbs": "off",
         "@azure/azure-sdk/ts-apisurface-supportcancellation": "off",

--- a/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/common/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -149,7 +149,7 @@ export const getVerifiers = (
         fix: (fixer: TSESLint.RuleFixer): TSESLint.RuleFix =>
           fixer.replaceText(
             nodeValue,
-            typeof expected === "string" ? `"${expected}"` : (expected as string),
+            typeof expected === "string" ? `"${expected}"` : String(expected),
           ),
       });
     }
@@ -218,7 +218,7 @@ export const getVerifiers = (
         fix: (fixer: TSESLint.RuleFixer): TSESLint.RuleFix =>
           fixer.replaceText(
             nodeValue,
-            typeof expected === "string" ? `"${expected}"` : (expected as string),
+            typeof expected === "string" ? `"${expected}"` : String(expected),
           ),
       });
     }

--- a/common/tools/vite-plugin-browser-test-map/package.json
+++ b/common/tools/vite-plugin-browser-test-map/package.json
@@ -47,12 +47,12 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "typescript": "catalog:",
-    "typescript-eslint": "~8.65.0"
+    "typescript-eslint": "catalog:"
   }
 }

--- a/common/tools/vite-plugin-browser-test-map/package.json
+++ b/common/tools/vite-plugin-browser-test-map/package.json
@@ -47,12 +47,12 @@
     "tslib": "^2.2.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "typescript": "catalog:",
-    "typescript-eslint": "~8.60.0"
+    "typescript-eslint": "~8.65.0"
   }
 }

--- a/common/tools/warp/package.json
+++ b/common/tools/warp/package.json
@@ -38,13 +38,13 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "rimraf": "catalog:",
     "tslib": "^2.8.1",
-    "typescript-eslint": "~8.65.0",
+    "typescript-eslint": "catalog:",
     "vitest": "catalog:testing"
   },
   "files": [

--- a/common/tools/warp/package.json
+++ b/common/tools/warp/package.json
@@ -38,13 +38,13 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "rimraf": "catalog:",
     "tslib": "^2.8.1",
-    "typescript-eslint": "~8.60.0",
+    "typescript-eslint": "~8.65.0",
     "vitest": "catalog:testing"
   },
   "files": [

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.24.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^22.0.0",
     "@vitest/coverage-istanbul": "^4.0.0",
     "eslint": "^9.9.0",
@@ -43,7 +43,7 @@
     "rimraf": "catalog:",
     "tsx": "^4.17.0",
     "typescript": "~6.0.2",
-    "typescript-eslint": "~8.60.0",
+    "typescript-eslint": "~8.65.0",
     "vitest": "^4.0.0"
   },
   "scripts": {

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "catalog:",
     "@types/node": "^22.0.0",
     "@vitest/coverage-istanbul": "^4.0.0",
     "eslint": "^9.9.0",
@@ -43,7 +43,7 @@
     "rimraf": "catalog:",
     "tsx": "^4.17.0",
     "typescript": "~6.0.2",
-    "typescript-eslint": "~8.65.0",
+    "typescript-eslint": "catalog:",
     "vitest": "^4.0.0"
   },
   "scripts": {

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -37,7 +37,7 @@
     "@eslint/js": "catalog:",
     "@types/node": "^22.0.0",
     "@vitest/coverage-istanbul": "^4.0.0",
-    "eslint": "^9.9.0",
+    "eslint": "catalog:",
     "pino-pretty": "^13.1.1",
     "prettier": "catalog:",
     "rimraf": "catalog:",

--- a/eng/tools/ci-runner/package.json
+++ b/eng/tools/ci-runner/package.json
@@ -10,7 +10,7 @@
     "test": "vitest"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^22.0.0",
     "@vitest/coverage-istanbul": "^4.0.0",
     "eslint": "^9.9.0",

--- a/eng/tools/ci-runner/package.json
+++ b/eng/tools/ci-runner/package.json
@@ -13,7 +13,7 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.0.0",
     "@vitest/coverage-istanbul": "^4.0.0",
-    "eslint": "^9.9.0",
+    "eslint": "^10.8.0",
     "prettier": "^3.6.2",
     "vitest": "^4.0.0",
     "typescript": "~6.0.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "turbo": "^2.8.9"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.13"
   },
   "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ catalogs:
       specifier: ^10.1.0
       version: 10.1.0
     eslint:
-      specifier: ^10.3.0
+      specifier: ^10.8.0
       version: 10.8.0
     prettier:
       specifier: ^3.9.1
@@ -440,7 +440,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: 'catalog:'
-        version: 10.0.1(eslint@9.39.5)
+        version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.1
@@ -448,8 +448,8 @@ importers:
         specifier: ^4.0.0
         version: 4.1.10(vitest@4.1.10)
       eslint:
-        specifier: ^9.9.0
-        version: 9.39.5
+        specifier: 'catalog:'
+        version: 10.8.0
       pino-pretty:
         specifier: ^13.1.1
         version: 13.1.3
@@ -467,7 +467,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.65.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -36351,25 +36351,13 @@ packages:
       eslint:
         optional: true
 
-  '@eslint/config-array@0.21.2':
-    resolution: {integrity: sha1-8p4iBXrVMWzyODbO6aNMgf/8t+Y=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha1-G9AGzut+LlWyt3OrMY0wDhpmrto=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/config-helpers@0.7.0':
     resolution: {integrity: sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha1-dyJYIEE9lhdQnak0IZCiAZ54dhw=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@1.2.1':
     resolution: {integrity: sha1-wdp80bgvqHh/mLVin7gRhIobY84=}
@@ -36388,21 +36376,9 @@ packages:
       eslint:
         optional: true
 
-  '@eslint/js@9.39.5':
-    resolution: {integrity: sha1-by+8/3VQDSKdU14KlJrhNHLIR4c=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha1-biEmoTR+hqTe34cG7Gf/jhB+u60=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha1-iOm/TRHSsZwILnjr586IckpesJE=}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha1-l3nj/Zt+4zVxpXQ1z0M1oXlKbLI=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha1-Swli8/LHzovJiz7P40UlwJ0styk=}
@@ -38907,10 +38883,6 @@ packages:
   eslint-plugin-tsdoc@0.5.2:
     resolution: {integrity: sha1-UUMhDnf//fDfCV9AkNfdP2SUpKI=}
 
-  eslint-scope@8.4.0:
-    resolution: {integrity: sha1-iOZGogf61hQ2/6OetQUUcgBlXII=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-scope@9.1.2:
     resolution: {integrity: sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -38930,16 +38902,6 @@ packages:
   eslint@10.8.0:
     resolution: {integrity: sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  eslint@9.39.5:
-    resolution: {integrity: sha1-Kk48iw91MZbvrpQ8j/qocw/Go/o=}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -43084,11 +43046,6 @@ snapshots:
       eslint: 10.8.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5)':
-    dependencies:
-      eslint: 9.39.5
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/compat@2.1.0(eslint@10.8.0)':
@@ -43096,14 +43053,6 @@ snapshots:
       '@eslint/core': 1.2.1
     optionalDependencies:
       eslint: 10.8.0
-
-  '@eslint/config-array@0.21.2':
-    dependencies:
-      '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
-      minimatch: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@eslint/config-array@0.23.5':
     dependencies:
@@ -43113,17 +43062,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.2':
-    dependencies:
-      '@eslint/core': 0.17.0
-
   '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
-
-  '@eslint/core@0.17.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
 
   '@eslint/core@1.2.1':
     dependencies:
@@ -43147,20 +43088,7 @@ snapshots:
     optionalDependencies:
       eslint: 10.8.0
 
-  '@eslint/js@10.0.1(eslint@9.39.5)':
-    optionalDependencies:
-      eslint: 9.39.5
-
-  '@eslint/js@9.39.5': {}
-
-  '@eslint/object-schema@2.1.7': {}
-
   '@eslint/object-schema@3.0.5': {}
-
-  '@eslint/plugin-kit@0.4.1':
-    dependencies:
-      '@eslint/core': 0.17.0
-      levn: 0.4.1
 
   '@eslint/plugin-kit@0.7.2':
     dependencies:
@@ -44732,22 +44660,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.65.0
-      eslint: 9.39.5
-      ignore: 7.0.6
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
@@ -44756,18 +44668,6 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       eslint: 10.8.0
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
-      eslint: 9.39.5
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -44838,18 +44738,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 9.39.5
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/types@8.56.1': {}
 
   '@typescript-eslint/types@8.60.1': {}
@@ -44904,17 +44792,6 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       eslint: 10.8.0
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.65.0(eslint@9.39.5)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
-      '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      eslint: 9.39.5
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -46056,11 +45933,6 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-scope@8.4.0:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -46104,45 +45976,6 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       minimatch: 10.2.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@9.39.5:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6
-      '@eslint/js': 9.39.5
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -49024,17 +48857,6 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       eslint: 10.8.0
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typescript-eslint@8.65.0(eslint@9.39.5)(typescript@6.0.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
-      eslint: 9.39.5
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ catalogs:
       specifier: ^10.1.0
       version: 10.1.0
     eslint:
-      specifier: ^9.39.1
-      version: 9.39.5
+      specifier: ^10.3.0
+      version: 10.8.0
     prettier:
       specifier: ^3.9.1
       version: 3.9.6
@@ -198,8 +198,8 @@ importers:
         version: 2.9.0
     devDependencies:
       '@eslint/js':
-        specifier: ^9.9.0
-        version: 9.39.5
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.0)
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.6
@@ -232,7 +232,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -240,8 +240,8 @@ importers:
         specifier: 'catalog:'
         version: 6.1.3
       typescript-eslint:
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: catalog:testing
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -250,13 +250,13 @@ importers:
     dependencies:
       '@eslint/compat':
         specifier: ^2.0.1
-        version: 2.1.0(eslint@9.39.5)
+        version: 2.1.0(eslint@10.8.0)
       '@eslint/eslintrc':
         specifier: ^3.2.0
         version: 3.3.6
       '@eslint/js':
-        specifier: ^9.9.0
-        version: 9.39.5
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.0)
       '@types/eslint':
         specifier: ^9.6.0
         version: 9.6.1
@@ -264,23 +264,23 @@ importers:
         specifier: ~1.0.0
         version: 1.0.9
       '@typescript-eslint/typescript-estree':
-        specifier: ~8.60.0
-        version: 8.60.1(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(typescript@6.0.3)
       eslint-config-prettier:
         specifier: ^10.0.1
-        version: 10.1.8(eslint@9.39.5)
+        version: 10.1.8(eslint@10.8.0)
       eslint-plugin-n:
         specifier: ^17.15.0
-        version: 17.24.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 17.24.0(eslint@10.8.0)(typescript@6.0.3)
       eslint-plugin-no-only-tests:
         specifier: ^3.3.0
         version: 3.4.0
       eslint-plugin-promise:
-        specifier: ^7.2.1
-        version: 7.3.0(eslint@9.39.5)
+        specifier: ^7.3.0
+        version: 7.3.0(eslint@10.8.0)
       eslint-plugin-tsdoc:
         specifier: ^0.5.0
-        version: 0.5.2(eslint@9.39.5)(typescript@6.0.3)
+        version: 0.5.2(eslint@10.8.0)(typescript@6.0.3)
       glob:
         specifier: ^13.0.0
         version: 13.0.6
@@ -294,8 +294,8 @@ importers:
         specifier: ~6.0.2
         version: 6.0.3
       typescript-eslint:
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
     devDependencies:
       '@microsoft/warp':
         specifier: workspace:^
@@ -310,17 +310,17 @@ importers:
         specifier: 'catalog:'
         version: 22.20.1
       '@typescript-eslint/eslint-plugin':
-        specifier: ~8.60.0
-        version: 8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       '@typescript-eslint/rule-tester':
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       '@typescript-eslint/utils':
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       '@vitest/coverage-istanbul':
         specifier: catalog:testing
         version: 4.1.10(vitest@4.1.10)
@@ -329,10 +329,10 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -353,14 +353,14 @@ importers:
         version: 2.8.1
     devDependencies:
       '@eslint/js':
-        specifier: ^9.9.0
-        version: 9.39.5
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: ^3.3.3
         version: 3.9.6
@@ -371,8 +371,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       typescript-eslint:
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
 
   common/tools/warp:
     dependencies:
@@ -390,14 +390,14 @@ importers:
         version: 2.9.0
     devDependencies:
       '@eslint/js':
-        specifier: ^9.9.0
-        version: 9.39.5
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -408,8 +408,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       typescript-eslint:
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: catalog:testing
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -439,8 +439,8 @@ importers:
         version: 2.8.1
     devDependencies:
       '@eslint/js':
-        specifier: ^9.24.0
-        version: 9.39.5
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@9.39.5)
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.1
@@ -466,8 +466,8 @@ importers:
         specifier: ~6.0.2
         version: 6.0.3
       typescript-eslint:
-        specifier: ~8.60.0
-        version: 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+        specifier: ~8.65.0
+        version: 8.65.0(eslint@9.39.5)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -528,7 +528,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -607,7 +607,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -686,7 +686,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -856,7 +856,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -965,7 +965,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1086,7 +1086,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1168,7 +1168,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -1241,7 +1241,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -1314,7 +1314,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -1503,7 +1503,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       magic-string:
         specifier: ^0.30.8
         version: 0.30.21
@@ -1561,7 +1561,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -1640,7 +1640,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -1807,7 +1807,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       nock:
         specifier: catalog:testing
         version: 13.5.6
@@ -1862,7 +1862,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -1935,7 +1935,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2014,7 +2014,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2087,7 +2087,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2166,7 +2166,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2245,7 +2245,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2391,7 +2391,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2470,7 +2470,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2613,7 +2613,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2695,7 +2695,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2780,7 +2780,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -2987,7 +2987,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3066,7 +3066,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3273,7 +3273,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3352,7 +3352,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3507,7 +3507,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3604,7 +3604,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3695,7 +3695,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -3780,7 +3780,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3859,7 +3859,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -3938,7 +3938,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4017,7 +4017,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4090,7 +4090,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4169,7 +4169,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4248,7 +4248,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4388,7 +4388,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4467,7 +4467,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4552,7 +4552,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4649,7 +4649,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4704,7 +4704,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -4777,7 +4777,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4850,7 +4850,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -4993,7 +4993,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5081,7 +5081,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5184,7 +5184,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       inherits:
         specifier: ^2.0.3
         version: 2.0.4
@@ -5278,7 +5278,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5357,7 +5357,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -5448,7 +5448,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5545,7 +5545,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5627,7 +5627,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5721,7 +5721,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5815,7 +5815,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5909,7 +5909,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -5997,7 +5997,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6091,7 +6091,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6179,7 +6179,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6273,7 +6273,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6364,7 +6364,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6446,7 +6446,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6525,7 +6525,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6598,7 +6598,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6750,7 +6750,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6823,7 +6823,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6902,7 +6902,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -6981,7 +6981,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7060,7 +7060,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7139,7 +7139,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7218,7 +7218,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7288,7 +7288,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -7364,7 +7364,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7443,7 +7443,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7592,7 +7592,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7671,7 +7671,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7750,7 +7750,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7829,7 +7829,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7911,7 +7911,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -7957,7 +7957,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -8030,7 +8030,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8109,7 +8109,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8188,7 +8188,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8267,7 +8267,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8346,7 +8346,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8425,7 +8425,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8513,7 +8513,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8562,7 +8562,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8650,7 +8650,7 @@ importers:
         version: 4.4.3
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8708,7 +8708,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8778,7 +8778,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8842,7 +8842,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8897,7 +8897,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -8961,7 +8961,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9010,7 +9010,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9080,7 +9080,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9141,7 +9141,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       express:
         specifier: catalog:internal
         version: 5.2.1
@@ -9208,7 +9208,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       express:
         specifier: catalog:internal
         version: 5.2.1
@@ -9266,7 +9266,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9324,7 +9324,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9379,7 +9379,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9434,7 +9434,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9492,7 +9492,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9577,7 +9577,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9671,7 +9671,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       nock:
         specifier: catalog:testing
         version: 13.5.6
@@ -9756,7 +9756,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9835,7 +9835,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -9981,7 +9981,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10060,7 +10060,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10133,7 +10133,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10212,7 +10212,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10291,7 +10291,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10440,7 +10440,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10583,7 +10583,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10662,7 +10662,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10808,7 +10808,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -10887,7 +10887,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11036,7 +11036,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11115,7 +11115,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11258,7 +11258,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11334,7 +11334,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11410,7 +11410,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11489,7 +11489,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11568,7 +11568,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11717,7 +11717,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11799,7 +11799,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -11881,7 +11881,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12170,7 +12170,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12325,7 +12325,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12404,7 +12404,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12553,7 +12553,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12632,7 +12632,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12711,7 +12711,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12793,7 +12793,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12872,7 +12872,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -12951,7 +12951,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13030,7 +13030,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13100,7 +13100,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13182,7 +13182,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13261,7 +13261,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13334,7 +13334,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13407,7 +13407,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13486,7 +13486,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13565,7 +13565,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13644,7 +13644,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13714,7 +13714,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13796,7 +13796,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13875,7 +13875,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -13960,7 +13960,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14009,7 +14009,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -14064,7 +14064,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14152,7 +14152,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14346,7 +14346,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       https-proxy-agent:
         specifier: ^7.0.0
         version: 7.0.6
@@ -14413,7 +14413,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -14504,7 +14504,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14598,7 +14598,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14656,7 +14656,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14735,7 +14735,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14814,7 +14814,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -14890,7 +14890,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15033,7 +15033,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15188,7 +15188,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       magic-string:
         specifier: ~0.30.10
         version: 0.30.21
@@ -15246,7 +15246,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -15319,7 +15319,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15462,7 +15462,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15541,7 +15541,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15620,7 +15620,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15699,7 +15699,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15778,7 +15778,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15857,7 +15857,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -15936,7 +15936,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16015,7 +16015,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16097,7 +16097,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16176,7 +16176,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16255,7 +16255,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16404,7 +16404,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16568,7 +16568,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       jsonwebtoken:
         specifier: ^9.0.0
         version: 9.0.3
@@ -16650,7 +16650,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -16720,7 +16720,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16769,7 +16769,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -16830,7 +16830,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16909,7 +16909,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -16988,7 +16988,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17131,7 +17131,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17201,7 +17201,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17350,7 +17350,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17429,7 +17429,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17578,7 +17578,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17657,7 +17657,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17818,7 +17818,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17909,7 +17909,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -17961,7 +17961,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -18022,7 +18022,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18110,7 +18110,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18159,7 +18159,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -18241,7 +18241,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18293,7 +18293,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -18436,7 +18436,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18509,7 +18509,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18588,7 +18588,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18667,7 +18667,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18746,7 +18746,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18825,7 +18825,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -18974,7 +18974,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -19123,7 +19123,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -19202,7 +19202,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -19281,7 +19281,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -19470,7 +19470,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -19546,7 +19546,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -19616,7 +19616,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -19951,7 +19951,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20283,7 +20283,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20432,7 +20432,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20511,7 +20511,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20590,7 +20590,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20733,7 +20733,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20797,7 +20797,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20879,7 +20879,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -20961,7 +20961,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21046,7 +21046,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21131,7 +21131,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21216,7 +21216,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21359,7 +21359,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21706,7 +21706,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21785,7 +21785,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -21864,7 +21864,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22001,7 +22001,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22080,7 +22080,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22171,7 +22171,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22223,7 +22223,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -22362,7 +22362,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -22459,7 +22459,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       nock:
         specifier: catalog:testing
         version: 13.5.6
@@ -22517,7 +22517,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -22608,7 +22608,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22699,7 +22699,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22775,7 +22775,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -22921,7 +22921,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23000,7 +23000,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23079,7 +23079,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23158,7 +23158,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23307,7 +23307,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23386,7 +23386,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23465,7 +23465,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23544,7 +23544,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23623,7 +23623,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23702,7 +23702,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23781,7 +23781,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23930,7 +23930,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -23997,7 +23997,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24076,7 +24076,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       openai:
         specifier: ^6.16.0
         version: 6.49.0(ws@8.21.1)(zod@3.25.76)
@@ -24164,7 +24164,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24310,7 +24310,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24459,7 +24459,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24532,7 +24532,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24611,7 +24611,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24690,7 +24690,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24769,7 +24769,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24848,7 +24848,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -24921,7 +24921,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25064,7 +25064,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25201,7 +25201,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25347,7 +25347,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25411,7 +25411,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -25487,7 +25487,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25627,7 +25627,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25700,7 +25700,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25779,7 +25779,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25858,7 +25858,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -25937,7 +25937,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26010,7 +26010,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26089,7 +26089,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26168,7 +26168,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26247,7 +26247,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26317,7 +26317,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26393,7 +26393,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26472,7 +26472,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26554,7 +26554,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26630,7 +26630,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -26931,7 +26931,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27010,7 +27010,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27089,7 +27089,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27168,7 +27168,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27250,7 +27250,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27329,7 +27329,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27408,7 +27408,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27487,7 +27487,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27566,7 +27566,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27645,7 +27645,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27724,7 +27724,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27797,7 +27797,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -27870,7 +27870,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28013,7 +28013,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28092,7 +28092,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28235,7 +28235,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28314,7 +28314,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28393,7 +28393,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28469,7 +28469,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28557,7 +28557,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28618,7 +28618,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -28694,7 +28694,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28846,7 +28846,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -28922,7 +28922,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       openai:
         specifier: ^6.16.0
         version: 6.49.0(ws@8.21.1)(zod@4.4.3)
@@ -28980,7 +28980,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -29053,7 +29053,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29202,7 +29202,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29281,7 +29281,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29354,7 +29354,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29497,7 +29497,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29636,7 +29636,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       events:
         specifier: ^3.0.0
         version: 3.3.0
@@ -29697,7 +29697,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -29770,7 +29770,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29852,7 +29852,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -29931,7 +29931,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30074,7 +30074,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30223,7 +30223,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30302,7 +30302,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30381,7 +30381,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30600,7 +30600,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30679,7 +30679,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30758,7 +30758,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -30837,7 +30837,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31010,7 +31010,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31104,7 +31104,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31156,7 +31156,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -31220,7 +31220,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31323,7 +31323,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31372,7 +31372,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -31469,7 +31469,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31518,7 +31518,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -31570,7 +31570,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31667,7 +31667,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31752,7 +31752,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31831,7 +31831,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -31910,7 +31910,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32065,7 +32065,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32144,7 +32144,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32427,7 +32427,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32570,7 +32570,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32713,7 +32713,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32789,7 +32789,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32871,7 +32871,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -32947,7 +32947,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33017,7 +33017,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33090,7 +33090,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33181,7 +33181,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33230,7 +33230,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -33303,7 +33303,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33376,7 +33376,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33428,7 +33428,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -33556,7 +33556,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33635,7 +33635,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33693,7 +33693,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -33748,7 +33748,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       express:
         specifier: catalog:internal
         version: 5.2.1
@@ -33815,7 +33815,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33882,7 +33882,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -33967,7 +33967,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34019,7 +34019,7 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
@@ -34156,7 +34156,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34229,7 +34229,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34317,7 +34317,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34393,7 +34393,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34475,7 +34475,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34548,7 +34548,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -34776,7 +34776,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       microsoft-cognitiveservices-speech-sdk:
         specifier: ^1.47.0
         version: 1.51.0
@@ -34931,7 +34931,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -35019,7 +35019,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -35098,7 +35098,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -35171,7 +35171,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       move-file-cli:
         specifier: ^3.0.0
         version: 3.0.0
@@ -35241,7 +35241,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       express:
         specifier: catalog:internal
         version: 5.2.1
@@ -35326,7 +35326,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -35475,7 +35475,7 @@ importers:
         version: 16.6.1
       eslint:
         specifier: 'catalog:'
-        version: 9.39.5
+        version: 10.8.0
       playwright:
         specifier: catalog:testing
         version: 1.62.0
@@ -36355,9 +36355,17 @@ packages:
     resolution: {integrity: sha1-8p4iBXrVMWzyODbO6aNMgf/8t+Y=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/config-helpers@0.4.2':
     resolution: {integrity: sha1-G9AGzut+LlWyt3OrMY0wDhpmrto=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha1-Ce5KoHtz8FnsLUx0v0sv8CsyI3c=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@0.17.0':
     resolution: {integrity: sha1-dyJYIEE9lhdQnak0IZCiAZ54dhw=}
@@ -36371,6 +36379,15 @@ packages:
     resolution: {integrity: sha1-0iv9azp9jh8sCy8ubeERtT7G4T4=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha1-HoqHb1ARevirZ+R9WtlNONZiJYM=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
   '@eslint/js@9.39.5':
     resolution: {integrity: sha1-by+8/3VQDSKdU14KlJrhNHLIR4c=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -36379,9 +36396,17 @@ packages:
     resolution: {integrity: sha1-biEmoTR+hqTe34cG7Gf/jhB+u60=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha1-iOm/TRHSsZwILnjr586IckpesJE=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha1-l3nj/Zt+4zVxpXQ1z0M1oXlKbLI=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha1-Swli8/LHzovJiz7P40UlwJ0styk=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha1-/bCIenr1GrqujBgp6AmdNPjd0wI=}
@@ -37707,6 +37732,9 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha1-1Xla1zLOgXFfJ/ddqRMASlZ1FYQ=}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=}
 
@@ -37855,16 +37883,16 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha1-BwE+RqpNfX1QpJ4VYEwcU0DU6yQ=}
 
-  '@typescript-eslint/eslint-plugin@8.60.1':
-    resolution: {integrity: sha1-wQYLuPpL6AYk0/PeyN2crKNzr3Y=}
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.60.1
+      '@typescript-eslint/parser': ^8.65.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.60.1':
-    resolution: {integrity: sha1-qdfzCFA4TTS0H0aH3YlEgjwJ4ok=}
+  '@typescript-eslint/parser@8.65.0':
+    resolution: {integrity: sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -37876,14 +37904,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.60.1':
-    resolution: {integrity: sha1-6ylxL1jXLCIvxycWLpLyq0Zwlxs=}
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/rule-tester@8.60.1':
-    resolution: {integrity: sha1-ei1OjPhgDST8wxy29t55Fjnraog=}
+  '@typescript-eslint/rule-tester@8.65.0':
+    resolution: {integrity: sha1-Fv18FfQ1ILdXDhrgdkYYTm7bspA=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -37893,8 +37921,8 @@ packages:
     resolution: {integrity: sha1-JU35O1eJqHE1EzXdI+ILwWQGDyQ=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.60.1':
-    resolution: {integrity: sha1-L4dZYuqtCgeJzDw2rqm03est2cg=}
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -37909,8 +37937,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.60.1':
-    resolution: {integrity: sha1-GuRfDypwE1S+6kpYwhYeQKXjw3k=}
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -37924,14 +37958,18 @@ packages:
     resolution: {integrity: sha1-zNxIK6nhf5cjoQziQLXmfa0wRsQ=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.56.1':
     resolution: {integrity: sha1-O55X2BKahgxQhkxCGI92G97z6rA=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/typescript-estree@8.60.1':
-    resolution: {integrity: sha1-AWYwsRkii/SD3cZScDpqA48/3XQ=}
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -37943,8 +37981,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.60.1':
-    resolution: {integrity: sha1-Mc9WYJVgLZ/orZGDfS61ILjedis=}
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -37954,8 +37992,8 @@ packages:
     resolution: {integrity: sha1-UOA0dcM6QtEj3JnmOs8YQcAjH4c=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.60.1':
-    resolution: {integrity: sha1-Fl0diQETe5RO+vGPAKtey1fwaZU=}
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typespec/ts-http-runtime@0.3.7':
@@ -38879,6 +38917,10 @@ packages:
     resolution: {integrity: sha1-iOZGogf61hQ2/6OetQUUcgBlXII=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -38890,6 +38932,16 @@ packages:
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.8.0:
+    resolution: {integrity: sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   eslint@9.39.5:
     resolution: {integrity: sha1-Kk48iw91MZbvrpQ8j/qocw/Go/o=}
@@ -38904,6 +38956,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha1-1U9JSdRikAWh+haNk3w/8ffiqDc=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   espree@9.6.1:
     resolution: {integrity: sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=}
@@ -41438,8 +41494,8 @@ packages:
     resolution: {integrity: sha1-C3Dpgsnp2v4t721kWP9LPy0rbXA=}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.60.1:
-    resolution: {integrity: sha1-E9sFxuq7iWad7sRFRbeIoOmu5kA=}
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha1-dUyVP9apo9NvpUAVvbqApusqSVc=}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -43029,6 +43085,11 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0)':
+    dependencies:
+      eslint: 10.8.0
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5)':
     dependencies:
       eslint: 9.39.5
@@ -43036,11 +43097,11 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.1.0(eslint@9.39.5)':
+  '@eslint/compat@2.1.0(eslint@10.8.0)':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 9.39.5
+      eslint: 10.8.0
 
   '@eslint/config-array@0.21.2':
     dependencies:
@@ -43050,9 +43111,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/config-helpers@0.4.2':
     dependencies:
       '@eslint/core': 0.17.0
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
 
   '@eslint/core@0.17.0':
     dependencies:
@@ -43076,13 +43149,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/js@10.0.1(eslint@10.8.0)':
+    optionalDependencies:
+      eslint: 10.8.0
+
+  '@eslint/js@10.0.1(eslint@9.39.5)':
+    optionalDependencies:
+      eslint: 9.39.5
+
   '@eslint/js@9.39.5': {}
 
   '@eslint/object-schema@2.1.7': {}
 
+  '@eslint/object-schema@3.0.5': {}
+
   '@eslint/plugin-kit@0.4.1':
     dependencies:
       '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
       levn: 0.4.1
 
   '@fastify/ajv-compiler@4.0.5':
@@ -44483,6 +44571,8 @@ snapshots:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@5.1.2':
@@ -44639,14 +44729,30 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/type-utils': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.60.1
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 10.8.0
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
       eslint: 9.39.5
       ignore: 7.0.6
       natural-compare: 1.4.0
@@ -44655,12 +44761,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.60.1
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      eslint: 10.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       eslint: 9.39.5
       typescript: 6.0.3
@@ -44669,15 +44787,6 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
-    dependencies:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.60.1
       debug: 4.4.3
@@ -44685,13 +44794,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.60.1(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/rule-tester@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       ajv: 6.15.0
-      eslint: 9.39.5
+      eslint: 10.8.0
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.8.5
@@ -44704,10 +44822,10 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/scope-manager@8.60.1':
+  '@typescript-eslint/scope-manager@8.65.0':
     dependencies:
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/visitor-keys': 8.60.1
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
 
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@6.0.3)':
     dependencies:
@@ -44717,11 +44835,27 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.60.1(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.8.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.5
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -44732,6 +44866,8 @@ snapshots:
   '@typescript-eslint/types@8.56.1': {}
 
   '@typescript-eslint/types@8.60.1': {}
+
+  '@typescript-eslint/types@8.65.0': {}
 
   '@typescript-eslint/typescript-estree@8.56.1(typescript@6.0.3)':
     dependencies:
@@ -44748,12 +44884,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/visitor-keys': 8.60.1
+      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
@@ -44763,23 +44899,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.8.0)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@6.0.3)
-      eslint: 9.39.5
+      eslint: 10.8.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.60.1(eslint@9.39.5)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.65.0(eslint@10.8.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      eslint: 10.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@9.39.5)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
-      '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       eslint: 9.39.5
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -44790,9 +44937,9 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.60.1':
+  '@typescript-eslint/visitor-keys@8.65.0':
     dependencies:
-      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
   '@typespec/ts-http-runtime@0.3.7':
@@ -45827,14 +45974,14 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.39.5):
+  eslint-compat-utils@0.5.1(eslint@10.8.0):
     dependencies:
-      eslint: 9.39.5
+      eslint: 10.8.0
       semver: 7.8.5
 
-  eslint-config-prettier@10.1.8(eslint@9.39.5):
+  eslint-config-prettier@10.1.8(eslint@10.8.0):
     dependencies:
-      eslint: 9.39.5
+      eslint: 10.8.0
 
   eslint-import-resolver-node@0.3.10:
     dependencies:
@@ -45844,24 +45991,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
-      eslint: 9.39.5
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es-x@7.8.0(eslint@9.39.5):
+  eslint-plugin-es-x@7.8.0(eslint@10.8.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.5
-      eslint-compat-utils: 0.5.1(eslint@9.39.5)
+      eslint: 10.8.0
+      eslint-compat-utils: 0.5.1(eslint@10.8.0)
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -45870,9 +46017,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.5
+      eslint: 10.8.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.8.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -45884,18 +46031,18 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-n@17.24.0(eslint@9.39.5)(typescript@6.0.3):
+  eslint-plugin-n@17.24.0(eslint@10.8.0)(typescript@6.0.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
       enhanced-resolve: 5.24.3
-      eslint: 9.39.5
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.5)
+      eslint: 10.8.0
+      eslint-plugin-es-x: 7.8.0(eslint@10.8.0)
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -45907,16 +46054,16 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.4.0: {}
 
-  eslint-plugin-promise@7.3.0(eslint@9.39.5):
+  eslint-plugin-promise@7.3.0(eslint@10.8.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
-      eslint: 9.39.5
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      eslint: 10.8.0
 
-  eslint-plugin-tsdoc@0.5.2(eslint@9.39.5)(typescript@6.0.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.8.0)(typescript@6.0.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -45927,11 +46074,53 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@9.39.5:
     dependencies:
@@ -45977,6 +46166,12 @@ snapshots:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
 
   espree@9.6.1:
     dependencies:
@@ -48835,12 +49030,23 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.60.1(eslint@9.39.5)(typescript@6.0.3):
+  typescript-eslint@8.65.0(eslint@10.8.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@6.0.3))(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0)(typescript@6.0.3)
+      eslint: 10.8.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.65.0(eslint@9.39.5)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
       eslint: 9.39.5
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
   default:
+    '@eslint/js':
+      specifier: ^10.0.1
+      version: 10.0.1
     '@types/node':
       specifier: ^22.0.0
       version: 22.20.1
@@ -46,6 +49,9 @@ catalogs:
     typescript:
       specifier: ~6.0.2
       version: 6.0.3
+    typescript-eslint:
+      specifier: ~8.65.0
+      version: 8.65.0
   internal:
     '@azure/identity':
       specifier: 4.13.0
@@ -198,7 +204,7 @@ importers:
         version: 2.9.0
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 'catalog:'
         version: 10.0.1(eslint@10.8.0)
       '@types/express':
         specifier: ^5.0.1
@@ -240,7 +246,7 @@ importers:
         specifier: 'catalog:'
         version: 6.1.3
       typescript-eslint:
-        specifier: ~8.65.0
+        specifier: 'catalog:'
         version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: catalog:testing
@@ -255,11 +261,8 @@ importers:
         specifier: ^3.2.0
         version: 3.3.6
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 'catalog:'
         version: 10.0.1(eslint@10.8.0)
-      '@types/eslint':
-        specifier: ^9.6.0
-        version: 9.6.1
       '@types/estree':
         specifier: ~1.0.0
         version: 1.0.9
@@ -294,15 +297,12 @@ importers:
         specifier: ~6.0.2
         version: 6.0.3
       typescript-eslint:
-        specifier: ~8.65.0
+        specifier: 'catalog:'
         version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
     devDependencies:
       '@microsoft/warp':
         specifier: workspace:^
         version: link:../warp
-      '@types/eslint-config-prettier':
-        specifier: 6.11.3
-        version: 6.11.3
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -353,7 +353,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 'catalog:'
         version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: 'catalog:'
@@ -371,7 +371,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
       typescript-eslint:
-        specifier: ~8.65.0
+        specifier: 'catalog:'
         version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
 
   common/tools/warp:
@@ -390,7 +390,7 @@ importers:
         version: 2.9.0
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 'catalog:'
         version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: 'catalog:'
@@ -408,7 +408,7 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       typescript-eslint:
-        specifier: ~8.65.0
+        specifier: 'catalog:'
         version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: catalog:testing
@@ -439,7 +439,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 'catalog:'
         version: 10.0.1(eslint@9.39.5)
       '@types/node':
         specifier: ^22.0.0
@@ -466,7 +466,7 @@ importers:
         specifier: ~6.0.2
         version: 6.0.3
       typescript-eslint:
-        specifier: ~8.65.0
+        specifier: 'catalog:'
         version: 8.65.0(eslint@9.39.5)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0
@@ -37726,12 +37726,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha1-M0MRlx06BxIefrkbaEpgXn7qnL0=}
 
-  '@types/eslint-config-prettier@6.11.3':
-    resolution: {integrity: sha1-MZ9T7rWotQ5wL6CBqf45vwHfjB0=}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha1-1Xla1zLOgXFfJ/ddqRMASlZ1FYQ=}
-
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=}
 
@@ -44563,13 +44557,6 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
-
-  '@types/eslint-config-prettier@6.11.3': {}
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
 
   '@types/esrecurse@4.3.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ packages:
   - '!sdk/eventhub/event-hubs/test/stress/**'
 
 catalog:
+  '@eslint/js': ^10.0.1
   '@types/node': ^22.0.0
   autorest: latest
   cross-env: ^10.1.0
@@ -27,6 +28,7 @@ catalog:
   tslib: ^2.8.1
   tsx: ^4.20.4
   typescript: ~6.0.2
+  typescript-eslint: ~8.65.0
 
 catalogs:
   arm:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@types/node': ^22.0.0
   autorest: latest
   cross-env: ^10.1.0
-  eslint: ^10.3.0
+  eslint: ^10.8.0
   prettier: ^3.9.1
   rimraf: ^6.1.0
   tslib: ^2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   '@types/node': ^22.0.0
   autorest: latest
   cross-env: ^10.1.0
-  eslint: ^9.39.1
+  eslint: ^10.3.0
   prettier: ^3.9.1
   rimraf: ^6.1.0
   tslib: ^2.8.1
@@ -58,6 +58,13 @@ overrides:
   '@azure/core-rest-pipeline': 'link:sdk/core/core-rest-pipeline'
   'vitest>vite': ^8.0.0
   '@vitest/mocker>vite': ^8.0.0
+
+# eslint-plugin-import 2.32.0 (latest) caps its eslint peer at ^9, but the only
+# rule we consume (import/no-extraneous-dependencies) works functionally under
+# ESLint 10. Allow it explicitly rather than switching to eslint-plugin-import-x.
+peerDependencyRules:
+  allowedVersions:
+    'eslint-plugin-import>eslint': ^10.0.0
 
 linkWorkspacePackages: true
 

--- a/samples/frameworks/react/ts/package.json
+++ b/samples/frameworks/react/ts/package.json
@@ -36,8 +36,8 @@
     "@types/node": "^22.0.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
-    "@typescript-eslint/eslint-plugin": "~8.60.0",
-    "@typescript-eslint/parser": "~8.60.0",
+    "@typescript-eslint/eslint-plugin": "~8.65.0",
+    "@typescript-eslint/parser": "~8.65.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
     "typescript": "^4.0.3"


### PR DESCRIPTION
## Summary

Upgrades the repo from ESLint **v9 → v10** (latest 10.x, resolves 10.8.0) and bumps `typescript-eslint` / `@typescript-eslint/*` from `~8.60.0` → `~8.65.0`. The repo already uses flat config (`eslint.config.mjs`) via the internal `@azure/eslint-plugin-azure-sdk`, so this is a version-bump + compatibility effort, not a config migration. Follow-up commits tidy up dependency declarations (pnpm catalog + redundant `@types/*`), address review feedback, and fix the real-world v10 lint breaks surfaced by CI.

**Repo-wide lint verified:** `turbo lint --continue` across the whole workspace → **468/468 packages pass, 0 errors** (remaining `✖` are warnings only — the intentionally-downgraded rules).

ESLint version is controlled centrally by the pnpm catalog in `pnpm-workspace.yaml`.

## Commit 1 — ESLint v9 → v10 + typescript-eslint 8.65

- **pnpm catalog**: `eslint ^9.39.1 → ^10.x`.
- `@eslint/js ^9 → ^10.0.1`; `eslint-plugin-promise ^7.2.1 → ^7.3.0` (adds eslint `^10` peer); plugin `peerDependencies.eslint ^9.22.0 → ^10.0.0`.
- `typescript-eslint` / `@typescript-eslint/*` `~8.60.0 → ~8.65.0` across the plugin, tooling packages, and `samples/frameworks/react/ts`.
- **`eslint-plugin-import` peer blocker** (its latest still caps eslint at `^9`) resolved via pnpm `peerDependencyRules.allowedVersions` — only `import/no-extraneous-dependencies` is consumed and it works functionally under v10 (chosen over switching to `eslint-plugin-import-x` for lower risk / zero code change).
- **`engines.node`** tightened to `>=22.13` (root) / `>=22.13.0` (plugin), matching ESLint 10's Node floor.
- **ESLint 10 compat fix** in `src/utils/verifiers.ts`: `RuleFixer.replaceText` now hard-asserts a string, so a lying `(expected as string)` cast was replaced with `String(expected)` (2 fixers).
- **3 new v10 `eslint:recommended` rules** (`preserve-caught-error`, `no-useless-assignment`, `no-unassigned-vars`) downgraded to `"warn"` in `eslint-customized.ts` with a justification comment, so the bump doesn't break `lint` repo-wide at once (mirrors the existing `no-param-reassign` precedent; can be promoted back to `error` after cleanup — tracked in #39423).

**Validation:** plugin build OK; **vitest 703/703 pass**; `@azure/storage-queue` lint **0 errors, 51 warnings**.

## Commit 2 — pnpm catalog cleanup + redundant `@types/*` removal

- Move **`@eslint/js`** and **`typescript-eslint`** into the `pnpm-workspace.yaml` default catalog and reference them via `"catalog:"` in workspace members (`eslint-plugin-azure-sdk`, `dev-tool`, `warp`, `vite-plugin-browser-test-map`, `turborepo-remote-cache`).
- **`eng/tools/ci-runner`** is **not** a pnpm workspace member, so it keeps **direct** versions (a `catalog:` ref would not resolve there). The v7-pinned `js-sdk-release-tools` breaking-change-detector is left untouched.
- Remove 3 redundant `@types/*` devDependencies from `eslint-plugin-azure-sdk` (`@types/eslint` — which was duplicated in both `dependencies` and `devDependencies` — plus `@types/eslint-config-prettier`), now that `eslint@10` and `eslint-config-prettier@10` ship their own bundled type definitions.

## Commit 3 — review feedback: bump the `eslint` runtime to v10 too

- Two packages had `@eslint/js` bumped to v10 but still declared the `eslint` **runtime** at `^9`. Fixed: `turborepo-remote-cache` → `eslint: "catalog:"`; `ci-runner` → direct `eslint: ^10.8.0` (not a workspace member).
- Catalog `eslint` pinned to the latest 10.x (`^10.8.0`); catalog now resolves eslint 10.8.0 everywhere.

## Commit 4 — repo-wide lint fix: `no-useless-assignment` in dev-tool

Broad CI linting surfaced one real v10 error the shared `warn` downgrade did **not** cover: tooling packages (`dev-tool`, `warp`, `turborepo-remote-cache`, `ci-runner`, and the plugin itself) use **standalone** `eslint.config.mjs` files that apply `@eslint/js` `recommended` **directly**, bypassing the shared `eslint-customized.ts` overrides — so the 3 new rules fire as **errors** there, not warnings.

- Fixed the single violation: `common/tools/dev-tool/.../checkNodeVersions.ts` dropped a redundant `= undefined` initializer on `artifactURL` (every code path reassigns or throws before it's read). Lint + `tsc` both clean.
- Audited every standalone-config package in CI lint scope — `warp`, `vite-plugin-browser-test-map`, `turborepo-remote-cache`, and `eslint-plugin-azure-sdk` all lint clean; `dev-tool` was the only error.

## Commit 5 — `no-shadow-restricted-names` now reports `globalThis` (v10 change)

A second CI run surfaced a different v10 behavior change: `no-shadow-restricted-names`'s `reportGlobalThis` option flipped its default from `false` → `true`, so it now flags `declare const globalThis` **ambient TypeScript declarations** (used to narrowly type `globalThis.*` without pulling in full lib types) as shadowing a restricted name. This broke `@typespec/ts-http-runtime` lint (`src/util/uuidUtils.ts` + `uuidUtils-react-native.mts`, 2 errors — the only two such declarations in the repo).

- Restored the v9 behavior in the shared `eslint-customized.ts` via `"no-shadow-restricted-names": ["error", { reportGlobalThis: false }]`, keeping the rest of the rule active (still catches shadowing of `NaN`, `undefined`, `Infinity`, `eval`, `arguments`). This is the fix ESLint's own migration guide documents for the ambient-declaration case.

## Notes

- The 3 new v10 recommended rules are intentionally `warn`, not `off`, for packages on the shared config — they stay visible for later cleanup (#39423).
- The other `[ELIFECYCLE] Command failed` lines in the CI logs were turbo fail-fast casualties (different set each run), not independent errors — confirmed by linting them directly (all pass) and by the full-repo `turbo lint` (468/468).
- No source/runtime behavior changes beyond the `verifiers.ts` compat fix and the dev-tool `artifactURL` cleanup; the rest is dependency + config metadata.

## Commit 6 — review feedback: downgrade the 3 new v10 rules in the `internal` config too

_Copilot agent :copilot: (on behalf of @jeremymeng):_ Review feedback surfaced one more path the shared `eslint-customized.ts` warning downgrades did **not** reach: the `internal` config (in `src/configs/index.ts`) builds its own array that spreads `eslint.configs.recommended` but never includes `eslintCustomized`, so `preserve-caught-error`, `no-useless-assignment`, and `no-unassigned-vars` stayed as **errors** for consumers of `configs.internal` (e.g. `sdk/test-utils/recorder`) — contrary to the repo-wide warning-only migration intent.

- Added the three `"warn"` downgrades directly to the `internal` config's inline `rules` block so it matches the `recommended` config. Scoped to just those three rules; no other restructuring.