### PR TITLE
[compute] Update arm-compute-bulkactions 1.0.0-beta.2 release date for release plan 35410

### DIFF
--- a/sdk/compute/arm-compute-bulkactions/CHANGELOG.md
+++ b/sdk/compute/arm-compute-bulkactions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (2026-07-28)
+## 1.0.0-beta.2 (2026-07-30)
 Compared with version 1.0.0-beta.1
 
 ### Features Added

--- a/sdk/compute/arm-compute-bulkactions/CHANGELOG.md
+++ b/sdk/compute/arm-compute-bulkactions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (2026-07-23)
+## 1.0.0-beta.2 (2026-07-28)
 Compared with version 1.0.0-beta.1
 
 ### Features Added


### PR DESCRIPTION
Updates the `@azure/arm-compute-bulkactions` **1.0.0-beta.2** CHANGELOG release date to `2026-07-30` so the release pipeline recognizes a valid planned release date.

This unblocks the first publish of the package (Public Preview) for release plan **35410**. The generation PR (#39351) is already merged; only the changelog release date needs to reflect the planned release day.

No code changes -- changelog date only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>