### PR TITLE
[identity] Bump @azure/msal-node to ^5.1.5 to drop vulnerable uuid transitive dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16518,7 +16518,7 @@ importers:
         specifier: ^5.5.0
         version: 5.17.1
       '@azure/msal-node':
-        specifier: ^5.1.0
+        specifier: ^5.1.5
         version: 5.4.2
       open:
         specifier: ^11.0.0

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Bumped the minimum `@azure/msal-node` dependency to `^5.1.5` so installs no longer resolve older `5.1.x` versions that pull in the vulnerable `uuid@8.3.0` transitive dependency. [#1512](https://github.com/microsoft/ApplicationInsights-node.js/issues/1512)
+
 ### Other Changes
 
 ## 4.14.0-beta.4 (2026-06-08)

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -93,7 +93,7 @@
     "@azure/core-util": "^1.11.0",
     "@azure/logger": "^1.0.0",
     "@azure/msal-browser": "^5.5.0",
-    "@azure/msal-node": "^5.1.0",
+    "@azure/msal-node": "^5.1.5",
     "open": "^11.0.0",
     "tslib": "^2.2.0"
   },


### PR DESCRIPTION
### Packages impacted by this PR

- `@azure/identity`

### Description

Bumps the minimum `@azure/msal-node` dependency from `^5.1.0` to `^5.1.5` and refreshes the pnpm lockfile so installs resolve msal-node `5.1.5`, which drops the vulnerable `uuid@8.3.0` transitive dependency pulled in by older `5.1.x` releases.

Changes:
- `sdk/identity/identity/package.json` — dependency range bumped to `^5.1.5`
- `sdk/identity/identity/CHANGELOG.md` — Bugs Fixed entry added
- `pnpm-lock.yaml` — regenerated to pin the resolved msal-node version