### PR TITLE
Fix turborepo-remote-cache Docker build (internal feed .npmrc + pinned deps)

### DIFF
--- a/eng/containers/turborepo-remote-cache/.npmrc
+++ b/eng/containers/turborepo-remote-cache/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/

--- a/eng/containers/turborepo-remote-cache/Dockerfile
+++ b/eng/containers/turborepo-remote-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azurelinux/base/nodejs:20.14 AS base
+FROM mcr.microsoft.com/azurelinux/base/nodejs:24.18 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/eng/containers/turborepo-remote-cache/Dockerfile
+++ b/eng/containers/turborepo-remote-cache/Dockerfile
@@ -1,13 +1,22 @@
 FROM mcr.microsoft.com/azurelinux/base/nodejs:20.14 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install -g pnpm
 
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy package.json
-COPY package.json ./
+# Copy the .npmrc (points npm/pnpm at the internal azure-sdk feed) and
+# package.json before installing pnpm so both the npm bootstrap of pnpm and
+# all subsequent pnpm installs use the internal registry.
+COPY .npmrc package.json ./
+
+# npm ignores a project/cwd-level .npmrc when installing global packages
+# (`npm install -g`), so point npm's *user* config at the copied .npmrc. This
+# makes the internal feed apply to the pnpm bootstrap below. pnpm's later
+# installs run in WORKDIR /app and pick up the same .npmrc as project config.
+ENV NPM_CONFIG_USERCONFIG=/app/.npmrc
+
+RUN npm install -g pnpm
 
 FROM base AS prod-deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod

--- a/eng/containers/turborepo-remote-cache/Dockerfile
+++ b/eng/containers/turborepo-remote-cache/Dockerfile
@@ -19,11 +19,11 @@ ENV NPM_CONFIG_USERCONFIG=/app/.npmrc
 RUN npm install -g pnpm
 
 FROM base AS prod-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --ignore-scripts
 
 FROM base AS build
 COPY . ./
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --ignore-scripts
 RUN pnpm run build
 
 FROM base

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@azure/identity": "^4.9.0",
     "@azure/storage-blob": "^12.27.0",
-    "@fastify/multipart": "^10.1.0",
     "@hapi/boom": "^10.0.1",
     "dotenv": "^16.5.0",
     "fastify": "^5.3.2",

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@azure/identity": "^4.9.0",
     "@azure/storage-blob": "^12.27.0",
-    "@fastify/multipart": "^9.0.3",
+    "@fastify/multipart": "^10.1.0",
     "@hapi/boom": "^10.0.1",
     "dotenv": "^16.5.0",
     "fastify": "^5.3.2",

--- a/eng/containers/turborepo-remote-cache/package.json
+++ b/eng/containers/turborepo-remote-cache/package.json
@@ -34,16 +34,16 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@eslint/js": "catalog:",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^22.0.0",
     "@vitest/coverage-istanbul": "^4.0.0",
-    "eslint": "catalog:",
+    "eslint": "^10.8.0",
     "pino-pretty": "^13.1.1",
-    "prettier": "catalog:",
-    "rimraf": "catalog:",
+    "prettier": "^3.9.1",
+    "rimraf": "^6.1.0",
     "tsx": "^4.17.0",
     "typescript": "~6.0.2",
-    "typescript-eslint": "catalog:",
+    "typescript-eslint": "~8.65.0",
     "vitest": "^4.0.0"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,9 +422,6 @@ importers:
       '@azure/storage-blob':
         specifier: ^12.27.0
         version: link:../../../sdk/storage/storage-blob
-      '@fastify/multipart':
-        specifier: ^10.1.0
-        version: 10.1.0
       '@hapi/boom':
         specifier: ^10.0.1
         version: 10.0.1
@@ -36396,12 +36393,6 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha1-/bCIenr1GrqujBgp6AmdNPjd0wI=}
 
-  '@fastify/busboy@3.2.0':
-    resolution: {integrity: sha1-E+2CEvO5uml2EVKdFTR/hSgFjOo=}
-
-  '@fastify/deepmerge@3.2.1':
-    resolution: {integrity: sha1-D+VqTuPuyHRVYAZDn3vH1hbxDcE=}
-
   '@fastify/error@4.2.0':
     resolution: {integrity: sha1-1A9GunX1Qf3MTcJ2tzCLvI6ObXo=}
 
@@ -36413,9 +36404,6 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha1-OqMNLwyBqKxZlbbZTtTqosMFWCQ=}
-
-  '@fastify/multipart@10.1.0':
-    resolution: {integrity: sha1-78AQjrYKqExJLBw2eG9qn9jj/Mc=}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha1-9TYLXdg8fePUG0Fb5Kq4SuRKoQY=}
@@ -39064,9 +39052,6 @@ packages:
   fast-xml-parser@5.10.1:
     resolution: {integrity: sha1-GTE/fJOGxH+kod5SdUe3PtLPzt4=}
     hasBin: true
