### PR TITLE
[iot] Mock sendRequest in iot-modelsrepository browser test

### DIFF
--- a/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
@@ -33,7 +33,7 @@ describe("resolver -  browser", () => {
       };
 
       const sendRequestStub = vi.spyOn(ServiceClient.prototype, "sendRequest");
-      sendRequestStub.mockImplementationOnce((request: PipelineRequest) => {
+      sendRequestStub.mockImplementation((request: PipelineRequest) => {
         expect(request.url, "URL not formatted for request correctly.").to.equal(expectedUri);
         const pipelineResponse: any = {
           request,

--- a/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
+++ b/sdk/iot/iot-modelsrepository/test/browser/browserTest.spec.ts
@@ -2,17 +2,54 @@
 // Licensed under the MIT License.
 
 import { ModelsRepositoryClient } from "../../src/index.js";
-import { describe, it, expect } from "vitest";
+import { ServiceClient } from "@azure/core-client";
+import type { PipelineRequest } from "@azure/core-rest-pipeline";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("resolver -  browser", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("single resolution (no pseudo-parsing)", () => {
     it("integration works in browser", async () => {
       const dtmi: string = "dtmi:azure:DeviceManagement:DeviceInformation;1";
       const endpoint = "https://devicemodels.azure.com";
+      const expectedUri =
+        "https://devicemodels.azure.com/dtmi/azure/devicemanagement/deviceinformation-1.expanded.json";
+      const mockedModel = {
+        "@context": "dtmi:dtdl:context;2",
+        "@id": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+        "@type": "Interface",
+        displayName: "Device Information",
+        contents: [
+          {
+            "@type": "Property",
+            name: "manufacturer",
+            displayName: "Manufacturer",
+            schema: "string",
+          },
+        ],
+      };
+
+      const sendRequestStub = vi.spyOn(ServiceClient.prototype, "sendRequest");
+      sendRequestStub.mockImplementationOnce((request: PipelineRequest) => {
+        expect(request.url, "URL not formatted for request correctly.").to.equal(expectedUri);
+        const pipelineResponse: any = {
+          request,
+          bodyAsText: JSON.stringify([mockedModel]),
+          status: 200,
+          headers: undefined,
+        };
+        return Promise.resolve(pipelineResponse);
+      });
+
       const client = new ModelsRepositoryClient({ repositoryLocation: endpoint });
       const actualOutput: { [x: string]: any } = await client.getModels(dtmi, {
         dependencyResolution: "tryFromExpanded",
       });
+
+      expect(sendRequestStub).toHaveBeenCalledOnce();
       expect(actualOutput["dtmi:azure:DeviceManagement:DeviceInformation;1"]).to.not.equal(
         undefined,
       );


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng):

## Why

The `@azure/iot-modelsrepository` browser test started failing on `main`. The cause is that `test/browser/browserTest.spec.ts` was never a playback test. Unlike the node integration test, it made a live HTTP call to `https://devicemodels.azure.com` and asserted on the live response. Investigating the endpoint from inside the browser showed it now returns `404 "Page not found"` for every path (including `/`), served by Azure Front Door (`x-azure-ref`, `x-cache: CONFIG_NOCACHE`) with no origin behind it. In other words, the model repository content backend was decommissioned between the passing run (2026-07-11, HTTP 200) and the failing run (2026-07-14). The test was one outage away from failing on every run, and the pnpm-update PR just happened to be the next CI run after the endpoint went dark.

## What

Make the browser test deterministic and offline by mocking the transport, matching the existing node integration test (`test/node/integration/index.spec.ts`):

- Stub `ServiceClient.prototype.sendRequest` with `vi.spyOn`, returning a canned expanded DTDL array and asserting the request URL.
- Assert the stub is called (`toHaveBeenCalledOnce`) so a silent network leak can't pass unnoticed.
- Restore mocks in `afterEach`.

## Verification

- Browser test passes in ~4ms with no network access (previously threw `RestError: Error on HTTP Request in remote model fetcher`).
- `prettier` and `eslint` clean on the changed file.

No source or dependency changes; this is a test-only fix.