### PR TITLE
Revert "ci: move browser test leg from Windows to Linux agent (#39397)"

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -39,18 +39,7 @@
         "sample": {
           "TestType": "sample",
           "TestResultsFiles": "**/test-results.xml"
-        }
-      }
-    },
-    {
-      "Agent": {
-        "ubuntu": {
-          "OSVmImage": "env:LINUXVMIMAGE",
-          "Pool": "env:LINUXPOOL"
-        }
-      },
-      "NodeTestVersion": "env:NODE_VERSION_LTS_MAINTENANCE",
-      "Scenario": {
+        },
         "browser": {
           "TestType": "browser",
           "TestResultsFiles": "**/test-results.browser.xml"


### PR DESCRIPTION
This reverts commit 33146627198f3359e186c11dd8f240699d623f30.

It turns out that some pipeline issue is blocking browser live testing: https://github.com/Azure/azure-sdk-for-js/issues/39440
