### PR TITLE
[engsys] Fix browser credential relay step hanging on Linux runners

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -161,7 +161,7 @@ jobs:
             pwsh: true
             ScriptType: InlineScript
             Inline: |
-              Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool"
+              Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool" -RedirectStandardOutput "$(Agent.TempDirectory)/browser-relay.out.log" -RedirectStandardError "$(Agent.TempDirectory)/browser-relay.err.log"
               for ($i = 0; $i -lt 10; $i++) {
                   try {
                       Invoke-WebRequest -Uri "http://localhost:4895/health" | Out-Null
@@ -171,6 +171,8 @@ jobs:
                       Start-Sleep 6
                   }
               }
+              if (Test-Path "$(Agent.TempDirectory)/browser-relay.out.log") { Write-Host '----- browser-relay stdout -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.out.log" }
+              if (Test-Path "$(Agent.TempDirectory)/browser-relay.err.log") { Write-Host '----- browser-relay stderr -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.err.log" }
               Write-Error "Could not connect to browser credential relay."
               exit 1
           displayName: "Start browser credential relay"
@@ -182,7 +184,7 @@ jobs:
 
       - ${{ else }}:
         - pwsh: |
-            Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool"
+            Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "$(Build.SourcesDirectory)/common/tools/dev-tool" -RedirectStandardOutput "$(Agent.TempDirectory)/browser-relay.out.log" -RedirectStandardError "$(Agent.TempDirectory)/browser-relay.err.log"
             for ($i = 0; $i -lt 10; $i++) {
                 try {
                     Invoke-WebRequest -Uri "http://localhost:4895/health" | Out-Null
@@ -192,6 +194,8 @@ jobs:
                     Start-Sleep 6
                 }
             }
+            if (Test-Path "$(Agent.TempDirectory)/browser-relay.out.log") { Write-Host '----- browser-relay stdout -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.out.log" }
+            if (Test-Path "$(Agent.TempDirectory)/browser-relay.err.log") { Write-Host '----- browser-relay stderr -----'; Get-Content "$(Agent.TempDirectory)/browser-relay.err.log" }
             Write-Error "Could not connect to browser credential relay."
             exit 1
           displayName: "Start browser credential relay"


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): 

Fixes #39440

## Problem

The "Start browser credential relay" step in `eng/pipelines/templates/jobs/live.tests.yml` gets stuck on Linux runners. The agent logs `The STDIO streams did not close within 10 seconds of the exit event from process '/usr/bin/pwsh'...` and the step hangs until the job is cancelled by timeout (~50 min later). The same step passes on Windows.

## Root cause

The step launches the browser credential relay with `Start-Process -NoNewWindow` **without** redirecting the child's standard streams:

```powershell
Start-Process "node" -ArgumentList "launch.ts run start-browser-relay" -NoNewWindow -WorkingDirectory "..."
```

The relay (`common/tools/dev-tool/src/util/browserRelayServer.ts`) is a long-lived Express HTTP server that never exits. On Linux, file descriptors are inherited across `fork`/`exec` unless `O_CLOEXEC` is set, so the spawned `node` process inherits the pipeline agent's stdout/stderr (fds 1/2). The still-running relay holds those pipe write-ends open forever, so the agent step never sees EOF on its STDIO streams and hangs.

On Windows this passes because .NET's `CreateProcess` uses `bInheritHandles=false` when no streams are redirected, so the grandchild does not inherit the agent's pipe.

## Fix

In both `Start-Process` invocations (the `AzurePowerShell@5` federated-auth branch and the plain `pwsh` else branch), redirect the child's stdout/stderr to files under `$(Agent.TempDirectory)`. This stops `node` from inheriting the agent's pipes — making the Linux behavior match Windows — and also captures the relay logs.

Additionally, on the failure path of each step, the captured relay logs are now printed before `Write-Error` to aid future diagnosis.

## Validation

- YAML validated (parses cleanly, no tabs, indentation preserved for both the differently-indented `Inline: |` and `pwsh: |` blocks).
- Pipeline not run as part of this change.