-
-  fastify-plugin@6.0.0:
-    resolution: {integrity: sha1-fNZZxqrV878HtMWSBUEjUaR9Ocg=}
 
   fastify@5.10.0:
     resolution: {integrity: sha1-PJSlJDklmmaInbrRTg/D1rG8k04=}
@@ -43116,10 +43101,6 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.4
 
-  '@fastify/busboy@3.2.0': {}
-
-  '@fastify/deepmerge@3.2.1': {}
-
   '@fastify/error@4.2.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.1.0':
@@ -43131,14 +43112,6 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
-
-  '@fastify/multipart@10.1.0':
-    dependencies:
-      '@fastify/busboy': 3.2.0
-      '@fastify/deepmerge': 3.2.1
-      '@fastify/error': 4.2.0
-      fastify-plugin: 6.0.0
-      secure-json-parse: 4.1.0
 
   '@fastify/proxy-addr@5.1.0':
     dependencies:
@@ -46167,8 +46140,6 @@ snapshots:
       path-expression-matcher: 1.6.2
       strnum: 2.4.1
       xml-naming: 0.3.0
-
-  fastify-plugin@6.0.0: {}
 
   fastify@5.10.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
         specifier: ^12.27.0
         version: link:../../../sdk/storage/storage-blob
       '@fastify/multipart':
-        specifier: ^9.0.3
-        version: 9.4.0
+        specifier: ^10.1.0
+        version: 10.1.0
       '@hapi/boom':
         specifier: ^10.0.1
         version: 10.0.1
@@ -36414,8 +36414,8 @@ packages:
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha1-OqMNLwyBqKxZlbbZTtTqosMFWCQ=}
 
-  '@fastify/multipart@9.4.0':
-    resolution: {integrity: sha1-vlDn0S2YnLQrg1peRuCLQKtbByg=}
+  '@fastify/multipart@10.1.0':
+    resolution: {integrity: sha1-78AQjrYKqExJLBw2eG9qn9jj/Mc=}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha1-9TYLXdg8fePUG0Fb5Kq4SuRKoQY=}
@@ -39065,8 +39065,8 @@ packages:
     resolution: {integrity: sha1-GTE/fJOGxH+kod5SdUe3PtLPzt4=}
     hasBin: true
 
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha1-cIPgOdZBhBX5pmn4wl5y/Fvy0+c=}
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha1-fNZZxqrV878HtMWSBUEjUaR9Ocg=}
 
   fastify@5.10.0:
     resolution: {integrity: sha1-PJSlJDklmmaInbrRTg/D1rG8k04=}
@@ -43132,12 +43132,12 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  '@fastify/multipart@9.4.0':
+  '@fastify/multipart@10.1.0':
     dependencies:
       '@fastify/busboy': 3.2.0
       '@fastify/deepmerge': 3.2.1
       '@fastify/error': 4.2.0
-      fastify-plugin: 5.1.0
+      fastify-plugin: 6.0.0
       secure-json-parse: 4.1.0
 
   '@fastify/proxy-addr@5.1.0':
@@ -46168,7 +46168,7 @@ snapshots:
       strnum: 2.4.1
       xml-naming: 0.3.0
 
-  fastify-plugin@5.1.0: {}
+  fastify-plugin@6.0.0: {}
 
   fastify@5.10.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,7 +439,7 @@ importers:
         version: 2.8.1
     devDependencies:
       '@eslint/js':
-        specifier: 'catalog:'
+        specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0)
       '@types/node':
         specifier: ^22.0.0
@@ -448,16 +448,16 @@ importers:
         specifier: ^4.0.0
         version: 4.1.10(vitest@4.1.10)
       eslint:
-        specifier: 'catalog:'
+        specifier: ^10.8.0
         version: 10.8.0
       pino-pretty:
         specifier: ^13.1.1
         version: 13.1.3
       prettier:
-        specifier: 'catalog:'
+        specifier: ^3.9.1
         version: 3.9.6
       rimraf:
-        specifier: 'catalog:'
+        specifier: ^6.1.0
         version: 6.1.3
       tsx:
         specifier: ^4.17.0
@@ -466,7 +466,7 @@ importers:
         specifier: ~6.0.2
         version: 6.0.3
       typescript-eslint:
-        specifier: 'catalog:'
+        specifier: ~8.65.0
         version: 8.65.0(eslint@10.8.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): 

## Summary

The Docker build for `@azure-tools/turborepo-remote-cache` (`eng/containers/turborepo-remote-cache/`) was failing in CI. This PR addresses the network/registry timeout, the pnpm catalog resolution failure, the global-install bootstrap and lockfile follow-ups, the ignored-build-scripts error, and removes an unused dependency.

### 1. Registry/network timeout (`ETIMEDOUT` to `registry.npmjs.org`)

