### PR TITLE
[dev-tool] Only install chromium for browser tests

### DIFF
--- a/common/tools/dev-tool/src/commands/run/testVitest.ts
+++ b/common/tools/dev-tool/src/commands/run/testVitest.ts
@@ -48,15 +48,17 @@ export const commandInfo = makeCommandInfo(
 );
 
 async function playwrightInstall(): Promise<void> {
+  // Our browser tests only run on chromium (see vitest.browser.base.config.ts),
+  // so only install that browser instead of all supported browsers.
   const { result } = concurrently([
     {
-      command: "npx playwright install",
+      command: "npx playwright install chromium",
       name: "playwright install",
     },
   ]);
 
   await result;
-  log.info("playwright browsers installed");
+  log.info("playwright chromium browser installed");
 }
 
 export default leafCommand(commandInfo, async (options) => {

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -161,7 +161,7 @@ jobs:
             pwsh: true
             ScriptType: InlineScript
             Inline: |
-              Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool"
+              Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool" -RedirectStandardOutput "$(Agent.TempDirectory)/browser-relay.out.log" -RedirectStandardError "$(Agent.TempDirectory)/browser-relay.err.log"
               for ($i = 0; $i -lt 10; $i++) {
                   try {
                       Invoke-WebRequest -Uri "http://localhost:4895/health" | Out-Null
@@ -171,6 +171,8 @@ jobs:
                       Start-Sleep 6
                   }
               }
+              if (Test-Path "$(Agent.TempDirectory)/browser-relay.out.log") { Write-Host '----- browser-relay stdout -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.out.log" }
+              if (Test-Path "$(Agent.TempDirectory)/browser-relay.err.log") { Write-Host '----- browser-relay stderr -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.err.log" }
               Write-Error "Could not connect to browser credential relay."
               exit 1
           displayName: "Start browser credential relay"
@@ -182,7 +184,7 @@ jobs:
 
       - ${{ else }}:
         - pwsh: |
-            Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool"
+            Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool" -RedirectStandardOutput "$(Agent.TempDirectory)/browser-relay.out.log" -RedirectStandardError "$(Agent.TempDirectory)/browser-relay.err.log"
             for ($i = 0; $i -lt 10; $i++) {
                 try {
                     Invoke-WebRequest -Uri "http://localhost:4895/health" | Out-Null
@@ -192,6 +194,8 @@ jobs:
                     Start-Sleep 6
                 }
             }
+            if (Test-Path "$(Agent.TempDirectory)/browser-relay.out.log") { Write-Host '----- browser-relay stdout -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.out.log" }
+            if (Test-Path "$(Agent.TempDirectory)/browser-relay.err.log") { Write-Host '----- browser-relay stderr -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.err.log" }
             Write-Error "Could not connect to browser credential relay."
             exit 1
           displayName: "Start browser credential relay"

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -39,7 +39,18 @@
         "sample": {
           "TestType": "sample",
           "TestResultsFiles": "**/test-results.xml"
-        },
+        }
+      }
+    },
+    {
+      "Agent": {
+        "ubuntu": {
+          "OSVmImage": "env:LINUXVMIMAGE",
+          "Pool": "env:LINUXPOOL"
+        }
+      },
+      "NodeTestVersion": "env:NODE_VERSION_LTS_MAINTENANCE",
+      "Scenario": {
         "browser": {
           "TestType": "browser",
           "TestResultsFiles": "**/test-results.browser.xml"


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng):

### Why

`dev-tool run test:vitest --browser` runs `npx playwright install`, which downloads every supported Playwright browser (chromium, firefox, webkit) at the start of each browser test run. Our browser tests only ever run on chromium, so downloading firefox and webkit is wasted time and bandwidth on every CI browser test step.

### What

Narrows the install to `npx playwright install chromium`. This is safe because the shared browser config (`vitest.browser.base.config.ts`) declares `instances: [{ browser: "chromium" }]`, and no package overrides it with `firefox` or `webkit`.

Verified `@azure/dev-tool` still builds after the change.