`RUN npm install -g pnpm` and the later `pnpm install` steps failed with `ETIMEDOUT` because CI cannot reach the public npm registry. The repo root `.npmrc` redirects installs to the internal azure-sdk feed, but the Docker build context (`eng/containers/turborepo-remote-cache/`) did not include an `.npmrc`.

**Fix:**
- Added `eng/containers/turborepo-remote-cache/.npmrc` as a copy of the repo root `.npmrc`, pointing npm/pnpm at the internal feed (`https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/`).
- In the `Dockerfile` `base` stage, `WORKDIR /app` and `COPY .npmrc package.json ./` now happen **before** `RUN npm install -g pnpm`.
- **Global-install bootstrap fix:** npm ignores a project/cwd-level `.npmrc` when installing global packages (`npm install -g`), so the pnpm bootstrap would still hit the public registry. Added `ENV NPM_CONFIG_USERCONFIG=/app/.npmrc` (after the `COPY`, before the global install) so the internal feed applies to the pnpm bootstrap too. pnpm's subsequent installs run in `WORKDIR /app` and read the same `.npmrc` as project config. The registry URL stays only in `.npmrc` (single source of truth), not hardcoded in the Dockerfile.
- pnpm installation itself is otherwise unchanged (still `RUN npm install -g pnpm`, no `packageManager` field, no pinned pnpm version). Consolidated the previously-separate later `COPY package.json ./` into the base stage.

### 2. Catalog resolution (`ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`)

`pnpm install` failed with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC No catalog entry 'prettier' was found for catalog 'default'` because `package.json` used `catalog:` specifiers, but the Docker build context does not include the root `pnpm-workspace.yaml` that defines the catalog. Since the `build` stage runs a full `pnpm install`, every `catalog:` entry would hit this error, not just `prettier`.

**Fix:** Replaced all `catalog:` devDependency specifiers with hard-pinned versions matching the root `pnpm-workspace.yaml` catalog:

| Dependency | Was | Now |
| --- | --- | --- |
| `@eslint/js` | `catalog:` | `^10.0.1` |
| `eslint` | `catalog:` | `^10.8.0` |
| `prettier` | `catalog:` | `^3.9.1` |
| `rimraf` | `catalog:` | `^6.1.0` |
| `typescript-eslint` | `catalog:` | `~8.65.0` |

> Note: aligning `eslint` to the current root catalog moves it from v9 to `^10.8.0` (and `@eslint/js` to `^10.0.1`), matching the rest of the repo's catalog-managed tooling.

### 3. Ignored build scripts (`ERR_PNPM_IGNORED_BUILDS: esbuild@0.28.1`)

pnpm 10 fails in strict/CI mode when dependency build scripts are ignored, and the standalone Docker build context does not include the root `pnpm-workspace.yaml` (which sets `allowBuilds: esbuild: false`, i.e. the monorepo intentionally does **not** build esbuild).

**Fix:** Added `--ignore-scripts` to **both** `pnpm install` commands in the `Dockerfile` so all dependency lifecycle scripts are explicitly disabled — matching the repo's `esbuild: false` intent and correct for this runtime image:
- `RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --ignore-scripts`
- `RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --ignore-scripts`

`pnpm run build` (the app's own `tsc` build) is left unchanged — `--ignore-scripts` only affects dependency lifecycle scripts, not the explicit build script.

### 4. Remove unused `@fastify/multipart` dependency

`@fastify/multipart` has been an unused dependency since the package was introduced in #35575 (`90065d7`) — it is never imported or registered in `src/` or `test/`. The service parses `application/octet-stream` request bodies via `fastify.addContentTypeParser` (`parseAs: "buffer"`), not multipart. Removed the dependency entirely and regenerated the lockfile so the entry and its now-unused transitive deps drop out of the `turborepo-remote-cache` importer.

### Lockfile regeneration

Because the manifest changed (`catalog:` → direct ranges, and removal of `@fastify/multipart`), the root `pnpm-lock.yaml` was regenerated (`pnpm install` from the repository root against the internal feed) and committed so `pnpm install --frozen-lockfile` in repo CI stays green. Also bumped the base image to `mcr.microsoft.com/azurelinux/base/nodejs:24.18`.

## Verification

- Confirmed no `catalog:` references remain in the package's `package.json`.
- Confirmed no `@fastify/multipart` references remain in `src/` or `test/`.
- Confirmed `package.json` is valid JSON.
- Built the package (`pnpm turbo build --filter=@azure-tools/turborepo-remote-cache`) — `tsc` succeeds.
- Regenerated `pnpm-lock.yaml` from the repo root against the internal feed; diffs limited to the affected importer entries.
- Confirmed no `.dockerignore` exists in the build context that could exclude `.npmrc`.
- Docker was not available in this environment, so a full `docker build` could not be run here.
